### PR TITLE
Auto-trigger skill scripts via lifecycle hooks

### DIFF
--- a/docs/plans/v02-plan.md
+++ b/docs/plans/v02-plan.md
@@ -432,8 +432,11 @@ hooks:
 - `script` 必須是 skill `scripts/` 目錄下的相對路徑；禁止 absolute path、`..` traversal、或跳出 skill 目錄。
 - `args` 會轉為 CLI 參數（`--key value`），並支援 placeholder interpolation（如 `{output_file}`）。
 - `schema` 採最小 JSON-schema 子集：`type=object`、`required`、`properties`、`additionalProperties=false`、primitive type（string/boolean/integer/number）、`enum`。
+- `timeout_seconds`（可選）可設定 script subprocess timeout；逾時會中止 pipeline 並回報 `script_hook` timeout 事件。
 - `when_status_codes`（可選）只在 `after_execute` 使用，狀態不匹配時跳過執行。
-- script 以 sandbox 內 subprocess 執行；非 0 exit code 或 schema 驗證失敗會中止 pipeline，並回報可觀測事件。
+- script 只允許掛在 `before_execute` / `after_execute`；若在 `prepare_input` 或 `publish_output` 宣告 script dict，playbook 載入時即報錯。
+- script 以 sandbox 內 subprocess 執行；非 0 exit code、schema 驗證失敗、或 timeout 皆會中止 pipeline，並回報可觀測事件。
+- `schema` 驗證失敗與 script 非 0 / timeout 目前都映射為 `CAFE_NEED_PERMISSION`，表示需要 host/operator 介入處理。
 
 blackboard 事件 payload（`event_type=script_hook`）：
 - `type`, `step`, `skill`, `stage`, `script`, `status`

--- a/docs/plans/v02-plan.md
+++ b/docs/plans/v02-plan.md
@@ -404,6 +404,42 @@ before_execute → prepare_input → execute_agent → after_execute → publish
 
 **v0.2.x 擴展**：使用者可在 Skill 的 `scripts/` 定義 custom hook（shell script），透過 playbook 的 `hooks:` 欄位掛載。
 
+#### Script Hook Contract (v0.2.x)
+
+v0.2.x 支援在 `before_execute` / `after_execute` 直接宣告 script hook（與字串型 builtin hook 並存）：
+
+```yaml
+hooks:
+  after_execute:
+    - script: sync_github.sh
+      when_status_codes: [CAFE_CONFIRMED]
+      args:
+        phase: plan
+        output: "{output_file}"
+      schema:
+        type: object
+        required: [phase, output]
+        additionalProperties: false
+        properties:
+          phase:
+            type: string
+            enum: [spec, plan]
+          output:
+            type: string
+```
+
+執行規則：
+- `script` 必須是 skill `scripts/` 目錄下的相對路徑；禁止 absolute path、`..` traversal、或跳出 skill 目錄。
+- `args` 會轉為 CLI 參數（`--key value`），並支援 placeholder interpolation（如 `{output_file}`）。
+- `schema` 採最小 JSON-schema 子集：`type=object`、`required`、`properties`、`additionalProperties=false`、primitive type（string/boolean/integer/number）、`enum`。
+- `when_status_codes`（可選）只在 `after_execute` 使用，狀態不匹配時跳過執行。
+- script 以 sandbox 內 subprocess 執行；非 0 exit code 或 schema 驗證失敗會中止 pipeline，並回報可觀測事件。
+
+blackboard 事件 payload（`event_type=script_hook`）：
+- `type`, `step`, `skill`, `stage`, `script`, `status`
+- `exit_code`, `stdout`, `stderr`
+- `validation_errors`
+
 ### Hook Result Contract
 
 每個 hook 回傳統一的 `HookResult`，GenericPhase 根據結果決定後續行為：

--- a/src/cafe/core/hooks/native.py
+++ b/src/cafe/core/hooks/native.py
@@ -23,6 +23,7 @@ from cafe.utils.github import (
     format_comments_for_prompt,
     get_all_pr_comments,
     get_processed_comment_ids_from_history,
+    load_pr_last_seen_comment_ids,
 )
 
 
