### PR TITLE
Implement smart template selection with auto mode for plan phase

### DIFF
--- a/src/cafe/phases/plan_phase.py
+++ b/src/cafe/phases/plan_phase.py
@@ -33,6 +33,7 @@ class PlanPhase(Phase):
         dev_agent: str = "David",
         interactive: bool = True,
         template_path: Optional[str] = None,
+        template_mode: str = "auto",
         user_input: str = "",
     ) -> None:
         """Initialize plan phase.
@@ -46,7 +47,8 @@ class PlanPhase(Phase):
             issue_id: GitHub issue ID (required for github mode)
             issue_name: Issue name for history tracking (default: derived from current branch)
             dev_agent: Developer agent name (default: David)
-            template_path: Path to plan template file (optional)
+            template_path: Path to plan template file (optional, used when template_mode='manual')
+            template_mode: Template selection mode ('auto' or 'manual', default: 'auto')
             interactive: Whether to allow interactive prompts (default: True)
             user_input: User input for non-interactive mode (default: "")
         """
@@ -59,6 +61,7 @@ class PlanPhase(Phase):
         self.issue_id = issue_id
         self.dev_agent = dev_agent
         self.template_path = template_path
+        self.template_mode = template_mode
         self.user_input = user_input
         self.display = Display()
         self.iteration = 0
@@ -338,9 +341,22 @@ class PlanPhase(Phase):
             },
         )
 
-        # Add template reference if template is provided
+        # Add template reference
         template_instruction = ""
-        if template_path:
+        if self.template_mode == "auto":
+            # Auto mode: include template list and ask agent to pick
+            from cafe.templates.manager import TemplateManager
+            template_manager = TemplateManager(".cafe")
+            available_templates = template_manager.list_templates()
+
+            if available_templates:
+                template_list_str = ", ".join(f"`{t}`" for t in available_templates)
+                template_instruction = f"""
+**Important: Must pick a most suitable template**
+Please pick a most suitable template from .cafe/templates/plan/ (available: {template_list_str}). After reading the requirements, select the template that best fits the task type and complexity.
+"""
+        elif template_path:
+            # Manual mode: use the specified template
             template_instruction = f"""
 **Important: Must strictly follow template format**
 Please first read {template_path}, then strictly follow the template's format, section structure, and writing style to write plan.md.

--- a/src/cafe/ui/cli.py
+++ b/src/cafe/ui/cli.py
@@ -1687,6 +1687,7 @@ def plan(
         # Handle template selection
         template_manager = TemplateManager(config_dir)
         selected_template = None
+        template_mode = "auto"  # Track if template is 'auto' or manually specified
 
         if is_resume:
             console.print(f"[dim]Resuming existing plan from: {plan_file_path}[/dim]")
@@ -1698,6 +1699,34 @@ def plan(
                 console.print("[dim]Use 'cafe template list' to see available templates[/dim]")
                 raise typer.Exit(1)
             selected_template = template
+            template_mode = "manual"
+        elif not is_resume:
+            # No template specified and not resuming - need to select one for first iteration
+            if interactive:
+                # Interactive mode: prompt user to select 'auto' or a specific template
+                import sys
+                is_interactive = sys.stdin.isatty()
+
+                if is_interactive:
+                    from cafe.ui.template_selector import select_template
+
+                    templates = template_manager.list_templates()
+                    template_paths = {name: template_manager.get_template_path(name) for name in templates}
+                    selected_template = select_template(templates, template_paths, include_auto=True)
+
+                    if selected_template == "auto":
+                        template_mode = "auto"
+                    else:
+                        template_mode = "manual"
+                else:
+                    # Non-interactive but interactive flag set (piped stdin)
+                    # Default to auto mode
+                    selected_template = "auto"
+                    template_mode = "auto"
+            else:
+                # Non-interactive mode with no --template: default to auto
+                selected_template = "auto"
+                template_mode = "auto"
 
         # Display start message
         console.print("[bold blue]📋 Plan Phase: Implementation Planning[/bold blue]")
@@ -1711,11 +1740,16 @@ def plan(
             console.print(f"Spec file: {spec_file_path}")
         elif issue_id:
             console.print(f"GitHub Issue: #{issue_id}")
+        if selected_template:
+            if template_mode == "auto":
+                console.print("[dim]Template mode: auto (agent will decide)[/dim]")
+            else:
+                console.print(f"[dim]Template: {selected_template}[/dim]")
         console.print()
 
-        # Get template path if selected
+        # Get template path if manually selected (not auto)
         template_path_str = None
-        if selected_template:
+        if selected_template and template_mode == "manual":
             template_path_obj = template_manager.get_template_path(selected_template)
             if template_path_obj:
                 template_path_str = str(template_path_obj)
@@ -1735,6 +1769,7 @@ def plan(
             dev_agent=dev_agent,
             interactive=interactive,
             template_path=template_path_str,
+            template_mode=template_mode,  # Pass template mode to plan phase
         )
 
         # Determine if should be interactive

--- a/src/cafe/ui/template_selector.py
+++ b/src/cafe/ui/template_selector.py
@@ -11,38 +11,49 @@ from cafe.ui.inquirer_prompts import prompt_list
 console = Console()
 
 
-def select_template(templates: List[str], template_paths: Dict[str, Path]) -> Optional[str]:
+def select_template(templates: List[str], template_paths: Dict[str, Path], include_auto: bool = False) -> Optional[str]:
     """Select a template interactively.
 
     Args:
         templates: List of template names
         template_paths: Dict mapping template names to their file paths
