### PR TITLE
Issue 225 — PR review loop, baton runtime, auto-advance, and follow-up fixes

### DIFF
--- a/src/cafe/core/workflow_runtime.py
+++ b/src/cafe/core/workflow_runtime.py
@@ -163,6 +163,31 @@ class BlackboardWorkflowRuntime:
                 continue
         return None
 
+    def _resolve_next_step_from_handoff(self, *, current_step: str) -> Optional[str]:
+        """Derive the next step from the blackboard handoff contract.
+
+        When an agent omits a status code but the step executor has already
+        written a handoff contract (e.g. ``confirm_output`` → ``user``),
+        we use the contract's ``to_step`` to advance the workflow.  This
+        keeps the engine baton-first rather than status-code-first.
+        """
+        try:
+            contract = self.blackboard_store.load_handoff_contract(
+                self.blackboard,
+                allowed_steps=list(self.steps.keys()),
+                allow_legacy_text=True,
+            )
+        except Exception:
+            return None
+        to_step = getattr(contract, "to_step", None)
+        if to_step is None or to_step == current_step:
+            return None
+        # Validate the target step exists in the playbook or is a known
+        # synthetic step (user, done, _done).
+        if to_step in self.steps or to_step in {"user", "done", "_done"}:
+            return str(to_step)
+        return None
+
     def _pr_step_requires_publish_receipt(self, current_step: str) -> bool:
         if current_step != "pr":
             return False
@@ -769,20 +794,46 @@ class BlackboardWorkflowRuntime:
                             completed=False,
                         )
                     else:
-                        self.blackboard_store.record_event(
-                            self.blackboard,
-                            "status_code_missing",
-                            {
-                                "step": current_step,
-                                "response": frame.response,
-                                "runtime": runtime_label,
-                            },
+                        # Baton-first fallback: when the agent omits a
+                        # status code, use the handoff contract on the
+                        # blackboard (written by the step executor) to
+                        # determine the next step.  This advances the
+                        # engine deterministically via the baton model
+                        # rather than falling back to status-code transitions.
+                        baton_next = self._resolve_next_step_from_handoff(
+                            current_step=current_step,
                         )
-                        return PlaybookRunResult(
-                            final_step=current_step,
-                            final_status_code="NO_STATUS_CODE",
-                            completed=False,
-                        )
+                        if baton_next is not None:
+                            self.blackboard_store.record_event(
+                                self.blackboard,
+                                "status_code_missing",
+                                {
+                                    "step": current_step,
+                                    "response": frame.response,
+                                    "runtime": runtime_label,
+                                    "baton_fallback": True,
+                                    "fallback_next_step": baton_next,
+                                },
+                            )
+                            handoff_next_step = baton_next
+                            handoff_transition_source = "baton"
+                            status_code = "NO_STATUS_CODE"
+                            last_status_code = status_code
+                        else:
+                            self.blackboard_store.record_event(
+                                self.blackboard,
+                                "status_code_missing",
+                                {
+                                    "step": current_step,
+                                    "response": frame.response,
+                                    "runtime": runtime_label,
+                                },
+                            )
+                            return PlaybookRunResult(
+                                final_step=current_step,
+                                final_status_code="NO_STATUS_CODE",
+                                completed=False,
+                            )
             else:
                 handoff_next_step = None
                 handoff_transition_source = "terminal"

--- a/src/cafe/phases/generic_workflow_step.py
+++ b/src/cafe/phases/generic_workflow_step.py
@@ -287,7 +287,7 @@ class GenericWorkflowStepExecutor(Phase):
                     }
                 )
 
-        if require_status_code and status_code is not None:
+        if status_code is not None:
             align_pr_baton_after_execution(
                 issue_dir=self.issue_dir,
                 playbook=self.playbook,

--- a/src/cafe/phases/generic_workflow_step.py
+++ b/src/cafe/phases/generic_workflow_step.py
@@ -7,7 +7,14 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from cafe.agents.manager import AgentManager
-from cafe.core.blackboard import ArtifactEntry, ArtifactKind, BlackboardState, BlackboardStore
+from cafe.core.blackboard import (
+    ArtifactEntry,
+    ArtifactKind,
+    BlackboardState,
+    BlackboardStore,
+    HandoffIntent,
+    HandoffOwner,
+)
 from cafe.core.git import GitOperations
 from cafe.core.phase import Phase
 from cafe.core.status_codes import PhaseStatusCode, StatusCodeParser
@@ -21,6 +28,50 @@ from cafe.utils.checklist_generator import (
     generate_spec_checklist,
 )
 from cafe.utils.git_utils import to_cwd_relative_path
+
+
+def align_pr_baton_after_execution(
+    *,
+    issue_dir: Path,
+    playbook: Dict[str, Any],
+    blackboard_state: BlackboardState,
+    step_name: str,
+    status_code: Optional[str],
+) -> None:
+    """If PR feedback needs code changes, ensure the baton leaves the PR step.
+
+    Agents should update ``next_step.txt`` themselves, but when they return
+    ``CAFE_NEEDS_CHANGES`` while the baton still targets ``pr``, advance it to
+    ``develop`` so ``BlackboardWorkflowRuntime`` can transition.
+    """
+    if step_name != "pr" or not status_code:
+        return
+    if status_code != PhaseStatusCode.NEEDS_CHANGES.value:
+        return
+
+    allowed = list(playbook.get("steps", {}).keys())
+    store = BlackboardStore(issue_dir)
+    contract = store.load_handoff_contract(
+        blackboard_state,
+        allowed_steps=allowed,
+        allow_legacy_text=True,
+    )
+    if contract.to_owner != HandoffOwner.AGENT or contract.to_step != "pr":
+        return
+
+    store.update_handoff_contract(
+        blackboard_state,
+        from_step="pr",
+        to_owner=HandoffOwner.AGENT,
+        to_step="develop",
+        intent=HandoffIntent.AWAIT_AGENT,
+        status_code=status_code,
+        source="workflow.pr_needs_changes",
+    )
+    store.set_handoff_summary(
+        blackboard_state,
+        "PR feedback requires development work; next playbook step is develop.",
+    )
 
 
 class GenericWorkflowStepExecutor(Phase):
@@ -235,6 +286,15 @@ class GenericWorkflowStepExecutor(Phase):
                         "intent": handoff_intent,
                     }
                 )
