### PR TITLE
issue227: finish workflow compatibility cleanup

### DIFF
--- a/docs/plans/v02-plan.md
+++ b/docs/plans/v02-plan.md
@@ -1039,22 +1039,34 @@ Artifact 分工：
 - [x] 補齊 summary / timeline 對 baton-driven phases 的支援：phase `status.json` 缺席時，能從 iteration `context.json` + blackboard / baton 推導 phase 狀態，避免 `cafe summary` 失真
 - [x] 讓 workflow 主入口可直接承接初始需求：`cafe make --user-input ...` / `cafe workflow --execute --user-input ...` 能直接把需求送進第一個 `spec` step，不再需要先跑 `cafe spec`
 - [x] 統一人工編輯入口為 `cafe edit <phase>`，並將 `cafe spec edit` / `cafe plan edit` / `cafe review edit` 收斂為 legacy wrapper
-- [ ] 繼續縮小 `GenericWorkflowStepExecutor` 的責任邊界，移除剩餘的 status-code persistence 與 `context.json` / `status.json` 依賴，讓 step executor 只負責 iteration 執行與 artifact 產出
-- [ ] 清掉 generic workflow prompt / context 組裝裡殘留的 status-code 語意，避免新 runtime 仍被舊 completion model 反向污染
+- [x] 繼續縮小 `GenericWorkflowStepExecutor` 的責任邊界，移除剩餘的 status-code persistence 與 `context.json` / `status.json` 依賴，讓 step executor 只負責 iteration 執行與 artifact 產出
+- [x] 清掉 generic workflow prompt / context 組裝裡殘留的 status-code 語意，避免新 runtime 仍被舊 completion model 反向污染
 - [x] 把 `cafe spec`、`cafe plan`、`cafe develop`、`cafe review`、`cafe pr` 收斂成 `BlackboardWorkflowRuntime` 的 thin wrapper，不再維持各自獨立的 status-code-driven UX
 - [x] 將 `spec/plan/develop/review/pr/dev` 從 `cafe --help` 主命令清單隱藏，並把 wrapper / runtime 內部的使用者提示全面導回 `cafe make`
 - [x] 將純文字 `next_step.txt` 相容解析限制在 chat / CLI handoff 邊界；workflow runtime 與 PR baton alignment 預設只接受結構化 baton contract
-- [ ] 盤點並移除 CLI / workflow entry / resume / debug 路徑上剩餘的 legacy 狀態來源，確保 pause、resume、complete 的判定都只信 blackboard 與 baton
-- [ ] 決定 legacy phase alias 的最終退場形式：保留一段過渡期後直接刪除，或保留極薄兼容層但完全退出主要文件與互動流程
-- [ ] 將 `core/phase.py` 與 legacy `spec_phase.py`、`plan_phase.py`、`develop_phase.py`、`review_phase.py`、`pr_phase.py` 逐步隔離出 workflow 核心路徑，最後只保留過渡用途或直接刪除
+- [x] 盤點並移除 CLI / workflow entry / resume / debug 路徑上剩餘的 legacy 狀態來源，確保 pause、resume、complete 的判定都只信 blackboard 與 baton
+- [x] 決定 legacy phase alias 的最終退場形式：保留一段過渡期後直接刪除，或保留極薄兼容層但完全退出主要文件與互動流程
+- [x] 將 `core/phase.py` 與 legacy `spec_phase.py`、`plan_phase.py`、`develop_phase.py`、`review_phase.py`、`pr_phase.py` 逐步隔離出 workflow 核心路徑，最後只保留過渡用途或直接刪除
 - [x] 讓 `PlaybookRunner` 退出 active workflow path，只保留必要的過渡層與測試依賴；等新 runtime 接完主流程後再刪除
-- [ ] 當 default workflow 主路徑已完全切到 blackboard runtime 後，再集中做真實情境手測：`cafe make`、pause/resume、chat handoff、`cafe reset` 後續跑、`pr` publish / receipt
+- [x] 當 default workflow 主路徑已完全切到 blackboard runtime 後，再集中做真實情境手測：`cafe make`、pause/resume、chat handoff、`cafe reset` 後續跑、`pr` publish / receipt
 
 ### 保留的相容層
 
 - `next_step.txt` 的純文字 step name 格式只保留給 chat / CLI handoff 過渡使用，讀取時必須顯式傳入 `allow_legacy_text=True`。
 - Workflow runtime、baton validation、PR feedback alignment 只讀結構化 baton contract，避免 Milestone C 期間繼續把 legacy handoff shape 當成核心執行模型。
 - Hidden legacy phase commands (`cafe spec` / `plan` / `develop` / `review` / `pr`) 暫時保留為 thin wrapper，使用者導引與主要入口都指向 `cafe make` / `cafe workflow`。
