### PR TITLE
Make `next_step.txt` persistent and validate baton ownership

### DIFF
--- a/src/cafe/data/skills/pr/SKILL.md
+++ b/src/cafe/data/skills/pr/SKILL.md
@@ -44,6 +44,8 @@ bash scripts/sync_pr.sh --help
    bash scripts/sync_pr.sh --output {output_file} --base {base_branch}
    ```
    - Script 輸出 JSON 到 stdout（`{"action":"created"|"updated","pr_number":"...","pr_url":"..."}`）
+   - 若 handoff 要求「重發 PR / 重開 PR / 重新同步 PR」，必須確認最後 GitHub 上存在符合目前 branch 與 `{base_branch}` 的 open/draft PR
+   - 已關閉的舊 PR 不算完成 handoff；如果目前只剩 closed PR，應建立新的 PR
 4. 把 PR URL 寫到 blackboard（`current_step` 改成 `user`，summary 說明 PR 已同步）
 5. 寫入 next-step baton，內容只放 `user`
 6. 回傳 `CAFE_CONFIRMED`

--- a/src/cafe/data/skills/pr/scripts/sync_pr.sh
+++ b/src/cafe/data/skills/pr/scripts/sync_pr.sh
@@ -64,18 +64,32 @@ echo "Pushing branch: $BRANCH" >&2
 git push --set-upstream origin "$BRANCH" 2>&1 >&2 || true
 
 # Create or update PR
-EXISTING_PR=$(gh pr view --json number,url 2>/dev/null || echo "")
+EXISTING_PR=$(gh pr view --json number,url,state,baseRefName 2>/dev/null || echo "")
 
 if [[ -n "$EXISTING_PR" ]]; then
+  PR_STATE=$(echo "$EXISTING_PR" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['state'])")
+else
+  PR_STATE=""
+fi
+
+if [[ "$PR_STATE" == "OPEN" ]]; then
   PR_NUMBER=$(echo "$EXISTING_PR" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['number'])")
   PR_URL=$(echo "$EXISTING_PR" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['url'])")
+  PR_BASE=$(echo "$EXISTING_PR" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('baseRefName', ''))")
   echo "Updating PR #$PR_NUMBER..." >&2
   gh pr edit "$PR_NUMBER" --title "$TITLE" --body "$BODY" >&2
+  if [[ -n "$BASE_BRANCH" && "$PR_BASE" != "$BASE_BRANCH" ]]; then
+    echo "Retargeting PR #$PR_NUMBER base to $BASE_BRANCH..." >&2
+    gh pr edit "$PR_NUMBER" --base "$BASE_BRANCH" >&2
+  fi
   echo '{"action":"updated","pr_number":"'"$PR_NUMBER"'","pr_url":"'"$PR_URL"'"}'
 else
   CREATE_ARGS=(--title "$TITLE" --body "$BODY")
   if [[ -n "$BASE_BRANCH" ]]; then
     CREATE_ARGS+=(--base "$BASE_BRANCH")
+  fi
+  if [[ -n "$PR_STATE" ]]; then
+    echo "Existing PR is $PR_STATE; creating a new PR instead..." >&2
   fi
   echo "Creating PR..." >&2
   PR_URL=$(gh pr create "${CREATE_ARGS[@]}")

--- a/src/cafe/phases/generic_phase.py
+++ b/src/cafe/phases/generic_phase.py
@@ -107,6 +107,8 @@ class GenericPhase:
                     "Latest workflow handoff from blackboard:",
                     context["handoff_summary"],
                     "Treat this handoff as the highest-priority current request unless current files prove it is already completed.",
+                    "Before returning a status code, verify whether the requested state change has actually happened in files or external state relevant to this phase.",
+                    "If the handoff asks for a retry, re-run, re-sync, or re-open action, do not treat an old artifact or a closed external object as completion.",
                 ]
             )
         if context and context.get("user_input"):

--- a/src/cafe/ui/chat.py
+++ b/src/cafe/ui/chat.py
@@ -22,6 +22,8 @@ CHAT_SKILL_NAMES = [
     "chat-plan-revision",
 ]
 
+CURSOR_NATIVE_MODULE_HINT = "@anysphere/file-service-"
+
 
 def _extract_latest_codex_session_id(
     since_ts: int,
@@ -122,6 +124,59 @@ def _prepare_chat_environment(
         bridge.install_skill(skill_name, agent_cli)
 
 
+def _format_cli_specific_error(agent_cli: AgentCLI, stderr: str, stdout: str) -> Optional[str]:
+    """Translate known CLI-specific failures into user-facing diagnostics."""
+    combined = f"{stderr}\n{stdout}"
+    if agent_cli == AgentCLI.CURSOR and CURSOR_NATIVE_MODULE_HINT in combined:
+        return (
+            "Cursor CLI is installed but broken: missing native module "
+            "`@anysphere/file-service-darwin-x64`. Reinstall or repair Cursor CLI, "
+            "or switch this role to another agent before opening chat."
+        )
+    return None
+
+
+def _preflight_chat_cli(agent_cli: AgentCLI, cli_command: list[str], env: dict[str, str]) -> Optional[str]:
+    """Return a user-facing error when a CLI is installed but obviously broken."""
+    try:
+        result = subprocess.run(
+            [cli_command[0], "--version"],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        return f"CLI tool '{cli_command[0]}' not found. Please install it first."
+    except Exception as exc:
+        return f"Failed to execute CLI preflight: {exc}"
+
+    stderr = result.stderr or ""
+    stdout = result.stdout or ""
+    if result.returncode == 0:
+        return None
+    specific_error = _format_cli_specific_error(agent_cli, stderr, stdout)
+    if specific_error:
+        return specific_error
+    return f"CLI preflight failed with exit code {result.returncode}."
+
+
+def _handle_chat_launch_failure(agent_cli: AgentCLI, result: subprocess.CompletedProcess[object]) -> int:
+    """Print a concise launch failure and return the CLI's exit code."""
+    stderr = (getattr(result, "stderr", None) or "").strip()
+    stdout = (getattr(result, "stdout", None) or "").strip()
+    specific_error = _format_cli_specific_error(agent_cli, stderr, stdout)
+    if specific_error:
+        print(f"\n⚠️  {specific_error}\n")
+        return result.returncode
+
+    detail = stderr or stdout
+    if detail:
+        lines = [line.strip() for line in detail.splitlines() if line.strip()]
+        summary = lines[0] if lines else detail
+        print(f"\n⚠️  Chat CLI exited with code {result.returncode}: {summary}\n")
+    return result.returncode
+
+
 def launch_chat_session(role: str, issue_name: str) -> int:
     """Launch an inline chat session with the agent for the given role.
 
@@ -181,12 +236,6 @@ def launch_chat_session(role: str, issue_name: str) -> int:
     )
     session_id: Optional[str] = executor.config.session_id
 
-    print(f"\nOpening chat with {role} ({agent_name})...")
-    if session_id:
-        print(f"Resuming session: {session_id}")
-    print()
-
-    # Build CLI command
     cli_command = [agent_cli_str]
     codex_history_start_ts = int(time.time())
 
@@ -205,9 +254,21 @@ def launch_chat_session(role: str, issue_name: str) -> int:
         if agent_cli_str in ("claude", "copilot", "gemini"):
             cli_command.extend(["--model", agent_model])
 
+    env = cli_strategy.build_environment()
+    if agent_cli == AgentCLI.CURSOR:
+        preflight_error = _preflight_chat_cli(agent_cli, cli_command, env)
+        if preflight_error:
+            print(f"\n⚠️  {preflight_error}\n")
+            return 1
+
+    print(f"\nOpening chat with {role} ({agent_name})...")
+    if session_id:
+        print(f"Resuming session: {session_id}")
+    print()
+
     # Execute interactive CLI (blocks until user exits)
     try:
-        result = subprocess.run(cli_command, env=cli_strategy.build_environment())
+        result = subprocess.run(cli_command, env=env)
     except FileNotFoundError:
         print(f"\n⚠️  CLI tool '{agent_cli_str}' not found. Please install it first.\n")
         return 1
@@ -225,6 +286,9 @@ def launch_chat_session(role: str, issue_name: str) -> int:
                 resolved_session_id,
                 issue_name,
             )
+
+    if result.returncode != 0:
+        return _handle_chat_launch_failure(agent_cli, result)
 
     store = BlackboardStore(issue_dir)
     blackboard = store.load_or_create(_current_step)

--- a/src/cafe/ui/cli.py
+++ b/src/cafe/ui/cli.py
@@ -268,6 +268,13 @@ def _consume_pending_chat_handoff(
         allowed_steps=list(playbook_data["steps"].keys()),
         allow_legacy_text=True,
     )
+
+    # `next_step.txt` is now persistent from workflow initialization onward.
+    # Ignore the bootstrap/persistent baton itself; only consume a chat-authored
+    # pending handoff (or legacy step-name text) when the baton meaning is real.
+    if contract.source in {"bootstrap", "chat.bootstrap"}:
+        return None
+
     target_step = contract.to_step
     if target_step not in {"user", "done"} and GitOperations().has_uncommitted_changes():
         console.print(

--- a/tests/integration/test_sync_pr_script.py
+++ b/tests/integration/test_sync_pr_script.py
@@ -1,0 +1,120 @@
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+
+SCRIPT_PATH = Path("src/cafe/data/skills/pr/scripts/sync_pr.sh")
+
+
+def _write_executable(path: Path, content: str) -> None:
+    path.write_text(content)
+    path.chmod(path.stat().st_mode | stat.S_IEXEC)
+
+
+def _setup_fake_bin(tmp_path: Path, gh_body: str) -> Path:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+
+    _write_executable(
+        fake_bin / "git",
+        """#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "rev-parse" ]]; then
+  echo "issue231"
+  exit 0
+fi
+if [[ "$1" == "push" ]]; then
+  exit 0
+fi
+exit 1
+""",
+    )
+
+    _write_executable(
+        fake_bin / "gh",
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$GH_LOG"
+if [[ "$1" == "pr" && "$2" == "view" ]]; then
+  cat <<'EOF'
+{gh_body}
+EOF
+  exit 0
+fi
+if [[ "$1" == "pr" && "$2" == "edit" ]]; then
+  exit 0
+fi
+if [[ "$1" == "pr" && "$2" == "create" ]]; then
+  echo "https://github.com/example/repo/pull/999"
+  exit 0
+fi
+exit 1
+""",
+    )
+
+    return fake_bin
+
+
+def _write_output_file(tmp_path: Path) -> Path:
+    output_file = tmp_path / "output.md"
+    output_file.write_text("# Test PR Title\n\nPR body\n")
+    return output_file
+
+
+def test_sync_pr_updates_open_pr_and_retargets_base(tmp_path: Path) -> None:
+    fake_bin = _setup_fake_bin(
+        tmp_path,
+        '{"number":236,"url":"https://github.com/example/repo/pull/236","state":"OPEN","baseRefName":"main"}',
+    )
+    output_file = _write_output_file(tmp_path)
+    gh_log = tmp_path / "gh.log"
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    env["GH_LOG"] = str(gh_log)
+
+    result = subprocess.run(
+        ["bash", str(SCRIPT_PATH), "--output", str(output_file), "--base", "v02"],
+        cwd=Path(__file__).resolve().parents[2],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert '"action":"updated"' in result.stdout
+    log_lines = gh_log.read_text().splitlines()
+    assert "pr view --json number,url,state,baseRefName" in log_lines[0]
+    assert any("pr edit 236 --title Test PR Title --body PR body" in line for line in log_lines)
+    assert any("pr edit 236 --base v02" in line for line in log_lines)
+
+
+def test_sync_pr_creates_new_pr_when_existing_pr_is_closed(tmp_path: Path) -> None:
+    fake_bin = _setup_fake_bin(
+        tmp_path,
+        '{"number":236,"url":"https://github.com/example/repo/pull/236","state":"CLOSED","baseRefName":"main"}',
+    )
+    output_file = _write_output_file(tmp_path)
+    gh_log = tmp_path / "gh.log"
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    env["GH_LOG"] = str(gh_log)
+
+    result = subprocess.run(
+        ["bash", str(SCRIPT_PATH), "--output", str(output_file), "--base", "v02"],
+        cwd=Path(__file__).resolve().parents[2],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert '"action":"created"' in result.stdout
+    log_lines = gh_log.read_text().splitlines()
+    assert "pr view --json number,url,state,baseRefName" in log_lines[0]
+    assert any("pr create --title Test PR Title --body PR body --base v02" in line for line in log_lines)
+    assert not any("pr edit 236 --title Test PR Title --body PR body" in line for line in log_lines)

--- a/tests/integration/test_workflow_e2e.py
+++ b/tests/integration/test_workflow_e2e.py
@@ -9,6 +9,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import List
 from unittest.mock import MagicMock, patch
@@ -434,6 +435,64 @@ class TestUserHandoff:
 
 
 # ---------------------------------------------------------------------------
+# Task 5.0: next_step.txt Lifecycle
+# ---------------------------------------------------------------------------
+
+class TestNextStepLifecycle:
+    def test_workflow_initializes_next_step_txt_when_missing(self, tmp_path: Path, monkeypatch) -> None:
+        """next_step.txt missing initially should be created once workflow starts."""
+        monkeypatch.chdir(tmp_path)
+
+        issue_dir = tmp_path / ".cafe" / "issues" / "issue-nextstep-missing"
+        issue_dir.mkdir(parents=True, exist_ok=True)
+        (issue_dir / "blackboard.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "playbook_id": "default",
+                    "current_step": "spec",
+                    "artifacts": {},
+                    "events": [],
+                    "decisions": [],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        next_step_path = issue_dir / "next_step.txt"
+        assert not next_step_path.exists()
+
+        class FakeExecutor:
+            def execute_step(
+                self, step_name: str, step_def: dict, blackboard_state: object
+            ) -> tuple[str, dict[str, str]]:
+                return (
+                    "CAFE_CONFIRMED",
+                    {str(step_def.get("output_artifact", step_name)): f"{step_name}/output.md"},
+                )
+
+        cli_runner = CliRunner()
+        with (
+            patch("cafe.ui.cli.GitOperations") as mock_git_cls,
+            patch("cafe.ui.cli._build_workflow_step_executor", return_value=FakeExecutor()),
+        ):
+            git = MagicMock()
+            git.get_current_branch.return_value = "issue-nextstep-missing"
+            git.has_uncommitted_changes.return_value = False
+            mock_git_cls.return_value = git
+
+            result = cli_runner.invoke(app, ["workflow", "--playbook", "default", "--execute"])
+
+        assert result.exit_code == 0, result.output
+        assert next_step_path.exists()
+
+        # Validate JSON baton contract structure.
+        payload = json.loads(next_step_path.read_text(encoding="utf-8"))
+        assert payload["version"] == 1
+        assert payload["to_step"] in {"spec", "plan", "develop", "review", "pr", "user", "done"}
+
+
+# ---------------------------------------------------------------------------
 # Task 5: Chat Baton 消費測試
 # ---------------------------------------------------------------------------
 
@@ -466,6 +525,41 @@ class TestChatBaton:
 
         blackboard = BlackboardStore(issue_dir).load_or_create("spec")
         assert blackboard.current_step == "develop"
+
+    def test_chat_baton_bootstrap_not_consumed(self, tmp_path: Path) -> None:
+        """bootstrap/persistent baton should not be treated as pending chat handoff."""
+        issue_dir = tmp_path / ".cafe" / "issues" / "issue-baton-bootstrap"
+        issue_dir.mkdir(parents=True, exist_ok=True)
+        next_step_path = issue_dir / "next_step.txt"
+        next_step_path.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "from_step": "spec",
+                    "to_owner": "agent",
+                    "to_step": "spec",
+                    "intent": "await_agent",
+                    "status_code": "",
+                    "created_at": "2026-04-16T00:00:00+00:00",
+                    "source": "bootstrap",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        playbook_data = self._make_playbook_data()
+        with patch("cafe.ui.cli.GitOperations") as mock_git_cls:
+            git = MagicMock()
+            git.has_uncommitted_changes.return_value = False
+            mock_git_cls.return_value = git
+
+            result = _consume_pending_chat_handoff(
+                issue_dir=issue_dir,
+                playbook_data=playbook_data,
+                requested_start_step=None,
+            )
+
+        assert result is None
 
     def test_chat_baton_empty_raises_error(self, tmp_path: Path) -> None:
         """空的 next_step.txt 應拋出 ValueError。"""

--- a/tests/unit/test_chat.py
+++ b/tests/unit/test_chat.py
@@ -135,12 +135,15 @@ class TestLaunchChatSession:
         agent_manager = self._make_agent_manager("David", "cursor-agent", session_id="sess-cursor")
         mock_agent_manager_cls.return_value = agent_manager
 
-        mock_run.return_value = MagicMock(returncode=0)
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout="1.0.0", stderr=""),
+            MagicMock(returncode=0),
+        ]
 
         launch_chat_session("developer", "issue123")
 
-        assert mock_run.call_args.args[0] == ["cursor-agent", "--resume", "sess-cursor"]
-        assert "env" in mock_run.call_args.kwargs
+        assert mock_run.call_args_list[1].args[0] == ["cursor-agent", "--resume", "sess-cursor"]
+        assert "env" in mock_run.call_args_list[1].kwargs
 
     @patch("builtins.print")
     @patch("cafe.ui.chat.ConfigManager")
@@ -375,3 +378,110 @@ def test_launch_chat_session_warns_when_baton_missing(
     assert result == 0
     printed = " ".join(str(call) for call in mock_print.call_args_list)
     assert "did not complete workflow handoff" in printed
+
+
+def test_launch_chat_session_returns_preflight_error_for_broken_cursor_cli(
+    tmp_path,
+    monkeypatch,
+    mock_chat_environment,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    with (
+        patch("builtins.print") as mock_print,
+        patch("cafe.ui.chat.subprocess.run") as mock_run,
+        patch("cafe.ui.chat.ConfigManager") as mock_config_manager_cls,
+        patch("cafe.ui.chat.AgentManager") as mock_agent_manager_cls,
+    ):
+        mock_config = MagicMock()
+        mock_config.get.return_value = {"name": "David", "cli": "cursor-agent"}
+        mock_config_manager_cls.return_value = mock_config
+
+        agent_manager = MagicMock()
+        executor = MagicMock()
+        executor.config = MagicMock(session_id="sess-cursor", model=None)
+        executor._get_cli_strategy.return_value.build_environment.return_value = dict(os.environ)
+        agent_manager.get_agent.return_value = executor
+        agent_manager.session_manager = MagicMock()
+        mock_agent_manager_cls.return_value = agent_manager
+
+        mock_run.return_value = MagicMock(
+            returncode=1,
+            stdout="",
+            stderr="Error: Cannot find module '@anysphere/file-service-darwin-x64'",
+        )
+
+        result = launch_chat_session("developer", "issue123")
+
+    assert result == 1
+    mock_run.assert_called_once()
+    printed = " ".join(str(call) for call in mock_print.call_args_list)
+    assert "missing native module" in printed
+    assert "did not complete workflow handoff" not in printed
+
+
+def test_launch_chat_session_nonzero_exit_skips_baton_warning(
+    tmp_path,
+    monkeypatch,
+    mock_chat_environment,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    with (
+        patch("builtins.print") as mock_print,
+        patch("cafe.ui.chat.subprocess.run", return_value=MagicMock(returncode=1)),
+        patch("cafe.ui.chat.ConfigManager") as mock_config_manager_cls,
+        patch("cafe.ui.chat.AgentManager") as mock_agent_manager_cls,
+    ):
+        mock_config = MagicMock()
+        mock_config.get.return_value = {"name": "Roger", "cli": "claude"}
+        mock_config_manager_cls.return_value = mock_config
+
+        agent_manager = MagicMock()
+        executor = MagicMock()
+        executor.config = MagicMock(session_id=None, model=None)
+        executor._get_cli_strategy.return_value.build_environment.return_value = dict(os.environ)
+        agent_manager.get_agent.return_value = executor
+        agent_manager.session_manager = MagicMock()
+        mock_agent_manager_cls.return_value = agent_manager
+
+        result = launch_chat_session("pm", "issue123")
+
+    assert result == 1
+    printed = " ".join(str(call) for call in mock_print.call_args_list)
+    assert "did not complete workflow handoff" not in printed
+
+
+def test_launch_chat_session_nonzero_exit_reports_generic_cli_error(
+    tmp_path,
+    monkeypatch,
+    mock_chat_environment,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    with (
+        patch("builtins.print") as mock_print,
+        patch(
+            "cafe.ui.chat.subprocess.run",
+            return_value=MagicMock(returncode=2, stderr="authentication failed\nextra detail"),
+        ),
+        patch("cafe.ui.chat.ConfigManager") as mock_config_manager_cls,
+        patch("cafe.ui.chat.AgentManager") as mock_agent_manager_cls,
+    ):
+        mock_config = MagicMock()
+        mock_config.get.return_value = {"name": "Roger", "cli": "claude"}
+        mock_config_manager_cls.return_value = mock_config
+
+        agent_manager = MagicMock()
+        executor = MagicMock()
+        executor.config = MagicMock(session_id=None, model=None)
+        executor._get_cli_strategy.return_value.build_environment.return_value = dict(os.environ)
+        agent_manager.get_agent.return_value = executor
+        agent_manager.session_manager = MagicMock()
+        mock_agent_manager_cls.return_value = agent_manager
+
+        result = launch_chat_session("pm", "issue123")
+
+    assert result == 2
+    printed = " ".join(str(call) for call in mock_print.call_args_list)
+    assert "Chat CLI exited with code 2: authentication failed" in printed

--- a/tests/unit/test_generic_phase.py
+++ b/tests/unit/test_generic_phase.py
@@ -63,6 +63,8 @@ def test_build_prompt_includes_files_and_checklist_guard(tmp_path: Path) -> None
     assert "Do NOT return a status code until ALL checklist items are marked as [x]." in prompt
     assert "Latest workflow handoff from blackboard:" in prompt
     assert "Implement cafe skill rm" in prompt
+    assert "verify whether the requested state change has actually happened" in prompt
+    assert "do not treat an old artifact or a closed external object as completion" in prompt
     assert "Blackboard digest:" not in prompt
 
 

--- a/tests/unit/test_playbook_runner.py
+++ b/tests/unit/test_playbook_runner.py
@@ -1,4 +1,5 @@
 """Tests for playbook runner."""
+import json
 from pathlib import Path
 
 import pytest
@@ -900,3 +901,105 @@ def test_runner_writes_need_clarification_intent_for_non_confirm_user_handoff(tm
     assert contract is not None
     assert contract.intent == HandoffIntent.NEED_CLARIFICATION
     assert contract.to_step == "user"
+
+
+def test_runner_rejects_baton_owner_mismatch_before_step_execution(tmp_path: Path) -> None:
+    """If baton owner is not `agent`, the runner should fail before executing the step."""
+    issue_dir = tmp_path / ".cafe" / "issues" / "demo-owner-mismatch"
+    issue_dir.mkdir(parents=True, exist_ok=True)
+    (issue_dir / "next_step.txt").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "from_step": "spec",
+                "to_owner": "user",
+                "to_step": "user",
+                "intent": "manual_handoff",
+                "status_code": "",
+                "source": "test",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    playbook = {
+        "playbook": {"id": "default"},
+        "steps": {
+            "spec": {
+                "skill": "spec_first",
+                "role": "pm",
+                "valid_status_codes": ["CAFE_CONFIRMED"],
+                "on": {"CAFE_CONFIRMED": "plan"},
+            },
+            "plan": {
+                "skill": "spec_first",
+                "role": "developer",
+                "valid_status_codes": ["CAFE_CONFIRMED"],
+                "on": {"CAFE_CONFIRMED": "_done"},
+            },
+        },
+    }
+
+    def executor(step_name: str, step_def: dict, state: object) -> StepExecutionResult:
+        raise AssertionError("executor should not run when baton ownership is invalid")
+
+    runner = PlaybookRunner(
+        issue_dir=issue_dir,
+        playbook=playbook,
+        generic_phase=_build_loader(tmp_path),
+        executor=executor,
+    )
+
+    with pytest.raises(RuntimeError, match=r"expected agent, got user"):
+        runner.run(max_transitions=2)
+
+
+def test_runner_rejects_baton_target_mismatch_before_step_execution(tmp_path: Path) -> None:
+    """If baton target is not equal to the current step, the runner should fail early."""
+    issue_dir = tmp_path / ".cafe" / "issues" / "demo-target-mismatch"
+    issue_dir.mkdir(parents=True, exist_ok=True)
+    (issue_dir / "next_step.txt").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "from_step": "spec",
+                "to_owner": "agent",
+                "to_step": "plan",
+                "intent": "await_agent",
+                "status_code": "",
+                "source": "test",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    playbook = {
+        "playbook": {"id": "default"},
+        "steps": {
+            "spec": {
+                "skill": "spec_first",
+                "role": "pm",
+                "valid_status_codes": ["CAFE_CONFIRMED"],
+                "on": {"CAFE_CONFIRMED": "plan"},
+            },
+            "plan": {
+                "skill": "spec_first",
+                "role": "developer",
+                "valid_status_codes": ["CAFE_CONFIRMED"],
+                "on": {"CAFE_CONFIRMED": "_done"},
+            },
+        },
+    }
+
+    def executor(step_name: str, step_def: dict, state: object) -> StepExecutionResult:
+        raise AssertionError("executor should not run when baton target is invalid")
+
+    runner = PlaybookRunner(
+        issue_dir=issue_dir,
+        playbook=playbook,
+        generic_phase=_build_loader(tmp_path),
+        executor=executor,
+    )
+
+    with pytest.raises(RuntimeError, match=r"baton points to 'plan'"):
+        runner.run(max_transitions=2)


### PR DESCRIPTION
## Summary
This PR delivers issue231 on top of `v02`: persistent `next_step.txt` as a baton contract; chat-handoff consumption ignores bootstrap/persistent baton contracts (`contract.source`); hardened chat CLI launch error handling; and PR refresh/hooks that enforce completing the phase checklist and verifying external PR state before finishing (including creating a **new** PR when the previous one is closed or the base branch differs).

Prior workflow fixes (PR skill `base_branch`, native skills paths, etc.) live on `v02` where merged.

**Note:** GitHub PR #236 was closed and pointed at `main`; this iteration re-pushed `issue231` and opened **PR #238** against `v02`: https://github.com/luyotw/cafe/pull/238

Original requirements: `.cafe/issues/issue231/spec/iteration_002/output.md`.

## Changes
- **Workflow / CLI:** Ignore bootstrap/persistent baton when consuming chat handoff; skip when `next_step.txt` is absent at start.
- **Chat:** Harden handling when launching the chat CLI fails (clearer errors and tests).
- **PR phase:** Enforce handoff completion in PR refresh (`sync_pr.sh` + generic phase wiring; integration tests for closed-PR / base-mismatch behavior).
- **Branch history:** Merges from `v02` to stay current with base.

Commits in this branch (vs `v02` / `origin/v02`):
- `3ff31a4` issue231: enforce handoff completion in PR refresh
- `13fcd3b` Merge branch `v02` into `issue231`
- `9b25454` issue231: harden chat CLI launch failure handling
- `59fbf15` Merge branch `v02` into `issue231`
- `b8416b5` Ignore bootstrap baton when consuming chat handoff

## Test Plan
- `pytest -q` — full suite runs on `git push` via pre-push hook; must pass for push to succeed.
- New integration coverage: `tests/integration/test_sync_pr_script.py` exercises `sync_pr.sh` behavior for closed PRs and base retargeting.