+
+        if require_status_code and status_code is not None:
+            align_pr_baton_after_execution(
+                issue_dir=self.issue_dir,
+                playbook=self.playbook,
+                blackboard_state=blackboard_state,
+                step_name=step_name,
+                status_code=status_code.value,
+            )
 
         return StepExecutionResult(
             response=response,

--- a/src/cafe/phases/pr_phase.py
+++ b/src/cafe/phases/pr_phase.py
@@ -1,5 +1,6 @@
 """Pull Request creation phase."""
 
+from dataclasses import dataclass
 from datetime import datetime
 import json
 import re
@@ -18,6 +19,14 @@ from cafe.core.types import PhaseResult, PhaseStatus
 from cafe.ui.inquirer_prompts import prompt_confirm
 from cafe.utils.github import GitHubOps, GitHubError, get_all_pr_comments
 from cafe.utils.prompt_utils import format_checklist_instruction
+
+
+@dataclass(frozen=True)
+class PRCommentPersistOutcome:
+    """Result of persisting PR discussion into the issue workspace."""
+
+    path: Optional[str] = None
+    error: Optional[str] = None
 
 
 class PRPhase(Phase):
@@ -774,9 +783,15 @@ class PRPhase(Phase):
                 self.iteration = pr_iteration_info["iteration_number"] + 1
 
                 # Fetch comments from GitHub
-                user_input_path = self._save_pr_comments_to_user_input(int(pr_number))
+                outcome = self._save_pr_comments_to_user_input(int(pr_number))
+                if outcome.error:
+                    return PhaseResult(
+                        status=PhaseStatus.FAILED,
+                        message=outcome.error,
+                    )
 
-                if user_input_path:
+                if outcome.path:
+                    user_input_path = outcome.path
                     # New comments found - organize into todo list
                     pr_dir = self.issue_dir / "pr"
                     iteration_dir = pr_dir / f"iteration_{self.iteration:03d}"
@@ -1036,7 +1051,7 @@ class PRPhase(Phase):
 
         return result
 
-    def _save_pr_comments_to_user_input(self, pr_number: int) -> Optional[str]:
+    def _save_pr_comments_to_user_input(self, pr_number: int) -> PRCommentPersistOutcome:
         """Fetch PR comments from GitHub and save to pr/iteration_XXX/user_input.md.
 
         This centralizes PR comment detection in the PR phase. When a PR exists on GitHub,
@@ -1047,7 +1062,8 @@ class PRPhase(Phase):
             pr_number: GitHub PR number
 
         Returns:
-            Path to saved user_input.md file if comments were saved, None if no new comments
+            ``path`` set when comments were saved; empty outcome when there is nothing new;
+            ``error`` set when discussion data could not be loaded or persisted.
         """
         from cafe.utils.github import format_comments_for_prompt, GitHubOps
         from datetime import datetime
@@ -1066,14 +1082,14 @@ class PRPhase(Phase):
 
             if not comments:
                 print(f"  → No new comments found for PR #{pr_number}")
-                return None
+                return PRCommentPersistOutcome()
 
             # Format comments for saving
             formatted_comments = format_comments_for_prompt(comments)
 
             if not formatted_comments or not formatted_comments.strip():
                 print(f"  → No non-empty comments to save")
-                return None
+                return PRCommentPersistOutcome()
 
             # Save to pr/iteration_XXX/user_input.md
             pr_dir = self.issue_dir / "pr"
@@ -1142,12 +1158,12 @@ class PRPhase(Phase):
             console.print(f"[green]✓ Saved {len(comments)} PR comments to {user_input_file_display}[/green]")
             console.print()
 
-            return str(user_input_file)
+            return PRCommentPersistOutcome(path=str(user_input_file))
 
         except Exception as e:
-            # Log error but don't fail the PR phase
-            console.print(f"[yellow]⚠️  Warning: Failed to fetch/save PR comments: {e}[/yellow]")
-            return None
+            message = f"Failed to fetch/save PR comments: {e}"
+            console.print(f"[yellow]⚠️  Warning: {message}[/yellow]")
+            return PRCommentPersistOutcome(error=message)
 
     @staticmethod
     def _build_todo_list_comment(todo_content: str, user_input_path: str) -> str:

--- a/src/cafe/ui/cli_shared.py
+++ b/src/cafe/ui/cli_shared.py
@@ -89,9 +89,8 @@ def _get_github_helpers():
     from cafe.utils.github import (
         filter_unresolved_comments,
         get_all_pr_comments,
-        get_processed_comment_ids_from_history,
     )
-    return get_processed_comment_ids_from_history, get_all_pr_comments, filter_unresolved_comments
+    return get_all_pr_comments, filter_unresolved_comments
 
 
 def check_agent_clis_available(config_manager: ConfigManager) -> List[str]:
@@ -583,8 +582,10 @@ def _find_external_resume_step(
             return None
 
         try:
-            _get_processed_ids, _get_comments, _filter_comments = _get_github_helpers()
-            exclude_ids = _get_processed_ids(issue_dir / step_name)
+            from cafe.utils.github import load_pr_last_seen_comment_ids
+
+            _get_comments, _filter_comments = _get_github_helpers()
+            exclude_ids = load_pr_last_seen_comment_ids(issue_dir / step_name)
             comments = _get_comments(int(existing_pr["number"]), exclude_ids=exclude_ids)
             unresolved_comments = _filter_comments(comments)
         except Exception as exc:

--- a/src/cafe/ui/cli_shared.py
+++ b/src/cafe/ui/cli_shared.py
@@ -583,18 +583,15 @@ def _find_external_resume_step(
             return None
 
         try:
-            has_unpushed_commits = git_ops.has_unpushed_commits()
-        except Exception:
-            has_unpushed_commits = False
-        if has_unpushed_commits:
-            return None
-
-        try:
             _get_processed_ids, _get_comments, _filter_comments = _get_github_helpers()
             exclude_ids = _get_processed_ids(issue_dir / step_name)
             comments = _get_comments(int(existing_pr["number"]), exclude_ids=exclude_ids)
             unresolved_comments = _filter_comments(comments)
-        except Exception:
+        except Exception as exc:
+            console.print(
+                "[red]Error:[/red] could not evaluate unresolved PR discussion for external resume "
+                f"({exc}). Leaving workflow paused."
+            )
             return None
 
         if unresolved_comments:

--- a/src/cafe/ui/commands/workflow.py
+++ b/src/cafe/ui/commands/workflow.py
@@ -508,6 +508,10 @@ def workflow(
                     pending_start_step = external_step
                     store = BlackboardStore(issue_dir)
                     store.set_current_step(blackboard, external_step)
+                    store.set_handoff_summary(
+                        blackboard,
+                        "Unresolved PR discussion detected while the workflow was paused; resuming the PR step.",
+                    )
                     store.update_handoff_contract(
                         blackboard,
                         from_step=external_step,

--- a/src/cafe/ui/commands/workflow.py
+++ b/src/cafe/ui/commands/workflow.py
@@ -544,9 +544,12 @@ def workflow(
                         # contract to find which step produced the output,
                         # then advance to the natural next step in the
                         # playbook (the step after from_step).
-                        contract = BlackboardStore(issue_dir).load_handoff_contract(blackboard)
-                        from_step = getattr(contract, "from_step", None) or blackboard.current_step
                         step_keys = list(playbook_data.get("steps", {}).keys())
+                        contract = BlackboardStore(issue_dir).load_handoff_contract(
+                            blackboard,
+                            allowed_steps=step_keys,
+                        )
+                        from_step = getattr(contract, "from_step", None) or blackboard.current_step
                         next_step = None
                         try:
                             idx = step_keys.index(from_step)

--- a/src/cafe/ui/commands/workflow.py
+++ b/src/cafe/ui/commands/workflow.py
@@ -118,6 +118,11 @@ def make(
         "-u",
         help="Initial requirements to pass into the first spec step",
     ),
+    auto_advance: bool = typer.Option(
+        False,
+        "--auto-advance",
+        help="Auto-confirm user handoffs and advance without interactive prompts",
+    ),
 ) -> None:
     """🚀 Check environment and execute complete development workflow.
 
@@ -171,6 +176,8 @@ def make(
     cmd = [sys.executable, "-m", "cafe.ui.cli", "workflow", "--execute"]
     if user_input:
         cmd.extend(["--user-input", user_input])
+    if auto_advance:
+        cmd.append("--auto-advance")
 
     # Execute the command
     try:
@@ -361,6 +368,7 @@ def workflow(
     issue: Optional[str] = typer.Option(None, "--issue", help="Issue directory name"),
     start_step: Optional[str] = typer.Option(None, "--start-step", help="Start execution from a specific step"),
     single_step: bool = typer.Option(False, "--single-step", help="Run only one playbook step"),
+    auto_advance: bool = typer.Option(False, "--auto-advance", help="Auto-confirm user handoffs and advance without interactive prompts"),
     dry_run: bool = typer.Option(True, "--dry-run/--execute", help="Run with built-in dry executor"),
     user_input: Optional[str] = typer.Option(
         None,
@@ -398,7 +406,7 @@ def workflow(
 
         playbook_loader = PlaybookLoader()
         playbook_data = playbook_loader.load(selected_playbook)
-        interactive = sys.stdin.isatty() or os.getenv("CAFE_FORCE_INTERACTIVE") == "1"
+        interactive = (sys.stdin.isatty() or os.getenv("CAFE_FORCE_INTERACTIVE") == "1") and not auto_advance
         generic_phase = GenericPhase(SkillLoader())
 
         def dry_executor(step_name: str, step_def: Dict, blackboard_state: object) -> StepExecutionResult:
@@ -525,9 +533,49 @@ def workflow(
                     )
                     continue
             if not dry_run and active_step in {"user", "done"}:
+                if active_step == "done" and not interactive:
+                    console.print("[green]Workflow already completed[/green] step=done")
+                    console.print("[yellow]Workflow is waiting for user input[/yellow] step=user")
+                    return
+                # active_step in {"user", "done"} (done only reaches here in interactive mode)
                 if not interactive:
-                    if active_step == "done":
-                        console.print("[green]Workflow already completed[/green] step=done")
+                    if auto_advance:
+                        # Baton-first auto-advance: look at the handoff
+                        # contract to find which step produced the output,
+                        # then advance to the natural next step in the
+                        # playbook (the step after from_step).
+                        contract = BlackboardStore(issue_dir).load_handoff_contract(blackboard)
+                        from_step = getattr(contract, "from_step", None) or blackboard.current_step
+                        step_keys = list(playbook_data.get("steps", {}).keys())
+                        next_step = None
+                        try:
+                            idx = step_keys.index(from_step)
+                            next_step = step_keys[idx + 1] if idx + 1 < len(step_keys) else None
+                        except ValueError:
+                            pass
+                        if next_step is not None:
+                            store = BlackboardStore(issue_dir)
+                            store.set_current_step(blackboard, next_step)
+                            store.set_handoff_summary(blackboard, f"Auto-advanced from {from_step} to {next_step}")
+                            store.update_handoff_contract(
+                                blackboard,
+                                from_step=from_step,
+                                to_owner=HandoffOwner.AGENT,
+                                to_step=next_step,
+                                intent=HandoffIntent.MANUAL_HANDOFF,
+                                source="workflow.auto_advance",
+                            )
+                            store.record_event(
+                                blackboard,
+                                "auto_advance",
+                                {"from_phase": from_step, "to_step": next_step},
+                            )
+                            console.print(f"[dim]Auto-advancing[/dim] step={from_step} → {next_step}")
+                            pending_start_step = next_step
+                            continue
+                        else:
+                            console.print("[yellow]Workflow is waiting for user input[/yellow] step=user")
+                            return
                     console.print("[yellow]Workflow is waiting for user input[/yellow] step=user")
                     return
                 user_selected_step = _handle_user_phase(
@@ -568,6 +616,9 @@ def workflow(
                 pending_start_step = "user"
                 continue
             if not interactive and not dry_run and not single_step and latest_blackboard.current_step == "user":
+                if auto_advance:
+                    pending_start_step = "user"
+                    continue
                 console.print("[yellow]Workflow is waiting for user input[/yellow] step=user")
                 return
             if result.completed:

--- a/src/cafe/utils/github.py
+++ b/src/cafe/utils/github.py
@@ -1065,6 +1065,56 @@ def get_all_pr_comments(pr_number: int, exclude_ids: Optional[Set[str]] = None) 
     return list(comments_by_id.values())
 
 
+def load_pr_last_seen_comment_ids(pr_dir: Path) -> Set[str]:
+    """Comment IDs already synced for PR resume / external-feedback detection.
+
+    Matches :meth:`cafe.phases.pr_phase.PRPhase._get_last_seen_comment_ids` without
+    constructing ``PRPhase``: primary source is
+    ``<pr_dir>/artifacts/pr_last_seen_comments.json`` (written by
+    ``_persist_last_seen_comment_ids``); legacy fallback scans
+    ``<pr_dir>/iteration_*/context.json`` for ``last_seen_comment_ids``.
+
+    ``get_processed_comment_ids_from_history`` (``pr_comments_processed`` /
+    ``pr_comments_skipped``) is not used here: those fields are not populated in
+    normal runs, so relying on them caused false external resumes.
+    """
+    artifact_file = pr_dir / "artifacts" / "pr_last_seen_comments.json"
+    if artifact_file.exists():
+        try:
+            payload = json.loads(artifact_file.read_text(encoding="utf-8"))
+            if isinstance(payload, dict):
+                raw_ids = payload.get("last_seen_comment_ids", [])
+            elif isinstance(payload, list):
+                raw_ids = payload
+            else:
+                raw_ids = []
+            if not isinstance(raw_ids, list):
+                return set()
+            return {str(item) for item in raw_ids}
+        except (json.JSONDecodeError, OSError, TypeError):
+            return set()
+
+    if not pr_dir.exists():
+        return set()
+
+    iteration_dirs = sorted(pr_dir.glob("iteration_*"))
+    for iter_dir in reversed(iteration_dirs):
+        context_file = iter_dir / "context.json"
+        if not context_file.exists():
+            continue
+        try:
+            with open(context_file, encoding="utf-8") as f:
+                context = json.load(f)
+            if isinstance(context, dict) and "last_seen_comment_ids" in context:
+                raw = context["last_seen_comment_ids"]
+                if isinstance(raw, list):
+                    return {str(x) for x in raw}
+        except (json.JSONDecodeError, TypeError, OSError):
+            continue
+
+    return set()
+
+
 def get_processed_comment_ids_from_history(phase_dir: "Path") -> set:
     """Get all processed and skipped comment IDs from previous iterations' history.
 

--- a/tests/unit/test_checklist_generator.py
+++ b/tests/unit/test_checklist_generator.py
@@ -209,6 +209,22 @@ class TestGenerateReviewChecklist:
         assert "- [ ]" in content
         assert "- [x]" in content
 
+    def test_review_checklist_embeds_pr_todo_path_when_provided(self, tmp_path):
+        checklist_path = tmp_path / "checklist.md"
+        pr_todo = ".cafe/issues/demo/pr/iteration_001/output.md"
+
+        generate_review_checklist(
+            agent_name="Richard",
+            spec_file_path=".cafe/issues/test/spec/iteration_001/output.md",
+            review_file_path=".cafe/issues/test/review/iteration_001/output.md",
+            base_branch="main",
+            checklist_file_path=checklist_path,
+            pr_todo_list_file_path=pr_todo,
+        )
+
+        content = checklist_path.read_text()
+        assert pr_todo in content
+
 
 class TestGeneratePRChecklist:
     """Tests for generate_pr_checklist function."""

--- a/tests/unit/test_checklist_generator.py
+++ b/tests/unit/test_checklist_generator.py
@@ -1,7 +1,11 @@
 """Tests for checklist generator."""
 
-import pytest
 from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from cafe.agents.manager import AgentManager
 from cafe.utils.checklist_generator import (
     generate_spec_checklist,
     generate_plan_checklist,
@@ -266,20 +270,24 @@ class TestChecklistFileCreation:
         assert checklist_path.parent.exists()
 
     def test_resolves_agent_guidelines_from_real_agent_file(self, tmp_path):
-        """Test resolves agent guidelines from actual agent file."""
+        """Agent guidelines come from the resolved agent file (hermetic stub)."""
         checklist_path = tmp_path / "checklist.md"
-
-        # Use a real agent name that exists in the system
-        generate_spec_checklist(
-            iteration=1,
-            agent_name="Roger",
-            current_spec_file=".cafe/issues/test/spec/iteration_001/output.md",
-            prev_spec_file=None,
-            checklist_file_path=checklist_path,
+        agent_md = tmp_path / "Roger.md"
+        agent_md.write_text(
+            "- **Test guideline**: Example guideline for checklist extraction.\n",
+            encoding="utf-8",
         )
 
+        with patch.object(AgentManager, "get_agent_file_path", return_value=str(agent_md)):
+            generate_spec_checklist(
+                iteration=1,
+                agent_name="Roger",
+                current_spec_file=".cafe/issues/test/spec/iteration_001/output.md",
+                prev_spec_file=None,
+                checklist_file_path=checklist_path,
+            )
+
         content = checklist_path.read_text()
-        # Should have agent guidelines checklist section
         assert "## Agent Guidelines Checklist" in content
 
 

--- a/tests/unit/test_cli_workflow_command.py
+++ b/tests/unit/test_cli_workflow_command.py
@@ -871,13 +871,58 @@ def test_find_external_resume_step_returns_pr_when_new_pr_comments_exist(tmp_pat
 
     with (
         patch("cafe.ui.cli.GitHubOps") as mock_github_ops,
-        patch("cafe.ui.cli.get_processed_comment_ids_from_history", return_value=set()),
-        patch("cafe.ui.cli.get_all_pr_comments", return_value=["comment-1"]),
-        patch("cafe.ui.cli.filter_unresolved_comments", return_value=["comment-1"]),
+        patch(
+            "cafe.utils.github.get_processed_comment_ids_from_history",
+            return_value=set(),
+        ),
+        patch("cafe.utils.github.get_all_pr_comments", return_value=["comment-1"]),
+        patch("cafe.utils.github.filter_unresolved_comments", return_value=["comment-1"]),
     ):
         mock_github_ops.return_value.get_pr_for_branch.return_value = {
             "number": 238,
             "url": "https://github.com/test/repo/pull/238",
+        }
+
+        result = _find_external_resume_step(
+            issue_dir=issue_dir,
+            playbook_data=playbook_data,
+            git_ops=git_ops,
+        )
+
+    assert result == "pr"
+
+
+def test_find_external_resume_step_returns_pr_when_unpushed_commits_but_unresolved_exist(
+    tmp_path: Path,
+) -> None:
+    """Unresolved feedback must still wake the PR step even with local commits."""
+    issue_dir = tmp_path / ".cafe" / "issues" / "issue-239"
+    (issue_dir / "pr").mkdir(parents=True, exist_ok=True)
+    playbook_data = {
+        "steps": {
+            "pr": {
+                "hooks": {
+                    "prepare_input": ["GitHubPRCreator", "UserInputCollector"],
+                },
+            },
+        },
+    }
+    git_ops = MagicMock()
+    git_ops.get_current_branch.return_value = "issue-239"
+    git_ops.has_unpushed_commits.return_value = True
+
+    with (
+        patch("cafe.ui.cli.GitHubOps") as mock_github_ops,
+        patch(
+            "cafe.utils.github.get_processed_comment_ids_from_history",
+            return_value=set(),
+        ),
+        patch("cafe.utils.github.get_all_pr_comments", return_value=["comment-1"]),
+        patch("cafe.utils.github.filter_unresolved_comments", return_value=["comment-1"]),
+    ):
+        mock_github_ops.return_value.get_pr_for_branch.return_value = {
+            "number": 239,
+            "url": "https://github.com/test/repo/pull/239",
         }
 
         result = _find_external_resume_step(

--- a/tests/unit/test_cli_workflow_command.py
+++ b/tests/unit/test_cli_workflow_command.py
@@ -934,6 +934,37 @@ def test_find_external_resume_step_returns_pr_when_unpushed_commits_but_unresolv
     assert result == "pr"
 
 
+def test_find_external_resume_step_returns_none_when_no_github_pr(tmp_path: Path) -> None:
+    """Control case: missing remote PR means no resume (plan Test 1.3 branch)."""
+    issue_dir = tmp_path / ".cafe" / "issues" / "issue-240"
+    (issue_dir / "pr").mkdir(parents=True, exist_ok=True)
+    playbook_data = {
+        "steps": {
+            "pr": {
+                "hooks": {
+                    "prepare_input": ["GitHubPRCreator", "UserInputCollector"],
+                },
+            },
+        },
+    }
+    git_ops = MagicMock()
+    git_ops.get_current_branch.return_value = "issue-240"
+
+    with (
+        patch("cafe.ui.cli.GitHubOps") as mock_github_ops,
+        patch("cafe.utils.github.get_all_pr_comments") as mock_fetch,
+    ):
+        mock_github_ops.return_value.get_pr_for_branch.return_value = None
+        result = _find_external_resume_step(
+            issue_dir=issue_dir,
+            playbook_data=playbook_data,
+            git_ops=git_ops,
+        )
+
+    assert result is None
+    mock_fetch.assert_not_called()
+
+
 def test_workflow_command_resumes_pr_when_external_feedback_arrives_while_done(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.chdir(tmp_path)
     executed_steps: list[str] = []

--- a/tests/unit/test_cli_workflow_command.py
+++ b/tests/unit/test_cli_workflow_command.py
@@ -871,10 +871,6 @@ def test_find_external_resume_step_returns_pr_when_new_pr_comments_exist(tmp_pat
 
     with (
         patch("cafe.ui.cli.GitHubOps") as mock_github_ops,
-        patch(
-            "cafe.utils.github.get_processed_comment_ids_from_history",
-            return_value=set(),
-        ),
         patch("cafe.utils.github.get_all_pr_comments", return_value=["comment-1"]),
         patch("cafe.utils.github.filter_unresolved_comments", return_value=["comment-1"]),
     ):
@@ -890,6 +886,53 @@ def test_find_external_resume_step_returns_pr_when_new_pr_comments_exist(tmp_pat
         )
 
     assert result == "pr"
+
+
+def test_find_external_resume_step_returns_none_when_last_seen_covers_all_comments(
+    tmp_path: Path,
+) -> None:
+    """P2: stale context.json processed fields must not be the only source; last-seen artifact excludes known IDs."""
+    issue_dir = tmp_path / ".cafe" / "issues" / "issue-241"
+    pr_dir = issue_dir / "pr"
+    artifact = pr_dir / "artifacts" / "pr_last_seen_comments.json"
+    artifact.parent.mkdir(parents=True, exist_ok=True)
+    artifact.write_text(
+        json.dumps({"last_seen_comment_ids": ["c1", "c2"]}, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    playbook_data = {
+        "steps": {
+            "pr": {
+                "hooks": {
+                    "prepare_input": ["GitHubPRCreator", "UserInputCollector"],
+                },
+            },
+        },
+    }
+    git_ops = MagicMock()
+    git_ops.get_current_branch.return_value = "issue-241"
+
+    with (
+        patch("cafe.ui.cli.GitHubOps") as mock_github_ops,
+        patch("cafe.utils.github.get_all_pr_comments") as mock_fetch,
+        patch("cafe.utils.github.filter_unresolved_comments", return_value=[]),
+    ):
+        mock_github_ops.return_value.get_pr_for_branch.return_value = {
+            "number": 241,
+            "url": "https://github.com/test/repo/pull/241",
+        }
+        mock_fetch.return_value = []
+
+        result = _find_external_resume_step(
+            issue_dir=issue_dir,
+            playbook_data=playbook_data,
+            git_ops=git_ops,
+        )
+
+    assert result is None
+    mock_fetch.assert_called_once()
+    call_kw = mock_fetch.call_args[1]
+    assert call_kw["exclude_ids"] == {"c1", "c2"}
 
 
 def test_find_external_resume_step_returns_pr_when_unpushed_commits_but_unresolved_exist(
@@ -913,10 +956,6 @@ def test_find_external_resume_step_returns_pr_when_unpushed_commits_but_unresolv
 
     with (
         patch("cafe.ui.cli.GitHubOps") as mock_github_ops,
-        patch(
-            "cafe.utils.github.get_processed_comment_ids_from_history",
-            return_value=set(),
-        ),
         patch("cafe.utils.github.get_all_pr_comments", return_value=["comment-1"]),
         patch("cafe.utils.github.filter_unresolved_comments", return_value=["comment-1"]),
     ):

--- a/tests/unit/test_generic_workflow_step.py
+++ b/tests/unit/test_generic_workflow_step.py
@@ -8,7 +8,8 @@ from types import SimpleNamespace
 from unittest.mock import patch
 import pytest
 
-from cafe.core.blackboard import ArtifactEntry, ArtifactKind, BlackboardStore
+from cafe.core.blackboard import ArtifactEntry, ArtifactKind, BlackboardStore, HandoffIntent, HandoffOwner
+from cafe.core.status_codes import PhaseStatusCode
 from cafe.core.types import AgentCLI, TokenUsage
 from cafe.phases.generic_phase import GenericPhaseExecution
 from cafe.phases.generic_phase import GenericPhase
@@ -1029,6 +1030,90 @@ def test_generic_workflow_step_pr_does_not_parse_status_from_response(tmp_path: 
     assert result.response == "CAFE_CONFIRMED"
     assert result.status_code is None
     assert all(event.get("type") != "handoff_intent" for event in result.events)
+
+
+def test_generic_workflow_step_pr_aligns_baton_when_execute_returns_needs_changes(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """align_pr_baton_after_execution must run for pr even though require_status_code is False."""
+    monkeypatch.chdir(tmp_path)
+    issue_dir = tmp_path / ".cafe" / "issues" / "issue-pr-baton-integrate"
+    playbook = {
+        "playbook": {"id": "default"},
+        "roles": {"developer": {"default_agent": "Nick"}},
+        "steps": {
+            "pr": {
+                "skill": "pr",
+                "role": "developer",
+                "output_artifact": "pr_result",
+                "allowed_tools": ["Read"],
+                "on": {"CAFE_NEEDS_CHANGES": "develop"},
+            },
+            "develop": {"skill": "develop", "role": "developer", "allowed_tools": ["Read"]},
+        },
+    }
+    issue_dir.mkdir(parents=True, exist_ok=True)
+    (issue_dir / "next_step.txt").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "from_step": "pr",
+                "to_owner": "agent",
+                "to_step": "pr",
+                "intent": "await_agent",
+                "status_code": "",
+                "created_at": "2026-05-11T12:00:00+08:00",
+                "source": "test",
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    state = BlackboardStore(issue_dir).load_or_create("pr")
+    state.handoff_summary = "PR feedback requires follow-up."
+    state.artifacts["spec"] = ArtifactEntry(
+        name="spec",
+        kind=ArtifactKind.DOCUMENT,
+        version=1,
+        updated_by="spec",
+        path="spec/iteration_001/output.md",
+    )
+    state.artifacts["plan"] = ArtifactEntry(
+        name="plan",
+        kind=ArtifactKind.DOCUMENT,
+        version=1,
+        updated_by="plan",
+        path="plan/iteration_001/output.md",
+    )
+    executor = GenericWorkflowStepExecutor(
+        issue_dir=issue_dir,
+        issue_name="issue-pr-baton-integrate",
+        playbook=playbook,
+        generic_phase=_build_loader(tmp_path),
+        agent_manager=FakeAgentManager("unused"),
+        git_ops=FakeGitOperations(),
+        role_agent_map={"developer": "Nick"},
+    )
+
+    def fake_execute(*args, **kwargs):
+        return GenericPhaseExecution(
+            response="CAFE_NEEDS_CHANGES",
+            status_code=PhaseStatusCode.NEEDS_CHANGES,
+            goto_target=None,
+            context_updates={},
+            events=[],
+        )
+
+    executor.generic_phase.execute = fake_execute
+
+    result = executor.execute_step("pr", playbook["steps"]["pr"], state)
+
+    assert result.status_code == "CAFE_NEEDS_CHANGES"
+    reloaded = BlackboardStore(issue_dir).load_or_create("pr")
+    assert reloaded.handoff_contract is not None
+    assert reloaded.handoff_contract.to_step == "develop"
+    assert reloaded.handoff_contract.to_owner == HandoffOwner.AGENT
+    assert reloaded.handoff_contract.intent == HandoffIntent.AWAIT_AGENT
 
 
 def test_generic_workflow_step_pr_prompt_uses_baton_wording(tmp_path: Path, monkeypatch) -> None:

--- a/tests/unit/test_github_pr_comments.py
+++ b/tests/unit/test_github_pr_comments.py
@@ -4,6 +4,7 @@
 """
 
 import pytest
+from pathlib import Path
 from unittest.mock import Mock, patch, MagicMock
 import json
 from cafe.utils.github import (
@@ -1096,3 +1097,29 @@ class TestGetProcessedCommentIDs:
             # Should only include valid comment IDs
             assert "111" in result
             assert len(result) == 1
+
+
+def test_load_pr_last_seen_comment_ids_reads_artifact(tmp_path: Path) -> None:
+    from cafe.utils.github import load_pr_last_seen_comment_ids
+
+    pr_dir = tmp_path / "pr"
+    art = pr_dir / "artifacts" / "pr_last_seen_comments.json"
+    art.parent.mkdir(parents=True, exist_ok=True)
+    art.write_text(
+        json.dumps({"last_seen_comment_ids": ["a", "b"]}, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    assert load_pr_last_seen_comment_ids(pr_dir) == {"a", "b"}
+
+
+def test_load_pr_last_seen_comment_ids_legacy_context(tmp_path: Path) -> None:
+    from cafe.utils.github import load_pr_last_seen_comment_ids
+
+    pr_dir = tmp_path / "pr"
+    it = pr_dir / "iteration_001"
+    it.mkdir(parents=True)
+    (it / "context.json").write_text(
+        json.dumps({"last_seen_comment_ids": ["x"]}, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    assert load_pr_last_seen_comment_ids(pr_dir) == {"x"}

--- a/tests/unit/test_pr_baton_alignment.py
+++ b/tests/unit/test_pr_baton_alignment.py
@@ -1,0 +1,106 @@
+"""Tests for playbook baton alignment after PR step execution."""
+
+import json
+from pathlib import Path
+
+from cafe.core.blackboard import BlackboardStore, HandoffIntent, HandoffOwner
+from cafe.phases.generic_workflow_step import align_pr_baton_after_execution
+
+
+def _bootstrap_issue(issue_dir: Path) -> None:
+    issue_dir.mkdir(parents=True)
+    (issue_dir / "blackboard.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "current_step": "pr",
+                "owner": "agent",
+                "playbook_id": "default",
+                "artifacts": {},
+                "events": [],
+                "decisions": [],
+                "handoff_summary": "",
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_align_pr_baton_updates_when_needs_changes_and_stale(tmp_path: Path) -> None:
+    issue_dir = tmp_path / ".cafe" / "issues" / "demo-pr-baton"
+    _bootstrap_issue(issue_dir)
+
+    playbook = {"steps": {"pr": {}, "develop": {}, "review": {}}}
+    (issue_dir / "next_step.txt").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "from_step": "pr",
+                "to_owner": "agent",
+                "to_step": "pr",
+                "intent": "await_agent",
+                "status_code": "",
+                "created_at": "2026-05-10T12:00:00+08:00",
+                "source": "test",
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    store = BlackboardStore(issue_dir)
+    state = store.load_or_create("pr", playbook_id="default")
+
+    align_pr_baton_after_execution(
+        issue_dir=issue_dir,
+        playbook=playbook,
+        blackboard_state=state,
+        step_name="pr",
+        status_code="CAFE_NEEDS_CHANGES",
+    )
+
+    loaded = BlackboardStore(issue_dir).load_or_create("pr", playbook_id="default")
+    contract = loaded.handoff_contract
+    assert contract is not None
+    assert contract.to_step == "develop"
+    assert contract.to_owner == HandoffOwner.AGENT
+    assert contract.intent == HandoffIntent.AWAIT_AGENT
+
+
+def test_align_pr_baton_noop_when_status_not_needs_changes(tmp_path: Path) -> None:
+    issue_dir = tmp_path / ".cafe" / "issues" / "demo-pr-skip"
+    _bootstrap_issue(issue_dir)
+
+    playbook = {"steps": {"pr": {}, "develop": {}}}
+    (issue_dir / "next_step.txt").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "from_step": "pr",
+                "to_owner": "agent",
+                "to_step": "pr",
+                "intent": "await_agent",
+                "status_code": "",
+                "created_at": "2026-05-10T12:00:00+08:00",
+                "source": "test",
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    store = BlackboardStore(issue_dir)
+    state = store.load_or_create("pr", playbook_id="default")
+
+    align_pr_baton_after_execution(
+        issue_dir=issue_dir,
+        playbook=playbook,
+        blackboard_state=state,
+        step_name="pr",
+        status_code="CAFE_CONFIRMED",
+    )
+
+    loaded = BlackboardStore(issue_dir).load_or_create("pr", playbook_id="default")
+    assert loaded.handoff_contract is not None
+    assert loaded.handoff_contract.to_step == "pr"

--- a/tests/unit/test_pr_phase_github_mode.py
+++ b/tests/unit/test_pr_phase_github_mode.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch, PropertyMock
 
 import pytest
 
-from cafe.phases.pr_phase import PRPhase
+from cafe.phases.pr_phase import PRCommentPersistOutcome, PRPhase
 from cafe.core.types import PhaseStatus, PhaseResult
 from cafe.core.status_codes import PhaseStatusCode
 
@@ -205,7 +205,9 @@ class TestPRPhaseGitHubMode:
         # Mock fetching comments
         with patch.object(PRPhase, "_get_issue_dir", return_value=issue_dir):
             with patch.object(PRPhase, "_save_pr_comments_to_user_input") as mock_save_comments:
-                mock_save_comments.return_value = iteration_001 / "iteration_002" / "user_input.md"
+                mock_save_comments.return_value = PRCommentPersistOutcome(
+                    path=str(tmp_path / "stub_user_input.md")
+                )
                 with patch.object(PRPhase, "_organize_comments_to_todo_list") as mock_organize:
                     mock_organize.return_value = PhaseResult(
                         status=PhaseStatus.COMPLETED,
@@ -224,6 +226,50 @@ class TestPRPhaseGitHubMode:
         # Assert
         assert result.status == PhaseStatus.COMPLETED
         assert result.data.get("status_code") in ["CAFE_NEEDS_CHANGES", "CAFE_CONFIRMED"]
+
+    def test_scenario_d_comment_fetch_failure_returns_failed(
+        self, tmp_path, mock_dependencies, setup_issue_dir
+    ):
+        """When discussion cannot be fetched, surface failure instead of 'no comments'."""
+        issue_dir, spec_file = setup_issue_dir
+
+        pr_dir = issue_dir / "pr"
+        iteration_001 = pr_dir / "iteration_001"
+        iteration_001.mkdir(parents=True)
+        (iteration_001 / "context.json").write_text(
+            json.dumps(
+                {
+                    "iteration": 1,
+                    "timestamp": "2026-01-27T10:00:00+08:00",
+                    "end_time": "2026-01-27T10:05:00+08:00",
+                    "status_code": "CAFE_READY_FOR_REVIEW",
+                }
+            )
+        )
+
+        mock_dependencies["git_ops"].has_unpushed_commits.return_value = False
+        mock_dependencies["github_ops"].check_gh_auth.return_value = True
+        mock_dependencies["github_ops"].get_pr_for_branch.return_value = {
+            "number": 1,
+            "url": "https://github.com/test/repo/pull/1",
+        }
+
+        with patch.object(PRPhase, "_get_issue_dir", return_value=issue_dir):
+            with patch.object(
+                PRPhase,
+                "_save_pr_comments_to_user_input",
+                return_value=PRCommentPersistOutcome(error="GitHub unreachable"),
+            ):
+                phase = PRPhase(
+                    spec_file=str(spec_file),
+                    issue_name="test-issue",
+                    **mock_dependencies,
+                )
+
+                result = phase._execute_github_mode()
+
+        assert result.status == PhaseStatus.FAILED
+        assert "GitHub unreachable" in result.message
 
     # =========================================================================
     # Scenario E: No new commits, PR exists, last iteration CONFIRMED
@@ -1098,7 +1144,7 @@ class TestSavePRCommentsFiltersLastSeen:
                 phase = self._make_phase(issue_dir, mock_dependencies, iteration=2)
                 result = phase._save_pr_comments_to_user_input(42)
 
-        assert result is not None
+        assert result.path is not None
         user_input_file = pr_dir / "iteration_002" / "user_input.md"
         assert user_input_file.exists()
         content = user_input_file.read_text()
@@ -1130,7 +1176,7 @@ class TestSavePRCommentsFiltersLastSeen:
                 phase = self._make_phase(issue_dir, mock_dependencies, iteration=2)
                 result = phase._save_pr_comments_to_user_input(42)
 
-        assert result is None
+        assert result.path is None and result.error is None
         # user_input.md should NOT be created
         user_input_file = pr_dir / "iteration_002" / "user_input.md"
         assert not user_input_file.exists()
@@ -1161,7 +1207,7 @@ class TestSavePRCommentsFiltersLastSeen:
                 phase = self._make_phase(issue_dir, mock_dependencies, iteration=1)
                 result = phase._save_pr_comments_to_user_input(42)
 
-        assert result is not None
+        assert result.path is not None
         pr_dir = issue_dir / "pr"
         user_input_file = pr_dir / "iteration_001" / "user_input.md"
         assert user_input_file.exists()

--- a/tests/unit/test_workflow_runtime.py
+++ b/tests/unit/test_workflow_runtime.py
@@ -815,3 +815,101 @@ def test_runtime_emits_expected_runtime_labels_per_path(tmp_path: Path) -> None:
     assert single_started[-1].data["runtime"] == "single_step"
     assert single_completed[-1].data["runtime"] == "single_step"
     assert single_done[-1].data["runtime"] == "single_step"
+
+
+def test_runtime_chains_pr_need_changes_through_develop_to_review(tmp_path: Path) -> None:
+    """PR (NEEDS_CHANGES) → develop → review with baton updates (issue-225 plan Test 4.2)."""
+    issue_dir = tmp_path / ".cafe" / "issues" / "e2e-chain-225"
+    issue_dir.mkdir(parents=True)
+    (issue_dir / "blackboard.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "current_step": "pr",
+                "owner": "agent",
+                "playbook_id": "default",
+                "artifacts": {},
+                "events": [],
+                "decisions": [],
+                "handoff_summary": "",
+            }
+        ),
+        encoding="utf-8",
+    )
+    _write_baton(issue_dir, from_step="pr", to_owner="agent", to_step="pr", intent="await_agent")
+
+    playbook = {
+        "playbook": {"id": "default"},
+        "steps": {
+            "pr": {"skill": "spec_first", "role": "developer", "assignee_type": "agent", "on": {}},
+            "develop": {
+                "skill": "develop",
+                "role": "developer",
+                "assignee_type": "agent",
+                "valid_status_codes": ["CAFE_CONFIRMED"],
+                "on": {"CAFE_CONFIRMED": "review"},
+            },
+            "review": {
+                "skill": "review",
+                "role": "reviewer",
+                "assignee_type": "agent",
+                "valid_status_codes": ["CAFE_CONFIRMED"],
+                "on": {"CAFE_CONFIRMED": "_done"},
+            },
+        },
+    }
+
+    calls: list[str] = []
+
+    def executor(step_name: str, step_def: dict, state: object) -> StepExecutionResult:
+        calls.append(step_name)
+        store = BlackboardStore(issue_dir)
+        if step_name == "pr":
+            store.update_handoff_contract(
+                state,
+                from_step="pr",
+                to_owner=HandoffOwner.AGENT,
+                to_step="develop",
+                intent=HandoffIntent.AWAIT_AGENT,
+                status_code="CAFE_NEEDS_CHANGES",
+                source="test",
+            )
+            return StepExecutionResult(response="todos", artifacts={}, status_code="CAFE_NEEDS_CHANGES")
+        if step_name == "develop":
+            store.update_handoff_contract(
+                state,
+                from_step="develop",
+                to_owner=HandoffOwner.AGENT,
+                to_step="review",
+                intent=HandoffIntent.AWAIT_AGENT,
+                status_code="CAFE_CONFIRMED",
+                source="test",
+            )
+            return StepExecutionResult(response="done", artifacts={}, status_code="CAFE_CONFIRMED")
+        if step_name == "review":
+            store.update_handoff_contract(
+                state,
+                from_step="review",
+                to_owner=HandoffOwner.USER,
+                to_step="user",
+                intent=HandoffIntent.MANUAL_HANDOFF,
+                status_code="CAFE_CONFIRMED",
+                source="test",
+            )
+            return StepExecutionResult(response="lgtm", artifacts={}, status_code="CAFE_CONFIRMED")
+        raise AssertionError(f"unexpected step {step_name}")
+
+    runtime = BlackboardWorkflowRuntime(
+        issue_dir=issue_dir,
+        playbook=playbook,
+        executor=executor,
+    )
+    result = runtime.run(start_step="pr", max_transitions=15)
+
+    assert calls == ["pr", "develop", "review"]
+    assert result.completed is False
+    blackboard = BlackboardStore(issue_dir).load_or_create("pr")
+    assert blackboard.current_step == "user"
+    transitions = [e for e in blackboard.events if e.event_type == "transition"]
+    assert any(e.data.get("to") == "develop" for e in transitions)
+    assert any(e.data.get("to") == "review" for e in transitions)

--- a/tests/unit/test_workflow_runtime.py
+++ b/tests/unit/test_workflow_runtime.py
@@ -591,6 +591,7 @@ def test_runtime_records_status_code_invalid_event(tmp_path: Path) -> None:
 
 def test_runtime_records_status_code_missing_event(tmp_path: Path) -> None:
     issue_dir = tmp_path / ".cafe" / "issues" / "missing-status"
+    issue_dir.mkdir(parents=True, exist_ok=True)
     playbook = {
         "playbook": {"id": "default"},
         "steps": {
@@ -604,6 +605,17 @@ def test_runtime_records_status_code_missing_event(tmp_path: Path) -> None:
     }
 
     def executor(step_name: str, step_def: dict, state: object):
+        # Simulate what a real step executor does: write a handoff
+        # contract pointing to "user" with confirm_output intent.
+        store = BlackboardStore(issue_dir)
+        store.update_handoff_contract(
+            state,
+            from_step="spec",
+            to_owner=HandoffOwner.USER,
+            to_step="user",
+            intent=HandoffIntent.CONFIRM_OUTPUT,
+            source="test.executor",
+        )
         return ("plain response without status token", {})
 
     runtime = BlackboardWorkflowRuntime(
@@ -613,12 +625,57 @@ def test_runtime_records_status_code_missing_event(tmp_path: Path) -> None:
     )
     result = runtime.run(start_step="spec")
 
+    # The baton-first fallback resolves the next step from the handoff
+    # contract.  When the contract points to "user" (confirm_output),
+    # the runtime pauses for user input — this is the correct baton
+    # outcome, not a stall.
     assert result.completed is False
     assert result.final_status_code == "NO_STATUS_CODE"
     blackboard = BlackboardStore(issue_dir).load_or_create("spec")
     missing_events = [e for e in blackboard.events if e.event_type == "status_code_missing"]
     assert missing_events
-    assert missing_events[-1].data["runtime"] == "legacy_until_boundary"
+    latest = missing_events[-1].data
+    assert latest["runtime"] == "legacy_until_boundary"
+    assert latest["baton_fallback"] is True
+    assert latest["fallback_next_step"] == "user"
+    # Verify the blackboard was advanced to "user"
+    assert blackboard.current_step == "user"
+
+
+def test_runtime_status_code_missing_no_handoff_contract(tmp_path: Path) -> None:
+    """When the agent omits a status code and no handoff contract exists, the runtime still pauses."""
+    issue_dir = tmp_path / ".cafe" / "issues" / "missing-no-handoff"
+    playbook = {
+        "playbook": {"id": "default"},
+        "steps": {
+            "spec": {
+                "skill": "spec_first",
+                "role": "pm",
+                "valid_status_codes": ["CAFE_NEED_CLARIFICATION"],
+                "on": {"CAFE_NEED_CLARIFICATION": "spec"},
+            },
+        },
+    }
+
+    def executor(step_name: str, step_def: dict, state: object):
+        # No handoff contract written — agent produced nothing useful.
+        return ("plain response without status token", {})
+
+    runtime = BlackboardWorkflowRuntime(
+        issue_dir=issue_dir,
+        playbook=playbook,
+        executor=executor,
+    )
+    result = runtime.run(start_step="spec")
+
+    # No handoff contract → baton fallback not possible → still pauses
+    assert result.completed is False
+    assert result.final_status_code == "NO_STATUS_CODE"
+    blackboard = BlackboardStore(issue_dir).load_or_create("spec")
+    missing_events = [e for e in blackboard.events if e.event_type == "status_code_missing"]
+    assert missing_events
+    # No baton_fallback key when fallback was not possible
+    assert "baton_fallback" not in missing_events[-1].data
 
 
 def test_runtime_pauses_ready_for_review_with_confirm_output_intent(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Implements [issue #225](https://github.com/luyotw/cafe/issues/225): resilient **GitHub PR feedback → develop → review** behavior in the generic workflow (external resume with unpushed commits, **`CAFE_NEEDS_CHANGES`** baton alignment, GitHub comment fetch failures as hard errors), adds regression tests, introduces **baton-first runtime fallback** and **`--auto-advance`** for the workflow CLI, and closes **PR review P0/P1** (missing **`allowed_steps`** on **`load_handoff_contract`** in the auto-advance path; **`align_pr_baton_after_execution`** unreachable for the **`pr`** step because of the **`require_status_code`** guard).

## Changes

### `211651efdd366b9d605f824616c7fc2f794b925c` — issue225: harden PR external resume, NEEDS_CHANGES baton, comment fetch failures

- External resume: unresolved PR threads can still wake **`pr`** when there are unpushed commits; GitHub helper errors surface clearly.
- **`align_pr_baton_after_execution`**: when status is **`CAFE_NEEDS_CHANGES`** but the baton still targets **`pr`**, advance toward **`develop`** with a short **`handoff_summary`**.
- Legacy **`pr_phase`**: comment persist outcome distinguishes success / empty / error; fetch failures fail the phase instead of looking like “no comments”.
- **`workflow`**: external resume sets an explicit **`handoff_summary`**.

### `7eb9ae771307da87ec110cd86152c724438a964a` — issue225: add tests for PR resume guard and workflow chain

- **`test_find_external_resume_step_returns_none_when_no_github_pr`**: no remote PR → no resume, no **`get_all_pr_comments`** call.
- **`test_runtime_chains_pr_need_changes_through_develop_to_review`**: **`BlackboardWorkflowRuntime`** **`pr` → `develop` → `review`** with transition assertions.

### `263af8f713c9d256179b289d9643be963e5cb551` — issue225: add baton-first runtime fallback and --auto-advance CLI flag

- Workflow runtime / CLI: baton-first behavior and **`--auto-advance`** (see commit message and diff for scope).

### `312fd5e47067b62c05f8f6e110ccd664f67bc06c` — issue225: fix PR baton alignment path and auto-advance handoff load

- **`workflow.py`**: pass **`allowed_steps`** into **`load_handoff_contract`** in the **`--auto-advance`** path (fixes **P0** **`TypeError`**).
- **`generic_workflow_step.py`**: run **`align_pr_baton_after_execution`** whenever **`status_code` is not `None`** so the **`pr`** step applies baton alignment on **`CAFE_NEEDS_CHANGES`** (fixes **P1** stall).
- **`test_generic_workflow_step_pr_aligns_baton_when_execute_returns_needs_changes`**: integration coverage for **P1**.

## Test Plan

```bash
uv run pytest tests/unit/test_pr_baton_alignment.py tests/unit/test_cli_workflow_command.py tests/unit/test_workflow_runtime.py::test_runtime_chains_pr_need_changes_through_develop_to_review tests/unit/test_generic_workflow_step.py::test_generic_workflow_step_pr_aligns_baton_when_execute_returns_needs_changes -q
```

Host-side **`publish_output`** will run **`scripts/sync_pr.sh --output`** for this file after the workflow records **`CAFE_CONFIRMED`**; no remote verification in this phase.