+- Generic workflow step 仍會接受現有 skill 回傳的 `CAFE_*` 結果，但只在 step executor 邊界轉成結構化 baton contract（`workflow.status_transition_adapter`）。`BlackboardWorkflowRuntime` 先消費 baton，再把 status parser 留給 mock / legacy executor 測試與過渡 wrapper。
+- `core/phase.py` 在 generic workflow path 僅保留 iteration 目錄、session、token、checklist retry 等執行輔助；它不再是 workflow transition owner。Legacy `*_phase.py` class 僅供隱藏 phase alias 與過渡測試使用。
+- `context.json` 保留作 iteration debug / summary input；`status.json` 不再由 generic workflow step 寫入，也不是 workflow pause、resume、complete 的權威來源。
+
+### #227 smoke / verification
+
+- Targeted runtime tests: `uv run --with pytest pytest tests/unit/test_generic_phase.py tests/unit/test_generic_workflow_step.py tests/unit/test_workflow_runtime.py`
+- CLI / integration coverage: `uv run --with pytest pytest tests/unit/test_cli_workflow_command.py tests/integration/test_workflow_e2e.py`
+- Full suite: `uv run --with pytest pytest` (`1899 passed, 5 skipped, 1 xfailed`)
+- Temp repo smoke: `cafe workflow --issue issue227-smoke --dry-run --user-input "issue 227 smoke test"` 跑完 `spec -> plan -> develop -> review -> pr -> done`，PR 以 `BATON_WORKFLOW_COMPLETE` 完成。
+- `cafe make` 由 `tests/unit/test_cli_make.py` 覆蓋入口轉接與 `--user-input`；此命令沒有 dry-run option，未在 smoke 中啟動真實 agent。
+- `cafe reset pr` 在 dry-run smoke issue 上沒有 versioned iteration 可 reset；reset 對 real iteration 的行為由 `tests/unit/test_reset_command.py` 覆蓋，未在本 cleanup 引入新的 reset state source。
 
 ## v0.2 預留但不完整實作的入口
 

--- a/docs/plans/v02-plan.md
+++ b/docs/plans/v02-plan.md
@@ -1043,11 +1043,18 @@ Artifact 分工：
 - [ ] 清掉 generic workflow prompt / context 組裝裡殘留的 status-code 語意，避免新 runtime 仍被舊 completion model 反向污染
 - [x] 把 `cafe spec`、`cafe plan`、`cafe develop`、`cafe review`、`cafe pr` 收斂成 `BlackboardWorkflowRuntime` 的 thin wrapper，不再維持各自獨立的 status-code-driven UX
 - [x] 將 `spec/plan/develop/review/pr/dev` 從 `cafe --help` 主命令清單隱藏，並把 wrapper / runtime 內部的使用者提示全面導回 `cafe make`
+- [x] 將純文字 `next_step.txt` 相容解析限制在 chat / CLI handoff 邊界；workflow runtime 與 PR baton alignment 預設只接受結構化 baton contract
 - [ ] 盤點並移除 CLI / workflow entry / resume / debug 路徑上剩餘的 legacy 狀態來源，確保 pause、resume、complete 的判定都只信 blackboard 與 baton
 - [ ] 決定 legacy phase alias 的最終退場形式：保留一段過渡期後直接刪除，或保留極薄兼容層但完全退出主要文件與互動流程
 - [ ] 將 `core/phase.py` 與 legacy `spec_phase.py`、`plan_phase.py`、`develop_phase.py`、`review_phase.py`、`pr_phase.py` 逐步隔離出 workflow 核心路徑，最後只保留過渡用途或直接刪除
 - [x] 讓 `PlaybookRunner` 退出 active workflow path，只保留必要的過渡層與測試依賴；等新 runtime 接完主流程後再刪除
 - [ ] 當 default workflow 主路徑已完全切到 blackboard runtime 後，再集中做真實情境手測：`cafe make`、pause/resume、chat handoff、`cafe reset` 後續跑、`pr` publish / receipt
+
+### 保留的相容層
+
+- `next_step.txt` 的純文字 step name 格式只保留給 chat / CLI handoff 過渡使用，讀取時必須顯式傳入 `allow_legacy_text=True`。
+- Workflow runtime、baton validation、PR feedback alignment 只讀結構化 baton contract，避免 Milestone C 期間繼續把 legacy handoff shape 當成核心執行模型。
+- Hidden legacy phase commands (`cafe spec` / `plan` / `develop` / `review` / `pr`) 暫時保留為 thin wrapper，使用者導引與主要入口都指向 `cafe make` / `cafe workflow`。
 
 ## v0.2 預留但不完整實作的入口
 

--- a/src/cafe/core/blackboard.py
+++ b/src/cafe/core/blackboard.py
@@ -308,19 +308,25 @@ class BlackboardStore:
         self.file_path = issue_dir / BLACKBOARD_FILENAME
         self.next_step_path = issue_dir / NEXT_STEP_FILENAME
 
-    def load_or_create(self, initial_step: str, playbook_id: str = "default") -> BlackboardState:
+    def load_or_create(
+        self,
+        initial_step: str,
+        playbook_id: str = "default",
+        *,
+        allow_legacy_text: bool = False,
+    ) -> BlackboardState:
         if self.file_path.exists():
             raw = json.loads(self.file_path.read_text(encoding="utf-8"))
             state = BlackboardState.from_dict(raw, initial_step=initial_step)
             if not getattr(state, "playbook_id", None):
                 state.playbook_id = playbook_id
                 self.save(state)
