### PR TITLE
Add update_issue method to GitHubOps and update spec sync to use it

### DIFF
--- a/src/cafe/phases/spec_phase.py
+++ b/src/cafe/phases/spec_phase.py
@@ -772,29 +772,29 @@ class SpecPhase(Phase):
         pass
 
     def _sync_confirmed_spec_to_github(self) -> None:
-        """Sync confirmed spec to GitHub issue as a comment.
-        
+        """Sync confirmed spec to GitHub issue description.
+
         Only syncs when:
         1. Spec was fetched from GitHub (has _fetched_issue_id)
         2. User has confirmed the spec (CAFE_CONFIRMED status)
         """
         if not hasattr(self, '_fetched_issue_id'):
             return
-        
+
         try:
             spec_path = Path(self.spec_file)
             if not spec_path.exists():
                 return
-            
+
             spec_content = spec_path.read_text(encoding="utf-8")
-            
-            # Post confirmed spec as comment to GitHub issue
+
+            # Update GitHub issue description with confirmed spec
             gh_ops = GitHubOps()
-            gh_ops.add_issue_comment(self._fetched_issue_id, spec_content)
-            
+            gh_ops.update_issue(self._fetched_issue_id, body=spec_content)
+
         except GitHubError as e:
             # Log error but don't fail the phase
-            print(f"Warning: Failed to post confirmed spec to GitHub issue: {e}")
+            print(f"Warning: Failed to update GitHub issue description: {e}")
 
     def _create_github_issue(self, content: str) -> str:
         """Create a new GitHub issue with requirements.

--- a/src/cafe/utils/github.py
+++ b/src/cafe/utils/github.py
@@ -326,6 +326,35 @@ class GitHubOps:
         except subprocess.CalledProcessError as e:
             raise GitHubError(f"Failed to update PR {pr_number}: {e.stderr}") from e
 
+    def update_issue(self, issue_id: str, title: Optional[str] = None, body: Optional[str] = None) -> None:
+        """Update an existing GitHub issue.
+
+        Args:
+            issue_id: Issue number or ID
+            title: New issue title (optional)
+            body: New issue body/description (optional)
+
+        Raises:
+            GitHubError: If failed to update issue
+        """
+        try:
+            cmd = ["gh", "issue", "edit", issue_id]
+
+            if title is not None:
+                cmd.extend(["--title", title])
+            if body is not None:
+                cmd.extend(["--body", body])
+
+            subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+
+        except subprocess.CalledProcessError as e:
+            raise GitHubError(f"Failed to update issue {issue_id}: {e.stderr}") from e
+
 
 # PR Comments utilities
 

--- a/tests/unit/test_github.py
+++ b/tests/unit/test_github.py
@@ -543,3 +543,72 @@ class TestUpdatePR:
 
         with pytest.raises(GitHubError, match="Failed to update PR"):
             gh_ops.update_pr("10", title="New Title")
+
+
+class TestUpdateIssue:
+    """Test update_issue functionality."""
+
+    @patch("subprocess.run")
+    def test_update_issue_title_only(self, mock_run: Mock) -> None:
+        """測試只更新 title"""
+        mock_run.return_value = Mock(returncode=0, stdout="", stderr="")
+
+        gh_ops = GitHubOps()
+        gh_ops.update_issue("123", title="New Title")
+
+        # Should be called twice: once for --version check, once for actual call
+        assert mock_run.call_count == 2
+        # Check the actual call (last one)
+        args = mock_run.call_args[0][0]
+        assert "gh" in args
+        assert "issue" in args
+        assert "edit" in args
+        assert "123" in args
+        assert "--title" in args
+        assert "New Title" in args
+        assert "--body" not in args
+
+    @patch("subprocess.run")
+    def test_update_issue_body_only(self, mock_run: Mock) -> None:
+        """測試只更新 body"""
+        mock_run.return_value = Mock(returncode=0, stdout="", stderr="")
+
+        gh_ops = GitHubOps()
+        gh_ops.update_issue("123", body="New Body")
+
+        # Should be called twice: once for --version check, once for actual call
+        assert mock_run.call_count == 2
+        # Check the actual call (last one)
+        args = mock_run.call_args[0][0]
+        assert "--body" in args
+        assert "New Body" in args
+        assert "--title" not in args
+
+    @patch("subprocess.run")
+    def test_update_issue_both(self, mock_run: Mock) -> None:
+        """測試同時更新 title and body"""
+        mock_run.return_value = Mock(returncode=0, stdout="", stderr="")
+
+        gh_ops = GitHubOps()
+        gh_ops.update_issue("123", title="New Title", body="New Body")
+
+        # Should be called twice: once for --version check, once for actual call
+        assert mock_run.call_count == 2
+        # Check the actual call (last one)
+        args = mock_run.call_args[0][0]
+        assert "--title" in args
+        assert "New Title" in args
+        assert "--body" in args
+        assert "New Body" in args
+
+    @patch("subprocess.run")
+    def test_update_issue_error(self, mock_run: Mock) -> None:
+        """測試更新失敗"""
+        mock_run.side_effect = subprocess.CalledProcessError(
+            1, ["gh", "issue", "edit", "123"], stderr="Issue not found"
+        )
+
+        gh_ops = GitHubOps()
+
+        with pytest.raises(GitHubError, match="Failed to update issue"):
+            gh_ops.update_issue("123", title="New Title")

