### PR TITLE
Issue 226: Centralize workflow rules in shared skills

### DIFF
--- a/src/cafe/data/skills/develop/SKILL.md
+++ b/src/cafe/data/skills/develop/SKILL.md
@@ -19,23 +19,7 @@ Read your agent file: {agent_file}
 - 每輪完成後更新 checklist
 - 維持既有 commit 風格與程式碼註解語言
 - 優先重用現有模式與工具
-- Runtime prompt 會提供 shared workflow blackboard 路徑與 next-step baton 路徑。
-- blackboard `current_step` 代表目前 workflow 接下來要去哪個 phase；必要時可以把它設成 built-in phase `user`。
-- 如果 reviewer 的要求合理，直接修正並用正常流程完成，不要多做 handoff。
-- 如果你認為 reviewer 的要求不合理，先把技術理由寫進本輪 `output.md`，再把同樣的爭議摘要追加到 blackboard `events`。
-- 第一次對 reviewer 提出異議時：
-  - 把 blackboard `current_step` 改成 `review`
-  - 寫入 next-step baton，內容只放 `review`
-- develop/review 對同一個爭議最多往返 3 輪。
-- 如果 blackboard 已經顯示同一個 review feedback 已經往返到第 3 輪，且 reviewer 仍未接受，就不要再把 baton 寫回 `review`。
-- 遇到重複爭議時，改成請 user 仲裁：
-  - 在 `questions.xml` 清楚列出雙方分歧與需要 user 決定的點
-  - 在 blackboard 記錄「developer requests user arbitration」
-  - 把 blackboard `current_step` 改成 `user`
-  - 寫入 next-step baton，內容只放 `user`
-- 如果這輪開發工作已經真的完成，而且接下來應由 user 決定是否還要繼續，允許把 blackboard `current_step` 改成 `user`，並在 blackboard summary/event 說明目前已完成、等待 user 決策。
-- 如果這輪開發工作已經完成且應進入 review，把 next-step baton 寫成 `review`。
-- 不要讓同一個 reviewer/developer 爭議在沒有新資訊的情況下無限往返。
+- 與 reviewer 往返、blackboard/baton 更新、以及 user 仲裁等跨 phase 規則：請依 shared skill「workflow-common」的 **Develop and review disagreement protocol** 與 **Shared Rules**；本 skill 不重複敘述。
 
 ## Handoff
 - 依照本輪結果更新 blackboard 與 next-step baton。

--- a/src/cafe/data/skills/plan/SKILL.md
+++ b/src/cafe/data/skills/plan/SKILL.md
@@ -24,17 +24,8 @@ bash scripts/sync_github.sh --help
 - 依規格拆解實作步驟，先列測試，再列實作
 - 嚴格遵守 TDD，避免直接寫程式碼
 - 延續既有計畫格式與使用者需求
-- 計畫草稿完成後，把 blackboard `current_step` 改成 `user`，並在 next-step baton 寫入 `user`，讓 workflow 先交給 user 確認；不要直接交給 `develop`
-- 只有在 user 已確認計畫可接受時，才可以把 next-step baton 寫成 `develop`
-- 如果這輪要交給 `develop`，先依照 issue 設定判斷是否需要同步，若需要就先執行：
-  ```bash
-  bash scripts/sync_github.sh --phase plan --output {output_file}
-  ```
-  - Script 會輸出 JSON 到 stdout（`action=commented|skipped`）
-  - 同步執行完再把 next-step baton 寫成 `develop`
-- 若計畫仍需要 user 決定或補充資訊：
-  - 把 blackboard `current_step` 改成 `user`
-  - 寫入 next-step baton，內容只放 `user`
+- User 確認暫停、交給 `develop` 前是否執行 GitHub sync、以及 baton 順序：請依 shared skill「workflow-common」的 **Confirming spec and plan with the user**、**Where policies live**，並搭配 `github_sync` skill 的腳本說明；本 skill 不重複敘述。
+- 計畫草稿需 user 確認時：把 next-step baton 寫入 `user`，不要直接交給 `develop`（其餘細節以 workflow-common 為準）。
 
 ## Output
 Write plan to: {output_file}

