### PR TITLE
issue241: split cli command groups into modules

### DIFF
--- a/src/cafe/ui/cli.py
+++ b/src/cafe/ui/cli.py
@@ -3,11 +3,9 @@
 import copy
 import json
 import os
-import shutil
 import subprocess
 import sys
 import textwrap
-from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -22,8 +20,8 @@ from cafe.ui.commands import phases_legacy as phases_legacy_commands
 from cafe.ui.commands import issues as issues_commands
 from cafe.ui.commands import workflow as workflow_commands
 from cafe.ui.cli_shared import (
-    CONTENT_TYPE_FILE_MAP,
-    VALID_CONTENT_TYPES,
+    CONTENT_TYPE_FILE_MAP as _SHARED_CONTENT_TYPE_FILE_MAP,
+    VALID_CONTENT_TYPES as _SHARED_VALID_CONTENT_TYPES,
     check_agent_clis_available as _shared_check_agent_clis_available,
     display_iteration_delta as _shared_display_iteration_delta,
     find_latest_iteration_dir as _shared_find_latest_iteration_dir,
@@ -40,10 +38,10 @@ from rich.console import Console
 from cafe.agents.manager import AgentManager
 from cafe.core.blackboard import BlackboardStore, HandoffIntent, HandoffOwner
 from cafe.core.git import GitOperations
-from cafe.core.workflow_models import StepExecutionResult
+from cafe.core.permission import PermissionHandler as _CompatPermissionHandler
+from cafe.core.types import CriticalPhaseError as _CompatCriticalPhaseError
+from cafe.core.workflow_models import StepExecutionResult as _CompatStepExecutionResult
 from cafe.core.workflow_runtime import BlackboardWorkflowRuntime
-from cafe.core.permission import PermissionHandler
-from cafe.core.types import CriticalPhaseError
 from cafe.phases.generic_phase import GenericPhase
 from cafe.phases.generic_workflow_step import GenericWorkflowStepExecutor
 from cafe.playbooks.loader import PlaybookLoader
@@ -51,8 +49,8 @@ from cafe.skills.importer import SkillImportSummary, import_skills, preview_impo
 from cafe.skills.loader import SkillLoader
 from cafe.skills.remover import SkillRemoveSummary, remove_skills
 from cafe.templates.manager import TemplateManager
-from cafe.ui import init_helpers
-from cafe.ui.chat import get_chat_next_step_path, launch_chat_session
+from cafe.ui import init_helpers as _compat_init_helpers
+from cafe.ui.chat import get_chat_next_step_path as _compat_get_chat_next_step_path, launch_chat_session
 from cafe.ui.display import Display
 from cafe.ui.init_helpers import (
     check_available_clis,
@@ -216,6 +214,17 @@ ALL_PHASES = ["spec", "plan", "develop", "review", "pr"]
 
 # Constants for cafe show command
 VALID_PHASES = ["spec", "plan", "develop", "review", "pr"]
+VALID_CONTENT_TYPES = _SHARED_VALID_CONTENT_TYPES
+CONTENT_TYPE_FILE_MAP = _SHARED_CONTENT_TYPE_FILE_MAP
+
+# Backward-compat re-exports for test patch targets
+import shutil as _shutil  # noqa: F401 — re-exported for backward compat
+shutil = _shutil
+PermissionHandler = _CompatPermissionHandler
+StepExecutionResult = _CompatStepExecutionResult
+CriticalPhaseError = _CompatCriticalPhaseError
+init_helpers = _compat_init_helpers
+get_chat_next_step_path = _compat_get_chat_next_step_path
 
 
 def _resolve_issue_playbook_name(issue_name: str) -> str:
@@ -1433,8 +1442,6 @@ def _interactive_agent_setup(available_clis: list) -> dict:
     Raises:
         typer.Exit: If user cancels or agents not found
     """
-    from InquirerPy.separator import Separator
-
     agents_config = {}
     roles = [("pm", "PM"), ("developer", "Developer"), ("reviewer", "Reviewer")]
 
@@ -1738,6 +1745,26 @@ app.command()(workflow_commands.summary)
 app.command()(workflow_commands.workflow)
 
 
+# Backward-compatible module-level command aliases for tests and integrations.
+prepare = lifecycle_commands.prepare
+close = lifecycle_commands.close
+restore = lifecycle_commands.restore
+reset = lifecycle_commands.reset
+
+spec = phases_legacy_commands.spec
+plan = phases_legacy_commands.plan
+develop = phases_legacy_commands.develop
+review = phases_legacy_commands.review
+pr = phases_legacy_commands.pr
+
+config = issues_commands.config
+list_issues = issues_commands.list_issues
+remove_issue = issues_commands.remove_issue
+
+make = workflow_commands.make
+show = workflow_commands.show
+summary = workflow_commands.summary
+workflow = workflow_commands.workflow
 
 
 # Template management commands
@@ -1759,8 +1786,6 @@ def template_add(
         cafe template add --source-file path/to/template.md --name my-template --type plan
         cafe template add  # Interactive mode
     """
-    import tempfile
-
     # Interactive prompting for missing arguments
     try:
         if not template_type:
@@ -2519,7 +2544,6 @@ def agent_ls(
 @agent_app.command(name="rm")
 def agent_rm() -> None:
     """Remove an agent interactively."""
-    from pathlib import Path
     from cafe.utils.config import get_global_cafe_dir
 
     # Get global agents directory
@@ -2987,7 +3011,6 @@ def _check_for_updates() -> None:
     import urllib.request
     import json
     import importlib.metadata
-    from pathlib import Path
     import subprocess
 
     # Check if update check is explicitly disabled via environment variable

--- a/src/cafe/ui/commands/issues.py
+++ b/src/cafe/ui/commands/issues.py
@@ -2,9 +2,21 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict
+import shutil
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Optional
 
 import typer
+import yaml
+from rich.console import Console
+
+from cafe.ui.commands import lifecycle as lifecycle_commands
+from cafe.ui.inquirer_prompts import prompt_confirm, prompt_text
+from cafe.utils.config import ConfigError, ConfigManager
+
+ALL_PHASES = ["spec", "plan", "develop", "review", "pr"]
+console = Console()
 
 
 def set_runtime(runtime_globals: Dict[str, Any]) -> None:
@@ -169,8 +181,6 @@ def list_issues() -> None:
         config_file = issue / "issue.yaml"
         if config_file.exists():
             try:
-                import yaml
-
                 with open(config_file, "r") as f:
                     config = yaml.safe_load(f)
                     if config and "worktree_path" in config:
@@ -206,9 +216,7 @@ def list_issues() -> None:
         phases_str = ", ".join(phases) if phases else "empty"
 
         # Get last modified time
-        import datetime
-
-        mtime = datetime.datetime.fromtimestamp(issue.stat().st_mtime)
+        mtime = datetime.fromtimestamp(issue.stat().st_mtime)
         mtime_str = mtime.strftime("%Y-%m-%d %H:%M")
 
         issue_name = str(issue.relative_to(issues_dir))
@@ -323,7 +331,7 @@ def remove_issue(
             if worktree_path is not None and worktree_path.exists():
                 worktree_issue_dir = worktree_path / ".cafe" / "issues" / issue_name
                 if worktree_issue_dir.exists():
-                    archive_path = _backup_issue_directory(worktree_issue_dir, issue_name)
+                    archive_path = lifecycle_commands._backup_issue_directory(worktree_issue_dir, issue_name)
                     backup_info = str(archive_path)
                     console.print(f"[green]✓[/green] Backed up issue '{issue_name}' to {archive_path}")
                 shutil.rmtree(worktree_path)

--- a/src/cafe/ui/commands/lifecycle.py
+++ b/src/cafe/ui/commands/lifecycle.py
@@ -3,11 +3,9 @@
 from __future__ import annotations
 
 import json
-import os
 import shutil
-from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, List, Optional
 
 import typer
 import yaml

--- a/src/cafe/ui/commands/phases_legacy.py
+++ b/src/cafe/ui/commands/phases_legacy.py
@@ -2,9 +2,42 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, Optional
 
 import typer
+from rich.console import Console
+
+from cafe.ui.cli_shared import get_latest_review_iteration as _get_latest_review_iteration
+from cafe.ui.cli_shared import get_latest_versioned_file as _get_latest_versioned_file
+from cafe.ui.inquirer_prompts import prompt_multiline
+from cafe.utils.config import ConfigError, ConfigManager
+
+console = Console()
+
+
+def _missing_runtime(*args: Any, **kwargs: Any) -> Any:
+    raise RuntimeError("phases_legacy runtime dependencies are not initialized")
+
+
+_print_legacy_phase_command_notice: Any = _missing_runtime
+_edit_latest_phase_artifact: Any = _missing_runtime
+_get_and_validate_branch: Any = _missing_runtime
+_reject_unsupported_phase_options: Any = _missing_runtime
+_run_iterative_alias_step: Any = _missing_runtime
+_alias_status: Any = _missing_runtime
+_alias_is_confirmed_transition: Any = _missing_runtime
+_execute_next_phase_auto: Any = _missing_runtime
+_alias_confirm_output_pause: Any = _missing_runtime
+_alias_needs_clarification: Any = _missing_runtime
+_execute_single_step_alias: Any = _missing_runtime
+_alias_needs_permission: Any = _missing_runtime
+_alias_next_step: Any = _missing_runtime
+_alias_targets: Any = _missing_runtime
+_alias_is_done: Any = _missing_runtime
+_handle_phase_exception: Any = _missing_runtime
 
 
 def set_runtime(runtime_globals: Dict[str, Any]) -> None:

--- a/src/cafe/ui/commands/workflow.py
+++ b/src/cafe/ui/commands/workflow.py
@@ -2,9 +2,48 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, Optional
 
 import typer
+from rich.console import Console
+
+from cafe.core.blackboard import BlackboardStore, HandoffIntent, HandoffOwner
+from cafe.core.git import GitOperations
+from cafe.core.types import CriticalPhaseError
+from cafe.core.workflow_models import StepExecutionResult
+from cafe.core.workflow_runtime import BlackboardWorkflowRuntime
+from cafe.phases.generic_phase import GenericPhase
+from cafe.playbooks.loader import PlaybookLoader
+from cafe.skills.loader import SkillLoader
+from cafe.ui.cli_shared import (
+    VALID_CONTENT_TYPES,
+    get_show_file_path as _get_show_file_path,
+    resolve_iteration_number as _resolve_iteration_number,
+)
+from cafe.utils.config import ConfigError, ConfigManager
+
+console = Console()
+
+
+def _missing_runtime(*args: Any, **kwargs: Any) -> Any:
+    raise RuntimeError("workflow runtime dependencies are not initialized")
+
+
+_check_agent_clis_available: Any = _missing_runtime
+_load_issue_step_names: Any = _missing_runtime
+_resolve_selected_playbook: Any = _missing_runtime
+_build_workflow_step_executor: Any = _missing_runtime
+_consume_pending_chat_handoff: Any = _missing_runtime
+_find_incomplete_workflow_step: Any = _missing_runtime
+_find_external_resume_step: Any = _missing_runtime
+_handle_user_phase: Any = _missing_runtime
+_build_workflow_pause_guidance: Any = _missing_runtime
+_print_workflow_pause_guidance: Any = _missing_runtime
+_handle_phase_exception: Any = _missing_runtime
 
 
 def set_runtime(runtime_globals: Dict[str, Any]) -> None:


### PR DESCRIPTION
## Summary
- move lifecycle, legacy phase, issue, and workflow command handlers out of cli.py into ui/commands modules
- keep cli.py focused on registration/runtime wiring and preserve dynamic-step routing
- carry full validation from pre-push run (unit + integration)

## Validation
- python3 -m pytest tests/unit tests/integration -q