@@ -109,6 +110,37 @@ def _pr_publish_requested(
         and contract.to_owner == HandoffOwner.DONE
         and contract.to_step == "done"
         and contract.intent == HandoffIntent.WORKFLOW_COMPLETE
+    )
+
+
+def _extract_pr_comment_ids(comments: list[Any]) -> list[str]:
+    comment_ids: list[str] = []
+    for comment in comments:
+        raw_id = getattr(comment, "id", None)
+        if raw_id is None and isinstance(comment, dict):
+            raw_id = comment.get("id")
+        if raw_id is not None:
+            comment_ids.append(str(raw_id))
+    return comment_ids
+
+
+def _persist_pr_last_seen_comment_ids(pr_dir: Path, comment_ids: list[str]) -> None:
+    if not comment_ids:
+        return
+
+    seen_ids = load_pr_last_seen_comment_ids(pr_dir)
+    seen_ids.update(str(comment_id) for comment_id in comment_ids)
+
+    artifact_file = pr_dir / "artifacts" / "pr_last_seen_comments.json"
+    artifact_file.parent.mkdir(parents=True, exist_ok=True)
+    artifact_file.write_text(
+        json.dumps(
+            {"last_seen_comment_ids": sorted(seen_ids)},
+            ensure_ascii=False,
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
     )
 
 
@@ -578,8 +610,11 @@ class GitHubPRCreator(NoOpHook):
             return HookResult(context_updates=context_updates)
 
         try:
-            exclude_ids = get_processed_comment_ids_from_history(phase.phase_dir)
+            exclude_ids = load_pr_last_seen_comment_ids(phase.phase_dir)
+            if not exclude_ids:
+                exclude_ids = get_processed_comment_ids_from_history(phase.phase_dir)
             comments = get_all_pr_comments(int(existing_pr["number"]), exclude_ids=exclude_ids)
+            _persist_pr_last_seen_comment_ids(phase.phase_dir, _extract_pr_comment_ids(comments))
             unresolved_comments = filter_unresolved_comments(comments)
         except Exception:
             return HookResult(context_updates=context_updates)

--- a/src/cafe/core/hooks/native.py
+++ b/src/cafe/core/hooks/native.py
@@ -97,7 +97,10 @@ def _pr_publish_requested(
         return False
 
     try:
-        contract = HandoffContract.from_dict(json.loads(baton_file.read_text(encoding="utf-8")))
+        raw_baton = baton_file.read_text(encoding="utf-8").strip()
+        contract = HandoffContract.from_dict(json.loads(raw_baton))
+    except json.JSONDecodeError:
+        return raw_baton == "done"
     except Exception:
         return False
 

--- a/src/cafe/core/hooks/script_schema.py
+++ b/src/cafe/core/hooks/script_schema.py
@@ -1,0 +1,75 @@
+"""Minimal schema validation helpers for script hook arguments."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def validate_script_args_schema(
+    *,
+    args: dict[str, Any],
+    schema: dict[str, Any],
+) -> list[str]:
+    """Validate hook args using a minimal JSON-schema subset."""
+    errors: list[str] = []
+
+    schema_type = schema.get("type")
+    if schema_type != "object":
+        return ["schema.type must be 'object'"]
+
+    properties = schema.get("properties", {})
+    if properties is None:
+        properties = {}
+    if not isinstance(properties, dict):
+        return ["schema.properties must be an object"]
+
+    required = schema.get("required", [])
+    if required is None:
+        required = []
+    if not isinstance(required, list) or not all(isinstance(item, str) for item in required):
+        return ["schema.required must be a list of strings"]
+
+    for key in required:
+        if key not in args:
+            errors.append(f"missing required key '{key}'")
+
+    additional_properties = schema.get("additionalProperties", True)
+    if additional_properties is False:
+        unknown = sorted(set(args.keys()) - set(properties.keys()))
+        for key in unknown:
+            errors.append(f"unknown key '{key}' is not allowed")
+
+    for key, rule in properties.items():
+        if key not in args:
+            continue
+        if not isinstance(rule, dict):
+            errors.append(f"schema.properties.{key} must be an object")
+            continue
+
+        value = args[key]
+        expected_type = rule.get("type")
+        if expected_type and not _matches_type(value, expected_type):
+            errors.append(
+                f"key '{key}' expected type '{expected_type}' but got '{type(value).__name__}'"
+            )
+
+        enum_values = rule.get("enum")
+        if enum_values is not None:
+            if not isinstance(enum_values, list):
+                errors.append(f"schema.properties.{key}.enum must be a list")
+            elif value not in enum_values:
+                errors.append(f"key '{key}' must be one of {enum_values}")
+
+    return errors
+
+
+def _matches_type(value: Any, expected_type: str) -> bool:
+    if expected_type == "string":
+        return isinstance(value, str)
+    if expected_type == "boolean":
+        return isinstance(value, bool)
+    if expected_type == "integer":
+        return isinstance(value, int) and not isinstance(value, bool)
+    if expected_type == "number":
+        return (isinstance(value, int) and not isinstance(value, bool)) or isinstance(value, float)
+    return False

--- a/src/cafe/core/playbook.py
+++ b/src/cafe/core/playbook.py
@@ -14,6 +14,7 @@ from cafe.skills.loader import SkillLoader
 
 
 DONE_TARGET = "_done"
+SCRIPT_HOOK_STAGES = {"before_execute", "after_execute"}
 
 
 class PlaybookMeta(BaseModel):
@@ -185,6 +186,7 @@ def validate_playbook(
     for step_name, step in steps.items():
         _validate_step_role(step_name, step, model.roles)
         _validate_step_skills(step_name, step, skill_loader)
+        _validate_script_hook_stages(step_name, step.hooks)
         _validate_targets(step_name, step.allowed_goto, steps, "allowed_goto")
         _validate_transition_targets(step_name, step.on, steps)
         warnings.extend(_collect_tool_warnings(step_name, step.allowed_tools))
@@ -229,6 +231,23 @@ def _validate_step_skills(step_name: str, step: StepConfig, skill_loader: SkillL
             raise ValueError(
                 f"Step '{step_name}' references unknown skill '{skill_name}'"
             ) from exc
+
+
+def _validate_script_hook_stages(step_name: str, hooks: StepHooks) -> None:
+    stage_entries = {
+        "before_execute": hooks.before_execute,
+        "prepare_input": hooks.prepare_input,
+        "after_execute": hooks.after_execute,
+        "publish_output": hooks.publish_output,
+    }
+    for stage_name, entries in stage_entries.items():
+        if stage_name in SCRIPT_HOOK_STAGES:
+            continue
+        for entry in entries:
+            if isinstance(entry, dict) and "script" in entry:
+                raise ValueError(
+                    f"Step '{step_name}' has script hook in unsupported stage '{stage_name}'"
+                )
 
 
 def _validate_targets(

--- a/src/cafe/core/playbook.py
+++ b/src/cafe/core/playbook.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Literal, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
@@ -40,10 +40,10 @@ class StepHooks(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    before_execute: List[str] = Field(default_factory=list)
-    prepare_input: List[str] = Field(default_factory=list)
-    after_execute: List[str] = Field(default_factory=list)
-    publish_output: List[str] = Field(default_factory=list)
+    before_execute: List[Union[str, Dict[str, Any]]] = Field(default_factory=list)
+    prepare_input: List[Union[str, Dict[str, Any]]] = Field(default_factory=list)
+    after_execute: List[Union[str, Dict[str, Any]]] = Field(default_factory=list)
+    publish_output: List[Union[str, Dict[str, Any]]] = Field(default_factory=list)
 
 
 SkillSelector = Union[str, Dict[str, str]]

--- a/src/cafe/core/workflow_runtime.py
+++ b/src/cafe/core/workflow_runtime.py
@@ -186,6 +186,19 @@ class BlackboardWorkflowRuntime:
             return str(to_step)
         return None
 
+    def _load_agent_written_handoff_contract(self, *, current_step: str):
+        """Load and normalize a baton written by a just-finished agent step."""
+        contract = self.blackboard_store.load_handoff_contract(
+            self.blackboard,
+            allowed_steps=list(self.steps.keys()),
+            allow_legacy_text=True,
+        )
+        if contract.source == "legacy_text":
+            contract.from_step = current_step
+            contract.source = "workflow.legacy_baton_normalized"
+            self.blackboard_store.write_handoff_contract(self.blackboard, contract)
+        return contract
+
     def _pr_step_requires_publish_receipt(self, current_step: str) -> bool:
         if current_step != "pr":
             return False
@@ -202,22 +215,21 @@ class BlackboardWorkflowRuntime:
         return pr_cfg.get("auto_create", True) is not False
 
     def _status_from_contract(self, current_step: str, execution_result: Any) -> str:
-        contract = self.blackboard_store.load_handoff_contract(
-            self.blackboard,
-            allowed_steps=list(self.steps.keys()),
-        )
+        contract = self._load_agent_written_handoff_contract(current_step=current_step)
         if contract.to_owner == HandoffOwner.AGENT and contract.to_step == current_step:
             explicit_status_code = getattr(execution_result, "status_code", None)
             if explicit_status_code:
                 return str(explicit_status_code)
             return "NO_BATON_TRANSITION"
-        return contract.status_code or f"BATON_{contract.intent.value.upper()}"
+        explicit_status_code = getattr(execution_result, "status_code", None)
+        return (
+            contract.status_code
+            or str(explicit_status_code or "")
+            or f"BATON_{contract.intent.value.upper()}"
+        )
 
     def _load_step_handoff_contract(self, *, current_step: str):
-        contract = self.blackboard_store.load_handoff_contract(
-            self.blackboard,
-            allowed_steps=list(self.steps.keys()),
-        )
+        contract = self._load_agent_written_handoff_contract(current_step=current_step)
         if contract.from_step != current_step:
             return None
         return contract
@@ -580,10 +592,7 @@ class BlackboardWorkflowRuntime:
                 hop_count=hop_count,
             )
 
-            contract = self.blackboard_store.load_handoff_contract(
-                self.blackboard,
-                allowed_steps=list(self.steps.keys()),
-            )
+            contract = self._load_agent_written_handoff_contract(current_step=current_step)
             next_step = contract.to_step
 
             if contract.to_owner == HandoffOwner.AGENT and next_step == current_step:

--- a/src/cafe/data/playbooks/default.yaml
+++ b/src/cafe/data/playbooks/default.yaml
@@ -46,6 +46,22 @@ steps:
     allowed_tools: [Read, Grep, Glob, WebFetch, WebSearch]
     hooks:
       prepare_input: [UserInputCollector]
+      after_execute:
+        - script: sync_github.sh
+          when_status_codes: [CAFE_CONFIRMED]
+          args:
+            phase: plan
+            output: "{output_file}"
+          schema:
+            type: object
+            required: [phase, output]
+            additionalProperties: false
+            properties:
+              phase:
+                type: string
+                enum: [spec, plan]
+              output:
+                type: string
     "on":
       CAFE_READY_FOR_REVIEW: plan
       CAFE_NEED_CLARIFICATION: plan

--- a/src/cafe/phases/generic_phase.py
+++ b/src/cafe/phases/generic_phase.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import re
+import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from cafe.core.hooks import BUILTIN_HOOKS, HookResult
+from cafe.core.hooks.script_schema import validate_script_args_schema
 from cafe.core.questions_schema import validate_questions_xml
 from cafe.core.status_codes import PhaseStatusCode, StatusCodeParser
 from cafe.skills.loader import SkillLoader
@@ -35,6 +37,7 @@ class GenericPhase:
     """Build prompts from skill content and run lifecycle hooks."""
 
     GOTO_PATTERN = re.compile(r"CAFE_GOTO\s*:\s*([a-zA-Z0-9_-]+)")
+    SCRIPT_HOOK_STAGES = {"before_execute", "after_execute"}
 
     def __init__(
         self,
@@ -257,6 +260,16 @@ class GenericPhase:
             artifact_ready = artifact_ready and after.artifact_ready
             if after.override_status_code is not None:
                 status_code = after.override_status_code
+            if not after.continue_pipeline:
+                return GenericPhaseExecution(
+                    response=response,
+                    status_code=status_code,
+                    goto_target=goto_target,
+                    context_updates=runtime_context,
+                    events=events,
+                    artifact_ready=artifact_ready,
+                    published=False,
+                )
 
             if not after.retry_requested:
                 break
@@ -297,16 +310,30 @@ class GenericPhase:
         stage: str,
         **kwargs: Any,
     ) -> HookResult:
-        hook_names = kwargs["step_def"].get("hooks", {}).get(stage, [])
+        hook_entries = kwargs["step_def"].get("hooks", {}).get(stage, [])
         aggregate = HookResult()
 
-        for hook_name in hook_names:
-            hook_cls = self.hook_registry.get(str(hook_name))
-            if hook_cls is None:
-                raise ValueError(f"Unknown hook '{hook_name}' in stage '{stage}'")
+        for hook_entry in hook_entries:
+            result: HookResult
+            if isinstance(hook_entry, str):
+                hook_cls = self.hook_registry.get(str(hook_entry))
+                if hook_cls is None:
+                    raise ValueError(f"Unknown hook '{hook_entry}' in stage '{stage}'")
+                hook = hook_cls()
+                result = hook.run(stage=stage, **kwargs)
+            elif isinstance(hook_entry, dict):
+                result = self._run_script_hook(
+                    stage=stage,
+                    declaration=hook_entry,
+                    step_def=kwargs["step_def"],
+                    skill_name=str(kwargs.get("skill_name", "")),
+                    context=kwargs.get("context"),
+                    response=kwargs.get("response"),
+                    hook_kwargs=kwargs,
+                )
+            else:
+                raise ValueError(f"Unsupported hook entry type '{type(hook_entry).__name__}' in stage '{stage}'")
 
-            hook = hook_cls()
-            result = hook.run(stage=stage, **kwargs)
             aggregate.context_updates.update(result.context_updates)
             aggregate.events.extend(result.events)
             aggregate.artifact_ready = aggregate.artifact_ready and result.artifact_ready
@@ -318,3 +345,240 @@ class GenericPhase:
                 break
 
         return aggregate
+
+    def _run_script_hook(
+        self,
+        *,
+        stage: str,
+        declaration: Dict[str, Any],
+        step_def: Dict[str, Any],
+        skill_name: str,
+        context: Optional[Dict[str, str]],
+        response: Optional[str],
+        hook_kwargs: Dict[str, Any],
+    ) -> HookResult:
+        if stage not in self.SCRIPT_HOOK_STAGES:
+            raise ValueError(f"Script hooks are only supported in {sorted(self.SCRIPT_HOOK_STAGES)}")
+
+        script, args_template, schema, when_status_codes = self._parse_script_hook_declaration(declaration)
+
+        if when_status_codes:
+            detected_status = self._detect_status_code(response=response or "", step_def=step_def)
+            if detected_status not in when_status_codes:
+                return HookResult(
+                    events=[
+                        {
+                            "type": "script_hook",
+                            "step": str(hook_kwargs.get("step_name") or ""),
+                            "skill": skill_name,
+                            "stage": stage,
+                            "script": script,
+                            "status": "skipped",
+                            "reason": "status_mismatch",
+                            "detected_status": detected_status,
+                            "when_status_codes": when_status_codes,
+                        }
+                    ]
+                )
+
+        script_path = self._resolve_script_path(skill_name=skill_name, script=script)
+        resolved_args = self._resolve_script_args(
+            args_template=args_template,
+            context=context or {},
+            hook_kwargs=hook_kwargs,
+        )
+
+        validation_errors: list[str] = []
+        if schema is not None:
+            validation_errors = validate_script_args_schema(args=resolved_args, schema=schema)
+            if validation_errors:
+                return HookResult(
+                    continue_pipeline=False,
+                    override_status_code=PhaseStatusCode.NEED_PERMISSION,
+                    events=[
+                        {
+                            "type": "script_hook",
+                            "step": str(hook_kwargs.get("step_name") or ""),
+                            "skill": skill_name,
+                            "stage": stage,
+                            "script": script,
+                            "status": "validation_failed",
+                            "exit_code": None,
+                            "stdout": "",
+                            "stderr": "",
+                            "validation_errors": validation_errors,
+                        }
+                    ],
+                )
+
+        cmd = self._build_script_command(script_path=script_path, args=resolved_args)
+        result = subprocess.run(
+            cmd,
+            cwd=str(Path.cwd().resolve()),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            return HookResult(
+                continue_pipeline=False,
+                override_status_code=PhaseStatusCode.NEED_PERMISSION,
+                events=[
+                    {
+                        "type": "script_hook",
+                        "step": str(hook_kwargs.get("step_name") or ""),
+                        "skill": skill_name,
+                        "stage": stage,
+                        "script": script,
+                        "status": "failed",
+                        "exit_code": result.returncode,
+                        "stdout": result.stdout or "",
+                        "stderr": result.stderr or "",
+                        "validation_errors": [],
+                    }
+                ],
+            )
+
+        return HookResult(
+            events=[
+                {
+                    "type": "script_hook",
+                    "step": str(hook_kwargs.get("step_name") or ""),
+                    "skill": skill_name,
+                    "stage": stage,
+                    "script": script,
+                    "status": "success",
+                    "exit_code": result.returncode,
+                    "stdout": result.stdout or "",
+                    "stderr": result.stderr or "",
+                    "validation_errors": [],
+                }
+            ]
+        )
+
+    @staticmethod
+    def _parse_script_hook_declaration(
+        declaration: Dict[str, Any],
+    ) -> tuple[str, Dict[str, Any], Optional[Dict[str, Any]], list[str]]:
+        allowed_fields = {"script", "args", "schema", "when_status_codes"}
+        unknown = sorted(set(declaration.keys()) - allowed_fields)
+        if unknown:
+            raise ValueError(f"Script hook contains unsupported fields: {unknown}")
+
+        script = declaration.get("script")
+        if not isinstance(script, str) or not script.strip():
+            raise ValueError("Script hook requires non-empty 'script'")
+        script = script.strip()
+
+        args = declaration.get("args", {})
+        if args is None:
+            args = {}
+        if not isinstance(args, dict):
+            raise ValueError("Script hook 'args' must be an object")
+
+        schema = declaration.get("schema")
+        if schema is not None and not isinstance(schema, dict):
+            raise ValueError("Script hook 'schema' must be an object")
+
+        when_status_codes_raw = declaration.get("when_status_codes", [])
+        if when_status_codes_raw is None:
+            when_status_codes_raw = []
+        if not isinstance(when_status_codes_raw, list) or not all(
+            isinstance(item, str) for item in when_status_codes_raw
+        ):
+            raise ValueError("Script hook 'when_status_codes' must be a list of strings")
+
+        return script, args, schema, [item.strip() for item in when_status_codes_raw if item.strip()]
+
+    def _resolve_script_path(self, *, skill_name: str, script: str) -> Path:
+        script_path = Path(script)
+        if script_path.is_absolute():
+            raise ValueError("Script hook does not allow absolute paths")
+
+        script_parts = list(script_path.parts)
+        if any(part == ".." for part in script_parts):
+            raise ValueError("Script hook does not allow parent traversal")
+
+        if script_parts and script_parts[0] == "scripts":
+            script_parts = script_parts[1:]
+        if not script_parts:
+            raise ValueError("Script hook script path is empty")
+
+        skill_dir = self.skill_loader.get_skill_dir(skill_name)
+        scripts_dir = (skill_dir / "scripts").resolve()
+        candidate = (scripts_dir / Path(*script_parts)).resolve()
+
+        if not str(candidate).startswith(str(scripts_dir)):
+            raise ValueError("Script hook path must stay inside skill scripts directory")
+        if not candidate.exists() or not candidate.is_file():
+            raise ValueError(f"Script hook file not found: {candidate}")
+        return candidate
+
+    def _resolve_script_args(
+        self,
+        *,
+        args_template: Dict[str, Any],
+        context: Dict[str, str],
+        hook_kwargs: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        template_values: Dict[str, str] = {}
+        for key, value in context.items():
+            if value is None:
+                continue
+            template_values[key] = str(value)
+
+        for key, value in hook_kwargs.items():
+            if value is None:
+                continue
+            if isinstance(value, (str, int, float, bool, Path)):
+                template_values[key] = str(value)
+
+        resolved: Dict[str, Any] = {}
+        for key, value in args_template.items():
+            resolved[str(key)] = self._resolve_script_arg_value(value=value, template_values=template_values)
+        return resolved
+
+    def _resolve_script_arg_value(
+        self,
+        *,
+        value: Any,
+        template_values: Dict[str, str],
+    ) -> Any:
+        if isinstance(value, str):
+            try:
+                return value.format(**template_values)
+            except KeyError as exc:
+                raise ValueError(f"Missing template value for '{exc.args[0]}' in script hook args") from exc
+        if isinstance(value, list):
+            return [self._resolve_script_arg_value(value=item, template_values=template_values) for item in value]
+        if isinstance(value, dict):
+            return {
+                str(key): self._resolve_script_arg_value(value=item, template_values=template_values)
+                for key, item in value.items()
+            }
+        return value
+
+    @staticmethod
+    def _build_script_command(*, script_path: Path, args: Dict[str, Any]) -> list[str]:
+        cmd = ["/bin/bash", str(script_path)]
+        for key, value in args.items():
+            flag = f"--{key}"
+            if isinstance(value, list):
+                for item in value:
+                    cmd.extend([flag, str(item)])
+                continue
+            if isinstance(value, bool):
+                cmd.extend([flag, "true" if value else "false"])
+                continue
+            cmd.extend([flag, str(value)])
+        return cmd
+
+    @staticmethod
+    def _detect_status_code(*, response: str, step_def: Dict[str, Any]) -> Optional[str]:
+        valid = [
+            PhaseStatusCode(code)
+            for code in step_def.get("valid_status_codes", [])
+            if code in {item.value for item in PhaseStatusCode}
+        ]
+        status_code = StatusCodeParser.extract(response, valid_codes=valid or list(PhaseStatusCode))
+        return status_code.value if status_code is not None else None

--- a/src/cafe/phases/generic_phase.py
+++ b/src/cafe/phases/generic_phase.py
@@ -508,7 +508,9 @@ class GenericPhase:
         scripts_dir = (skill_dir / "scripts").resolve()
         candidate = (scripts_dir / Path(*script_parts)).resolve()
 
-        if not str(candidate).startswith(str(scripts_dir)):
+        try:
+            candidate.relative_to(scripts_dir)
+        except ValueError:
             raise ValueError("Script hook path must stay inside skill scripts directory")
         if not candidate.exists() or not candidate.is_file():
             raise ValueError(f"Script hook file not found: {candidate}")

--- a/src/cafe/phases/generic_phase.py
+++ b/src/cafe/phases/generic_phase.py
@@ -360,7 +360,9 @@ class GenericPhase:
         if stage not in self.SCRIPT_HOOK_STAGES:
             raise ValueError(f"Script hooks are only supported in {sorted(self.SCRIPT_HOOK_STAGES)}")
 
-        script, args_template, schema, when_status_codes = self._parse_script_hook_declaration(declaration)
+        script, args_template, schema, when_status_codes, timeout_seconds = self._parse_script_hook_declaration(
+            declaration
+        )
 
         if when_status_codes:
             detected_status = self._detect_status_code(response=response or "", step_def=step_def)
@@ -412,13 +414,36 @@ class GenericPhase:
                 )
 
         cmd = self._build_script_command(script_path=script_path, args=resolved_args)
-        result = subprocess.run(
-            cmd,
-            cwd=str(Path.cwd().resolve()),
-            capture_output=True,
-            text=True,
-            check=False,
-        )
+        try:
+            result = subprocess.run(
+                cmd,
+                cwd=str(Path.cwd().resolve()),
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=timeout_seconds,
+            )
+        except subprocess.TimeoutExpired as exc:
+            stdout = exc.stdout if isinstance(exc.stdout, str) else ""
+            stderr = exc.stderr if isinstance(exc.stderr, str) else ""
+            return HookResult(
+                continue_pipeline=False,
+                override_status_code=PhaseStatusCode.NEED_PERMISSION,
+                events=[
+                    {
+                        "type": "script_hook",
+                        "step": str(hook_kwargs.get("step_name") or ""),
+                        "skill": skill_name,
+                        "stage": stage,
+                        "script": script,
+                        "status": "timeout",
+                        "exit_code": None,
+                        "stdout": stdout,
+                        "stderr": stderr,
+                        "validation_errors": [],
+                    }
+                ],
+            )
         if result.returncode != 0:
             return HookResult(
                 continue_pipeline=False,
@@ -459,8 +484,8 @@ class GenericPhase:
     @staticmethod
     def _parse_script_hook_declaration(
         declaration: Dict[str, Any],
-    ) -> tuple[str, Dict[str, Any], Optional[Dict[str, Any]], list[str]]:
-        allowed_fields = {"script", "args", "schema", "when_status_codes"}
+    ) -> tuple[str, Dict[str, Any], Optional[Dict[str, Any]], list[str], Optional[float]]:
+        allowed_fields = {"script", "args", "schema", "when_status_codes", "timeout_seconds"}
         unknown = sorted(set(declaration.keys()) - allowed_fields)
         if unknown:
             raise ValueError(f"Script hook contains unsupported fields: {unknown}")
@@ -488,7 +513,22 @@ class GenericPhase:
         ):
             raise ValueError("Script hook 'when_status_codes' must be a list of strings")
 
-        return script, args, schema, [item.strip() for item in when_status_codes_raw if item.strip()]
+        timeout_seconds_raw = declaration.get("timeout_seconds")
+        timeout_seconds: Optional[float] = None
+        if timeout_seconds_raw is not None:
+            if isinstance(timeout_seconds_raw, bool) or not isinstance(timeout_seconds_raw, (int, float)):
+                raise ValueError("Script hook 'timeout_seconds' must be a positive number")
+            if timeout_seconds_raw <= 0:
+                raise ValueError("Script hook 'timeout_seconds' must be a positive number")
+            timeout_seconds = float(timeout_seconds_raw)
+
+        return (
+            script,
+            args,
+            schema,
+            [item.strip() for item in when_status_codes_raw if item.strip()],
+            timeout_seconds,
+        )
 
     def _resolve_script_path(self, *, skill_name: str, script: str) -> Path:
         script_path = Path(script)

--- a/src/cafe/phases/generic_phase.py
+++ b/src/cafe/phases/generic_phase.py
@@ -424,8 +424,8 @@ class GenericPhase:
                 timeout=timeout_seconds,
             )
         except subprocess.TimeoutExpired as exc:
-            stdout = exc.stdout if isinstance(exc.stdout, str) else ""
-            stderr = exc.stderr if isinstance(exc.stderr, str) else ""
+            stdout = self._normalize_process_output(exc.stdout)
+            stderr = self._normalize_process_output(exc.stderr)
             return HookResult(
                 continue_pipeline=False,
                 override_status_code=PhaseStatusCode.NEED_PERMISSION,
@@ -529,6 +529,14 @@ class GenericPhase:
             [item.strip() for item in when_status_codes_raw if item.strip()],
             timeout_seconds,
         )
+
+    @staticmethod
+    def _normalize_process_output(value: Any) -> str:
+        if isinstance(value, str):
+            return value
+        if isinstance(value, bytes):
+            return value.decode("utf-8", errors="replace")
+        return ""
 
     def _resolve_script_path(self, *, skill_name: str, script: str) -> Path:
         script_path = Path(script)

--- a/src/cafe/phases/generic_workflow_step.py
+++ b/src/cafe/phases/generic_workflow_step.py
@@ -259,7 +259,7 @@ class GenericWorkflowStepExecutor(Phase):
             )
 
         auto_continue = any(
-            event.get("type") in {"user_input_collected", "review_modification_requested"}
+            self._event_allows_auto_continue(event)
             for event in execution.events
             if isinstance(event, dict)
         )
@@ -274,6 +274,14 @@ class GenericWorkflowStepExecutor(Phase):
             for event in execution.events
             if isinstance(event, dict)
         ]
+        store = BlackboardStore(self.issue_dir)
+        for event in events:
+            if event.get("type") != "script_hook":
+                continue
+            payload = dict(event)
+            payload.setdefault("step", step_name)
+            store.record_event(blackboard_state, "script_hook", payload)
+
         if require_status_code and status_code is not None:
             handoff_intent = self._resolve_handoff_intent(step_name, status_code)
             if handoff_intent is not None:
@@ -629,6 +637,22 @@ class GenericWorkflowStepExecutor(Phase):
     @staticmethod
     def _should_validate_checklist(status_code: PhaseStatusCode) -> bool:
         return status_code in {PhaseStatusCode.CONFIRMED, PhaseStatusCode.READY_FOR_REVIEW}
+
+    @staticmethod
+    def _event_allows_auto_continue(event: Dict[str, Any]) -> bool:
+        """Return whether a hook event represents user feedback for a paused step.
+
+        Initial requirement collection also emits ``user_input_collected`` so
+        the prompt can receive GitHub/manual issue text. That input is not a
+        response to a clarification pause and must not suppress workflow
+        pausing when the agent returns ``CAFE_NEED_CLARIFICATION``.
+        """
+        event_type = event.get("type")
+        if event_type == "review_modification_requested":
+            return True
+        if event_type != "user_input_collected":
+            return False
+        return event.get("source") in {"questions_xml", "prompt", "user_input_file"}
 
     @staticmethod
     def _step_requires_status_code(step_name: str) -> bool:

--- a/src/cafe/ui/cli.py
+++ b/src/cafe/ui/cli.py
@@ -134,15 +134,15 @@ def _build_repo_entrypoint_mismatch_message(
     ).strip()
 
 
-def _check_repo_entrypoint_alignment() -> None:
+def _check_repo_entrypoint_alignment() -> bool:
     """Fail fast when running inside a checkout but importing a different install."""
     if os.getenv("CAFE_SKIP_ENTRYPOINT_CHECK"):
-        return
+        return True
     message = _build_repo_entrypoint_mismatch_message()
     if message is None:
-        return
+        return True
     console.print(f"[red]{message}[/red]")
-    raise typer.Exit(1)
+    return False
 
 
 def _build_dynamic_step_click_command(step_name: str) -> Optional[click.Command]:
@@ -1369,14 +1369,16 @@ def chat_with_agent(
     raise typer.Exit(launch_chat_session(role, issue_name))
 
 
-def main() -> None:
+def main() -> Optional[int]:
     """Entry point for CLI."""
     # Check if all dependencies are installed
     _check_dependencies()
-    _check_repo_entrypoint_alignment()
+    if not _check_repo_entrypoint_alignment():
+        return 1
     # Check for updates and auto-upgrade if available
     _check_for_updates()
     app()
+    return None
 
 
 def _check_dependencies() -> None:
@@ -1530,4 +1532,4 @@ def _check_for_updates() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/src/cafe/ui/cli.py
+++ b/src/cafe/ui/cli.py
@@ -104,14 +104,14 @@ def _build_repo_entrypoint_mismatch_message(
     imported_cli_file: Optional[Path] = None,
 ) -> Optional[str]:
     """Describe a repo/install mismatch when the CLI is not loaded from this checkout."""
-    repo_root = _find_repo_checkout_root(cwd)
-    if repo_root is None:
+    mismatch = _resolve_repo_entrypoint_mismatch(
+        cwd=cwd,
+        imported_cli_file=imported_cli_file,
+    )
+    if mismatch is None:
         return None
 
-    expected_cli = (repo_root / "src" / "cafe" / "ui" / "cli.py").resolve()
-    actual_cli = (imported_cli_file or Path(__file__)).resolve()
-    if actual_cli == expected_cli:
-        return None
+    repo_root, expected_cli, actual_cli = mismatch
 
     python_bin = Path(sys.executable).resolve()
     return textwrap.dedent(
@@ -134,14 +134,70 @@ def _build_repo_entrypoint_mismatch_message(
     ).strip()
 
 
+def _resolve_repo_entrypoint_mismatch(
+    *,
+    cwd: Optional[Path] = None,
+    imported_cli_file: Optional[Path] = None,
+) -> Optional[tuple[Path, Path, Path]]:
+    """Return checkout/expected/actual paths when a CLI install mismatch exists."""
+    repo_root = _find_repo_checkout_root(cwd)
+    if repo_root is None:
+        return None
+
+    expected_cli = (repo_root / "src" / "cafe" / "ui" / "cli.py").resolve()
+    actual_cli = (imported_cli_file or Path(__file__)).resolve()
+    if actual_cli == expected_cli:
+        return None
+    return repo_root, expected_cli, actual_cli
+
+
+def _build_repo_entrypoint_reexec_command(repo_root: Path) -> list[str]:
+    """Build a command that runs the CLI from the detected checkout."""
+    return [str(Path(sys.executable).resolve()), "-m", "cafe.ui.cli", *sys.argv[1:]]
+
+
+def _build_repo_entrypoint_reexec_env(repo_root: Path) -> dict[str, str]:
+    """Build an environment that imports CAFE from the detected checkout."""
+    env = os.environ.copy()
+    checkout_src = str((repo_root / "src").resolve())
+    current_pythonpath = env.get("PYTHONPATH", "")
+    if current_pythonpath:
+        env["PYTHONPATH"] = os.pathsep.join([checkout_src, current_pythonpath])
+    else:
+        env["PYTHONPATH"] = checkout_src
+    return env
+
+
+def _reexec_repo_entrypoint(repo_root: Path) -> None:
+    """Replace the current process with the checkout-local CLI."""
+    os.execvpe(
+        _build_repo_entrypoint_reexec_command(repo_root)[0],
+        _build_repo_entrypoint_reexec_command(repo_root),
+        _build_repo_entrypoint_reexec_env(repo_root),
+    )
+
+
 def _check_repo_entrypoint_alignment() -> bool:
     """Fail fast when running inside a checkout but importing a different install."""
     if os.getenv("CAFE_SKIP_ENTRYPOINT_CHECK"):
         return True
+    mismatch = _resolve_repo_entrypoint_mismatch()
+    if mismatch is None:
+        return True
+    repo_root, _, _ = mismatch
+    try:
+        _reexec_repo_entrypoint(repo_root)
+    except OSError:
+        pass
+
     message = _build_repo_entrypoint_mismatch_message()
     if message is None:
         return True
     console.print(f"[red]{message}[/red]")
+    console.print(
+        "[yellow]Failed to automatically run the checkout-local CLI. "
+        "Use the command above manually.[/yellow]"
+    )
     return False
 
 

--- a/src/cafe/ui/commands/workflow.py
+++ b/src/cafe/ui/commands/workflow.py
@@ -363,6 +363,54 @@ def summary() -> None:
         raise typer.Exit(1)
 
 
+def _is_baton_contract_error(error: Exception) -> bool:
+    message = str(error)
+    return "Invalid baton contract payload" in message or "Baton file is empty" in message
+
+
+def _print_baton_contract_recovery_guidance(
+    *,
+    issue_dir: Optional[Path],
+    playbook_name: Optional[str],
+) -> None:
+    baton_path = (
+        issue_dir / "next_step.txt"
+        if issue_dir is not None
+        else Path(".cafe/issues/<issue>/next_step.txt")
+    )
+    playbook_arg = f" --playbook {playbook_name}" if playbook_name else ""
+    console.print(
+        f"[yellow]Workflow baton file is not a valid handoff contract: {baton_path}[/yellow]"
+    )
+    console.print(
+        "[dim]If you know the step to resume, run "
+        f"`cafe workflow{playbook_arg} --execute --start-step <step>`; "
+        "the command will rebuild the baton for that step.[/dim]"
+    )
+    console.print(
+        "[dim]If you are not sure, inspect `blackboard.json` for `current_step` first.[/dim]"
+    )
+
+
+def _reset_baton_for_explicit_start_step(
+    *,
+    issue_dir: Path,
+    blackboard: object,
+    active_step: str,
+) -> None:
+    """Make an explicit --start-step runnable even when the persisted baton is stale."""
+    store = BlackboardStore(issue_dir)
+    store.set_current_step(blackboard, active_step)
+    store.update_handoff_contract(
+        blackboard,
+        from_step=active_step,
+        to_owner=HandoffOwner.AGENT,
+        to_step=active_step,
+        intent=HandoffIntent.AWAIT_AGENT,
+        source="workflow.start_step",
+    )
+
+
 def workflow(
     playbook: Optional[str] = typer.Option(None, "--playbook", help="Playbook name"),
     issue: Optional[str] = typer.Option(None, "--issue", help="Issue directory name"),
@@ -467,6 +515,7 @@ def workflow(
 
         pending_start_step = start_step
         while True:
+            has_explicit_start_step = pending_start_step is not None
             if dry_run:
                 pending_start_step = pending_start_step or str(
                     playbook_data.get("entry_point") or next(iter(playbook_data["steps"].keys()))
@@ -487,6 +536,12 @@ def workflow(
             )
 
             active_step = pending_start_step or blackboard.current_step
+            if not dry_run and has_explicit_start_step and active_step not in {"user", "done"}:
+                _reset_baton_for_explicit_start_step(
+                    issue_dir=issue_dir,
+                    blackboard=blackboard,
+                    active_step=active_step,
+                )
             if not dry_run and active_step in {"user", "done"}:
                 incomplete_step = _find_incomplete_workflow_step(
                     issue_dir=issue_dir,
@@ -660,5 +715,10 @@ def workflow(
     except CriticalPhaseError as e:
         _handle_phase_exception(e, "workflow")
     except Exception as e:
+        if _is_baton_contract_error(e):
+            _print_baton_contract_recovery_guidance(
+                issue_dir=locals().get("issue_dir"),
+                playbook_name=locals().get("selected_playbook"),
+            )
         console.print(f"[red]Error: workflow run failed: {e}[/red]")
         raise typer.Exit(1)

--- a/tests/unit/test_cli_entrypoint_alignment.py
+++ b/tests/unit/test_cli_entrypoint_alignment.py
@@ -5,7 +5,12 @@ from pathlib import Path
 import pytest
 
 from cafe.ui import cli
-from cafe.ui.cli import _build_repo_entrypoint_mismatch_message, _find_repo_checkout_root
+from cafe.ui.cli import (
+    _build_repo_entrypoint_mismatch_message,
+    _build_repo_entrypoint_reexec_command,
+    _build_repo_entrypoint_reexec_env,
+    _find_repo_checkout_root,
+)
 
 
 def _write_repo_marker(repo_root: Path) -> None:
@@ -65,25 +70,54 @@ def test_build_repo_entrypoint_mismatch_message_reports_external_install(tmp_pat
     assert "pip install -e ." in message
 
 
-def test_main_returns_error_code_without_traceback_for_entrypoint_mismatch(
+def test_reexec_command_preserves_cli_args(monkeypatch, tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    monkeypatch.setattr(cli.sys, "argv", ["cafe", "make", "--auto-advance"])
+
+    command = _build_repo_entrypoint_reexec_command(repo_root)
+
+    assert command[1:] == ["-m", "cafe.ui.cli", "make", "--auto-advance"]
+
+
+def test_reexec_env_prefers_checkout_src(monkeypatch, tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    (repo_root / "src").mkdir(parents=True)
+    monkeypatch.setenv("PYTHONPATH", "/existing/path")
+
+    env = _build_repo_entrypoint_reexec_env(repo_root)
+
+    assert env["PYTHONPATH"].split(":")[0] == str((repo_root / "src").resolve())
+    assert "/existing/path" in env["PYTHONPATH"].split(":")
+
+
+def test_main_returns_error_code_without_traceback_when_auto_reexec_fails(
     monkeypatch,
     capsys,
+    tmp_path: Path,
 ) -> None:
+    repo_root = tmp_path / "repo"
+    expected_cli = repo_root / "src" / "cafe" / "ui" / "cli.py"
+    actual_cli = tmp_path / "global" / "cafe" / "ui" / "cli.py"
     monkeypatch.setattr(cli, "_check_dependencies", lambda: None)
     monkeypatch.setattr(
         cli,
-        "_build_repo_entrypoint_mismatch_message",
-        lambda: "Error: `cafe` is running from a different installation than this checkout.",
+        "_resolve_repo_entrypoint_mismatch",
+        lambda **_: (repo_root, expected_cli, actual_cli),
+    )
+    monkeypatch.setattr(
+        cli,
+        "_reexec_repo_entrypoint",
+        lambda repo_root: (_ for _ in ()).throw(OSError("exec failed")),
     )
     monkeypatch.setattr(
         cli,
         "_check_for_updates",
-        lambda: pytest.fail("update check should not run on entrypoint mismatch"),
+        lambda: pytest.fail("update check should not run when re-exec fails"),
     )
     monkeypatch.setattr(
         cli,
         "app",
-        lambda: pytest.fail("app should not run on entrypoint mismatch"),
+        lambda: pytest.fail("app should not run when re-exec fails"),
     )
 
     result = cli.main()

--- a/tests/unit/test_cli_entrypoint_alignment.py
+++ b/tests/unit/test_cli_entrypoint_alignment.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
+from cafe.ui import cli
 from cafe.ui.cli import _build_repo_entrypoint_mismatch_message, _find_repo_checkout_root
 
 
@@ -60,3 +63,32 @@ def test_build_repo_entrypoint_mismatch_message_reports_external_install(tmp_pat
     assert str(repo_root.resolve()) in message
     assert str(external_cli.resolve()) in message
     assert "pip install -e ." in message
+
+
+def test_main_returns_error_code_without_traceback_for_entrypoint_mismatch(
+    monkeypatch,
+    capsys,
+) -> None:
+    monkeypatch.setattr(cli, "_check_dependencies", lambda: None)
+    monkeypatch.setattr(
+        cli,
+        "_build_repo_entrypoint_mismatch_message",
+        lambda: "Error: `cafe` is running from a different installation than this checkout.",
+    )
+    monkeypatch.setattr(
+        cli,
+        "_check_for_updates",
+        lambda: pytest.fail("update check should not run on entrypoint mismatch"),
+    )
+    monkeypatch.setattr(
+        cli,
+        "app",
+        lambda: pytest.fail("app should not run on entrypoint mismatch"),
+    )
+
+    result = cli.main()
+
+    captured = capsys.readouterr()
+    assert result == 1
+    assert "different installation than this checkout" in captured.out
+    assert "Traceback" not in captured.out

--- a/tests/unit/test_cli_workflow_command.py
+++ b/tests/unit/test_cli_workflow_command.py
@@ -356,6 +356,117 @@ def test_workflow_command_rejects_malformed_baton_json(tmp_path: Path, monkeypat
     assert "Baton contract step '{not-json' is not valid" in result.stdout
 
 
+def test_workflow_command_start_step_rebuilds_stale_text_baton(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    issue_dir = tmp_path / ".cafe" / "issues" / "issue-206c"
+    issue_dir.mkdir(parents=True, exist_ok=True)
+    (issue_dir / "blackboard.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "playbook_id": "default",
+                "current_step": "spec",
+                "artifacts": {},
+                "events": [],
+                "decisions": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (issue_dir / "next_step.txt").write_text("done\n", encoding="utf-8")
+
+    class FakeExecutor:
+        def execute_step(
+            self,
+            step_name: str,
+            step_def: dict,
+            blackboard_state: object,
+        ) -> StepExecutionResult:
+            return _result(
+                status_code="CAFE_NEED_CLARIFICATION",
+                step_name=step_name,
+                step_def=step_def,
+                artifacts={},
+            )
+
+    with patch("cafe.ui.cli.GitOperations") as mock_git_cls, patch(
+        "cafe.ui.cli._build_workflow_step_executor",
+        return_value=FakeExecutor(),
+    ):
+        git = MagicMock()
+        git.get_current_branch.return_value = "issue-206c"
+        mock_git_cls.return_value = git
+
+        result = runner.invoke(
+            app,
+            [
+                "workflow",
+                "--playbook",
+                "default",
+                "--execute",
+                "--start-step",
+                "spec",
+                "--single-step",
+            ],
+        )
+
+    assert result.exit_code == 0
+    assert "Invalid baton contract payload" not in result.stdout
+
+    baton = json.loads((issue_dir / "next_step.txt").read_text(encoding="utf-8"))
+    assert baton["from_step"] == "spec"
+    assert baton["to_step"] in {"spec", "user"}
+
+
+def test_workflow_command_prints_guidance_for_invalid_runtime_baton(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    issue_dir = tmp_path / ".cafe" / "issues" / "issue-206d"
+    issue_dir.mkdir(parents=True, exist_ok=True)
+
+    class FakeExecutor:
+        def execute_step(
+            self,
+            step_name: str,
+            step_def: dict,
+            blackboard_state: object,
+        ) -> StepExecutionResult:
+            return _result(
+                status_code="CAFE_NEED_CLARIFICATION",
+                step_name=step_name,
+                step_def=step_def,
+                artifacts={},
+            )
+
+    class FailingRuntime:
+        def __init__(self, *args, **kwargs) -> None:
+            raise ValueError(
+                "Invalid baton contract payload: Expecting value: line 1 column 1 (char 0)"
+            )
+
+    with patch("cafe.ui.cli.GitOperations") as mock_git_cls, patch(
+        "cafe.ui.cli._build_workflow_step_executor",
+        return_value=FakeExecutor(),
+    ), patch("cafe.ui.commands.workflow.BlackboardWorkflowRuntime", FailingRuntime):
+        git = MagicMock()
+        git.get_current_branch.return_value = "issue-206d"
+        mock_git_cls.return_value = git
+
+        result = runner.invoke(app, ["workflow", "--playbook", "default", "--execute"])
+
+    assert result.exit_code == 1
+    assert "Workflow baton file is not a valid handoff contract" in result.stdout
+    assert "cafe workflow" in result.stdout
+    assert "--playbook default" in result.stdout
+    assert "--execute" in result.stdout
+    assert "--start-step <step>" in result.stdout
+    assert "Error: workflow run failed: Invalid baton contract payload" in result.stdout
+
+
 def test_workflow_command_prints_paused_when_human_input_is_needed(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.chdir(tmp_path)
 

--- a/tests/unit/test_generic_phase.py
+++ b/tests/unit/test_generic_phase.py
@@ -1,5 +1,6 @@
 """Tests for GenericPhase."""
 
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -709,3 +710,86 @@ def test_execute_script_hook_can_skip_when_status_mismatch(tmp_path: Path) -> No
     event = next(item for item in result.events if item.get("type") == "script_hook")
     assert event["status"] == "skipped"
     assert event["reason"] == "status_mismatch"
+
+
+def test_execute_script_hook_passes_timeout_to_subprocess(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    loader = _setup_loader(tmp_path)
+    _write_skill_script(
+        loader,
+        skill_name="plan",
+        script_name="noop.sh",
+        body="#!/usr/bin/env bash\necho noop\n",
+    )
+    phase = GenericPhase(loader)
+    captured: dict[str, object] = {}
+
+    def _run(*args, **kwargs):
+        captured["timeout"] = kwargs.get("timeout")
+        return subprocess.CompletedProcess(args=args[0], returncode=0, stdout="ok\n", stderr="")
+
+    monkeypatch.setattr("cafe.phases.generic_phase.subprocess.run", _run)
+
+    result = phase.execute(
+        skill_name="plan",
+        skill_invocation="/plan",
+        shared_skill_invocations=["/workflow-common"],
+        step_def={
+            "hooks": {
+                "before_execute": [
+                    {
+                        "script": "noop.sh",
+                        "args": {},
+                        "timeout_seconds": 2.5,
+                    }
+                ]
+            },
+            "valid_status_codes": ["CAFE_CONFIRMED"],
+        },
+        agent_executor=lambda prompt: "CAFE_CONFIRMED",
+    )
+
+    assert captured["timeout"] == 2.5
+    event = next(item for item in result.events if item.get("type") == "script_hook")
+    assert event["status"] == "success"
+
+
+def test_execute_script_hook_timeout_stops_pipeline(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    loader = _setup_loader(tmp_path)
+    _write_skill_script(
+        loader,
+        skill_name="plan",
+        script_name="slow.sh",
+        body="#!/usr/bin/env bash\nsleep 30\n",
+    )
+    phase = GenericPhase(loader)
+
+    def _run(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=args[0], timeout=1.0, output="partial", stderr="timed out")
+
+    monkeypatch.setattr("cafe.phases.generic_phase.subprocess.run", _run)
+
+    result = phase.execute(
+        skill_name="plan",
+        skill_invocation="/plan",
+        shared_skill_invocations=["/workflow-common"],
+        step_def={
+            "hooks": {
+                "before_execute": [
+                    {
+                        "script": "slow.sh",
+                        "args": {},
+                        "timeout_seconds": 1.0,
+                    }
+                ]
+            },
+            "valid_status_codes": ["CAFE_CONFIRMED", "CAFE_NEED_PERMISSION"],
+        },
+        agent_executor=lambda prompt: "CAFE_CONFIRMED",
+    )
+
+    assert result.status_code == PhaseStatusCode.NEED_PERMISSION
+    event = next(item for item in result.events if item.get("type") == "script_hook")
+    assert event["status"] == "timeout"
+    assert event["exit_code"] is None
+    assert "partial" in event["stdout"]
+    assert "timed out" in event["stderr"]

--- a/tests/unit/test_generic_phase.py
+++ b/tests/unit/test_generic_phase.py
@@ -793,3 +793,47 @@ def test_execute_script_hook_timeout_stops_pipeline(tmp_path: Path, monkeypatch:
     assert event["exit_code"] is None
     assert "partial" in event["stdout"]
     assert "timed out" in event["stderr"]
+
+
+def test_execute_script_hook_timeout_decodes_bytes_output(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    loader = _setup_loader(tmp_path)
+    _write_skill_script(
+        loader,
+        skill_name="plan",
+        script_name="slow.sh",
+        body="#!/usr/bin/env bash\nsleep 30\n",
+    )
+    phase = GenericPhase(loader)
+
+    def _run(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=args[0], timeout=1.0, output=b"partial-bytes", stderr=b"timed-bytes")
+
+    monkeypatch.setattr("cafe.phases.generic_phase.subprocess.run", _run)
+
+    result = phase.execute(
+        skill_name="plan",
+        skill_invocation="/plan",
+        shared_skill_invocations=["/workflow-common"],
+        step_def={
+            "hooks": {
+                "before_execute": [
+                    {
+                        "script": "slow.sh",
+                        "args": {},
+                        "timeout_seconds": 1.0,
+                    }
+                ]
+            },
+            "valid_status_codes": ["CAFE_CONFIRMED", "CAFE_NEED_PERMISSION"],
+        },
+        agent_executor=lambda prompt: "CAFE_CONFIRMED",
+    )
+
+    assert result.status_code == PhaseStatusCode.NEED_PERMISSION
+    event = next(item for item in result.events if item.get("type") == "script_hook")
+    assert event["status"] == "timeout"
+    assert event["exit_code"] is None
+    assert "partial-bytes" in event["stdout"]
+    assert "timed-bytes" in event["stderr"]

--- a/tests/unit/test_generic_phase.py
+++ b/tests/unit/test_generic_phase.py
@@ -551,6 +551,41 @@ def test_execute_rejects_script_hook_path_traversal(tmp_path: Path) -> None:
         )
 
 
+def test_execute_rejects_script_hook_symlink_outside_scripts_dir(tmp_path: Path) -> None:
+    loader = _setup_loader(tmp_path)
+    phase = GenericPhase(loader)
+    skill_dir = loader.get_skill_dir("plan")
+    scripts_dir = skill_dir / "scripts"
+    scripts_dir.mkdir(parents=True, exist_ok=True)
+
+    escaped_dir = skill_dir / "scripts_evil"
+    escaped_dir.mkdir(parents=True, exist_ok=True)
+    escaped_script = escaped_dir / "escaped.sh"
+    escaped_script.write_text("#!/usr/bin/env bash\necho escaped\n", encoding="utf-8")
+
+    link_script = scripts_dir / "escape.sh"
+    link_script.symlink_to(escaped_script)
+
+    with pytest.raises(ValueError, match="must stay inside"):
+        phase.execute(
+            skill_name="plan",
+            skill_invocation="/plan",
+            shared_skill_invocations=["/workflow-common"],
+            step_def={
+                "hooks": {
+                    "before_execute": [
+                        {
+                            "script": "escape.sh",
+                            "args": {},
+                        }
+                    ]
+                },
+                "valid_status_codes": ["CAFE_CONFIRMED"],
+            },
+            agent_executor=lambda prompt: "CAFE_CONFIRMED",
+        )
+
+
 def test_execute_script_hook_validation_failure_stops_pipeline(tmp_path: Path) -> None:
     loader = _setup_loader(tmp_path)
     marker = tmp_path / "marker.txt"

--- a/tests/unit/test_generic_phase.py
+++ b/tests/unit/test_generic_phase.py
@@ -461,3 +461,216 @@ def test_validate_skills_does_not_install_any_files(tmp_path: Path) -> None:
     bridge = _make_bridge(tmp_path)
     bridge.validate_skills(["plan", "workflow-common"], AgentCLI.CLAUDE)
     assert not (tmp_path / "project" / ".claude" / "skills").exists()
+
+
+def _write_skill_script(loader: SkillLoader, *, skill_name: str, script_name: str, body: str) -> Path:
+    skill_dir = loader.get_skill_dir(skill_name)
+    script_dir = skill_dir / "scripts"
+    script_dir.mkdir(parents=True, exist_ok=True)
+    script_path = script_dir / script_name
+    script_path.write_text(body, encoding="utf-8")
+    return script_path
+
+
+def test_execute_runs_script_hook_with_schema_and_interpolation(tmp_path: Path) -> None:
+    loader = _setup_loader(tmp_path)
+    _write_skill_script(
+        loader,
+        skill_name="plan",
+        script_name="echo_args.sh",
+        body=(
+            "#!/usr/bin/env bash\n"
+            "set -euo pipefail\n"
+            "echo \"$1|$2|$3|$4\"\n"
+        ),
+    )
+    phase = GenericPhase(loader)
+    output_file = tmp_path / "out.md"
+    output_file.write_text("x", encoding="utf-8")
+
+    result = phase.execute(
+        skill_name="plan",
+        skill_invocation="/plan",
+        shared_skill_invocations=["/workflow-common"],
+        context={"output_file": str(output_file)},
+        step_def={
+            "hooks": {
+                "before_execute": [
+                    {
+                        "script": "echo_args.sh",
+                        "args": {
+                            "phase": "plan",
+                            "output": "{output_file}",
+                        },
+                        "schema": {
+                            "type": "object",
+                            "required": ["phase", "output"],
+                            "additionalProperties": False,
+                            "properties": {
+                                "phase": {"type": "string", "enum": ["spec", "plan"]},
+                                "output": {"type": "string"},
+                            },
+                        },
+                    }
+                ]
+            },
+            "valid_status_codes": ["CAFE_CONFIRMED"],
+        },
+        output_file=output_file,
+        agent_executor=lambda prompt: "CAFE_CONFIRMED",
+    )
+
+    event = next(item for item in result.events if item.get("type") == "script_hook")
+    assert event["status"] == "success"
+    assert event["stage"] == "before_execute"
+    assert "--phase|plan|--output" in event["stdout"]
+    assert str(output_file) in event["stdout"]
+
+
+def test_execute_rejects_script_hook_path_traversal(tmp_path: Path) -> None:
+    loader = _setup_loader(tmp_path)
+    phase = GenericPhase(loader)
+
+    with pytest.raises(ValueError, match="parent traversal"):
+        phase.execute(
+            skill_name="plan",
+            skill_invocation="/plan",
+            shared_skill_invocations=["/workflow-common"],
+            step_def={
+                "hooks": {
+                    "before_execute": [
+                        {
+                            "script": "../evil.sh",
+                            "args": {},
+                        }
+                    ]
+                },
+                "valid_status_codes": ["CAFE_CONFIRMED"],
+            },
+            agent_executor=lambda prompt: "CAFE_CONFIRMED",
+        )
+
+
+def test_execute_script_hook_validation_failure_stops_pipeline(tmp_path: Path) -> None:
+    loader = _setup_loader(tmp_path)
+    marker = tmp_path / "marker.txt"
+    _write_skill_script(
+        loader,
+        skill_name="plan",
+        script_name="touch_marker.sh",
+        body=(
+            "#!/usr/bin/env bash\n"
+            "set -euo pipefail\n"
+            "echo touched > \"" + str(marker) + "\"\n"
+        ),
+    )
+    phase = GenericPhase(loader)
+
+    result = phase.execute(
+        skill_name="plan",
+        skill_invocation="/plan",
+        shared_skill_invocations=["/workflow-common"],
+        step_def={
+            "hooks": {
+                "before_execute": [
+                    {
+                        "script": "touch_marker.sh",
+                        "args": {"phase": 7},
+                        "schema": {
+                            "type": "object",
+                            "required": ["phase"],
+                            "additionalProperties": False,
+                            "properties": {"phase": {"type": "string"}},
+                        },
+                    }
+                ]
+            },
+            "valid_status_codes": ["CAFE_NEED_PERMISSION", "CAFE_CONFIRMED"],
+        },
+        agent_executor=lambda prompt: "CAFE_CONFIRMED",
+    )
+
+    assert not marker.exists()
+    assert result.status_code == PhaseStatusCode.NEED_PERMISSION
+    event = next(item for item in result.events if item.get("type") == "script_hook")
+    assert event["status"] == "validation_failed"
+    assert "expected type 'string'" in " ".join(event["validation_errors"])
+
+
+def test_execute_script_hook_failure_stops_pipeline(tmp_path: Path) -> None:
+    loader = _setup_loader(tmp_path)
+    _write_skill_script(
+        loader,
+        skill_name="plan",
+        script_name="fail.sh",
+        body=(
+            "#!/usr/bin/env bash\n"
+            "set -euo pipefail\n"
+            "echo boom >&2\n"
+            "exit 9\n"
+        ),
+    )
+    phase = GenericPhase(loader)
+
+    result = phase.execute(
+        skill_name="plan",
+        skill_invocation="/plan",
+        shared_skill_invocations=["/workflow-common"],
+        step_def={
+            "hooks": {
+                "after_execute": [
+                    {
+                        "script": "fail.sh",
+                        "args": {},
+                        "when_status_codes": ["CAFE_CONFIRMED"],
+                    }
+                ]
+            },
+            "valid_status_codes": ["CAFE_CONFIRMED", "CAFE_NEED_PERMISSION"],
+        },
+        agent_executor=lambda prompt: "CAFE_CONFIRMED",
+    )
+
+    assert result.status_code == PhaseStatusCode.NEED_PERMISSION
+    event = next(item for item in result.events if item.get("type") == "script_hook")
+    assert event["status"] == "failed"
+    assert event["exit_code"] == 9
+    assert "boom" in event["stderr"]
+
+
+def test_execute_script_hook_can_skip_when_status_mismatch(tmp_path: Path) -> None:
+    loader = _setup_loader(tmp_path)
+    _write_skill_script(
+        loader,
+        skill_name="plan",
+        script_name="noop.sh",
+        body=(
+            "#!/usr/bin/env bash\n"
+            "set -euo pipefail\n"
+            "echo noop\n"
+        ),
+    )
+    phase = GenericPhase(loader)
+
+    result = phase.execute(
+        skill_name="plan",
+        skill_invocation="/plan",
+        shared_skill_invocations=["/workflow-common"],
+        step_def={
+            "hooks": {
+                "after_execute": [
+                    {
+                        "script": "noop.sh",
+                        "args": {},
+                        "when_status_codes": ["CAFE_CONFIRMED"],
+                    }
+                ]
+            },
+            "valid_status_codes": ["CAFE_READY_FOR_REVIEW", "CAFE_CONFIRMED"],
+        },
+        agent_executor=lambda prompt: "CAFE_READY_FOR_REVIEW",
+    )
+
+    event = next(item for item in result.events if item.get("type") == "script_hook")
+    assert event["status"] == "skipped"
+    assert event["reason"] == "status_mismatch"

--- a/tests/unit/test_generic_workflow_step.py
+++ b/tests/unit/test_generic_workflow_step.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 import pytest
 
 from cafe.core.blackboard import ArtifactEntry, ArtifactKind, BlackboardStore, HandoffIntent, HandoffOwner
+from cafe.core.hooks import HookResult
 from cafe.core.status_codes import PhaseStatusCode
 from cafe.core.types import AgentCLI, TokenUsage
 from cafe.phases.generic_phase import GenericPhaseExecution
@@ -617,6 +618,134 @@ def test_generic_workflow_step_collects_clarification_before_next_agent_run(
         "Current user input for this iteration:" in prompt and "A1: CLI only" in prompt
         for prompt in agent_manager.prompts
     )
+
+
+def test_initial_requirements_collection_does_not_auto_continue_clarification(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    issue_dir = tmp_path / ".cafe" / "issues" / "issue-initial-input"
+    playbook = {
+        "playbook": {"id": "default"},
+        "roles": {"pm": {"default_agent": "Roger"}},
+        "steps": {
+            "spec": {
+                "skill": {"1": "spec_first", "default": "spec_first"},
+                "role": "pm",
+                "output_artifact": "spec",
+                "allowed_tools": ["Read"],
+                "valid_status_codes": ["CAFE_NEED_CLARIFICATION", "CAFE_CONFIRMED"],
+                "hooks": {"prepare_input": ["GitHubIssueFetcher"]},
+                "on": {
+                    "CAFE_NEED_CLARIFICATION": "spec",
+                    "CAFE_CONFIRMED": "_done",
+                },
+            }
+        },
+    }
+    issue_dir.mkdir(parents=True)
+    (issue_dir / "issue.yaml").write_text(
+        "spec:\n  input_method: manual\n",
+        encoding="utf-8",
+    )
+    state = BlackboardStore(issue_dir).load_or_create("spec")
+    executor = GenericWorkflowStepExecutor(
+        issue_dir=issue_dir,
+        issue_name="issue-initial-input",
+        playbook=playbook,
+        generic_phase=_build_loader(tmp_path),
+        agent_manager=FakeAgentManager("CAFE_NEED_CLARIFICATION"),
+        git_ops=FakeGitOperations(),
+        role_agent_map={"pm": "Roger"},
+        step_user_inputs={"spec": "Initial issue text"},
+    )
+
+    result = executor.execute_step("spec", playbook["steps"]["spec"], state)
+
+    assert result.status_code == "CAFE_NEED_CLARIFICATION"
+    assert result.auto_continue is False
+    reloaded = BlackboardStore(issue_dir).load_or_create("spec")
+    assert reloaded.handoff_contract is not None
+    assert reloaded.handoff_contract.to_owner == HandoffOwner.USER
+    assert reloaded.handoff_contract.to_step == "user"
+    assert reloaded.handoff_contract.intent == HandoffIntent.NEED_CLARIFICATION
+
+
+def test_generic_workflow_step_records_script_hook_events_to_blackboard(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    issue_dir = tmp_path / ".cafe" / "issues" / "issue-script-event"
+    playbook = {
+        "playbook": {"id": "default"},
+        "roles": {"developer": {"default_agent": "David"}},
+        "steps": {
+            "develop": {
+                "skill": "develop",
+                "role": "developer",
+                "output_artifact": "code",
+                "allowed_tools": ["Read"],
+                "hooks": {"before_execute": ["ScriptHook"]},
+                "valid_status_codes": ["CAFE_CONFIRMED"],
+                "on": {"CAFE_CONFIRMED": "_done"},
+            }
+        },
+    }
+
+    class ScriptHook:
+        name = "ScriptHook"
+
+        def run(self, **kwargs):
+            return HookResult(
+                events=[
+                    {
+                        "type": "script_hook",
+                        "step": "develop",
+                        "skill": "develop",
+                        "stage": "before_execute",
+                        "script": "demo.sh",
+                        "status": "success",
+                        "exit_code": 0,
+                        "stdout": "ok",
+                        "stderr": "",
+                        "validation_errors": [],
+                    }
+                ]
+            )
+
+    store = BlackboardStore(issue_dir)
+    state = store.load_or_create("develop")
+    spec_file = issue_dir / "spec" / "iteration_001" / "output.md"
+    plan_file = issue_dir / "plan" / "iteration_001" / "output.md"
+    spec_file.parent.mkdir(parents=True, exist_ok=True)
+    plan_file.parent.mkdir(parents=True, exist_ok=True)
+    spec_file.write_text("# Spec\n", encoding="utf-8")
+    plan_file.write_text("# Plan\n", encoding="utf-8")
+    store.set_artifact(state, "spec", str(spec_file))
+    store.set_artifact(state, "plan", str(plan_file))
+
+    base_phase = _build_loader(tmp_path)
+    phase_with_hook = GenericPhase(
+        base_phase.skill_loader,
+        hook_registry={"ScriptHook": ScriptHook},
+        skill_bridge=base_phase.skill_bridge,
+    )
+    executor = GenericWorkflowStepExecutor(
+        issue_dir=issue_dir,
+        issue_name="issue-script-event",
+        playbook=playbook,
+        generic_phase=phase_with_hook,
+        agent_manager=FakeAgentManager("CAFE_CONFIRMED"),
+        git_ops=FakeGitOperations(),
+        role_agent_map={"developer": "David"},
+    )
+
+    result = executor.execute_step("develop", playbook["steps"]["develop"], state)
+
+    assert result.status_code == "CAFE_CONFIRMED"
+    reloaded = BlackboardStore(issue_dir).load_or_create("develop")
+    script_event = next(item for item in reloaded.events if item.event_type == "script_hook")
+    assert script_event.data["script"] == "demo.sh"
+    assert script_event.data["status"] == "success"
 
 
 def test_generic_workflow_step_auto_continues_pause_statuses_in_interactive_mode(tmp_path: Path, monkeypatch) -> None:

--- a/tests/unit/test_native_user_input_hook.py
+++ b/tests/unit/test_native_user_input_hook.py
@@ -523,6 +523,44 @@ def test_github_pr_creator_prepare_input_loads_unresolved_comments(tmp_path: Pat
     assert result.events == [{"type": "pr_comments_loaded", "count": 1, "pr_number": "42"}]
 
 
+def test_github_pr_creator_prepare_input_uses_and_updates_last_seen_comments(tmp_path: Path) -> None:
+    phase_dir = tmp_path / "pr"
+    artifact_file = phase_dir / "artifacts" / "pr_last_seen_comments.json"
+    artifact_file.parent.mkdir(parents=True, exist_ok=True)
+    artifact_file.write_text(
+        json.dumps({"last_seen_comment_ids": ["OLD"]}, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    phase = _FakePhase(phase_dir=phase_dir, iteration=2)
+    phase.git_ops = MagicMock()
+    phase.git_ops.get_current_branch.return_value = "issue-250"
+    phase.git_ops.has_unpushed_commits.return_value = False
+
+    comment = MagicMock()
+    comment.id = "NEW"
+
+    hook = GitHubPRCreator()
+
+    with (
+        patch("cafe.core.hooks.native.get_processed_comment_ids_from_history") as mock_processed,
+        patch("cafe.core.hooks.native.GitHubOps") as mock_github_ops,
+        patch("cafe.core.hooks.native.get_all_pr_comments", return_value=[comment]) as mock_comments,
+        patch("cafe.core.hooks.native.filter_unresolved_comments", return_value=[comment]),
+        patch("cafe.core.hooks.native.format_comments_for_prompt", return_value="Comment #1\nPlease fix this"),
+    ):
+        mock_github_ops.return_value.get_pr_for_branch.return_value = {
+            "number": 250,
+            "url": "https://github.com/test/repo/pull/250",
+        }
+        result = hook.run(stage="prepare_input", phase=phase, step_name="pr")
+
+    mock_processed.assert_not_called()
+    mock_comments.assert_called_once_with(250, exclude_ids={"OLD"})
+    assert result.events == [{"type": "pr_comments_loaded", "count": 1, "pr_number": "250"}]
+    payload = json.loads(artifact_file.read_text(encoding="utf-8"))
+    assert payload["last_seen_comment_ids"] == ["NEW", "OLD"]
+
+
 def test_github_pr_creator_publish_output_runs_sync_pr_script(tmp_path: Path) -> None:
     issue_dir = tmp_path / ".cafe" / "issues" / "demo"
     phase_dir = issue_dir / "pr"

--- a/tests/unit/test_native_user_input_hook.py
+++ b/tests/unit/test_native_user_input_hook.py
@@ -662,6 +662,67 @@ def test_github_pr_creator_publish_output_runs_from_workflow_complete_baton_with
     ]
 
 
+def test_github_pr_creator_publish_output_runs_from_legacy_done_baton(
+    tmp_path: Path,
+) -> None:
+    issue_dir = tmp_path / ".cafe" / "issues" / "demo"
+    phase_dir = issue_dir / "pr"
+    output_file = phase_dir / "iteration_001" / "output.md"
+    publish_request_file = phase_dir / "iteration_001" / "publish_request.json"
+    next_step_file = issue_dir / "next_step.txt"
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    output_file.write_text("# Test PR\n\nBody\n", encoding="utf-8")
+    publish_request_file.write_text(
+        json.dumps(
+            {
+                "capability": "publish_pr",
+                "script": "src/cafe/data/skills/pr/scripts/sync_pr.sh",
+                "args": {
+                    "output": ".cafe/issues/demo/pr/iteration_001/output.md",
+                    "base": "develop",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    next_step_file.write_text("done\n", encoding="utf-8")
+
+    phase = _FakePhase(phase_dir=phase_dir, iteration=1)
+    phase.git_ops = MagicMock()
+    phase.git_ops.get_repo_root.return_value = tmp_path
+
+    completed = MagicMock()
+    completed.returncode = 0
+    completed.stdout = (
+        '{"action":"updated","pr_number":"42",'
+        '"pr_url":"https://github.com/test/repo/pull/42"}\n'
+    )
+    completed.stderr = ""
+
+    hook = GitHubPRCreator()
+    with patch("cafe.core.hooks.native.subprocess.run", return_value=completed) as mock_run:
+        result = hook.run(
+            stage="publish_output",
+            phase=phase,
+            step_name="pr",
+            output_file=output_file,
+            publish_request_file=publish_request_file,
+            context={"next_step_path": str(next_step_file)},
+            status_code=None,
+        )
+
+    mock_run.assert_called_once()
+    assert result.events == [
+        {
+            "type": "pr_synced",
+            "url": "https://github.com/test/repo/pull/42",
+            "pr_number": "42",
+            "action": "updated",
+            "source": "skill_script",
+        }
+    ]
+
+
 def test_github_pr_creator_publish_output_skips_local_pr_mode(tmp_path: Path) -> None:
     issue_dir = tmp_path / ".cafe" / "issues" / "demo"
     phase_dir = issue_dir / "pr"

--- a/tests/unit/test_playbook_loader.py
+++ b/tests/unit/test_playbook_loader.py
@@ -177,6 +177,41 @@ steps:
     assert hook_entry["script"] == "sync_github.sh"
 
 
+def test_load_rejects_script_hook_dict_in_unsupported_stage(tmp_path: Path) -> None:
+    builtin_root = tmp_path / "builtin"
+    _write_skill(builtin_root / "skills", "pr")
+    _write_playbook(
+        builtin_root / "playbooks",
+        "default",
+        """
+playbook:
+  id: default
+roles:
+  developer:
+    description: dev
+steps:
+  pr:
+    skill: pr
+    role: developer
+    hooks:
+      publish_output:
+        - script: sync_pr.sh
+    valid_status_codes: [CAFE_CONFIRMED]
+    on:
+      CAFE_CONFIRMED: _done
+""",
+    )
+
+    loader = PlaybookLoader(
+        project_root=tmp_path / "project",
+        global_root=tmp_path / "global",
+        builtin_root=builtin_root,
+    )
+
+    with pytest.raises(ValueError, match="unsupported stage 'publish_output'"):
+        loader.load_model("default")
+
+
 def test_load_missing_skill_raises(tmp_path: Path) -> None:
     builtin_root = tmp_path / "builtin"
     _write_playbook(

--- a/tests/unit/test_playbook_loader.py
+++ b/tests/unit/test_playbook_loader.py
@@ -125,6 +125,58 @@ steps:
     }
 
 
+def test_load_supports_dictionary_script_hook_declarations(tmp_path: Path) -> None:
+    builtin_root = tmp_path / "builtin"
+    _write_skill(builtin_root / "skills", "plan")
+    _write_playbook(
+        builtin_root / "playbooks",
+        "default",
+        """
+playbook:
+  id: default
+roles:
+  developer:
+    description: dev
+steps:
+  plan:
+    skill: plan
+    role: developer
+    hooks:
+      after_execute:
+        - script: sync_github.sh
+          when_status_codes: [CAFE_CONFIRMED]
+          args:
+            phase: plan
+            output: "{output_file}"
+          schema:
+            type: object
+            required: [phase, output]
+            additionalProperties: false
+            properties:
+              phase:
+                type: string
+                enum: [spec, plan]
+              output:
+                type: string
+    valid_status_codes: [CAFE_READY_FOR_REVIEW, CAFE_CONFIRMED]
+    on:
+      CAFE_READY_FOR_REVIEW: plan
+      CAFE_CONFIRMED: _done
+""",
+    )
+
+    loader = PlaybookLoader(
+        project_root=tmp_path / "project",
+        global_root=tmp_path / "global",
+        builtin_root=builtin_root,
+    )
+    result = loader.load_model("default")
+
+    hook_entry = result.model.steps["plan"].hooks.after_execute[0]
+    assert isinstance(hook_entry, dict)
+    assert hook_entry["script"] == "sync_github.sh"
+
+
 def test_load_missing_skill_raises(tmp_path: Path) -> None:
     builtin_root = tmp_path / "builtin"
     _write_playbook(

--- a/tests/unit/test_skill_sync_github_script.py
+++ b/tests/unit/test_skill_sync_github_script.py
@@ -4,6 +4,7 @@ import subprocess
 from pathlib import Path
 
 import pytest
+import yaml
 
 
 def test_phase_scripts_delegate_to_shared_implementation() -> None:
@@ -68,3 +69,17 @@ def test_sync_script_skips_when_sync_disabled_without_gh(
     payload = json.loads(result.stdout.strip())
     assert payload["action"] == "skipped"
     assert payload["reason"] == "sync_disabled"
+
+
+def test_default_playbook_migrates_plan_sync_to_script_hook() -> None:
+    project_root = Path(__file__).resolve().parents[2]
+    playbook_path = project_root / "src/cafe/data/playbooks/default.yaml"
+    data = yaml.safe_load(playbook_path.read_text(encoding="utf-8"))
+
+    plan_hooks = data["steps"]["plan"]["hooks"]["after_execute"]
+    assert isinstance(plan_hooks, list) and plan_hooks
+    script_hook = plan_hooks[0]
+    assert script_hook["script"] == "sync_github.sh"
+    assert script_hook["args"]["phase"] == "plan"
+    assert script_hook["args"]["output"] == "{output_file}"
+    assert script_hook["when_status_codes"] == ["CAFE_CONFIRMED"]

--- a/tests/unit/test_workflow_runtime.py
+++ b/tests/unit/test_workflow_runtime.py
@@ -1058,3 +1058,56 @@ def test_runtime_chains_pr_need_changes_through_develop_to_review(tmp_path: Path
     transitions = [e for e in blackboard.events if e.event_type == "transition"]
     assert any(e.data.get("to") == "develop" for e in transitions)
     assert any(e.data.get("to") == "review" for e in transitions)
+
+
+def test_runtime_normalizes_legacy_baton_written_by_pr_agent(tmp_path: Path) -> None:
+    issue_dir = tmp_path / ".cafe" / "issues" / "legacy-pr-handoff"
+    issue_dir.mkdir(parents=True)
+    _write_baton(issue_dir, from_step="pr", to_owner="agent", to_step="pr", intent="await_agent")
+    playbook = {
+        "playbook": {"id": "default"},
+        "steps": {
+            "pr": {"skill": "spec_first", "role": "developer", "assignee_type": "agent", "on": {}},
+            "develop": {
+                "skill": "develop",
+                "role": "developer",
+                "assignee_type": "agent",
+                "valid_status_codes": ["CAFE_CONFIRMED"],
+                "on": {"CAFE_CONFIRMED": "_done"},
+            },
+        },
+    }
+
+    calls: list[str] = []
+
+    def executor(step_name: str, step_def: dict, state: object) -> StepExecutionResult:
+        calls.append(step_name)
+        if step_name == "pr":
+            (issue_dir / "next_step.txt").write_text("develop\n", encoding="utf-8")
+            return StepExecutionResult(response="todo", artifacts={}, status_code="CAFE_NEEDS_CHANGES")
+        if step_name == "develop":
+            store = BlackboardStore(issue_dir)
+            store.update_handoff_contract(
+                state,
+                from_step="develop",
+                to_owner=HandoffOwner.DONE,
+                to_step="done",
+                intent=HandoffIntent.WORKFLOW_COMPLETE,
+                status_code="CAFE_CONFIRMED",
+                source="test",
+            )
+            return StepExecutionResult(response="done", artifacts={}, status_code="CAFE_CONFIRMED")
+        raise AssertionError(f"unexpected step {step_name}")
+
+    runtime = BlackboardWorkflowRuntime(
+        issue_dir=issue_dir,
+        playbook=playbook,
+        executor=executor,
+    )
+    result = runtime.run(start_step="pr", max_transitions=5)
+
+    assert calls == ["pr", "develop"]
+    assert result.completed is True
+    baton = json.loads((issue_dir / "next_step.txt").read_text(encoding="utf-8"))
+    assert baton["from_step"] == "develop"
+    assert baton["to_step"] == "done"


### PR DESCRIPTION
## Summary
This PR adds automatic execution for skill-bundled scripts at workflow lifecycle hooks, with validation, path bounds, structured blackboard events, and timeout handling. It also migrates the builtin plan sync hook and remembers loaded PR feedback so repeated PR iterations only surface new unresolved comments.

## Changes
- Added script hook declaration parsing for `before_execute` and `after_execute`, including skill-relative path validation and schema checks.
- Wired script execution into the generic phase and persisted structured `script_hook` events on the blackboard.
- Added configurable subprocess timeouts and unsupported-stage validation for mapping-style script hooks.
- Migrated the plan builtin to the new script hook mechanism.
- Updated PR feedback loading to persist last-seen comment IDs and avoid reprocessing the same unresolved comments.

## Test Plan
- `python3.10 -m pytest tests/unit/test_generic_phase.py tests/unit/test_playbook_loader.py tests/unit/test_skill_sync_github_script.py tests/unit/test_generic_workflow_step.py`
- `python3.10 -m pytest tests/unit/test_native_user_input_hook.py`
- Focused regression suites passed on the current head.