### PR TITLE
Remove interactive prompts for PR title/body customization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 .coverage
 .cafe
 MagicMock
+pr/

--- a/pr/body.md
+++ b/pr/body.md
@@ -1,1 +1,0 @@
-# TODO: Write PR body here

--- a/pr/title.txt
+++ b/pr/title.txt
@@ -1,1 +1,0 @@
-# TODO: Write PR title here


### PR DESCRIPTION
## Summary
Simplifies the `cafe pr` command workflow by removing interactive prompts that asked users whether to customize PR title and body. When `--title` or `--body` flags are not provided, the system now directly triggers agent auto-generation instead of prompting the user first.

## Changes
- Modified `src/cafe/phases/pr_phase.py` to remove interactive prompts for PR title/body customization in `_prepare_pr_content()` method
- Updated `tests/unit/test_pr_phase.py` to reflect the new non-interactive behavior:
  - Added `test_interactive_mode_auto_generates_without_asking` test to verify auto-generation in interactive mode
  - Fixed `test_gh_pr_create_error_fails_phase` to properly test error handling with correct mock setup
- System now uses CLI parameters (`--title`, `--body`) if provided, otherwise delegates to agent for auto-generation
- No change to existing `--title` and `--body` flag behavior - they continue to work as before

## Test Plan
- [x] Run `pytest tests/unit/test_pr_phase.py` - all 37 tests pass
- [x] Verify `test_interactive_mode_auto_generates_without_asking` validates that interactive mode auto-generates without prompting
- [x] Verify `test_auto_generate_title_and_body` continues to work for non-interactive mode
- [x] Verify `test_custom_title_and_body` ensures CLI parameters are respected
- [x] All unit and integration tests pass (1084 passed)