### PR TITLE
Fix incorrect path references in error messages and prompts

### DIFF
--- a/src/cafe/phases/plan_phase.py
+++ b/src/cafe/phases/plan_phase.py
@@ -372,7 +372,7 @@ class PlanPhase(Phase):
                 template_list_str = ", ".join(f"`{t}`" for t in available_templates)
                 template_instruction = f"""
 **Important: Must pick a most suitable template**
-Please pick a most suitable template from .cafe/templates/plan/ (available: {template_list_str}). After reading the requirements, select the template that best fits the task type and complexity.
+Please pick a most suitable template (available: {template_list_str}). After reading the requirements, select the template that best fits the task type and complexity.
 """
         elif template_path:
             # Manual mode: use the specified template

--- a/src/cafe/ui/cli.py
+++ b/src/cafe/ui/cli.py
@@ -563,7 +563,7 @@ def init() -> None:
             if not agents:
                 console.print(f"[red]Error: Agent files not found for {role_display} role.[/red]")
                 console.print(
-                    f"[yellow]Please ensure valid .md files exist in .cafe/agents/{role_key}/ directory.[/yellow]"
+                    f"[yellow]Please ensure valid .md files exist in ~/.cafe/agents/{role_key}/ or src/cafe/data/agents/{role_key}/ directory.[/yellow]"
                 )
                 raise typer.Exit(1)
 

--- a/tests/unit/test_cli_init.py
+++ b/tests/unit/test_cli_init.py
@@ -360,3 +360,47 @@ class TestInitCommandConfigSaving:
 
         assert result.exit_code == 0
         assert "default" in result.stdout
