### PR TITLE
Formalize native skill discovery and validation across supported CLIs

### DIFF
--- a/src/cafe/core/playbook.py
+++ b/src/cafe/core/playbook.py
@@ -9,6 +9,7 @@ from typing import Dict, List, Literal, Optional, Union
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from cafe.skills.exceptions import SkillDiscoveryError
 from cafe.skills.loader import SkillLoader
 
 
@@ -231,7 +232,7 @@ def _validate_step_skills(step_name: str, step: StepConfig, skill_loader: SkillL
     for skill_name in selectors:
         try:
             skill_loader.get_skill_dir(skill_name)
-        except FileNotFoundError as exc:
+        except (SkillDiscoveryError, FileNotFoundError) as exc:
             raise ValueError(
                 f"Step '{step_name}' references unknown skill '{skill_name}'"
             ) from exc

--- a/src/cafe/skills/__init__.py
+++ b/src/cafe/skills/__init__.py
@@ -1,5 +1,6 @@
 """Skill loading utilities."""
 
+from cafe.skills.exceptions import SkillDiscoveryError
 from cafe.skills.loader import SkillCatalogEntry, SkillLoader
 
-__all__ = ["SkillCatalogEntry", "SkillLoader"]
+__all__ = ["SkillCatalogEntry", "SkillDiscoveryError", "SkillLoader"]

--- a/src/cafe/skills/bridge.py
+++ b/src/cafe/skills/bridge.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Dict, Optional
 
+from cafe.skills.exceptions import SkillDiscoveryError
 from cafe.skills.loader import SkillLoader
 
 
@@ -26,7 +27,7 @@ def try_load_skill_body(name: str, *, context: Optional[Dict[str, str]] = None) 
     """Best-effort skill activation for compatibility paths."""
     try:
         return load_skill_body(name, context=context).strip()
-    except Exception:
+    except (SkillDiscoveryError, FileNotFoundError, OSError):
         return ""
 
 
@@ -34,5 +35,5 @@ def try_load_skill_reference(name: str, ref: str) -> str:
     """Best-effort skill reference load for compatibility paths."""
     try:
         return load_skill_reference(name, ref)
-    except Exception:
+    except (SkillDiscoveryError, FileNotFoundError, OSError):
         return ""

--- a/src/cafe/skills/exceptions.py
+++ b/src/cafe/skills/exceptions.py
@@ -1,0 +1,18 @@
+"""Custom exceptions for skill discovery and loading."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from cafe.core.types import AgentCLI
+
+
+class SkillDiscoveryError(LookupError):
+    """Raised when a skill cannot be found in the catalog."""
+
+    def __init__(self, name: str, *, cli: "AgentCLI | None" = None) -> None:
+        self.skill_name = name
+        self.cli = cli
+        context = f" (cli={cli.value})" if cli else ""
+        super().__init__(f"Skill not found: {name}{context}")

--- a/src/cafe/skills/loader.py
+++ b/src/cafe/skills/loader.py
@@ -8,6 +8,7 @@ from typing import Dict, List, Optional
 
 import yaml
 
+from cafe.skills.exceptions import SkillDiscoveryError
 from cafe.utils.config import get_global_cafe_dir
 
 
@@ -115,7 +116,7 @@ class SkillLoader:
     def get_skill_dir(self, name: str) -> Path:
         self._ensure_catalog()
         if name not in self._catalog:
-            raise FileNotFoundError(f"Skill not found: {name}")
+            raise SkillDiscoveryError(name)
         return self._catalog[name].directory
 
     def activate(self, name: str, context: Optional[Dict[str, str]] = None) -> str:

--- a/src/cafe/skills/native_bridge.py
+++ b/src/cafe/skills/native_bridge.py
@@ -3,10 +3,26 @@
 from __future__ import annotations
 
 import shutil
+from dataclasses import dataclass
 from pathlib import Path
 
 from cafe.core.types import AgentCLI
+from cafe.skills.exceptions import SkillDiscoveryError
 from cafe.skills.loader import SkillLoader
+
+
+@dataclass(frozen=True)
+class SkillValidationResult:
+    """Result of validating skill availability for a given CLI."""
+
+    cli: AgentCLI
+    available: list[str]
+    missing: list[str]
+
+    @property
+    def valid(self) -> bool:
+        """Return True when every requested skill is available."""
+        return not self.missing
 
 
 class NativeSkillBridge:
@@ -79,3 +95,15 @@ class NativeSkillBridge:
         """Return the CLI-native invocation syntax for one skill."""
         prefix = self.CLI_PREFIXES[cli]
         return f"{prefix}{self.get_installed_skill_name(name)}"
+
+    def validate_skills(self, names: list[str], cli: AgentCLI) -> SkillValidationResult:
+        """Check which skills are discoverable for a given CLI without installing anything."""
+        available: list[str] = []
+        missing: list[str] = []
+        for name in names:
+            try:
+                self.skill_loader.get_skill_dir(name)
+                available.append(name)
+            except (SkillDiscoveryError, FileNotFoundError):
+                missing.append(name)
+        return SkillValidationResult(cli=cli, available=available, missing=missing)

--- a/tests/unit/test_generic_phase.py
+++ b/tests/unit/test_generic_phase.py
@@ -289,3 +289,51 @@ def test_native_skill_bridge_keeps_global_dir_separate(tmp_path: Path) -> None:
     assert bridge.get_native_skills_dir(AgentCLI.CODEX) == project_root / ".codex" / "skills"
     assert bridge.get_global_native_skills_dir(AgentCLI.CODEX) == tmp_path / "home" / ".codex" / "skills"
     assert bridge.get_installed_skill_name("plan") == "cafe-plan"
+
+
+# --- Task 4: validate_skills on NativeSkillBridge ---
+
+
+def _make_bridge(tmp_path: Path) -> NativeSkillBridge:
+    loader = _setup_loader(tmp_path)
+    project_root = tmp_path / "project"
+    project_root.mkdir(parents=True, exist_ok=True)
+    return NativeSkillBridge(loader, project_root=project_root, home_dir=tmp_path / "home")
+
+
+def test_validate_skills_all_available(tmp_path: Path) -> None:
+    bridge = _make_bridge(tmp_path)
+    result = bridge.validate_skills(["plan", "workflow-common"], AgentCLI.CLAUDE)
+    assert result.valid
+    assert set(result.available) == {"plan", "workflow-common"}
+    assert result.missing == []
+
+
+def test_validate_skills_reports_missing_skill(tmp_path: Path) -> None:
+    bridge = _make_bridge(tmp_path)
+    result = bridge.validate_skills(["plan", "ghost"], AgentCLI.CLAUDE)
+    assert not result.valid
+    assert "ghost" in result.missing
+    assert "plan" in result.available
+
+
+def test_validate_skills_empty_list_is_valid(tmp_path: Path) -> None:
+    bridge = _make_bridge(tmp_path)
+    result = bridge.validate_skills([], AgentCLI.CLAUDE)
+    assert result.valid
+    assert result.available == []
+    assert result.missing == []
+
+
+@pytest.mark.parametrize("cli", list(AgentCLI))
+def test_validate_skills_all_clis(tmp_path: Path, cli: AgentCLI) -> None:
+    bridge = _make_bridge(tmp_path)
+    result = bridge.validate_skills(["plan"], cli)
+    assert result.valid
+    assert result.cli == cli
+
+
+def test_validate_skills_does_not_install_any_files(tmp_path: Path) -> None:
+    bridge = _make_bridge(tmp_path)
+    bridge.validate_skills(["plan", "workflow-common"], AgentCLI.CLAUDE)
+    assert not (tmp_path / "project" / ".claude" / "skills").exists()

--- a/tests/unit/test_phase_skill_bridge.py
+++ b/tests/unit/test_phase_skill_bridge.py
@@ -3,8 +3,11 @@
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from cafe.phases.plan_phase import PlanPhase
-from cafe.skills.bridge import load_skill_body
+from cafe.skills.bridge import load_skill_body, try_load_skill_body, try_load_skill_reference
+from cafe.skills.exceptions import SkillDiscoveryError
 from cafe.utils.checklist_generator import generate_plan_checklist
 
 
@@ -64,3 +67,40 @@ def test_load_skill_body_prefers_project_override(tmp_path: Path, monkeypatch) -
     body = load_skill_body("plan")
 
     assert "Custom project plan skill" in body
+
+
+# --- Task 3: Narrowed exception handling ---
+
+
+def test_try_load_skill_body_returns_empty_string_on_skill_discovery_error() -> None:
+    with patch("cafe.skills.bridge.load_skill_body", side_effect=SkillDiscoveryError("missing")):
+        result = try_load_skill_body("missing")
+    assert result == ""
+
+
+def test_try_load_skill_body_returns_empty_string_on_file_not_found_error() -> None:
+    with patch("cafe.skills.bridge.load_skill_body", side_effect=FileNotFoundError("gone")):
+        result = try_load_skill_body("gone")
+    assert result == ""
+
+
+def test_try_load_skill_body_propagates_unexpected_errors() -> None:
+    with patch("cafe.skills.bridge.load_skill_body", side_effect=RuntimeError("boom")):
+        with pytest.raises(RuntimeError):
+            try_load_skill_body("plan")
+
+
+def test_try_load_skill_reference_returns_empty_string_on_skill_discovery_error() -> None:
+    with patch(
+        "cafe.skills.bridge.load_skill_reference", side_effect=SkillDiscoveryError("missing")
+    ):
+        result = try_load_skill_reference("missing", "checklist.md")
+    assert result == ""
+
+
+def test_try_load_skill_reference_propagates_unexpected_errors() -> None:
+    with patch(
+        "cafe.skills.bridge.load_skill_reference", side_effect=RuntimeError("boom")
+    ):
+        with pytest.raises(RuntimeError):
+            try_load_skill_reference("plan", "checklist.md")

--- a/tests/unit/test_skill_loader.py
+++ b/tests/unit/test_skill_loader.py
@@ -8,6 +8,7 @@ from cafe.core.types import AgentCLI
 from cafe.skills.exceptions import SkillDiscoveryError
 from cafe.skills.importer import import_skills
 from cafe.skills.loader import SkillLoader
+from cafe.skills.native_bridge import NativeSkillBridge
 
 
 def _write_skill(root: Path, name: str, *, frontmatter_name: str | None = None) -> None:
@@ -202,3 +203,32 @@ def test_global_overrides_builtin_when_no_project_skill(tmp_path: Path) -> None:
     assert len(items) == 1
     assert items[0].source == "global"
 
+
+
+def test_install_skill_uses_project_version_over_global(tmp_path: Path) -> None:
+    """When a project skill overrides a global skill, install_skill uses the project version."""
+    global_root = tmp_path / "global" / "skills"
+    project = tmp_path / "project" / ".cafe" / "skills"
+    _write_skill(global_root, "plan")
+    project_skill_dir = project / "plan"
+    project_skill_dir.mkdir(parents=True, exist_ok=True)
+    (project_skill_dir / "SKILL.md").write_text(
+        "---\nname: plan\ndescription: project plan\n---\n\nProject version\n",
+        encoding="utf-8",
+    )
+
+    loader = SkillLoader(
+        project_root=tmp_path / "project",
+        global_root=tmp_path / "global",
+        builtin_root=tmp_path / "builtin",
+    )
+    loader.discover()
+    bridge = NativeSkillBridge(
+        loader,
+        project_root=tmp_path / "project",
+        home_dir=tmp_path / "home",
+    )
+    bridge.install_skill("plan", AgentCLI.CLAUDE)
+
+    installed = tmp_path / "project" / ".claude" / "skills" / "cafe-plan" / "SKILL.md"
+    assert "Project version" in installed.read_text(encoding="utf-8")

--- a/tests/unit/test_skill_loader.py
+++ b/tests/unit/test_skill_loader.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 import pytest
 
+from cafe.core.types import AgentCLI
+from cafe.skills.exceptions import SkillDiscoveryError
 from cafe.skills.importer import import_skills
 from cafe.skills.loader import SkillLoader
 
@@ -122,3 +124,81 @@ def test_builtin_catalog_includes_chat_handoff_skills(tmp_path: Path) -> None:
         "chat-spec-revision",
         "chat-plan-revision",
     }.issubset(names)
+
+
+# --- Task 1: SkillDiscoveryError ---
+
+
+def test_skill_discovery_error_is_lookup_error() -> None:
+    err = SkillDiscoveryError("my-skill")
+    assert isinstance(err, LookupError)
+    assert err.skill_name == "my-skill"
+    assert "my-skill" in str(err)
+
+
+def test_skill_discovery_error_without_cli_has_no_cli_context() -> None:
+    err = SkillDiscoveryError("my-skill")
+    assert err.cli is None
+    assert "cli=" not in str(err)
+
+
+def test_skill_discovery_error_with_cli_includes_cli_context() -> None:
+    err = SkillDiscoveryError("my-skill", cli=AgentCLI.CLAUDE)
+    assert err.cli == AgentCLI.CLAUDE
+    assert AgentCLI.CLAUDE.value in str(err)
+
+
+# --- Task 2: SkillLoader raises SkillDiscoveryError ---
+
+
+def test_get_skill_dir_raises_skill_discovery_error_for_unknown_skill(tmp_path: Path) -> None:
+    loader = SkillLoader(
+        project_root=tmp_path / "project",
+        global_root=tmp_path / "global",
+        builtin_root=tmp_path / "builtin",
+    )
+    loader.discover()
+
+    with pytest.raises(SkillDiscoveryError) as exc_info:
+        loader.get_skill_dir("nonexistent-skill")
+    assert "nonexistent-skill" in str(exc_info.value)
+
+
+# --- Task 5: Resolution order ---
+
+
+def test_all_three_roots_same_skill_project_wins(tmp_path: Path) -> None:
+    """Explicitly documents project > global > builtin precedence."""
+    builtin = tmp_path / "builtin" / "skills"
+    global_root = tmp_path / "global" / "skills"
+    project = tmp_path / "project" / ".cafe" / "skills"
+    for root in (builtin, global_root, project):
+        _write_skill(root, "plan")
+
+    loader = SkillLoader(
+        project_root=tmp_path / "project",
+        global_root=tmp_path / "global",
+        builtin_root=tmp_path / "builtin",
+    )
+    items = loader.discover()
+
+    assert len(items) == 1
+    assert items[0].source == "project"
+
+
+def test_global_overrides_builtin_when_no_project_skill(tmp_path: Path) -> None:
+    builtin = tmp_path / "builtin" / "skills"
+    global_root = tmp_path / "global" / "skills"
+    _write_skill(builtin, "plan")
+    _write_skill(global_root, "plan")
+
+    loader = SkillLoader(
+        project_root=tmp_path / "project",
+        global_root=tmp_path / "global",
+        builtin_root=tmp_path / "builtin",
+    )
+    items = loader.discover()
+
+    assert len(items) == 1
+    assert items[0].source == "global"
+


### PR DESCRIPTION
## Summary

Closes #224.

This PR formalizes skill discovery and validation behavior across all supported CLIs. Previously, a missing skill raised a generic `FileNotFoundError` and compatibility helpers silently swallowed all exceptions with a bare `except Exception`. This made it impossible to distinguish expected "skill not found" failures from real bugs, and provided no way to pre-validate skills before attempting installation.

Key improvements:
- A new `SkillDiscoveryError(LookupError)` exception gives callers a precise, structured signal when a skill cannot be found, including the skill name and optional CLI context.
- Compatibility helpers (`try_load_skill_body`, `try_load_skill_reference`) now only silence expected errors, letting unexpected exceptions propagate.
- `NativeSkillBridge.validate_skills()` lets callers check which skills are available for a given CLI **before** installing anything, returning a structured `SkillValidationResult` with `available` and `missing` lists.
- Skill resolution precedence (project > global > builtin) is now explicitly tested and documented.

## Changes

### New files
- `src/cafe/skills/exceptions.py` — `SkillDiscoveryError(LookupError)` with `skill_name` and optional `cli` attributes

### Modified files
- `src/cafe/skills/loader.py` — `get_skill_dir()` raises `SkillDiscoveryError` instead of `FileNotFoundError`
- `src/cafe/skills/__init__.py` — exports `SkillDiscoveryError`
- `src/cafe/skills/bridge.py` — `try_load_skill_body()` / `try_load_skill_reference()` catch only `(SkillDiscoveryError, FileNotFoundError, OSError)`
- `src/cafe/skills/native_bridge.py` — adds `SkillValidationResult` dataclass and `validate_skills(names, cli)` method
- `src/cafe/core/playbook.py` — playbook validation catches `SkillDiscoveryError` alongside `FileNotFoundError`

### Commits
1. `Add SkillDiscoveryError and raise it from SkillLoader when skill is not found`
2. `Narrow exception handling in skill bridge compatibility helpers`
3. `Add validate_skills to NativeSkillBridge and test skill resolution precedence`

## Test Plan

- New tests in `tests/unit/test_skill_loader.py`: `SkillDiscoveryError` is a `LookupError`, carries `skill_name`, includes CLI context when provided; loader raises it for unknown skills; project > global > builtin resolution is explicitly verified; `NativeSkillBridge.install_skill()` uses the project version when a project skill overrides a global one.
- New tests in `tests/unit/test_phase_skill_bridge.py`: `try_load_skill_body()` returns `""` for `SkillDiscoveryError`/`FileNotFoundError`; `RuntimeError` propagates.
- New tests in `tests/unit/test_generic_phase.py`: `validate_skills()` happy path, missing skill detection, all five supported CLIs (parametrized), no files installed as a side effect.
- Full pre-commit suite: **1785 passed, 5 skipped, 1 xfailed** — no regressions.