--- a/src/cafe/data/skills/pr/SKILL.md
+++ b/src/cafe/data/skills/pr/SKILL.md
@@ -28,9 +28,9 @@ In workflow mode, do not run this script directly from the agent. The CAFE
 host-side `GitHubPRCreator` publish hook runs it after the PR artifact is ready,
 so GitHub/network access happens outside the agent sandbox.
 
-Important ordering: the host-side publish hook cannot run until this agent
-finishes the local PR artifact and returns the workflow status. Do not wait for,
-verify, or require a remote GitHub branch/PR before returning the status code.
+When the generic runtime includes a handoff block for the PR step, it repeats
+local-first completion and publish ordering; treat that text as authoritative
+alongside this skill.
 
 ## Instructions
 

--- a/src/cafe/data/skills/review/SKILL.md
+++ b/src/cafe/data/skills/review/SKILL.md
@@ -19,20 +19,7 @@ Read your agent file: {agent_file}
 - 優先指出行為回歸、缺少測試與高風險問題
 - 若需修改，把 next-step baton 寫成 `develop`
 - 通過時，把 next-step baton 寫成下一個 workflow step（預設 playbook 為 `pr`）
-- Runtime prompt 會提供 shared workflow blackboard 路徑與 next-step baton 路徑。
-- blackboard `current_step` 代表目前 workflow 接下來要去哪個 phase；必要時可以把它設成 built-in phase `user`。
-- 如果 developer 在最新一輪明確提出「review feedback 不成立」的技術理由，你必須先讀完 develop `output.md` 與 blackboard 中的爭議摘要，再決定是否接受。
-- 如果 developer 的理由成立，直接接受並用正常流程確認，不要為了維持立場而重複退回。
-- 如果你仍然不同意，但這是第一次針對同一個爭議重審，可以把 baton 寫回 `develop`。
-- developer/reviewer 對同一個爭議最多往返 3 輪。
-- 如果 blackboard 已經顯示同一個爭議在 review/develop 間已經到第 3 輪，且現在仍然無法收斂，就不要再把它退回 develop。
-- 遇到重複爭議時，改成請 user 仲裁：
-  - 在 `questions.xml` 清楚整理 reviewer 與 developer 的分歧
-  - 在 blackboard 記錄「reviewer requests user arbitration」
-  - 把 blackboard `current_step` 改成 `user`
-  - 寫入 next-step baton，內容只放 `user`
-- 如果 review 已經完成，而接下來應由 user 決定是否還要繼續流程，也可以把 blackboard `current_step` 改成 `user`。
-- 不要讓 review 與 develop 因為同一個未收斂意見無限循環。
+- 與 developer 往返、仲裁、以及 blackboard/baton 更新：請依 shared skill「workflow-common」的 **Develop and review disagreement protocol** 與 **Shared Rules**；本 skill 不重複敘述。
 
 ## Output
 Write review result to: {output_file}

--- a/src/cafe/data/skills/spec_first/SKILL.md
+++ b/src/cafe/data/skills/spec_first/SKILL.md
@@ -23,15 +23,12 @@ bash scripts/sync_github.sh --help
 ## Instructions
 - 閱讀需求與既有輸出
 - 整理規格內容並寫入輸出檔
