### PR TITLE
Add AGENTS.md with Cursor Cloud development environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Project overview
+
+CAFE (CLI Agent Flow Engine) is a Python CLI tool that orchestrates headless AI agents through a 5-phase development workflow: spec → plan → develop → review → PR. It is a single Python package (not a monorepo) using `uv` with `hatchling` as the build backend.
+
+### Running the application
+
+- `uv run cafe --help` — show all available commands
+- `uv run cafe version` — show current version
+- The full workflow (`cafe make`) requires at least one AI agent CLI (claude, copilot, cursor, gemini, codex) and `gh` CLI for GitHub integration. These are external dependencies not installed by the update script.
+
+### Lint / Test / Build
+
+Commands are run from the workspace root via `uv run`:
+
+| Task | Command |
+|------|---------|
+| Lint (ruff) | `uv run ruff check src/ tests/` |
+| Format check (black) | `uv run black --check src/ tests/` |
+| Type check (mypy) | `uv run mypy src/` |
+| Tests | `uv run pytest` |
+| Tests (fast, pre-commit) | `uv run pytest -m "not slow"` |
+| Tests (full, pre-push) | `uv run pytest` |
+
+The existing codebase has pre-existing lint warnings (ruff ~2135 issues, black formatting diffs, mypy ~265 errors). These are not regressions; do not attempt to fix them unless explicitly asked.
+
+### Gotchas
+
+- The project uses `uv` (with `uv.lock`), not plain `pip`. Always use `uv run <tool>` or `uv sync` rather than `pip install`.
+- Dev dependencies are in `[project.optional-dependencies] dev` and installed via `uv sync --extra dev`.
+- There is 1 pre-existing test failure in `test_agent_edit_auto_sync.py::test_agent_edit_triggers_sync_after_successful_edit`. This is a known issue in the repository.
+- Git hooks are configured via `.githooks/` directory (set up by `./setup-hooks.sh`). The pre-commit hook runs the fast test suite; the pre-push hook runs the full suite including slow tests.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with Cursor Cloud specific instructions for future agents, covering:

- Project overview (single Python CLI package using `uv` + `hatchling`)
- How to run the application (`uv run cafe`)
- Lint/test/build command reference table
- Known gotchas: use `uv` not `pip`, dev extras via `--extra dev`, pre-existing lint/test issues, git hooks setup
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5f62ba4c-5998-487b-97fa-37975af7808b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5f62ba4c-5998-487b-97fa-37975af7808b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