-            self.ensure_baton(state)
+            self.ensure_baton(state, allow_legacy_text=allow_legacy_text)
             return state
 
         state = BlackboardState(current_step=initial_step, playbook_id=playbook_id)
         self.save(state)
-        self.ensure_baton(state)
+        self.ensure_baton(state, allow_legacy_text=allow_legacy_text)
         return state
 
     def save(self, state: BlackboardState) -> None:
@@ -331,10 +337,19 @@ class BlackboardStore:
             encoding="utf-8",
         )
 
-    def ensure_baton(self, state: BlackboardState) -> HandoffContract:
+    def ensure_baton(
+        self,
+        state: BlackboardState,
+        *,
+        allow_legacy_text: bool = False,
+    ) -> HandoffContract:
         """Ensure a persistent baton file exists for this issue."""
         if self.next_step_path.exists():
-            contract = self.load_handoff_contract(state, allowed_steps=[])
+            contract = self.load_handoff_contract(
+                state,
+                allowed_steps=[],
+                allow_legacy_text=allow_legacy_text,
+            )
             state.handoff_contract = contract
             self.save(state)
             return contract
@@ -361,9 +376,15 @@ class BlackboardStore:
         state: BlackboardState,
         *,
         allowed_steps: List[str],
-        allow_legacy_text: bool = True,
+        allow_legacy_text: bool = False,
     ) -> HandoffContract:
-        """Load and parse baton contract from next_step.txt."""
+        """Load and parse a structured baton contract from next_step.txt.
+
+        Plain step-name batons are a compatibility format used only at
+        chat/CLI handoff boundaries. Core workflow execution should keep the
+        default strict so deprecated handoff shapes do not leak back into the
+        runtime path.
+        """
         if not self.next_step_path.exists():
             raise ValueError(f"Baton file is missing: {self.next_step_path}")
 

--- a/src/cafe/core/workflow_runtime.py
+++ b/src/cafe/core/workflow_runtime.py
@@ -94,7 +94,6 @@ class BlackboardWorkflowRuntime:
         contract = self.blackboard_store.load_handoff_contract(
             self.blackboard,
             allowed_steps=list(self.steps.keys()),
-            allow_legacy_text=True,
         )
         if contract.to_owner != HandoffOwner.AGENT:
             raise RuntimeError(
@@ -175,7 +174,6 @@ class BlackboardWorkflowRuntime:
             contract = self.blackboard_store.load_handoff_contract(
                 self.blackboard,
                 allowed_steps=list(self.steps.keys()),
-                allow_legacy_text=True,
             )
         except Exception:
             return None
@@ -207,7 +205,6 @@ class BlackboardWorkflowRuntime:
         contract = self.blackboard_store.load_handoff_contract(
             self.blackboard,
             allowed_steps=list(self.steps.keys()),
-            allow_legacy_text=True,
         )
         if contract.to_owner == HandoffOwner.AGENT and contract.to_step == current_step:
             explicit_status_code = getattr(execution_result, "status_code", None)
@@ -220,7 +217,6 @@ class BlackboardWorkflowRuntime:
         contract = self.blackboard_store.load_handoff_contract(
             self.blackboard,
             allowed_steps=list(self.steps.keys()),
-            allow_legacy_text=True,
         )
         if contract.from_step != current_step:
             return None
@@ -587,7 +583,6 @@ class BlackboardWorkflowRuntime:
             contract = self.blackboard_store.load_handoff_contract(
                 self.blackboard,
                 allowed_steps=list(self.steps.keys()),
-                allow_legacy_text=True,
             )
             next_step = contract.to_step
 

--- a/src/cafe/core/workflow_runtime.py
+++ b/src/cafe/core/workflow_runtime.py
@@ -725,6 +725,47 @@ class BlackboardWorkflowRuntime:
                 visit_count=visit_count,
                 validate_assignee_type=True,
             )