--- a/tests/unit/test_spec_github_sync.py
+++ b/tests/unit/test_spec_github_sync.py
@@ -50,50 +50,53 @@ class TestSyncConfirmedSpecToGitHub:
     """Test _sync_confirmed_spec_to_github method."""
     
     def test_sync_when_fetched_from_github(self, spec_phase):
-        """Test sync posts comment when spec was fetched from GitHub."""
+        """Test sync updates issue description when spec was fetched from GitHub."""
         # Setup: Create spec file and set _fetched_issue_id
         spec_content = "# Confirmed Requirements\n\nTest spec content"
         Path(spec_phase.spec_file).write_text(spec_content)
         spec_phase._fetched_issue_id = "123"
-        
+
         # Execute
         with patch("cafe.phases.spec_phase.GitHubOps") as mock_gh_ops_cls:
             mock_gh_ops = MagicMock()
             mock_gh_ops_cls.return_value = mock_gh_ops
-            
+
             spec_phase._sync_confirmed_spec_to_github()
-            
-            # Verify
-            mock_gh_ops.add_issue_comment.assert_called_once_with("123", spec_content)
+
+            # Verify: Should update issue description, not add comment
+            mock_gh_ops.update_issue.assert_called_once_with("123", body=spec_content)
+            mock_gh_ops.add_issue_comment.assert_not_called()
     
     def test_no_sync_without_fetched_issue_id(self, spec_phase):
         """Test no sync when spec was not fetched from GitHub."""
         # Setup: Create spec file but no _fetched_issue_id
         Path(spec_phase.spec_file).write_text("# Test spec")
-        
+
         # Execute
         with patch("cafe.phases.spec_phase.GitHubOps") as mock_gh_ops_cls:
             mock_gh_ops = MagicMock()
             mock_gh_ops_cls.return_value = mock_gh_ops
-            
+
             spec_phase._sync_confirmed_spec_to_github()
-            
+
             # Verify: No API call made
+            mock_gh_ops.update_issue.assert_not_called()
             mock_gh_ops.add_issue_comment.assert_not_called()
     
     def test_no_sync_when_spec_file_missing(self, spec_phase):
         """Test no sync when spec file doesn't exist."""
         # Setup: Set _fetched_issue_id but no spec file
         spec_phase._fetched_issue_id = "123"
-        
+
         # Execute
         with patch("cafe.phases.spec_phase.GitHubOps") as mock_gh_ops_cls:
             mock_gh_ops = MagicMock()
             mock_gh_ops_cls.return_value = mock_gh_ops
-            
+
             spec_phase._sync_confirmed_spec_to_github()
-            
+
             # Verify: No API call made
+            mock_gh_ops.update_issue.assert_not_called()
             mock_gh_ops.add_issue_comment.assert_not_called()
     
     def test_handles_github_error_gracefully(self, spec_phase, capsys):