-- 第一次把 spec 草稿整理完成後，把 blackboard `current_step` 改成 `user`，並在 next-step baton 寫入 `user`，讓 workflow 先交給 user 確認；不要直接交給 `plan`
-- 只有在 workflow 已經帶著 user 的確認結果回來時，才可以把 next-step baton 寫成 `plan`
-- 如果這輪要交給 `plan`，先依照 issue 設定判斷是否需要同步，若需要就先執行：
-  ```bash
-  bash scripts/sync_github.sh --phase spec --output {output_file}
-  ```
-  - Script 會輸出 JSON 到 stdout（`action=commented|skipped`）
-  - 同步執行完再把 next-step baton 寫成 `plan`
-- 若資訊不足，輸出 questions.xml 並把 next-step baton 寫成 `user`
-- 遇到需要 user 回答的情況時：
-  - 把 blackboard `current_step` 改成 `user`
-  - 寫入 next-step baton，內容只放 `user`
+- User 確認暫停、交給 `plan` 前是否執行 GitHub sync、以及 baton 順序：請依 shared skill「workflow-common」的 **Confirming spec and plan with the user**、**Where policies live**，並搭配 `github_sync` skill；本 skill 不重複敘述。
+- 第一次草稿需 user 確認時：把 blackboard `current_step` 改成 `user`，並把 next-step baton 寫入 `user`，不要直接交給 `plan`（其餘細節以 workflow-common 為準）。
+- 若資訊不足，輸出 `questions.xml` 並依 workflow-common 暫停給 `user`。
+
+## Output
+Write spec to: {output_file}
+
+## Handoff
+- 依照本輪結果更新 blackboard 與 next-step baton。

--- a/src/cafe/data/skills/spec_revise/SKILL.md
+++ b/src/cafe/data/skills/spec_revise/SKILL.md
@@ -23,18 +23,9 @@ bash scripts/sync_github.sh --help
 ## Instructions
 - 讀取上一版 spec 輸出與使用者回饋
 - 修訂內容並寫回指定輸出檔
-- 如果這輪修訂後還需要 user 再確認內容，把 blackboard `current_step` 改成 `user`，並在 next-step baton 寫入 `user`；不要直接交給 `plan`
-- 只有在 user 已經確認規格可接受時，才可以把 next-step baton 寫成 `plan`
-- 如果這輪要交給 `plan`，先依照 issue 設定判斷是否需要同步，若需要就先執行：
-  ```bash
-  bash scripts/sync_github.sh --phase spec --output {output_file}
-  ```
-  - Script 會輸出 JSON 到 stdout（`action=commented|skipped`）
-  - 同步執行完再把 next-step baton 寫成 `plan`
-- 若仍缺資訊，輸出 questions.xml 並把 next-step baton 寫成 `user`
-- 遇到需要 user 回答的情況時：
-  - 把 blackboard `current_step` 改成 `user`
-  - 寫入 next-step baton，內容只放 `user`
+- User 確認暫停、交給 `plan` 前是否執行 GitHub sync、以及 baton 順序：請依 shared skill「workflow-common」的 **Confirming spec and plan with the user**、**Where policies live**，並搭配 `github_sync` skill；本 skill 不重複敘述。
+- 若仍需 user 再看一輪：把 next-step baton 寫入 `user`，不要直接交給 `plan`（其餘細節以 workflow-common 為準）。
+- 若仍缺資訊，輸出 `questions.xml` 並依 workflow-common 暫停給 `user`。
 
 ## Output
 Write spec to: {output_file}

--- a/src/cafe/data/skills/workflow-common/SKILL.md
+++ b/src/cafe/data/skills/workflow-common/SKILL.md
@@ -54,7 +54,7 @@ Follow these in addition to **Shared Rules** whenever you are in **develop** or 
 - The runtime prompt includes concrete paths to the blackboard and `next_step` baton; read them before changing workflow state.
 - `blackboard.current_step` is the workflow pointer; you may set it to the built-in `user` phase when pausing for a human.
 - **Reasonable feedback:** if the other role’s request is technically sound, implement or accept it without extra handoff drama.
