### PR TITLE
Add cafe show command to display iteration file contents

### DIFF
--- a/src/cafe/ui/cli.py
+++ b/src/cafe/ui/cli.py
@@ -293,62 +293,81 @@ def _edit_file_with_editor(file_path: Path) -> None:
         raise typer.Exit(1)
 
 
-def _resolve_iteration_number(phase_dir: Path, iteration_input: int) -> int:
-    """Resolve iteration number (supports positive, zero, negative).
+def _resolve_iteration_number(phase_dir: Path, iteration_input: int, content_type: str) -> int:
+    """Resolve iteration number based on iterations that have the specified file.
 
     Args:
         phase_dir: Phase directory path (e.g., .cafe/issues/issue84/spec)
         iteration_input: User input iteration number (can be positive, 0, negative)
+        content_type: Content type to search for (output, context, etc.)
 
     Returns:
         Actual iteration number (positive integer)
 
     Raises:
-        ValueError: When iteration number does not exist
+        ValueError: When iteration number does not exist or file not found
     """
-    # Get all iteration directories (verified by context.json file)
-    iteration_files = sorted(phase_dir.glob("iteration_*/context.json"))
+    # Get filename for the content type
+    filename = CONTENT_TYPE_FILE_MAP.get(content_type)
+    if not filename:
+        raise ValueError(f"Unknown content type: {content_type}")
 
-    if not iteration_files:
+    # Get all iteration directories (verified by context.json file)
+    all_iteration_files = sorted(phase_dir.glob("iteration_*/context.json"))
+
+    if not all_iteration_files:
         raise ValueError(f"No iterations found in {phase_dir}")
 
-    # Extract iteration numbers from directory names
-    iteration_numbers = []
-    for file_path in iteration_files:
-        # Directory name format is iteration_XXX
+    # Extract all iteration numbers
+    all_iteration_numbers = []
+    for file_path in all_iteration_files:
         dir_name = file_path.parent.name
         if dir_name.startswith("iteration_"):
             try:
                 num = int(dir_name.split("_")[1])
-                iteration_numbers.append(num)
+                all_iteration_numbers.append(num)
             except (IndexError, ValueError):
                 continue
 
-    if not iteration_numbers:
+    if not all_iteration_numbers:
         raise ValueError(f"No valid iterations found in {phase_dir}")
+
+    # Find iterations that have the requested file
+    iteration_numbers_with_file = []
+    for iter_num in all_iteration_numbers:
+        iteration_dir = phase_dir / f"iteration_{iter_num:03d}"
+        file_path = iteration_dir / filename
+        if file_path.exists():
+            iteration_numbers_with_file.append(iter_num)
+
+    if not iteration_numbers_with_file:
+        raise ValueError(
+            f"No iterations found with file '{filename}'. "
+            f"Available iterations: {all_iteration_numbers}"
+        )
 
     # Handle different iteration number formats
     if iteration_input == 0:
-        # Zero means latest iteration
-        return iteration_numbers[-1]
+        # Zero means latest iteration with the file
+        return iteration_numbers_with_file[-1]
     elif iteration_input > 0:
         # Positive number used directly, but need to verify existence
-        if iteration_input not in iteration_numbers:
+        if iteration_input not in iteration_numbers_with_file:
             raise ValueError(
-                f"Iteration {iteration_input} not found. "
-                f"Available iterations: {iteration_numbers}"
+                f"Iteration {iteration_input} not found or does not have '{filename}'. "
+                f"Iterations with this file: {iteration_numbers_with_file}"
             )
         return iteration_input
     else:
         # Negative number: -1 means one before latest, -2 means two before, etc.
-        # Since 0 already represents latest (iteration_numbers[-1]),
+        # Since 0 already represents latest (iteration_numbers_with_file[-1]),
         # we need to offset: -1 -> [-2], -2 -> [-3], etc.
         try:
-            return iteration_numbers[iteration_input - 1]
+            return iteration_numbers_with_file[iteration_input - 1]
         except IndexError:
             raise ValueError(
                 f"Iteration index {iteration_input} out of range. "
-                f"Available iterations: {iteration_numbers}"
+                f"Iterations with '{filename}': {iteration_numbers_with_file}"
             )
 
 
@@ -3848,7 +3867,7 @@ def show(
     try:
         # Resolve iteration number (only for non-status/iterations files)
         if content_type not in ["status", "iterations"]:
-            resolved_iteration = _resolve_iteration_number(phase_dir, iteration)
+            resolved_iteration = _resolve_iteration_number(phase_dir, iteration, content_type)
             # Get file path
             file_path = _get_show_file_path(phase_dir, resolved_iteration, content_type)
         else:

--- a/tests/unit/test_cli_show.py
+++ b/tests/unit/test_cli_show.py
@@ -23,11 +23,12 @@ class TestResolveIterationNumber:
             iteration_dir = phase_dir / f"iteration_{i:03d}"
             iteration_dir.mkdir()
             (iteration_dir / "context.json").write_text("{}")
+            (iteration_dir / "output.md").write_text(f"# Output {i}")
 
         # 測試正數迭代號碼
-        assert _resolve_iteration_number(phase_dir, 1) == 1
-        assert _resolve_iteration_number(phase_dir, 2) == 2
-        assert _resolve_iteration_number(phase_dir, 3) == 3
+        assert _resolve_iteration_number(phase_dir, 1, "output") == 1
+        assert _resolve_iteration_number(phase_dir, 2, "output") == 2
+        assert _resolve_iteration_number(phase_dir, 3, "output") == 3
 
     def test_resolve_iteration_number_zero(self, tmp_path):
         """測試零（最新迭代）解析"""
@@ -38,9 +39,10 @@ class TestResolveIterationNumber:
             iteration_dir = phase_dir / f"iteration_{i:03d}"
             iteration_dir.mkdir()
             (iteration_dir / "context.json").write_text("{}")
+            (iteration_dir / "output.md").write_text(f"# Output {i}")
 
-        # 零應該返回最新的迭代號碼（3）
-        assert _resolve_iteration_number(phase_dir, 0) == 3
+        # 零應該返回最新的有該檔案的迭代號碼（3）
+        assert _resolve_iteration_number(phase_dir, 0, "output") == 3
 
     def test_resolve_iteration_number_negative(self, tmp_path):
         """測試負數（相對索引）解析"""
@@ -51,11 +53,12 @@ class TestResolveIterationNumber:
             iteration_dir = phase_dir / f"iteration_{i:03d}"
             iteration_dir.mkdir()
             (iteration_dir / "context.json").write_text("{}")
+            (iteration_dir / "output.md").write_text(f"# Output {i}")
 
         # -1 應該返回最新迭代的前一個（2）
-        assert _resolve_iteration_number(phase_dir, -1) == 2
+        assert _resolve_iteration_number(phase_dir, -1, "output") == 2
         # -2 應該返回最新迭代的前兩個（1）
-        assert _resolve_iteration_number(phase_dir, -2) == 1
+        assert _resolve_iteration_number(phase_dir, -2, "output") == 1
 
     def test_resolve_iteration_number_invalid_positive(self, tmp_path):
         """測試不存在的正數迭代號碼"""
@@ -66,10 +69,11 @@ class TestResolveIterationNumber:
             iteration_dir = phase_dir / f"iteration_{i:03d}"
             iteration_dir.mkdir()
             (iteration_dir / "context.json").write_text("{}")
+            (iteration_dir / "output.md").write_text(f"# Output {i}")
 
         # 迭代號碼 5 不存在，應該拋出 ValueError
         with pytest.raises(ValueError):
-            _resolve_iteration_number(phase_dir, 5)
+            _resolve_iteration_number(phase_dir, 5, "output")
 
     def test_resolve_iteration_number_invalid_negative(self, tmp_path):
         """測試超出範圍的負數迭代號碼"""
@@ -80,10 +84,11 @@ class TestResolveIterationNumber:
             iteration_dir = phase_dir / f"iteration_{i:03d}"
             iteration_dir.mkdir()
             (iteration_dir / "context.json").write_text("{}")
+            (iteration_dir / "output.md").write_text(f"# Output {i}")
 
         # -5 超出範圍，應該拋出 ValueError
         with pytest.raises(ValueError):
-            _resolve_iteration_number(phase_dir, -5)
+            _resolve_iteration_number(phase_dir, -5, "output")
 
     def test_resolve_iteration_number_no_iterations(self, tmp_path):
         """測試沒有任何迭代時"""
@@ -93,7 +98,26 @@ class TestResolveIterationNumber:
 
         # 沒有迭代時應該拋出 ValueError
         with pytest.raises(ValueError):
-            _resolve_iteration_number(phase_dir, 0)
+            _resolve_iteration_number(phase_dir, 0, "output")
+
+    def test_resolve_iteration_number_partial_files(self, tmp_path):
+        """測試部分迭代有特定檔案的情況"""
+        # 準備測試資料：iteration 1-3 有 output.md，iteration 4 只有 context.json
+        phase_dir = tmp_path / "spec"
+        phase_dir.mkdir(parents=True)
+        for i in [1, 2, 3, 4]:
+            iteration_dir = phase_dir / f"iteration_{i:03d}"
+            iteration_dir.mkdir()
+            (iteration_dir / "context.json").write_text("{}")
+            if i <= 3:  # 只有 1-3 有 output.md
+                (iteration_dir / "output.md").write_text(f"# Output {i}")
+
+        # 0 應該返回最後一個有 output.md 的迭代（3）
+        assert _resolve_iteration_number(phase_dir, 0, "output") == 3
+        # -1 應該返回倒數第二個有 output.md 的迭代（2）
+        assert _resolve_iteration_number(phase_dir, -1, "output") == 2
+        # -2 應該返回倒數第三個有 output.md 的迭代（1）
+        assert _resolve_iteration_number(phase_dir, -2, "output") == 1
 
 
 class TestGetShowFilePath:


### PR DESCRIPTION
## 摘要

新增 `cafe show` 命令，用於顯示各階段（spec、plan、develop、review、pr）迭代的檔案內容。此命令支援多種內容類型（output、context、streaming 等）和靈活的迭代號碼指定方式（正數、零、負數）。

## 主要變更

- **新增 `cafe show` 命令**
  - 支援五個階段類別：spec、plan、develop、review、pr
  - 支援八種內容類型：context、output、streaming、error、title、body、status、iterations
  - 預設顯示最新迭代的 output.md

- **迭代號碼解析功能**
  - 正數：直接指定迭代號碼（例如：`-i 2`）
  - 零：最新迭代（預設值）
  - 負數：相對索引，遵循 Python 陣列邏輯（例如：`-i -1` 表示前一個迭代）

- **輔助函式**
  - `_resolve_iteration_number()`: 解析並驗證迭代號碼
  - `_get_show_file_path()`: 根據內容類型取得檔案路徑

- **模塊級常數**
  - `VALID_PHASES`: 有效的階段名稱列表
  - `VALID_CONTENT_TYPES`: 有效的內容類型列表
  - `CONTENT_TYPE_FILE_MAP`: 內容類型與檔案名稱的映射

- **完整的單元測試和整合測試**
  - 15 個測試案例涵蓋所有功能和錯誤情境
  - 測試涵蓋率符合專案標準

## 測試計畫

**使用範例：**
```bash
# 顯示最新 spec 迭代的 output.md
cafe show spec

# 顯示最新 spec 迭代的 context.json
cafe show spec context

# 顯示 spec 第 2 個迭代的 output.md
cafe show spec output -i 2

# 顯示 spec 前一個迭代的 context.json
cafe show spec context -i -1

# 顯示 plan 倒數第二個迭代的 output.md
cafe show plan -i -2
```

**驗證方式：**
1. 執行 `pytest tests/unit/test_cli_show.py -v` 確認所有測試通過
2. 執行上述範例命令，驗證檔案內容正確顯示
3. 測試錯誤情境（不存在的迭代、無效的階段名稱等）確認錯誤訊息正確