@@ -102,19 +105,19 @@ class TestSyncConfirmedSpecToGitHub:
         spec_content = "# Test spec"
         Path(spec_phase.spec_file).write_text(spec_content)
         spec_phase._fetched_issue_id = "123"
-        
+
         # Execute
         with patch("cafe.phases.spec_phase.GitHubOps") as mock_gh_ops_cls:
             mock_gh_ops = MagicMock()
-            mock_gh_ops.add_issue_comment.side_effect = GitHubError("API rate limit exceeded")
+            mock_gh_ops.update_issue.side_effect = GitHubError("API rate limit exceeded")
             mock_gh_ops_cls.return_value = mock_gh_ops
-            
+
             # Should not raise exception
             spec_phase._sync_confirmed_spec_to_github()
-            
+
             # Verify warning message
             captured = capsys.readouterr()
-            assert "Warning: Failed to post confirmed spec to GitHub issue" in captured.out
+            assert "Warning: Failed to update GitHub issue description" in captured.out
             assert "API rate limit exceeded" in captured.out
 
 
@@ -203,16 +206,17 @@ class TestGetCompletionDataNoSync:
         # Setup
         Path(spec_phase.spec_file).write_text("# Test spec")
         spec_phase._fetched_issue_id = "123"
-        
+
         # Execute
         with patch("cafe.phases.spec_phase.GitHubOps") as mock_gh_ops_cls:
             mock_gh_ops = MagicMock()
             mock_gh_ops_cls.return_value = mock_gh_ops
-            
+
             data = spec_phase._get_completion_data()
-            
+
             # Verify: No GitHub API call made
+            mock_gh_ops.update_issue.assert_not_called()
             mock_gh_ops.add_issue_comment.assert_not_called()
-            
+
             # Verify: Still returns spec_file path
             assert "spec_file" in data


### PR DESCRIPTION
Closes #119

## Summary

此 PR 修正了 `cafe spec` 定稿後未能正確同步規格內容到 GitHub issue 描述的問題。實作了新的 `update_issue()` 方法，並將原本以 comment 形式發布的行為改為直接更新 issue 描述，確保 GitHub issue 能自動反映最新的已確認規格。

## Changes

- **新增 `GitHubOps.update_issue()` 方法**
  - 在 `src/cafe/utils/github.py` 中實作新方法
  - 支援選擇性更新 issue 的 title 或 body 參數
  - 使用 `gh issue edit` CLI 指令
  - 完整的錯誤處理機制（拋出 `GitHubError`）
  - 參考 `update_pr()` 方法的實作模式

- **更新 `_sync_confirmed_spec_to_github()` 方法**
  - 修改 `src/cafe/phases/spec_phase.py` 中的同步邏輯
  - 從 `add_issue_comment()` 改為 `update_issue()`
  - 直接更新 issue 描述而非新增 comment
  - 只更新 body 參數，保留原 issue title
  - 更新 docstring 說明新的同步行為

- **新增及更新測試**
  - 在 `tests/unit/test_github.py` 中新增 `TestUpdateIssue` 類別
  - 測試各種更新情境（只更新 title、只更新 body、同時更新、錯誤處理）
  - 更新 `tests/unit/test_spec_github_sync.py` 中的測試以驗證新行為
  - 所有測試採用 TDD 方式開發（先寫測試再實作）

## Test Plan

- ✅ 執行 `pytest tests/unit/test_github.py::TestUpdateIssue -v` 驗證新方法測試通過
- ✅ 執行 `pytest tests/unit/test_spec_github_sync.py -v` 驗證 spec 同步測試通過
- ✅ 執行完整測試套件 `pytest` 確認無迴歸問題（1063 passed, 5 skipped, 1 xfailed）
- 🔄 建議在實際環境測試：使用此 issue (#119) 執行完整的 `cafe spec` 流程，確認 spec 定稿後 issue 描述確實更新

## Technical Details

**API 設計**
```python
def update_issue(
    self,
    issue_id: str,
    title: Optional[str] = None,
    body: Optional[str] = None
) -> None
```

**使用範例**
```python
gh_ops = GitHubOps()
gh_ops.update_issue(self._fetched_issue_id, body=spec_content)
```

## Related Issues

- Closes #119
- Related to #113 (原本的 comment 同步功能無法運作)