+        include_auto: Whether to include 'auto' option (default: False)
 
     Returns:
-        Selected template name, or None if skipped
+        Selected template name (or 'auto'), or None if skipped
     """
-    if not templates:
+    if not templates and not include_auto:
         return None
 
     console.print()
     console.print("Please select a plan template:")
     console.print()
     console.print("[bold cyan]Available templates:[/bold cyan]")
-    for i, name in enumerate(templates, 1):
-        console.print(f"  [green]{i}[/green]. {name}")
+
+    # Build choices list with 'auto' option first if included
+    choices = []
+    choice_num = 1
+
+    if include_auto:
+        console.print(f"  [green]{choice_num}[/green]. auto (agent decides)")
+        choices.append(f"{choice_num}. auto")
+        choice_num += 1
+
+    for name in templates:
+        console.print(f"  [green]{choice_num}[/green]. {name}")
+        choices.append(f"{choice_num}. {name}")
+        choice_num += 1
+
     console.print()
     console.print("[dim]Tip: Use 'cafe template cat <name>' to preview template content[/dim]")
-    if len(templates) == 1:
+    if len(templates) == 1 and not include_auto:
         console.print("[dim]     Create your own: 'cafe template add <file> <name>' to add custom template[/dim]")
     console.print()
-
-    # Create choices for inquirer
-    choices = [f"{i}. {name}" for i, name in enumerate(templates, 1)]
 
     try:
         selected = prompt_list("Select template number:", choices, default=choices[0])
         # Parse the selection to get template name
-        # Format: "1. default" -> "default"
+        # Format: "1. auto" or "1. default" -> "auto" or "default"
         template_name = selected.split(". ", 1)[1]
         return template_name
     except (KeyboardInterrupt, EOFError):

--- a/tests/unit/test_plan_phase_template_mode.py
+++ b/tests/unit/test_plan_phase_template_mode.py
@@ -1,0 +1,171 @@
+"""Tests for PlanPhase template mode feature."""
+
+import pytest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from cafe.phases.plan_phase import PlanPhase
+from cafe.agents.manager import AgentManager
+from cafe.core.git import GitOperations
+from cafe.core.types import WorkflowMode, TokenUsage
+from cafe.core.permission import PermissionHandler
+
+
+@pytest.fixture
+def mock_git_ops() -> MagicMock:
+    """Create a mock GitOperations for testing."""
+    git_ops = MagicMock(spec=GitOperations)
+    git_ops.get_current_branch.return_value = "test-issue"
+    return git_ops
+
+
+def setup_agent_manager_mocks(agent_manager: MagicMock) -> None:
+    """Setup standard mocks for agent_manager used by PlanPhase."""
+    mock_agent = MagicMock()
+    mock_agent.config.cli.value = "copilot"
+    mock_agent.config.session_id = "test_session"
+    agent_manager.get_agent.return_value = mock_agent
+    agent_manager.get_agent_config.return_value = MagicMock(cli=MagicMock(value="copilot"))
+    agent_manager.get_total_token_usage.return_value = TokenUsage()
+
+
+class TestTemplateMode:
+    """Test template mode feature in PlanPhase."""
+
+    def test_init_with_auto_mode(self, mock_git_ops) -> None:
+        """Test initialization with auto template mode."""
+        agent_manager = MagicMock(spec=AgentManager)
+        setup_agent_manager_mocks(agent_manager)
+        permission_handler = MagicMock(spec=PermissionHandler)
+
+        phase = PlanPhase(
+            agent_manager=agent_manager,
+            permission_handler=permission_handler,
+            spec_file="requirements.md",
+            workflow_mode=WorkflowMode.LOCAL,
+            git_ops=mock_git_ops,
+            template_mode="auto",
+        )
+
+        assert phase.template_mode == "auto"
+        assert phase.template_path is None
+
+    def test_init_with_manual_mode(self, mock_git_ops) -> None:
+        """Test initialization with manual template mode."""
+        agent_manager = MagicMock(spec=AgentManager)
+        setup_agent_manager_mocks(agent_manager)
+        permission_handler = MagicMock(spec=PermissionHandler)
+
+        phase = PlanPhase(
+            agent_manager=agent_manager,
+            permission_handler=permission_handler,
+            spec_file="requirements.md",
+            workflow_mode=WorkflowMode.LOCAL,
+            git_ops=mock_git_ops,
+            template_mode="manual",
+            template_path="/path/to/template.md",
+        )
+
+        assert phase.template_mode == "manual"
+        assert phase.template_path == "/path/to/template.md"
+
+    def test_prompt_includes_auto_template_instruction(self, tmp_path: Path, mock_git_ops, monkeypatch) -> None:
+        """Test that auto mode prompt includes template selection instruction."""
+        monkeypatch.chdir(tmp_path)
+        mock_git_ops.get_current_branch.return_value = "test-feature"
+
+        # Create spec file
+        spec_file = tmp_path / ".cafe" / "issues" / "test-feature" / "spec" / "spec_001.md"
+        spec_file.parent.mkdir(parents=True, exist_ok=True)
+        spec_file.write_text("# Requirements\n\nSome requirements")
+
+        # Create template directory with sample templates
+        template_dir = tmp_path / ".cafe" / "templates" / "plan"
+        template_dir.mkdir(parents=True, exist_ok=True)
+        (template_dir / "default.md").write_text("# Default Template")
+        (template_dir / "simple.md").write_text("# Simple Template")
+        (template_dir / "bug.md").write_text("# Bug Template")
+
+        # Create plan file with development guide
+        plan_file = spec_file.parent.parent / "plan" / "plan_001.md"
+        plan_file.parent.mkdir(parents=True, exist_ok=True)
+        plan_file.write_text("## Development Guide\n\nSome guide")
+
+        agent_manager = MagicMock(spec=AgentManager)
+        setup_agent_manager_mocks(agent_manager)
+        permission_handler = MagicMock(spec=PermissionHandler)
+
+        phase = PlanPhase(
+            agent_manager=agent_manager,
+            permission_handler=permission_handler,
+            spec_file=str(spec_file),
+            workflow_mode=WorkflowMode.LOCAL,
+            git_ops=mock_git_ops,
+            template_mode="auto",
+            interactive=False,
+        )
+
+        prompt = phase._generate_local_prompt("")
+
+        # Verify auto mode prompt includes template selection instruction
+        assert "pick a most suitable template" in prompt
+        assert ".cafe/templates/plan/" in prompt
+        assert "`default`" in prompt or "`simple`" in prompt or "`bug`" in prompt
+
+    def test_prompt_includes_manual_template_instruction(self, tmp_path: Path, mock_git_ops, monkeypatch) -> None:
+        """Test that manual mode prompt includes specific template instruction."""
+        monkeypatch.chdir(tmp_path)
+        mock_git_ops.get_current_branch.return_value = "test-feature"
+
+        # Create spec file
+        spec_file = tmp_path / ".cafe" / "issues" / "test-feature" / "spec" / "spec_001.md"
+        spec_file.parent.mkdir(parents=True, exist_ok=True)
+        spec_file.write_text("# Requirements\n\nSome requirements")
+
+        # Create template file
+        template_file = tmp_path / ".cafe" / "templates" / "plan" / "custom.md"
+        template_file.parent.mkdir(parents=True, exist_ok=True)
+        template_file.write_text("# Custom Template")
+
+        # Create plan file with development guide
+        plan_file = spec_file.parent.parent / "plan" / "plan_001.md"
+        plan_file.parent.mkdir(parents=True, exist_ok=True)
+        plan_file.write_text("## Development Guide\n\nSome guide")
+
+        agent_manager = MagicMock(spec=AgentManager)
+        setup_agent_manager_mocks(agent_manager)
+        permission_handler = MagicMock(spec=PermissionHandler)
+
+        phase = PlanPhase(
+            agent_manager=agent_manager,
+            permission_handler=permission_handler,
+            spec_file=str(spec_file),
+            workflow_mode=WorkflowMode.LOCAL,
+            git_ops=mock_git_ops,
+            template_mode="manual",
+            template_path=str(template_file),
+            interactive=False,
+        )
+
+        prompt = phase._generate_local_prompt("")
+
+        # Verify manual mode prompt includes specific template path
+        assert "Please first read" in prompt
+        assert ".cafe/templates/plan/custom.md" in prompt
+        assert "strictly follow the template's format" in prompt
+
+    def test_template_mode_default_is_auto(self, mock_git_ops) -> None:
+        """Test that default template mode is 'auto'."""
+        agent_manager = MagicMock(spec=AgentManager)
+        setup_agent_manager_mocks(agent_manager)
+        permission_handler = MagicMock(spec=PermissionHandler)
+
+        phase = PlanPhase(
+            agent_manager=agent_manager,
+            permission_handler=permission_handler,
+            spec_file="requirements.md",
+            workflow_mode=WorkflowMode.LOCAL,
+            git_ops=mock_git_ops,
+        )
+
+        assert phase.template_mode == "auto"

--- a/tests/unit/test_template_selector_auto.py
+++ b/tests/unit/test_template_selector_auto.py
@@ -1,0 +1,112 @@
+"""Tests for template selector with auto option."""
+
+import pytest
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+from cafe.ui.template_selector import select_template
+
+
+class TestTemplateSelectorWithAuto:
+    """Test template selector with auto option."""
+
+    def test_select_template_without_auto(self):
+        """Test template selection without auto option."""
+        templates = ["default", "simple", "bug"]
+        template_paths = {name: Path(f"/path/to/{name}.md") for name in templates}
+
+        with patch("cafe.ui.template_selector.prompt_list") as mock_prompt:
+            mock_prompt.return_value = "1. default"
+            result = select_template(templates, template_paths, include_auto=False)
+
+            assert result == "default"
+            mock_prompt.assert_called_once()
+            # Verify choices don't include auto
+            call_args = mock_prompt.call_args
+            choices = call_args[0][1]
+            assert all("auto" not in choice for choice in choices)
+
+    def test_select_template_with_auto_option(self):
+        """Test template selection with auto option included."""
+        templates = ["default", "simple", "bug"]
+        template_paths = {name: Path(f"/path/to/{name}.md") for name in templates}
+
+        with patch("cafe.ui.template_selector.prompt_list") as mock_prompt:
+            mock_prompt.return_value = "1. auto"
+            result = select_template(templates, template_paths, include_auto=True)
+
+            assert result == "auto"
+            mock_prompt.assert_called_once()
+            # Verify choices include auto as first option
+            call_args = mock_prompt.call_args
+            choices = call_args[0][1]
+            assert choices[0] == "1. auto"
+
+    def test_select_manual_template_with_auto_option(self):
+        """Test selecting a manual template when auto option is available."""
+        templates = ["default", "simple", "bug"]
+        template_paths = {name: Path(f"/path/to/{name}.md") for name in templates}
+
+        with patch("cafe.ui.template_selector.prompt_list") as mock_prompt:
+            mock_prompt.return_value = "3. simple"
+            result = select_template(templates, template_paths, include_auto=True)
+
+            assert result == "simple"
+            mock_prompt.assert_called_once()
+            # Verify auto is first, then templates
+            call_args = mock_prompt.call_args
+            choices = call_args[0][1]
+            assert choices[0] == "1. auto"
+            assert "3. simple" in choices
+
+    def test_auto_option_is_first_choice(self):
+        """Test that auto option appears as the first choice."""
+        templates = ["default", "simple", "bug"]
+        template_paths = {name: Path(f"/path/to/{name}.md") for name in templates}
+
+        with patch("cafe.ui.template_selector.prompt_list") as mock_prompt:
+            mock_prompt.return_value = "1. auto"
+            select_template(templates, template_paths, include_auto=True)
+
+            call_args = mock_prompt.call_args
+            choices = call_args[0][1]
+            # First choice should be auto
+            assert choices[0].endswith("auto")
+            # Other choices should be templates
+            assert any("default" in choice for choice in choices)
+            assert any("simple" in choice for choice in choices)
+            assert any("bug" in choice for choice in choices)
+
+    def test_select_template_empty_list_with_auto(self):
+        """Test template selection with empty template list but auto enabled."""
+        templates = []
+        template_paths = {}
+
+        with patch("cafe.ui.template_selector.prompt_list") as mock_prompt:
+            mock_prompt.return_value = "1. auto"
+            result = select_template(templates, template_paths, include_auto=True)
+
+            assert result == "auto"
+            # Should still work with auto option even if no templates
+
+    def test_select_template_empty_list_without_auto(self):
+        """Test template selection returns None with empty list and no auto."""
+        templates = []
+        template_paths = {}
+
+        result = select_template(templates, template_paths, include_auto=False)
+        assert result is None
+
+    def test_default_choice_is_auto_when_included(self):
+        """Test that default choice is auto when auto option is included."""
+        templates = ["default", "simple"]
+        template_paths = {name: Path(f"/path/to/{name}.md") for name in templates}
+
+        with patch("cafe.ui.template_selector.prompt_list") as mock_prompt:
+            mock_prompt.return_value = "1. auto"
+            select_template(templates, template_paths, include_auto=True)
+
+            call_args = mock_prompt.call_args
+            # The default should be the first choice (auto)
+            default_choice = call_args[1]["default"]
+            assert default_choice.endswith("auto")


### PR DESCRIPTION
## Summary

實現智慧模板選擇機制，允許用戶在執行 `cafe plan` 時自動或手動選擇計畫模板。系統根據用戶的選擇（自動或手動指定），動態生成相應的 prompt 指導 agent 完成計畫分析。

## Changes

- **Template Selector 增強** (`src/cafe/ui/template_selector.py`)
  - 添加 `include_auto` 參數支持 "auto" 選項顯示
  - "auto" 選項作為列表中的第一個選擇

- **CLI 命令更新** (`src/cafe/ui/cli.py`)
  - 實現 `auto` 模式作為默認選項（未提供 `--template` 時）
  - 支持用戶手動指定模板（`--template <name>`）
  - 添加 `template_mode` 參數區分自動和手動模式

- **Plan Phase 改進** (`src/cafe/phases/plan_phase.py`)
  - 添加 `template_mode` 參數支持自動和手動模式
  - 自動模式：prompt 包含可用模板列表，指導 agent 選擇
  - 手動模式：保持既有邏輯，直接使用指定模板
  - 動態從 TemplateManager 加載可用模板列表

- **單元測試**
  - `test_plan_phase_template_mode.py`: PlanPhase 模板模式功能測試
  - `test_template_selector_auto.py`: 模板選擇器 auto 選項測試

## Test Plan

- [x] 驗證互動模式下，`auto` 選項顯示在列表首位
- [x] 驗證模板列表動態反映 `.cafe/templates/plan/` 目錄變更
- [x] 驗證自動模式下，prompt 包含模板列表和選擇指令
- [x] 驗證手動模式下，系統直接使用指定模板
- [x] 驗證 `--template` 參數可覆寫默認行為
- [x] 運行全套單元測試 (1250+ 測試通過)
- [x] 驗證 pre-commit hooks 通過