-- **Disagreement:** if you reject the other role’s position, write technical reasoning in this iteration’s `output.md` and append a short dispute summary to blackboard `events`.
+- **Disagreement:** if you reject the other role’s position, first read their full `output.md` and the dispute summary in blackboard `events` before deciding; then write technical reasoning in this iteration’s `output.md` and append a short dispute summary to blackboard `events`.
 - **First pushback from develop:** set blackboard `current_step` to `review` and write the baton target `review`.
 - **Round limit:** the same disagreement may go back and forth at most **three** times between develop and review. If the blackboard already shows three rounds without convergence, do **not** send the baton to the other engineering step again.
 - **User arbitration:** if you still disagree after the limit (or the issue is product-level), capture both sides in `questions.xml`, record whether the developer or reviewer requested arbitration in blackboard `events`, set `current_step` to `user`, and write the baton target `user`.

--- a/src/cafe/data/skills/workflow-common/SKILL.md
+++ b/src/cafe/data/skills/workflow-common/SKILL.md
@@ -32,3 +32,31 @@ version: 1.0.0
 - Do not re-explain the shared workflow model in every phase artifact.
 - Do not invent a new handoff format outside blackboard and the baton file.
 - Do not skip the blackboard read just because the phase prompt also includes artifact paths.
+
+## Where policies live (canonical index)
+
+| Concern | Canonical location |
+| --- | --- |
+| Blackboard-first read, baton hygiene, `user` / `done` | This skill (**First Steps**, **Shared Rules**) |
+| Spec/plan GitHub issue sync (`scripts/sync_github.sh`) | `github_sync` skill (script contract and stdout JSON) |
+| PR: local artifact vs remote publish ordering | Generic runtime prompt repeats PR-only lines on purpose; `pr` skill covers PR modes and title/body structure |
+| develop ↔ review disagreements and user arbitration | This skill (**Develop and review disagreement protocol**) |
+
+## Confirming spec and plan with the user
+
+- When a **spec** or **plan** draft needs human approval before the next playbook step, pause for the user: align blackboard `current_step` and the baton with `user` per **Shared Rules**. Do not jump straight to `plan` or `develop` while the user still owes a decision.
+- After the user has confirmed and you are advancing to the next step, optionally sync the approved artifact to GitHub **when your issue/playbook enables it**: run `scripts/sync_github.sh` with the correct `--phase` and `--output`, consume the JSON on stdout, then move the baton. Command details stay in the `github_sync` skill so phase skills stay short.
+
+## Develop and review disagreement protocol
+
+Follow these in addition to **Shared Rules** whenever you are in **develop** or **review**.
+
+- The runtime prompt includes concrete paths to the blackboard and `next_step` baton; read them before changing workflow state.
+- `blackboard.current_step` is the workflow pointer; you may set it to the built-in `user` phase when pausing for a human.
+- **Reasonable feedback:** if the other role’s request is technically sound, implement or accept it without extra handoff drama.
+- **Disagreement:** if you reject the other role’s position, write technical reasoning in this iteration’s `output.md` and append a short dispute summary to blackboard `events`.
+- **First pushback from develop:** set blackboard `current_step` to `review` and write the baton target `review`.
+- **Round limit:** the same disagreement may go back and forth at most **three** times between develop and review. If the blackboard already shows three rounds without convergence, do **not** send the baton to the other engineering step again.
+- **User arbitration:** if you still disagree after the limit (or the issue is product-level), capture both sides in `questions.xml`, record whether the developer or reviewer requested arbitration in blackboard `events`, set `current_step` to `user`, and write the baton target `user`.
+- **Normal completion:** when develop work is done and review should run next, set the baton to `review`. When review approves the default playbook path, set the baton to `pr` unless your playbook says otherwise.
+- Avoid infinite loops on the same unresolved point without new information.

--- a/tests/unit/test_cli_phase_commands.py
+++ b/tests/unit/test_cli_phase_commands.py
@@ -1,5 +1,7 @@
 """Tests for CLI phase commands passing phase_name to setup."""
 
+from pathlib import Path
+
 import pytest
 from unittest.mock import patch, MagicMock, ANY
 from typer.testing import CliRunner
@@ -9,11 +11,17 @@ runner = CliRunner()
 
 @pytest.fixture
 def mock_dependencies():