+
+
+class TestInitCommandErrorMessages:
+    """測試 init 指令的錯誤訊息"""
+
+    @patch("cafe.ui.cli.shutil.which")
+    @patch("cafe.ui.cli.list_available_agents")
+    @patch("cafe.ui.cli.prompt_list")
+    @patch("cafe.ui.cli.prompt_text")
+    def test_no_agents_error_message_shows_correct_paths(
+        self,
+        mock_prompt_text: MagicMock,
+        mock_prompt_list: MagicMock,
+        mock_list_agents: MagicMock,
+        mock_which: MagicMock,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """測試當沒有 agents 時錯誤訊息應該顯示正確的路徑 (不應該顯示 .cafe/agents/)"""
+        # 模擬有可用 CLI
+        mock_which.return_value = "/usr/bin/claude"
+
+        # 模擬選擇 CLI
+        mock_prompt_list.return_value = "claude"
+        
+        # 模擬輸入 model (empty string)
+        mock_prompt_text.return_value = ""
+        
+        # 模擬空 agent 列表
+        mock_list_agents.return_value = []
+
+        monkeypatch.chdir(tmp_path)
+
+        result = runner.invoke(app, ["init"])
+
+        assert result.exit_code == 1
+        assert "Agent files not found" in result.stdout
+        # 不應該包含錯誤的 .cafe/agents/ 路徑引用 (但允許 ~/.cafe/agents/)
+        # 檢查是否包含正確引用而不是錯誤引用 "Please ensure valid .md files exist in .cafe/agents/"
+        assert "in .cafe/agents/" not in result.stdout
+        # 應該提示正確的路徑：~/.cafe/agents/ 和 src/cafe/data/agents/
+        # Note: ANSI color codes may split the path, so check for the key components
+        assert "~" in result.stdout and "/.cafe/agents/" in result.stdout
+        assert "src/cafe/data/agents/" in result.stdout

--- a/tests/unit/test_plan_phase_template_mode.py
+++ b/tests/unit/test_plan_phase_template_mode.py
@@ -106,7 +106,8 @@ class TestTemplateMode:
 
         # Verify auto mode prompt includes template selection instruction
         assert "pick a most suitable template" in prompt
-        assert ".cafe/templates/plan/" in prompt
+        # 不應該包含錯誤的 .cafe/templates/plan/ 路徑
+        assert ".cafe/templates/plan/" not in prompt
         assert "`default`" in prompt or "`simple`" in prompt or "`bug`" in prompt
 
     def test_prompt_includes_manual_template_instruction(self, tmp_path: Path, mock_git_ops, monkeypatch) -> None:
@@ -240,3 +241,46 @@ class TestTemplateMode:
             assert phase.template_mode == "manual"
             # Template path should point to global directory
             assert "custom.md" in str(phase.template_path)
+
+
+class TestTemplatePromptPaths:
+    """測試模板提示訊息中的路徑引用"""
+
+    def test_auto_mode_prompt_does_not_reference_project_cafe_directory(
+        self, tmp_path: Path, mock_git_ops, monkeypatch
+    ) -> None:
+        """測試 auto 模式提示不應該引用專案的 .cafe/templates/plan/ 路徑"""
+        monkeypatch.chdir(tmp_path)
+        mock_git_ops.get_current_branch.return_value = "test-feature"
+
+        # Create spec file
+        spec_file = tmp_path / ".cafe" / "issues" / "test-feature" / "spec" / "spec_001.md"
+        spec_file.parent.mkdir(parents=True, exist_ok=True)
+        spec_file.write_text("# Requirements\n\nSome requirements")
+
+        # Create plan file with development guide
+        plan_file = spec_file.parent.parent / "plan" / "plan_001.md"
+        plan_file.parent.mkdir(parents=True, exist_ok=True)
+        plan_file.write_text("## Development Guide\n\nSome guide")
+
+        agent_manager = MagicMock(spec=AgentManager)
+        setup_agent_manager_mocks(agent_manager)
+        permission_handler = MagicMock(spec=PermissionHandler)
+
+        phase = PlanPhase(
+            agent_manager=agent_manager,
+            permission_handler=permission_handler,
+            spec_file=str(spec_file),
+            git_ops=mock_git_ops,
+            template_mode="auto",
+            interactive=False,
+        )
+
+        prompt = phase._generate_local_prompt("")
+
+        # Verify auto mode prompt includes template selection instruction
+        assert "pick a most suitable template" in prompt
+        # 不應該包含錯誤的 .cafe/templates/plan/ 路徑引用
+        assert ".cafe/templates/plan/" not in prompt
+        # 應該包含可用模板列表
+        assert "`default`" in prompt or "`simple`" in prompt or "`bug`" in prompt


### PR DESCRIPTION
Closes #110

## Summary
修正 `cafe init` 和 `cafe prepare` 指令中的錯誤訊息和提示文字，將錯誤的專案層級路徑引用（`.cafe/agents/` 和 `.cafe/templates/plan/`）改為正確的全域和系統路徑引用。系統實際上已經正確地從 `~/.cafe/` 和 `src/cafe/data/` 載入 agents 和 templates，但錯誤訊息仍引用了不存在的專案路徑，造成使用者混淆。

## Changes
- **修正 `cafe init` 錯誤訊息**：當找不到 agents 時，錯誤訊息現在正確地提示使用者檢查 `~/.cafe/agents/` 或 `src/cafe/data/agents/` 目錄，而非錯誤的 `.cafe/agents/` 路徑
- **修正 Plan Phase 提示訊息**：移除 auto 模式下對 `.cafe/templates/plan/` 的錯誤路徑引用，保持簡潔的模板列表提示
- **新增測試用例**：
  - 新增測試驗證 CLI 錯誤訊息使用正確路徑
  - 新增測試驗證 plan phase 提示不包含錯誤路徑引用
  - 更新現有測試以符合新行為
- **遵循 TDD 原則**：先編寫測試確認問題存在，修復後所有測試通過（1014 passed, 5 skipped, 1 xfailed）

## Test Plan
1. **自動測試**：執行 `pytest tests/` 確認所有測試通過
   - 新增測試：`tests/unit/test_cli_init.py::TestInitCommandErrorMessages`
   - 新增測試：`tests/unit/test_plan_phase_template_mode.py::TestTemplatePromptPaths`
   
2. **手動驗證**（可選）：
   - 執行 `cafe init` 在沒有 agents 的環境下，確認錯誤訊息顯示正確路徑
   - 執行 `cafe prepare` 確認不會在專案目錄建立 `.cafe/agents/` 或 `.cafe/templates/` 目錄

3. **回歸測試**：確認現有功能未受影響
   - Agent 和 template 載入機制維持不變
   - `_ensure_default_content()` 保持為 no-op（不建立目錄）