+            self._store_artifacts(frame.artifacts)
+
+            post_contract = self._load_step_handoff_contract(current_step=current_step)
+            if post_contract is not None and not (
+                post_contract.to_owner == HandoffOwner.AGENT and post_contract.to_step == current_step
+            ):
+                status_code = (
+                    post_contract.status_code
+                    or frame.explicit_status_code
+                    or f"BATON_{post_contract.intent.value.upper()}"
+                )
+                last_status_code = status_code
+                self._record_step_completion(
+                    event_type=completion_event_type,
+                    current_step=current_step,
+                    status_code=status_code,
+                    runtime=runtime_label,
+                    visit_count=visit_count,
+                    hop_count=hop_count,
+                )
+                post_contract_result = self._handle_post_contract(
+                    current_step=current_step,
+                    status_code=status_code,
+                    runtime=runtime_label,
+                    update_contract_on_transition=False,
+                )
+                if post_contract_result is not None:
+                    status_code = post_contract_result.status_code
+                    last_status_code = status_code
+                    if post_contract_result.terminal_result is not None:
+                        return post_contract_result.terminal_result
+                    if post_contract_result.next_step is not None:
+                        if single_step_mode:
+                            return PlaybookRunResult(
+                                final_step=current_step,
+                                final_status_code=status_code,
+                                completed=False,
+                            )
+                        current_step = post_contract_result.next_step
+                        continue
+
             status_code_obj, goto_target, valid_codes = self._parse_legacy_status(
                 step_def=step_def,
                 response=frame.response,
@@ -835,7 +876,6 @@ class BlackboardWorkflowRuntime:
                 status_code = status_code_obj.value
                 last_status_code = status_code
 
-            self._store_artifacts(frame.artifacts)
             self._record_step_completion(
                 event_type=completion_event_type,
                 current_step=current_step,
@@ -857,6 +897,12 @@ class BlackboardWorkflowRuntime:
                 if post_contract_result.terminal_result is not None:
                     return post_contract_result.terminal_result
                 if post_contract_result.next_step is not None:
+                    if single_step_mode:
+                        return PlaybookRunResult(
+                            final_step=current_step,
+                            final_status_code=status_code,
+                            completed=False,
+                        )
                     current_step = post_contract_result.next_step
                     continue
 

--- a/src/cafe/data/skills/pr/SKILL.md
+++ b/src/cafe/data/skills/pr/SKILL.md
@@ -52,7 +52,7 @@ alongside this skill.
 5. 完成本地 PR artifact 與 checklist 後，依照本輪結果更新 blackboard 與 next-step baton
 6. CAFE host-side hook 會執行 `scripts/sync_pr.sh --output {output_file}`，依 `issue.yaml` 的 `base_branch` 自動加上 `--base`
 7. Hook 會把 PR URL 作為 `pr_synced` event 回傳，CLI 會印出 PR URL
-8. 若目前 runtime 仍透過 phase-level status code 完成遷移，才回傳 `CAFE_CONFIRMED`
+8. 完成本地 artifact 後，把 next-step baton 寫成 `done`；不要用 response text status code 代表 workflow completion
 
 ### Gotchas
 - Script 的 progress/error 輸出在 stderr，JSON result 在 stdout

--- a/src/cafe/phases/generic_phase.py
+++ b/src/cafe/phases/generic_phase.py
@@ -69,7 +69,6 @@ class GenericPhase:
         output_file: Optional[Path] = None,
         checklist_file: Optional[Path] = None,
         questions_xml_file: Optional[Path] = None,
-        require_status_code: bool = True,
     ) -> str:
         lines = []
         runtime_files: list[str] = []
@@ -179,7 +178,6 @@ class GenericPhase:
         questions_xml_file: Optional[Path] = None,
         hook_context: Optional[Dict[str, Any]] = None,
         max_retries: int = 3,
-        require_status_code: bool = True,
     ) -> GenericPhaseExecution:
         runtime_context = dict(context or {})
         events: List[Dict[str, Any]] = []
@@ -241,7 +239,6 @@ class GenericPhase:
                 output_file=output_file,
                 checklist_file=checklist_file,
                 questions_xml_file=questions_xml_file,
-                require_status_code=require_status_code,
             )
             response = agent_executor(prompt)
 

--- a/src/cafe/phases/generic_phase.py
+++ b/src/cafe/phases/generic_phase.py
@@ -103,17 +103,12 @@ class GenericPhase:
             lines.append("")
 
         if context and context.get("handoff_summary"):
-            verification_instruction = (
-                "Before returning a status code, verify whether the requested state change has actually happened in files or external state relevant to this phase."
-                if require_status_code
-                else "Before finishing this step, verify whether the requested state change has actually happened in files or external state relevant to this phase."
-            )
             runtime_context.extend(
                 [
                     "Latest workflow handoff from blackboard:",
                     context["handoff_summary"],
                     "Treat this handoff as the highest-priority current request unless current files prove it is already completed.",
-                    verification_instruction,
+                    "Before finishing this step, verify whether the requested state change has actually happened in files or external state relevant to this phase.",
                     "If the handoff asks for a retry, re-run, re-sync, or re-open action, do not treat an old artifact or a closed external object as completion.",
                 ]
             )
@@ -134,10 +129,7 @@ class GenericPhase:
             lines.append("")
 
         if checklist_file is not None:
-            if require_status_code:
-                lines.append("Do NOT return a status code until ALL checklist items are marked as [x].")
-            else:
-                lines.append("Do NOT finish this step until ALL checklist items are marked as [x].")
+            lines.append("Do NOT finish this step until ALL checklist items are marked as [x].")
 
         return "\n".join(lines).strip()
 

--- a/src/cafe/phases/generic_workflow_step.py
+++ b/src/cafe/phases/generic_workflow_step.py
@@ -54,7 +54,6 @@ def align_pr_baton_after_execution(
     contract = store.load_handoff_contract(
         blackboard_state,
         allowed_steps=allowed,
-        allow_legacy_text=True,
     )
     if contract.to_owner != HandoffOwner.AGENT or contract.to_step != "pr":
         return

--- a/src/cafe/phases/generic_workflow_step.py
+++ b/src/cafe/phases/generic_workflow_step.py
@@ -287,6 +287,14 @@ class GenericWorkflowStepExecutor(Phase):
                 )
 
         if status_code is not None:
+            self._write_status_transition_handoff(
+                blackboard_state=blackboard_state,
+                step_name=step_name,
+                step_def=step_def,
+                response=response,
+                status_code=status_code,
+                auto_continue=auto_continue,
+            )
             align_pr_baton_after_execution(
                 issue_dir=self.issue_dir,
                 playbook=self.playbook,
@@ -638,6 +646,111 @@ class GenericWorkflowStepExecutor(Phase):
         if status_code == PhaseStatusCode.NEED_PERMISSION:
             return "need_permission"
         return None
+
+    def _write_status_transition_handoff(
+        self,
+        *,
+        blackboard_state: BlackboardState,
+        step_name: str,
+        step_def: Dict[str, Any],
+        response: str,
+        status_code: PhaseStatusCode,
+        auto_continue: bool,
+    ) -> None:
+        """Write the structured baton for status-based step contracts.
+
+        Status codes are still accepted as the step-level result language for
+        existing skills, but the workflow runtime should consume the baton
+        written here instead of re-deriving transitions from agent text.
+        """
+        if step_name == "pr":
+            return
+
+        store = BlackboardStore(self.issue_dir)
+        if not auto_continue and status_code.value in {
+            PhaseStatusCode.READY_FOR_REVIEW.value,
+            PhaseStatusCode.NEED_CLARIFICATION.value,
+            PhaseStatusCode.NEED_PERMISSION.value,
+        }:
+            raw_intent = self._resolve_handoff_intent(step_name, status_code) or "manual_handoff"
+            store.update_handoff_contract(
+                blackboard_state,
+                from_step=step_name,
+                to_owner=HandoffOwner.USER,
+                to_step="user",
+                intent=HandoffIntent(raw_intent),
+                status_code=status_code.value,
+                source="workflow.status_transition_adapter",
+            )
+            return
+
+        next_step = self._resolve_next_step_for_status(
+            step_name=step_name,
+            step_def=step_def,
+            response=response,
+            status_code=status_code,
+        )
+        if next_step is None:
+            return
+
+        if next_step in {"done", "_done"}:
+            store.update_handoff_contract(
+                blackboard_state,
+                from_step=step_name,
+                to_owner=HandoffOwner.DONE,
+                to_step="done",
+                intent=HandoffIntent.WORKFLOW_COMPLETE,
+                status_code=status_code.value,
+                source="workflow.status_transition_adapter",
+            )
+            return
+
+        if next_step == "user":
+            store.update_handoff_contract(
+                blackboard_state,
+                from_step=step_name,
+                to_owner=HandoffOwner.USER,
+                to_step="user",
+                intent=HandoffIntent.MANUAL_HANDOFF,
+                status_code=status_code.value,
+                source="workflow.status_transition_adapter",
+            )
+            return
+
+        if next_step not in self.playbook.get("steps", {}):
+            return
+
+        store.update_handoff_contract(
+            blackboard_state,
+            from_step=step_name,
+            to_owner=HandoffOwner.AGENT,
+            to_step=next_step,
+            intent=HandoffIntent.AWAIT_AGENT,
+            status_code=status_code.value,
+            source="workflow.status_transition_adapter",
+        )
+
+    def _resolve_next_step_for_status(
+        self,
+        *,
+        step_name: str,
+        step_def: Dict[str, Any],
+        response: str,
+        status_code: PhaseStatusCode,
+    ) -> Optional[str]:
+        goto_target = self.generic_phase.extract_goto_target(response)
+        if goto_target:
+            allowed_targets = {str(target) for target in step_def.get("allowed_goto", [])}
+            if goto_target in allowed_targets:
+                return goto_target
+
+        transitions = step_def.get("on", {})
+        if not isinstance(transitions, dict):
+            return None
+        target = transitions.get(status_code.value)
+        if target is None:
+            target = transitions.get("default")
+        return str(target) if target else None
 
     def _artifact_path(self, blackboard_state: BlackboardState, name: str) -> Optional[str]:
         entry = blackboard_state.artifacts.get(name)

--- a/src/cafe/phases/generic_workflow_step.py
+++ b/src/cafe/phases/generic_workflow_step.py
@@ -217,7 +217,6 @@ class GenericWorkflowStepExecutor(Phase):
                 "publish_request_file": publish_request_file if step_name == "pr" else None,
                 "blackboard_state": blackboard_state,
             },
-            require_status_code=require_status_code,
         )
 
         response = execution.response

--- a/src/cafe/ui/chat.py
+++ b/src/cafe/ui/chat.py
@@ -60,7 +60,7 @@ def get_chat_next_step_path(issue_dir: Path) -> Path:
 
 
 def _load_chat_workflow_context(issue_dir: Path) -> tuple[str, list[str], str]:
-    blackboard = BlackboardStore(issue_dir).load_or_create("spec")
+    blackboard = BlackboardStore(issue_dir).load_or_create("spec", allow_legacy_text=True)
     playbook_id = getattr(blackboard, "playbook_id", "default") or "default"
     current_step = blackboard.current_step
 
@@ -77,7 +77,7 @@ def _prepare_chat_handoff_state(issue_dir: Path) -> tuple[str, list[str], str]:
     current_step, valid_steps, playbook_id = _load_chat_workflow_context(issue_dir)
     issue_dir.mkdir(parents=True, exist_ok=True)
     store = BlackboardStore(issue_dir)
-    blackboard = store.load_or_create(current_step)
+    blackboard = store.load_or_create(current_step, allow_legacy_text=True)
     if current_step == "done":
         store.update_handoff_contract(
             blackboard,
@@ -261,7 +261,7 @@ def launch_chat_session(role: str, issue_name: str) -> int:
         return _handle_chat_launch_failure(agent_cli, result)
 
     store = BlackboardStore(issue_dir)
-    blackboard = store.load_or_create(_current_step)
+    blackboard = store.load_or_create(_current_step, allow_legacy_text=True)
     contract = store.load_handoff_contract(
         blackboard,
         allowed_steps=_valid_steps,

--- a/src/cafe/ui/cli_shared.py
+++ b/src/cafe/ui/cli_shared.py
@@ -460,6 +460,7 @@ def _consume_pending_chat_handoff(
     blackboard = store.load_or_create(
         str(playbook_data.get("entry_point") or next(iter(playbook_data["steps"].keys()))),
         playbook_id=str(playbook_data["playbook"]["id"]),
+        allow_legacy_text=True,
     )
     contract = store.load_handoff_contract(
         blackboard,
@@ -805,6 +806,7 @@ def _execute_single_step_alias(
     blackboard = BlackboardStore(issue_dir).load_or_create(
         str(playbook_data.get("entry_point") or next(iter(playbook_data["steps"].keys()))),
         playbook_id=str(playbook_data["playbook"]["id"]),
+        allow_legacy_text=True,
     )
     store = BlackboardStore(issue_dir)
     store.set_current_step(blackboard, step_name)
@@ -841,6 +843,7 @@ def _execute_single_step_alias(
     latest_blackboard = store.load_or_create(
         str(playbook_data.get("entry_point") or next(iter(playbook_data["steps"].keys()))),
         playbook_id=str(playbook_data["playbook"]["id"]),
+        allow_legacy_text=True,
     )
     handoff = store.load_handoff_contract(
         latest_blackboard,

--- a/src/cafe/ui/commands/workflow.py
+++ b/src/cafe/ui/commands/workflow.py
@@ -483,6 +483,7 @@ def workflow(
             blackboard = BlackboardStore(issue_dir).load_or_create(
                 str(playbook_data.get("entry_point") or next(iter(playbook_data["steps"].keys()))),
                 playbook_id=str(playbook_data["playbook"]["id"]),
+                allow_legacy_text=True,
             )
 
             active_step = pending_start_step or blackboard.current_step

--- a/tests/unit/test_generic_phase.py
+++ b/tests/unit/test_generic_phase.py
@@ -60,7 +60,8 @@ def test_build_prompt_includes_files_and_checklist_guard(tmp_path: Path) -> None
     assert "blackboard_file=.cafe/issues/demo/blackboard.json" in prompt
     assert "next_step_file=.cafe/issues/demo/next_step.txt" in prompt
     assert "Runtime context:" in prompt
-    assert "Do NOT return a status code until ALL checklist items are marked as [x]." in prompt
+    assert "Do NOT finish this step until ALL checklist items are marked as [x]." in prompt
+    assert "Do NOT return a status code" not in prompt
     assert "Latest workflow handoff from blackboard:" in prompt
     assert "Implement cafe skill rm" in prompt
     assert "verify whether the requested state change has actually happened" in prompt
@@ -185,7 +186,8 @@ def test_build_prompt_contract_covers_shared_skills_files_context_and_gate(tmp_p
         "next_step_file=.cafe/issues/demo/next_step.txt",
     ):
         assert line in prompt
-    assert "Do NOT return a status code until ALL checklist items are marked as [x]." in prompt
+    assert "Do NOT finish this step until ALL checklist items are marked as [x]." in prompt
+    assert "Do NOT return a status code" not in prompt
     assert_runtime_handoff_guardrails_persist(prompt)
 
 

--- a/tests/unit/test_generic_phase.py
+++ b/tests/unit/test_generic_phase.py
@@ -82,7 +82,6 @@ def test_build_prompt_uses_baton_wording_when_status_code_not_required(tmp_path:
         },
         output_file=Path("out.md"),
         checklist_file=Path("checklist.md"),
-        require_status_code=False,
     )
 
     assert "Before finishing this step" in prompt

--- a/tests/unit/test_generic_workflow_step.py
+++ b/tests/unit/test_generic_workflow_step.py
@@ -155,6 +155,52 @@ def test_generic_workflow_step_executor_writes_iteration_files(tmp_path: Path, m
     assert (iteration_dir / "artifact.json").exists()
     status_file = issue_dir / "spec" / "status.json"
     assert not status_file.exists()
+    reloaded = BlackboardStore(issue_dir).load_or_create("spec")
+    assert reloaded.handoff_contract is not None
+    assert reloaded.handoff_contract.to_owner == HandoffOwner.DONE
+    assert reloaded.handoff_contract.to_step == "done"
+    assert reloaded.handoff_contract.intent == HandoffIntent.WORKFLOW_COMPLETE
+    assert reloaded.handoff_contract.status_code == "CAFE_CONFIRMED"
+    assert reloaded.handoff_contract.source == "workflow.status_transition_adapter"
+
+
+def test_generic_workflow_step_writes_review_pause_contract(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    issue_dir = tmp_path / ".cafe" / "issues" / "issue-review-pause"
+    playbook = {
+        "playbook": {"id": "default"},
+        "roles": {"pm": {"default_agent": "Roger"}},
+        "steps": {
+            "spec": {
+                "skill": {"1": "spec_first", "default": "spec_first"},
+                "role": "pm",
+                "output_artifact": "spec",
+                "allowed_tools": ["Read"],
+                "valid_status_codes": ["CAFE_READY_FOR_REVIEW", "CAFE_CONFIRMED"],
+                "on": {"CAFE_READY_FOR_REVIEW": "spec", "CAFE_CONFIRMED": "_done"},
+            }
+        },
+    }
+    state = BlackboardStore(issue_dir).load_or_create("spec")
+    executor = GenericWorkflowStepExecutor(
+        issue_dir=issue_dir,
+        issue_name="issue-review-pause",
+        playbook=playbook,
+        generic_phase=_build_loader(tmp_path),
+        agent_manager=FakeAgentManager("CAFE_READY_FOR_REVIEW"),
+        git_ops=FakeGitOperations(),
+        role_agent_map={"pm": "Roger"},
+    )
+
+    result = executor.execute_step("spec", playbook["steps"]["spec"], state)
+
+    assert result.status_code == "CAFE_READY_FOR_REVIEW"
+    reloaded = BlackboardStore(issue_dir).load_or_create("spec")
+    assert reloaded.handoff_contract is not None
+    assert reloaded.handoff_contract.to_owner == HandoffOwner.USER
+    assert reloaded.handoff_contract.to_step == "user"
+    assert reloaded.handoff_contract.intent == HandoffIntent.CONFIRM_OUTPUT
+    assert reloaded.handoff_contract.source == "workflow.status_transition_adapter"
 
 
 def test_generic_workflow_step_does_not_retry_for_legacy_status_tokens(tmp_path: Path, monkeypatch) -> None:

--- a/tests/unit/test_workflow_runtime.py
+++ b/tests/unit/test_workflow_runtime.py
@@ -632,8 +632,8 @@ def test_runtime_records_status_code_invalid_event(tmp_path: Path) -> None:
     assert latest["runtime"] == "legacy_until_boundary"
 
 
-def test_runtime_records_status_code_missing_event(tmp_path: Path) -> None:
-    issue_dir = tmp_path / ".cafe" / "issues" / "missing-status"
+def test_runtime_prefers_step_baton_over_missing_status_text(tmp_path: Path) -> None:
+    issue_dir = tmp_path / ".cafe" / "issues" / "missing-status-with-baton"
     issue_dir.mkdir(parents=True, exist_ok=True)
     playbook = {
         "playbook": {"id": "default"},
@@ -668,21 +668,66 @@ def test_runtime_records_status_code_missing_event(tmp_path: Path) -> None:
     )
     result = runtime.run(start_step="spec")
 
-    # The baton-first fallback resolves the next step from the handoff
-    # contract.  When the contract points to "user" (confirm_output),
-    # the runtime pauses for user input — this is the correct baton
-    # outcome, not a stall.
     assert result.completed is False
-    assert result.final_status_code == "NO_STATUS_CODE"
+    assert result.final_status_code == "BATON_CONFIRM_OUTPUT"
     blackboard = BlackboardStore(issue_dir).load_or_create("spec")
     missing_events = [e for e in blackboard.events if e.event_type == "status_code_missing"]
-    assert missing_events
-    latest = missing_events[-1].data
-    assert latest["runtime"] == "legacy_until_boundary"
-    assert latest["baton_fallback"] is True
-    assert latest["fallback_next_step"] == "user"
-    # Verify the blackboard was advanced to "user"
+    assert missing_events == []
     assert blackboard.current_step == "user"
+    completed_events = [e for e in blackboard.events if e.event_type == "step_completed"]
+    assert completed_events[-1].data["status_code"] == "BATON_CONFIRM_OUTPUT"
+
+
+def test_runtime_prefers_step_baton_over_invalid_status_text(tmp_path: Path) -> None:
+    issue_dir = tmp_path / ".cafe" / "issues" / "invalid-status-with-baton"
+    issue_dir.mkdir(parents=True, exist_ok=True)
+    playbook = {
+        "playbook": {"id": "default"},
+        "steps": {
+            "spec": {
+                "skill": "spec_first",
+                "role": "pm",
+                "valid_status_codes": ["CAFE_CONFIRMED"],
+                "on": {"CAFE_CONFIRMED": "plan"},
+            },
+            "plan": {
+                "skill": "plan",
+                "role": "developer",
+                "valid_status_codes": ["CAFE_CONFIRMED"],
+                "on": {"CAFE_CONFIRMED": "_done"},
+            },
+        },
+    }
+
+    def executor(step_name: str, step_def: dict, state: object):
+        if step_name == "spec":
+            store = BlackboardStore(issue_dir)
+            store.update_handoff_contract(
+                state,
+                from_step="spec",
+                to_owner=HandoffOwner.AGENT,
+                to_step="plan",
+                intent=HandoffIntent.AWAIT_AGENT,
+                status_code="CAFE_CONFIRMED",
+                source="test.executor",
+            )
+            return ("CAFE_READY_FOR_REVIEW", {})
+        return ("CAFE_CONFIRMED", {})
+
+    runtime = BlackboardWorkflowRuntime(
+        issue_dir=issue_dir,
+        playbook=playbook,
+        executor=executor,
+    )
+    result = runtime.run(start_step="spec")
+
+    assert result.completed is True
+    assert result.final_step == "plan"
+    blackboard = BlackboardStore(issue_dir).load_or_create("spec")
+    invalid_events = [e for e in blackboard.events if e.event_type == "status_code_invalid"]
+    assert invalid_events == []
+    transitions = [e for e in blackboard.events if e.event_type == "transition"]
+    assert transitions[0].data["source"] == "baton"
 
 
 def test_runtime_status_code_missing_no_handoff_contract(tmp_path: Path) -> None:

--- a/tests/unit/test_workflow_runtime.py
+++ b/tests/unit/test_workflow_runtime.py
@@ -3,6 +3,8 @@
 import json
 from pathlib import Path
 
+import pytest
+
 from cafe.core.blackboard import BlackboardStore, HandoffIntent, HandoffOwner
 from cafe.core.workflow_models import StepExecutionResult
 from cafe.core.workflow_runtime import BlackboardWorkflowRuntime
@@ -109,6 +111,47 @@ def test_runtime_delegates_non_pr_steps_to_legacy_runner(tmp_path: Path) -> None
     assert result.completed is True
     assert result.final_step == "spec"
     assert result.final_status_code == "CAFE_CONFIRMED"
+
+
+def test_runtime_rejects_legacy_text_baton_in_core_path(tmp_path: Path) -> None:
+    issue_dir = tmp_path / ".cafe" / "issues" / "strict-baton"
+    issue_dir.mkdir(parents=True)
+    (issue_dir / "blackboard.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "playbook_id": "default",
+                "current_step": "spec",
+                "artifacts": {},
+                "events": [],
+                "decisions": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (issue_dir / "next_step.txt").write_text("spec\n", encoding="utf-8")
+    playbook = {
+        "playbook": {"id": "default"},
+        "steps": {
+            "spec": {
+                "skill": "spec_first",
+                "role": "pm",
+                "valid_status_codes": ["CAFE_CONFIRMED"],
+                "on": {"CAFE_CONFIRMED": "_done"},
+            },
+        },
+    }
+
+    def executor(step_name: str, step_def: dict, state: object):
+        return ("CAFE_CONFIRMED", {})
+
+    with pytest.raises(ValueError, match="Invalid baton contract payload"):
+        runtime = BlackboardWorkflowRuntime(
+            issue_dir=issue_dir,
+            playbook=playbook,
+            executor=executor,
+        )
+        runtime.run()
 
 
 def test_runtime_hands_off_to_pr_runtime_boundary(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Closes #227 by finishing the milestone B compatibility cleanup around workflow baton ownership.
- Makes generic workflow steps write structured baton contracts for status-based skill results, and makes the runtime consume those contracts before falling back to legacy status parsing.
- Removes remaining generic prompt and PR skill wording that told agents to drive workflow transitions with response text status codes.
- Documents the intentionally retained compatibility layers and the verification performed.

## Changes
- Restricted legacy text baton parsing to explicit chat/CLI boundaries.
- Converted generic non-PR step transitions into `workflow.status_transition_adapter` baton writes.
- Kept legacy status parsing only as a fallback for mocks/old wrappers when no transition baton is present.
- Updated #227 backlog documentation and retained-layer notes.

## Test Plan
- `uv run --with pytest pytest tests/unit/test_generic_phase.py tests/unit/test_generic_workflow_step.py tests/unit/test_workflow_runtime.py`
- `uv run --with pytest pytest tests/unit/test_cli_workflow_command.py tests/integration/test_workflow_e2e.py`
- `uv run --with pytest pytest`
- Pre-commit and pre-push hooks both passed.
- Temp repo smoke: `cafe workflow --issue issue227-smoke --dry-run --user-input "issue 227 smoke test"` completed spec -> plan -> develop -> review -> pr -> done with `BATON_WORKFLOW_COMPLETE`.