+    def _fake_latest_versioned_file(phase_name: str, issue_name: str) -> Path:
+        return Path(f".cafe/issues/{issue_name}/{phase_name}/iteration_001/output.md")
+
     with patch("cafe.ui.cli.ConfigManager") as mock_config_manager, \
          patch("cafe.ui.cli._execute_single_step_alias") as mock_execute_alias, \
          patch("cafe.ui.cli._setup_agents") as mock_setup_agents, \
          patch("cafe.ui.cli.GitOperations") as mock_git_ops, \
-         patch("cafe.ui.cli._get_latest_versioned_file") as mock_get_latest_file, \
+         patch(
+             "cafe.ui.commands.phases_legacy._get_latest_versioned_file",
+             side_effect=_fake_latest_versioned_file,
+         ) as mock_get_latest_file, \
          patch("cafe.ui.cli.is_branch_initialized", return_value=True):
         
         # Setup common mocks
@@ -29,7 +37,6 @@ def mock_dependencies():
         mock_agent_manager.get_agent.return_value = mock_agent_executor
         mock_setup_agents.return_value = mock_agent_manager
         
-        mock_get_latest_file.return_value = "some/file/path"
         mock_execute_alias.return_value = {"status_code": "CAFE_CONFIRMED", "iterations": 1}
         
         yield {

--- a/tests/unit/test_generic_phase.py
+++ b/tests/unit/test_generic_phase.py
@@ -90,6 +90,105 @@ def test_build_prompt_uses_baton_wording_when_status_code_not_required(tmp_path:
     assert "Do NOT return a status code" not in prompt
 
 
+def test_build_prompt_omits_questions_line_when_questions_file_not_passed(tmp_path: Path) -> None:
+    phase = GenericPhase(_setup_loader(tmp_path))
+    prompt = phase.build_prompt(
+        skill_name="plan",
+        skill_invocation="/plan",
+        shared_skill_invocations=["/workflow-common"],
+        context={
+            "blackboard_path": ".cafe/issues/demo/blackboard.json",
+            "next_step_path": ".cafe/issues/demo/next_step.txt",
+        },
+        output_file=Path("out.md"),
+        checklist_file=Path("checklist.md"),
+        questions_xml_file=None,
+    )
+    assert "questions_file=" not in prompt
+
+
+def test_build_prompt_includes_user_input_when_set(tmp_path: Path) -> None:
+    phase = GenericPhase(_setup_loader(tmp_path))
+    prompt = phase.build_prompt(
+        skill_name="plan",
+        skill_invocation="/plan",
+        shared_skill_invocations=["/workflow-common"],
+        context={
+            "blackboard_path": ".cafe/issues/demo/blackboard.json",
+            "next_step_path": ".cafe/issues/demo/next_step.txt",
+            "user_input": "Please prioritize the auth module.",
+        },
+        output_file=Path("out.md"),
+        checklist_file=Path("checklist.md"),
+    )
+    assert "Current user input for this iteration:" in prompt
+    assert "Please prioritize the auth module." in prompt
+
+
+def test_build_prompt_pr_phase_appends_publish_ordering_when_handoff_present(tmp_path: Path) -> None:
+    phase = GenericPhase(_setup_loader(tmp_path))
+    prompt = phase.build_prompt(
+        skill_name="pr",
+        skill_invocation="/pr",
+        shared_skill_invocations=["/workflow-common", "/github_sync"],
+        context={
+            "blackboard_path": ".cafe/issues/demo/blackboard.json",
+            "handoff_summary": "Finish local PR artifact.",
+            "next_step_path": ".cafe/issues/demo/next_step.txt",
+        },
+        output_file=Path("pr.md"),
+        checklist_file=Path("checklist.md"),
+    )
+    assert "For the PR phase, completion is local-only" in prompt
+    assert "host-side publish_output hook" in prompt
+
+
+def assert_runtime_handoff_guardrails_persist(prompt: str) -> None:
+    """When ``handoff_summary`` is injected, these lines must stay in the runtime prompt.
+
+    They intentionally overlap the spirit of ``workflow-common`` (read real state first)
+    but remain concrete execution checks for the agent. Removing them should fail this
+    test and force a coordinated update with the packaged ``workflow-common`` skill.
+    """
+
+    assert "Latest workflow handoff from blackboard:" in prompt
+    assert "Treat this handoff as the highest-priority current request" in prompt
+    assert "verify whether the requested state change has actually happened" in prompt
+    assert "do not treat an old artifact or a closed external object as completion" in prompt
+
+
+def test_build_prompt_contract_covers_shared_skills_files_context_and_gate(tmp_path: Path) -> None:
+    phase = GenericPhase(_setup_loader(tmp_path))
+    prompt = phase.build_prompt(
+        skill_name="develop",
+        skill_invocation="/develop",
+        shared_skill_invocations=["/workflow-common", "/github_sync"],
+        context={
+            "blackboard_path": ".cafe/issues/demo/blackboard.json",
+            "next_step_path": ".cafe/issues/demo/next_step.txt",
+            "user_input": "iteration notes",
+            "handoff_summary": "Continue milestone B cleanup.",
+        },
+        output_file=Path("develop/out.md"),
+        checklist_file=Path("develop/checklist.md"),
+        questions_xml_file=Path("develop/questions.xml"),
+    )
+    assert prompt.startswith("Shared skills:")
+    assert "/workflow-common" in prompt
+    assert "/github_sync" in prompt
+    assert "Phase skill: /develop" in prompt
+    for line in (
+        "output_file=develop/out.md",
+        "checklist_file=develop/checklist.md",
+        "questions_file=develop/questions.xml",
+        "blackboard_file=.cafe/issues/demo/blackboard.json",
+        "next_step_file=.cafe/issues/demo/next_step.txt",
+    ):
+        assert line in prompt
+    assert "Do NOT return a status code until ALL checklist items are marked as [x]." in prompt
+    assert_runtime_handoff_guardrails_persist(prompt)
+
+
 def test_parse_response_extracts_status_and_goto(tmp_path: Path) -> None:
     phase = GenericPhase(_setup_loader(tmp_path))
     status, goto_target = phase.parse_response(


### PR DESCRIPTION
## Summary

Closes the milestone **B** cleanup for **issue #226** (reduce generic workflow runtime prompt surface by moving repeatable discipline into `workflow-common` and trimming packaged phase skills). One commit on `issue-226` ahead of `develop`; review iteration 001 approved with no blocking follow-ups.

## Changes

- **`workflow-common`**: add a canonical policy index, **Confirming spec and plan with the user** (pause + optional GitHub sync ordering), and **Develop and review disagreement protocol** so develop/review/spec/plan handoff rules live in one place (`src/cafe/data/skills/workflow-common/SKILL.md`).
- **Phase skills**: shorten `develop`, `review`, `plan`, `spec_first`, `spec_revise`, and adjust `pr` to defer duplicate PR publish-order text to the runtime prompt (`src/cafe/data/skills/*/SKILL.md`).
- **Tests**: extend `tests/unit/test_generic_phase.py` with contract tests for runtime files, optional `questions_file` / `user_input`, PR-phase handoff extras, and handoff guardrail phrases; fix `tests/unit/test_cli_phase_commands.py` to patch `phases_legacy._get_latest_versioned_file` so legacy `cafe plan` / `develop` / `review` / `pr` tests see synthetic iteration paths.

### Commits

- `cbbf9b1` — issue226: centralize workflow skills and harden generic prompt tests

## Test Plan

- [x] `pytest tests/unit/test_generic_phase.py tests/unit/test_spec_skill_contract.py tests/unit/test_cli_phase_commands.py` (32 tests) — run during development
- [x] Pre-commit hook full fast suite (unit + selected integration) — passed at commit time for `cbbf9b1`