### PR TITLE
新增 myip 指令以顯示外網 IPv4 位址

### DIFF
--- a/src/cafe/ui/cli.py
+++ b/src/cafe/ui/cli.py
@@ -5170,6 +5170,34 @@ def chat_with_agent(
     raise typer.Exit(result.returncode)
 
 
+def _fetch_external_ip() -> str:
+    """向外部服務查詢目前的外網公開 IPv4 位址。
+
+    Returns:
+        外網 IPv4 位址字串（例如：203.0.113.1）
+
+    Raises:
+        urllib.error.URLError: 網路無法連線或查詢失敗時
+    """
+    import urllib.request
+
+    with urllib.request.urlopen("https://api.ipify.org", timeout=5) as response:
+        return response.read().decode("utf-8").strip()
+
+
+@app.command()
+def myip() -> None:
+    """顯示目前裝置的外網公開 IPv4 位址。"""
+    from urllib.error import URLError
+
+    try:
+        ip = _fetch_external_ip()
+        console.print(ip)
+    except URLError:
+        console.print("[red]Error: 無法取得外網 IP，請確認網路連線。[/red]")
+        raise typer.Exit(1)
+
+
 def main() -> None:
     """Entry point for CLI."""
     # Check if all dependencies are installed

--- a/tests/unit/test_cli_myip.py
+++ b/tests/unit/test_cli_myip.py
@@ -1,0 +1,28 @@
+"""Tests for cafe myip command."""
+
+from unittest.mock import patch
+from urllib.error import URLError
+
+from typer.testing import CliRunner
+
+from cafe.ui.cli import app
+
+runner = CliRunner()
+
+
+class TestMyipCommand:
+    """測試 myip 指令"""
+
+    def test_myip_success(self) -> None:
+        """測試成功取得外網 IP 時輸出正確的 IPv4 位址"""
+        with patch("cafe.ui.cli._fetch_external_ip", return_value="203.0.113.1"):
+            result = runner.invoke(app, ["myip"])
+        assert result.exit_code == 0
+        assert "203.0.113.1" in result.output
+
+    def test_myip_network_failure(self) -> None:
+        """測試網路連線失敗時顯示錯誤訊息並回傳 exit code 1"""
+        with patch("cafe.ui.cli._fetch_external_ip", side_effect=URLError("Network unreachable")):
+            result = runner.invoke(app, ["myip"])
+        assert result.exit_code == 1
+        assert result.output != ""


### PR DESCRIPTION
## Summary
新增 `myip` 子指令至 CAFE CLI，執行後向 `https://api.ipify.org` 查詢並顯示目前裝置的公開 IPv4 位址。若網路無法連線，則顯示明確的錯誤訊息並以 exit code 1 結束。

## Changes
- 新增 `_fetch_external_ip()` 函式，使用標準庫 `urllib.request` 查詢外網 IP
- 新增 `myip` CLI 指令，輸出外網 IPv4，錯誤時顯示提示訊息
- 新增 `tests/unit/test_cli_myip.py` 測試，涵蓋成功與網路失敗兩種情境

## Test Plan
```bash
# 執行單元測試
python3 -m pytest tests/unit/test_cli_myip.py -v

# 手動測試（需有網路）
cafe myip
```