### PR TITLE
issue256: replace CAFE_* status codes with baton intents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Breaking
+- Playbooks and phase hooks must use the six shipped **intent** keys (`await_agent`, `confirm_output`, `need_clarification`, `need_permission`, `manual_handoff`, `workflow_complete`) and outcome tokens without the legacy `CAFE_*` prefix. Step allow-lists use `valid_intents`; script hooks use `when_intents`. Agent prompts, bundled skill references, and checklists that still instruct models to print `CAFE_*` lines must be updated or routing and hook gates will misfire.
 - Issues created before the issue241 series no longer guarantee resume compatibility. The legacy `context.json` fallbacks for `_load_user_input` and `_get_previous_iteration_status` have been removed in favor of `user_input.md` and the blackboard `step_completed` event log respectively. If you have an in-progress issue from a prior version that has not yet recorded `step_completed` events on its blackboard (or stored `user_input` only inside `context.json`), the next iteration may skip the clarification / review prompt or resume with an empty user input. Workarounds: (a) finish the issue on the previous version before upgrading, (b) re-run the issue from scratch, or (c) manually create the missing `iteration_NNN/user_input.md` file.
 
 ## [0.1.6]

--- a/docs/manual-test-v02.md
+++ b/docs/manual-test-v02.md
@@ -28,7 +28,7 @@ Primary issue state used for isolated runs:
 ### 2) Workflow single-step pause behavior
 - Command: `workflow --issue manual-v02-smoke --dry-run --single-step --start-step spec`
 - Result: **PASS**
-- Observed: `Workflow paused step=spec status=CAFE_CONFIRMED next=plan` with handoff guidance.
+- Observed: `Workflow paused step=spec status=ready_for_review next=plan` with handoff guidance (plain outcome token + `next` pointer; no legacy `CAFE_*` prefix).
 
 ### 3) Workflow resume after pause
 - Command: `workflow --issue manual-v02-smoke --dry-run`
@@ -38,7 +38,7 @@ Primary issue state used for isolated runs:
 ### 4) Single-step pause near PR boundary
 - Command: `workflow --issue manual-v02-smoke --dry-run --single-step --start-step review`
 - Result: **PASS**
-- Observed: `Workflow paused step=review status=CAFE_CONFIRMED next=pr`.
+- Observed: `Workflow paused step=review status=confirmed next=pr` (outcome token reflects agent step result; routing uses baton / blackboard).
 
 ### 5) Edit artifact command
 - Command: `EDITOR=true edit spec`

--- a/docs/plans/v02-plan.md
+++ b/docs/plans/v02-plan.md
@@ -3,6 +3,8 @@
 本文件是 **v0.2 的 implementation plan / spec**。  
 版本定位、產品邊界、以及 `v0.3+` 的長期演進方向以 [docs/roadmap.md](/Users/YO_1/side_projects/cafe/docs/roadmap.md) 為準；本文件只定義 `v0.2` 要做什麼、怎麼做、以及如何驗收。
 
+> **備註（issue256 之後）：** 本檔為 v0.2 架構與驗收紀錄，內文嵌入的 YAML 範例可能仍含舊版 `CAFE_*` 控制字串。目前引擎與內建 playbook 已改為 **intent** 鍵（`on:` 轉移）與純文字 outcome token（如 `confirmed`、`ready_for_review`）；請以 `src/cafe/data/playbooks/` 現行檔案為準，勿將本檔內嵌範例當作現行操作介面規格。
+
 ## 核心需求
 
 1. **Skill 是核心抽象** — 每個工作流步驟就是一個 Skill（遵循 agentskills.io 規範），包含 SKILL.md + scripts/ + references/ + assets/

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -71,7 +71,7 @@ CAFE 長期採 **repo-first** 的 definition model，但不預設最終所有流
 - `Skill + Playbook + Blackboard + Hook`
 - GenericPhase / PlaybookRunner
 - 動態 step orchestration
-- status code + `CAFE_GOTO`
+- baton（`next_step.txt` / `HandoffContract`）+ playbook `on:` **intent** 鍵（`await_agent`、`confirm_output` 等）；舊版文件中的 `CAFE_GOTO` / `CAFE_*` 敘述僅作歷史對照
 - 共享 artifacts / events / decisions
 - suspend / resume 基礎模型
 - 明確定義 `WorkflowInstance`

--- a/examples/non_software/editorial/.cafe/playbooks/editorial.yaml
+++ b/examples/non_software/editorial/.cafe/playbooks/editorial.yaml
@@ -19,48 +19,48 @@ steps:
       default: brief_revise
     role: editor
     output_artifact: brief
-    valid_status_codes:
-      - CAFE_CONFIRMED
-      - CAFE_NEED_CLARIFICATION
-      - CAFE_READY_FOR_REVIEW
+    valid_intents:
+      - confirmed
+      - need_clarification
+      - ready_for_review
     "on":
-      CAFE_CONFIRMED: draft
-      CAFE_NEED_CLARIFICATION: brief
-      CAFE_READY_FOR_REVIEW: brief
+      await_agent: draft
+      need_clarification: brief
+      confirm_output: brief
 
   draft:
     skill: draft
     role: writer
     input_artifacts: [brief]
     output_artifact: manuscript
-    valid_status_codes:
-      - CAFE_CONFIRMED
-      - CAFE_NEED_CLARIFICATION
+    valid_intents:
+      - confirmed
+      - need_clarification
     "on":
-      CAFE_CONFIRMED: review
-      CAFE_NEED_CLARIFICATION: draft
+      await_agent: review
+      need_clarification: draft
 
   review:
     skill: editorial_review
     role: editor
     input_artifacts: [brief, manuscript]
     output_artifact: review_feedback
-    valid_status_codes:
-      - CAFE_CONFIRMED
-      - CAFE_NEEDS_CHANGES
+    valid_intents:
+      - confirmed
+      - needs_changes
     allowed_goto: [brief, draft]
     "on":
-      CAFE_CONFIRMED: publish
-      CAFE_NEEDS_CHANGES: draft
+      await_agent: publish
+      manual_handoff: draft
 
   publish:
     skill: publish
     role: writer
     input_artifacts: [brief, manuscript, review_feedback]
     output_artifact: published_piece
-    valid_status_codes:
-      - CAFE_CONFIRMED
+    valid_intents:
+      - confirmed
     "on":
-      CAFE_CONFIRMED: _done
+      await_agent: _done
 
 entry_point: brief

--- a/src/cafe/agents/manager.py
+++ b/src/cafe/agents/manager.py
@@ -49,8 +49,8 @@ class AgentManager:
         if self._use_mock:
             from cafe.agents.mock_executor import MockAgentExecutor
             
-            # Get mock response from env var (default: CAFE_READY_FOR_REVIEW with mock spec)
-            mock_response = os.getenv("CAFE_MOCK_RESPONSE", "CAFE_READY_FOR_REVIEW\n\n# Mock Spec\n\nThis is a mock specification.")
+            # Get mock response from env var (default: ready_for_review with mock spec)
+            mock_response = os.getenv("CAFE_MOCK_RESPONSE", "ready_for_review\n\n# Mock Spec\n\nThis is a mock specification.")
             self.agents[config.name] = MockAgentExecutor(
                 config=config,
                 response=mock_response

--- a/src/cafe/agents/mock_executor.py
+++ b/src/cafe/agents/mock_executor.py
@@ -24,14 +24,14 @@ class MockAgentExecutor:
     def __init__(
         self,
         config: AgentConfig,
-        response: str = "CAFE_READY_FOR_REVIEW\n\n# Mock Response\n\nThis is a mock response.",
+        response: str = "ready_for_review\n\n# Mock Response\n\nThis is a mock response.",
         token_usage: Optional[TokenUsage] = None,
     ):
         """Initialize mock executor.
 
         Args:
             config: Agent configuration
-            response: Predefined response (default: CAFE_READY_FOR_REVIEW with mock content)
+            response: Predefined response (default: ready_for_review with mock content)
             token_usage: Predefined token usage (default: empty)
         """
         self.config = config

--- a/src/cafe/core/blackboard.py
+++ b/src/cafe/core/blackboard.py
@@ -43,7 +43,6 @@ class HandoffIntent(str, Enum):
     CONFIRM_OUTPUT = "confirm_output"
     NEED_CLARIFICATION = "need_clarification"
     NEED_PERMISSION = "need_permission"
-    CHAT_HANDOFF = "chat_handoff"
     MANUAL_HANDOFF = "manual_handoff"
     WORKFLOW_COMPLETE = "workflow_complete"
 
@@ -176,12 +175,15 @@ class HandoffContract:
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "HandoffContract":
         try:
+            intent_raw = str(data["intent"])
+            if intent_raw == "chat_handoff":
+                intent_raw = HandoffIntent.MANUAL_HANDOFF.value
             return cls(
                 version=int(data["version"]),
                 from_step=str(data["from_step"]),
                 to_owner=HandoffOwner(str(data["to_owner"])),
                 to_step=str(data["to_step"]),
-                intent=HandoffIntent(str(data["intent"])),
+                intent=HandoffIntent(intent_raw),
                 status_code=str(data.get("status_code", "")),
                 created_at=str(data.get("created_at", _now_iso())),
                 source=str(data.get("source", "unknown")),

--- a/src/cafe/core/hooks/native.py
+++ b/src/cafe/core/hooks/native.py
@@ -251,12 +251,12 @@ class UserInputCollector(NoOpHook):
             )
 
         previous_status = _get_previous_iteration_status(phase)
-        if previous_status not in {"CAFE_NEED_CLARIFICATION", "CAFE_READY_FOR_REVIEW"}:
+        if previous_status not in {"need_clarification", "ready_for_review"}:
             return HookResult()
 
-        # PR step uses CAFE_READY_FOR_REVIEW to loop back and check for new comments,
+        # PR step uses ready_for_review to loop back and check for new comments,
         # not to request user confirmation — skip the review prompt entirely.
-        if step_name == "pr" and previous_status == "CAFE_READY_FOR_REVIEW":
+        if step_name == "pr" and previous_status in {"ready_for_review", "confirm_output"}:
             return HookResult()
 
         prompt_role = {"pm": "pm", "reviewer": "reviewer"}.get(role, "developer")
@@ -264,7 +264,7 @@ class UserInputCollector(NoOpHook):
         # For spec/plan READY_FOR_REVIEW flow, delta view is sufficient and less noisy.
         if not (
             step_name in {"spec", "plan"}
-            and previous_status == "CAFE_READY_FOR_REVIEW"
+            and previous_status == "ready_for_review"
         ):
             self._display_previous_output(phase, step_name, previous_output_file)
 
@@ -285,7 +285,7 @@ class UserInputCollector(NoOpHook):
                     ],
                 )
 
-        if previous_status == "CAFE_READY_FOR_REVIEW":
+        if previous_status in {"confirm_output", "ready_for_review"}:
             delta_displayed = self._display_previous_iteration_delta(phase, previous_output_file)
             if not delta_displayed:
                 self._display_previous_output(phase, step_name, previous_output_file)

--- a/src/cafe/core/phase.py
+++ b/src/cafe/core/phase.py
@@ -471,7 +471,7 @@ class Phase(PhaseStateMixin, PhaseCodexMixin, PhaseReviewMixin, PhaseChecklistMi
         agent_name: str,
         prompt: str,
         user_input: str,
-        valid_status_codes: List[PhaseStatusCode],
+        valid_intents: List[PhaseStatusCode],
         require_status_code: bool = True,
         persist_status: bool = True,
         allowed_tools: Optional[List[str]] = None,
@@ -494,7 +494,7 @@ class Phase(PhaseStateMixin, PhaseCodexMixin, PhaseReviewMixin, PhaseChecklistMi
             agent_name: Agent name (e.g. pm_agent, dev_agent)
             prompt: Prompt to send to agent
             user_input: User input for this round
-            valid_status_codes: Valid status codes accepted by this phase
+            valid_intents: Valid status codes accepted by this phase
             require_status_code: Whether missing/invalid status code should trigger retry/failure
             persist_status: Whether to persist status into phase metadata files
             allowed_tools: Tools available to agent (default None)
@@ -657,7 +657,7 @@ class Phase(PhaseStateMixin, PhaseCodexMixin, PhaseReviewMixin, PhaseChecklistMi
             # 4c. Attempt to recover response from written files
             recovered_response, recovered_status_code = self._recover_from_written_files(
                 changed_written_files,
-                valid_status_codes,
+                valid_intents,
             )
 
             # 4d. Create error.json file for debugging
@@ -799,24 +799,24 @@ class Phase(PhaseStateMixin, PhaseCodexMixin, PhaseReviewMixin, PhaseChecklistMi
         # 6. Extract status code
         status_code = self._extract_status_code_from_response(
             response,
-            valid_codes=valid_status_codes,
+            valid_codes=valid_intents,
         )
         if (
             status_code is None
             and permission_denials
-            and PhaseStatusCode.NEED_PERMISSION in valid_status_codes
+            and PhaseStatusCode.NEED_PERMISSION in valid_intents
         ):
             status_code = PhaseStatusCode.NEED_PERMISSION
         elif status_code is None:
             inferred_human_input_status = self._infer_human_input_status_from_response(response)
-            if inferred_human_input_status in valid_status_codes:
+            if inferred_human_input_status in valid_intents:
                 status_code = inferred_human_input_status
 
         # 6.1. Record missing status code in error log (single-pass mode, no retry loop)
         if require_status_code and status_code is None:
             self._write_status_code_error_log(
                 original_response=response,
-                valid_status_codes=valid_status_codes,
+                valid_intents=valid_intents,
                 status_code=status_code,
                 analysis_attempted=False,
                 analysis_response=None,
@@ -914,13 +914,13 @@ class Phase(PhaseStateMixin, PhaseCodexMixin, PhaseReviewMixin, PhaseChecklistMi
     def _recover_from_written_files(
         self,
         written_files: List[Path],
-        valid_status_codes: List[PhaseStatusCode],
+        valid_intents: List[PhaseStatusCode],
     ) -> tuple[Optional[str], Optional[PhaseStatusCode]]:
         """Attempt to recover agent response from written files.
 
         Args:
             written_files: List of files written by agent before failure
-            valid_status_codes: Valid status codes for this phase
+            valid_intents: Valid status codes for this phase
 
         Returns:
             Tuple[Optional[str], Optional[PhaseStatusCode]]:
@@ -939,7 +939,7 @@ class Phase(PhaseStateMixin, PhaseCodexMixin, PhaseReviewMixin, PhaseChecklistMi
             # Extract status code from file content
             status_code = self._extract_status_code_from_response(
                 recovered_response,
-                valid_codes=valid_status_codes,
+                valid_codes=valid_intents,
             )
 
             return recovered_response, status_code
@@ -1325,7 +1325,7 @@ class Phase(PhaseStateMixin, PhaseCodexMixin, PhaseReviewMixin, PhaseChecklistMi
         self,
         agent_name: str,
         user_input: str,
-        valid_status_codes: List[PhaseStatusCode],
+        valid_intents: List[PhaseStatusCode],
         allowed_tools: Optional[List[str]] = None,
         continue_codes: Optional[List[PhaseStatusCode]] = None,
         complete_codes: Optional[List[PhaseStatusCode]] = None,
@@ -1342,7 +1342,7 @@ class Phase(PhaseStateMixin, PhaseCodexMixin, PhaseReviewMixin, PhaseChecklistMi
         Args:
             agent_name: Agent name
             user_input: User input for this round
-            valid_status_codes: List of valid status codes
+            valid_intents: List of valid status codes
             allowed_tools: List of allowed tools
             continue_codes: Status codes that should continue loop
             complete_codes: Status codes indicating near completion
@@ -1369,7 +1369,7 @@ class Phase(PhaseStateMixin, PhaseCodexMixin, PhaseReviewMixin, PhaseChecklistMi
             agent_name=agent_name,
             prompt=prompt,
             user_input=user_input,
-            valid_status_codes=valid_status_codes,
+            valid_intents=valid_intents,
             allowed_tools=allowed_tools or ["write", "read"],
             phase_specific_data=phase_specific_data,
         )
@@ -1398,7 +1398,7 @@ class Phase(PhaseStateMixin, PhaseCodexMixin, PhaseReviewMixin, PhaseChecklistMi
                 agent_name=agent_name,
                 prompt=prompt,
                 user_input=user_input,
-                valid_status_codes=valid_status_codes,
+                valid_intents=valid_intents,
                 allowed_tools=allowed_tools or ["write", "read"],
                 max_retries=3,
             )

--- a/src/cafe/core/phase_checklist_mixin.py
+++ b/src/cafe/core/phase_checklist_mixin.py
@@ -24,7 +24,7 @@ class PhaseChecklistMixin:
         agent_name: str,
         prompt: str,
         user_input: str,
-        valid_status_codes: List[PhaseStatusCode],
+        valid_intents: List[PhaseStatusCode],
         allowed_tools: Optional[List[str]] = None,
         max_retries: int = 3,
     ) -> tuple[str, Optional[PhaseStatusCode], bool]:
@@ -37,7 +37,7 @@ class PhaseChecklistMixin:
             agent_name: Agent name
             prompt: Original prompt sent to agent
             user_input: User input for this iteration
-            valid_status_codes: Valid status codes for this phase
+            valid_intents: Valid status codes for this phase
             allowed_tools: Tools available to agent
             max_retries: Maximum number of retry attempts (default: 3)
 
@@ -85,7 +85,7 @@ class PhaseChecklistMixin:
                     response = context_data.get("response", "")
                     status_code = self._extract_status_code_from_response(
                         response,
-                        valid_codes=valid_status_codes,
+                        valid_codes=valid_intents,
                     )
                     return response, status_code, True
             return "", None, True
@@ -100,7 +100,7 @@ class PhaseChecklistMixin:
                     response = context_data.get("response", "")
                     status_code = self._extract_status_code_from_response(
                         response,
-                        valid_codes=valid_status_codes,
+                        valid_codes=valid_intents,
                     )
                     return response, status_code, True
             return "", None, True
@@ -140,7 +140,7 @@ Do NOT return a status code until ALL checklist items are marked as complete [x]
                 # Extract status code from retry response
                 retry_status_code = self._extract_status_code_from_response(
                     retry_response,
-                    valid_codes=valid_status_codes,
+                    valid_codes=valid_intents,
                 )
 
                 # Validate checklist again
@@ -210,7 +210,7 @@ Do NOT return a status code until ALL checklist items are marked as complete [x]
                 response = context_data.get("response", "")
                 status_code = self._extract_status_code_from_response(
                     response,
-                    valid_codes=valid_status_codes,
+                    valid_codes=valid_intents,
                 )
                 return response, status_code, False
 

--- a/src/cafe/core/phase_codex_mixin.py
+++ b/src/cafe/core/phase_codex_mixin.py
@@ -138,9 +138,9 @@ class PhaseCodexMixin:
         if not prev_data:
             return ([], "")
 
-        # Only handle permission denials if previous status was CAFE_NEED_PERMISSION
+        # Only handle permission denials if previous status was need_permission
         prev_status = self._context_status_code(prev_data) or ""
-        if prev_status != "CAFE_NEED_PERMISSION":
+        if prev_status != "need_permission":
             return ([], "")
 
         # Check if there are permission_denials

--- a/src/cafe/core/phase_review_mixin.py
+++ b/src/cafe/core/phase_review_mixin.py
@@ -341,7 +341,7 @@ class PhaseReviewMixin:
                     data={
                         "iterations": self.iteration - 1,
                         "last_response": prev_data.get("response", ""),
-                        "status_code": "CAFE_NEED_CLARIFICATION",
+                        "status_code": "need_clarification",
                     },
                 )
 
@@ -394,7 +394,7 @@ class PhaseReviewMixin:
                     data={
                         "iterations": self.iteration - 1,
                         "last_response": prev_data.get("response", ""),
-                        "status_code": "CAFE_NEED_PERMISSION",
+                        "status_code": "need_permission",
                     },
                 )
 
@@ -405,7 +405,7 @@ class PhaseReviewMixin:
                 data={
                     "iterations": self.iteration - 1,
                     "last_response": prev_data.get("response", ""),
-                    "status_code": "CAFE_NEED_PERMISSION",
+                    "status_code": "need_permission",
                 },
             )
 

--- a/src/cafe/core/phase_state_mixin.py
+++ b/src/cafe/core/phase_state_mixin.py
@@ -21,7 +21,7 @@ class PhaseStateMixin:
     def _analyze_missing_status_code(
         self,
         agent_name: str,
-        valid_status_codes: List[PhaseStatusCode],
+        valid_intents: List[PhaseStatusCode],
     ) -> Optional[PhaseStatusCode]:
         """When response has no status code, call agent to analyze status."""
         prompt = self._get_status_analysis_prompt()
@@ -31,7 +31,7 @@ class PhaseStateMixin:
         response, _, _, _, _, _ = self.agent_manager.execute(
             agent_name, prompt, allowed_directories=self._get_allowed_directories()
         )
-        return self._extract_status_code_from_response(response, valid_codes=valid_status_codes)
+        return self._extract_status_code_from_response(response, valid_codes=valid_intents)
 
     @staticmethod
     def _infer_human_input_status_from_response(response: str) -> Optional[PhaseStatusCode]:
@@ -60,7 +60,7 @@ class PhaseStateMixin:
     def _analyze_missing_status_code_with_logging(
         self,
         agent_name: str,
-        valid_status_codes: List[PhaseStatusCode],
+        valid_intents: List[PhaseStatusCode],
         original_response: str,
     ) -> tuple[Optional[str], Optional[PhaseStatusCode]]:
         """When response has no status code, call agent to analyze status (with logging)."""
@@ -78,7 +78,7 @@ class PhaseStateMixin:
             )
             status_code = self._extract_status_code_from_response(
                 response,
-                valid_codes=valid_status_codes,
+                valid_codes=valid_intents,
             )
 
             return response, status_code
@@ -89,7 +89,7 @@ class PhaseStateMixin:
     def _write_status_code_error_log(
         self,
         original_response: str,
-        valid_status_codes: List[PhaseStatusCode],
+        valid_intents: List[PhaseStatusCode],
         status_code: Optional[PhaseStatusCode],
         analysis_attempted: bool,
         analysis_response: Optional[str],
@@ -123,7 +123,7 @@ class PhaseStateMixin:
             "iteration": self.iteration,
             "phase": self.phase_name if hasattr(self, "phase_name") else "unknown",
             "original_response": original_response,
-            "valid_status_codes": [code.value for code in valid_status_codes],
+            "valid_intents": [code.value for code in valid_intents],
             "extracted_status_code": status_code.value if status_code else None,
             "multiple_codes_found": [code.value for code in multiple_codes_found] if multiple_codes_found else None,
             "analysis_attempted": analysis_attempted,

--- a/src/cafe/core/playbook.py
+++ b/src/cafe/core/playbook.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, List, Literal, Optional, Union
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from cafe.core.status_codes import PLAYBOOK_INTENT_KEYS, PhaseStatusCode
 from cafe.skills.exceptions import SkillDiscoveryError
 from cafe.skills.loader import SkillLoader
 
@@ -62,12 +63,42 @@ class StepConfig(BaseModel):
     input_artifacts: List[str] = Field(default_factory=list)
     output_artifact: Optional[str] = None
     allowed_tools: List[str] = Field(default_factory=list)
-    valid_status_codes: List[str] = Field(default_factory=list)
+    valid_intents: List[str] = Field(default_factory=list)
     max_iterations: Optional[Union[int, str]] = None
     allowed_goto: List[str] = Field(default_factory=list)
     hooks: StepHooks = Field(default_factory=StepHooks)
     auto_snapshot: bool = True
     on: Dict[str, str]
+
+    @field_validator("on")
+    @classmethod
+    def _validate_on_intents(cls, value: Dict[str, str]) -> Dict[str, str]:
+        for key in value:
+            if key == "default":
+                continue
+            if key.startswith("CAFE_"):
+                raise ValueError(f"Legacy CAFE_ transition key is not allowed in playbook on: {key!r}")
+            if key not in PLAYBOOK_INTENT_KEYS:
+                raise ValueError(
+                    f"Invalid playbook transition key {key!r}; "
+                    f"must be one of {sorted(PLAYBOOK_INTENT_KEYS)} or 'default'"
+                )
+        return value
+
+    @field_validator("valid_intents")
+    @classmethod
+    def _validate_valid_intents(cls, value: List[str]) -> List[str]:
+        for item in value:
+            if not isinstance(item, str) or not item.strip():
+                raise ValueError("valid_intents entries must be non-empty strings")
+            token = item.strip()
+            if token.startswith("CAFE_"):
+                raise ValueError(f"Legacy CAFE_ value is not allowed in valid_intents: {token!r}")
+            try:
+                PhaseStatusCode(token)
+            except ValueError as exc:
+                raise ValueError(f"Unknown step outcome token in valid_intents: {token!r}") from exc
+        return [item.strip() for item in value]
 
     @field_validator("skill")
     @classmethod

--- a/src/cafe/core/status_codes.py
+++ b/src/cafe/core/status_codes.py
@@ -1,76 +1,96 @@
-"""Status codes for phase execution control."""
+"""Step outcome tokens for workflow execution (non-legacy vocabulary)."""
+
+from __future__ import annotations
 
 from enum import Enum
 from typing import List, Optional, Set
 
+# Keys allowed in playbook step ``on`` maps (plus ``default``).
+PLAYBOOK_INTENT_KEYS: frozenset[str] = frozenset(
+    {
+        "await_agent",
+        "confirm_output",
+        "need_clarification",
+        "need_permission",
+        "workflow_complete",
+        "manual_handoff",
+    }
+)
+
 
 class PhaseStatusCode(str, Enum):
-    """Status codes that agents can return to control workflow.
+    """Agent-declared step outcomes.
 
-    These codes are designed to be:
-    - Prefixed with CAFE_ to avoid false positives
-    - Simple English words
-    - Token-efficient
-    - Easy for agents to understand and return
+    Values are plain tokens (no ``CAFE_`` prefix). Some values collapse to
+    playbook ``on`` keys via :func:`transition_map_key`; others already match
+    a playbook intent key.
     """
 
-    NO_RESPONSE = "CAFE_NO_RESPONSE"
-    CONFIRMED = "CAFE_CONFIRMED"
-    NEED_CLARIFICATION = "CAFE_NEED_CLARIFICATION"
-    REJECTED = "CAFE_REJECTED"
-    READY_FOR_REVIEW = "CAFE_READY_FOR_REVIEW"
-    NEEDS_CHANGES = "CAFE_NEEDS_CHANGES"
-    NO_CHANGES_NEEDED = "CAFE_NO_CHANGES_NEEDED"
-    CONFIRMED_SKIP_REVIEW = "CAFE_CONFIRMED_SKIP_REVIEW"
-    NEED_PERMISSION = "CAFE_NEED_PERMISSION"
+    AWAIT_AGENT = "await_agent"
+    CONFIRM_OUTPUT = "confirm_output"
+    NEED_CLARIFICATION = "need_clarification"
+    NEED_PERMISSION = "need_permission"
+    WORKFLOW_COMPLETE = "workflow_complete"
+    MANUAL_HANDOFF = "manual_handoff"
+
+    CONFIRMED = "confirmed"
+    READY_FOR_REVIEW = "ready_for_review"
+    NEEDS_CHANGES = "needs_changes"
+    NO_CHANGES_NEEDED = "no_changes_needed"
+    CONFIRMED_SKIP_REVIEW = "skip_review"
+    REJECTED = "rejected"
+    NO_RESPONSE = "no_response"
+
+
+def transition_map_key(code: PhaseStatusCode) -> str:
+    """Map a phase outcome to a playbook ``on`` transition key."""
+    if code.value in PLAYBOOK_INTENT_KEYS:
+        return code.value
+    collapsed: dict[PhaseStatusCode, str] = {
+        PhaseStatusCode.CONFIRMED: "await_agent",
+        PhaseStatusCode.NO_CHANGES_NEEDED: "await_agent",
+        PhaseStatusCode.NO_RESPONSE: "await_agent",
+        PhaseStatusCode.READY_FOR_REVIEW: "confirm_output",
+        PhaseStatusCode.NEED_CLARIFICATION: "need_clarification",
+        PhaseStatusCode.NEED_PERMISSION: "need_permission",
+        PhaseStatusCode.NEEDS_CHANGES: "manual_handoff",
+        PhaseStatusCode.CONFIRMED_SKIP_REVIEW: "manual_handoff",
+        PhaseStatusCode.REJECTED: "manual_handoff",
+    }
+    return collapsed.get(code, "manual_handoff")
 
 
 class StatusCodeParser:
-    """Parser for extracting status codes from agent responses."""
-
-    STATUS_CODE_ALIASES = {
-        "CAFE_SPEC_READY": PhaseStatusCode.READY_FOR_REVIEW.value,
-        "CAFE_PLAN_READY": PhaseStatusCode.READY_FOR_REVIEW.value,
-        "CAFE_DEVELOP_DONE": PhaseStatusCode.CONFIRMED.value,
-        "CAFE_PR_READY": PhaseStatusCode.READY_FOR_REVIEW.value,
-    }
-
-    @classmethod
-    def _normalize_aliases(cls, response: str) -> str:
-        normalized = response
-        for alias, canonical in cls.STATUS_CODE_ALIASES.items():
-            normalized = normalized.replace(alias, canonical)
-        return normalized
+    """Parser for extracting step outcome tokens from agent responses."""
 
     @staticmethod
     def extract(response: str, valid_codes: Optional[List[PhaseStatusCode]] = None) -> Optional[PhaseStatusCode]:
         if not response:
             return None
-        response = StatusCodeParser._normalize_aliases(response.upper())
         all_codes = StatusCodeParser.extract_all(response, valid_codes)
         if len(all_codes) > 1:
             return None
 
-        first_line = response.strip().split("\n")[0].strip().upper()
-        try:
-            code = PhaseStatusCode(first_line)
-            if valid_codes is None or code in valid_codes:
-                return code
-        except ValueError:
-            pass
+        first_line = response.strip().split("\n")[0].strip()
+        lowered = first_line.lower()
+        allowed = {c.value.lower(): c for c in (valid_codes or list(PhaseStatusCode))}
+        if lowered in allowed:
+            return allowed[lowered]
 
-        for code in sorted(PhaseStatusCode, key=lambda item: len(item.value), reverse=True):
-            if code.value in first_line and (valid_codes is None or code in valid_codes):
+        for token, code in sorted(allowed.items(), key=lambda item: len(item[0]), reverse=True):
+            if token in lowered:
                 return code
 
         if valid_codes:
-            for code in valid_codes:
-                if code.value in response:
+            haystack = response.lower()
+            for code in sorted(valid_codes, key=lambda item: len(item.value), reverse=True):
+                if code.value.lower() in haystack:
                     return code
 
         for code in sorted(PhaseStatusCode, key=lambda item: len(item.value), reverse=True):
-            if code.value in response and (valid_codes is None or code in valid_codes):
-                return code
+            if code.value.lower() in response.lower():
+                if valid_codes is None or code in valid_codes:
+                    return code
         return None
 
     @staticmethod
@@ -79,25 +99,26 @@ class StatusCodeParser:
             return set()
 
         found_codes: Set[PhaseStatusCode] = set()
-        response_upper = StatusCodeParser._normalize_aliases(response.upper())
+        haystack = response.lower()
         codes_to_check = sorted(
             valid_codes if valid_codes else list(PhaseStatusCode),
             key=lambda item: len(item.value),
             reverse=True,
         )
         for code in codes_to_check:
-            if code.value in response_upper:
-                if any(found.value.startswith(code.value) for found in found_codes):
+            token = code.value.lower()
+            if token in haystack:
+                if any(found.value.startswith(token) for found in found_codes):
                     continue
                 found_codes = {
-                    found for found in found_codes if not code.value.startswith(found.value)
+                    found for found in found_codes if not token.startswith(found.value.lower())
                 }
                 found_codes.add(code)
         return found_codes
 
     @staticmethod
     def is_success(code: Optional[PhaseStatusCode]) -> bool:
-        return code in {PhaseStatusCode.CONFIRMED}
+        return code in {PhaseStatusCode.CONFIRMED, PhaseStatusCode.AWAIT_AGENT}
 
     @staticmethod
     def is_failure(code: Optional[PhaseStatusCode]) -> bool:
@@ -109,6 +130,7 @@ class StatusCodeParser:
             PhaseStatusCode.NEED_CLARIFICATION,
             PhaseStatusCode.NEEDS_CHANGES,
             PhaseStatusCode.NEED_PERMISSION,
+            PhaseStatusCode.MANUAL_HANDOFF,
         }
 
     @staticmethod
@@ -117,13 +139,14 @@ class StatusCodeParser:
             PhaseStatusCode.NEED_PERMISSION,
             PhaseStatusCode.NEED_CLARIFICATION,
             PhaseStatusCode.READY_FOR_REVIEW,
+            PhaseStatusCode.CONFIRM_OUTPUT,
         }
 
 
 def generate_status_code_prompt(valid_codes: List[PhaseStatusCode], descriptions: dict) -> str:
-    """Generate prompt text instructing agent to use status codes."""
+    """Generate prompt text instructing the agent which outcome token to return."""
     lines = [
-        "Please clearly indicate the status code on the first line of your response (must include CAFE_ prefix):",
+        "Return exactly one outcome token on the first line of your response (snake_case, no legacy prefixes):",
         "",
     ]
     for code in valid_codes:
@@ -133,7 +156,7 @@ def generate_status_code_prompt(valid_codes: List[PhaseStatusCode], descriptions
         [
             "",
             "**Response format:**",
-            "- Return ONLY the status code on the first line",
+            "- Return ONLY the token on the first line",
             "- Do NOT include any summary or explanation",
         ]
     )

--- a/src/cafe/core/workflow_runtime.py
+++ b/src/cafe/core/workflow_runtime.py
@@ -13,14 +13,15 @@ import re
 from typing import Any, Dict, Optional
 
 from cafe.core.blackboard import BlackboardStore, HandoffIntent, HandoffOwner
-from cafe.core.status_codes import PhaseStatusCode, StatusCodeParser
+from cafe.core.status_codes import PhaseStatusCode, StatusCodeParser, transition_map_key
 from cafe.core.workflow_models import PlaybookRunResult, StepExecutionResult
 
 
 STATUS_TOKEN_PATTERN = re.compile(r"\bCAFE_[A-Z0-9_]+\b")
-GOTO_PATTERN = re.compile(r"CAFE_GOTO\s*:\s*([a-zA-Z0-9_-]+)")
+GOTO_PATTERN = re.compile(r"GOTO\s*:\s*([a-zA-Z0-9_-]+)")
 PAUSE_STATUS_CODES = {
     PhaseStatusCode.READY_FOR_REVIEW.value,
+    PhaseStatusCode.CONFIRM_OUTPUT.value,
     PhaseStatusCode.NEED_CLARIFICATION.value,
     PhaseStatusCode.NEED_PERMISSION.value,
 }
@@ -82,7 +83,10 @@ class BlackboardWorkflowRuntime:
 
     @staticmethod
     def _default_pause_intent(current_step: str, status_code: str) -> HandoffIntent:
-        if status_code == PhaseStatusCode.READY_FOR_REVIEW.value and current_step in {"spec", "plan"}:
+        if status_code in {
+            PhaseStatusCode.READY_FOR_REVIEW.value,
+            PhaseStatusCode.CONFIRM_OUTPUT.value,
+        } and current_step in {"spec", "plan"}:
             return HandoffIntent.CONFIRM_OUTPUT
         if status_code == PhaseStatusCode.NEED_CLARIFICATION.value:
             return HandoffIntent.NEED_CLARIFICATION
@@ -136,12 +140,19 @@ class BlackboardWorkflowRuntime:
                 },
             )
 
-        if status_code not in transitions:
+        transition_key = status_code
+        if status_code:
+            try:
+                transition_key = transition_map_key(PhaseStatusCode(status_code))
+            except ValueError:
+                transition_key = status_code
+        target = transitions.get(transition_key) if transition_key else None
+        if target is None:
             default_target = transitions.get("default")
             if default_target:
                 return str(default_target), "default"
             return None, "terminal"
-        return str(transitions[status_code]), "status"
+        return str(target), "status"
 
     @staticmethod
     def _extract_handoff_intent(execution_result: Any) -> Optional[HandoffIntent]:
@@ -248,8 +259,15 @@ class BlackboardWorkflowRuntime:
     @staticmethod
     def _extract_status_like_tokens(*, response: str, explicit_status_code: Optional[str]) -> set[str]:
         tokens = set(STATUS_TOKEN_PATTERN.findall(response or ""))
-        if explicit_status_code and explicit_status_code.startswith("CAFE_"):
+        haystack = f"{response or ''}\n{explicit_status_code or ''}"
+        if explicit_status_code:
             tokens.add(explicit_status_code)
+        for code in PhaseStatusCode:
+            token = code.value
+            if not token:
+                continue
+            if re.search(rf"(?<!\w){re.escape(token)}(?!\w)", haystack, flags=re.IGNORECASE):
+                tokens.add(token)
         return tokens
 
     def _resolve_review_confirmed_successor(self, current_step: str) -> Optional[str]:
@@ -258,7 +276,7 @@ class BlackboardWorkflowRuntime:
         if not isinstance(transitions, dict):
             return None
 
-        confirmed_target = transitions.get(PhaseStatusCode.CONFIRMED.value)
+        confirmed_target = transitions.get(transition_map_key(PhaseStatusCode.CONFIRMED))
         if confirmed_target and confirmed_target != current_step:
             return str(confirmed_target)
 
@@ -298,7 +316,7 @@ class BlackboardWorkflowRuntime:
     ) -> tuple[Optional[PhaseStatusCode], Optional[str], list[PhaseStatusCode]]:
         valid_codes = [
             PhaseStatusCode(code)
-            for code in step_def.get("valid_status_codes", [])
+            for code in step_def.get("valid_intents", [])
             if code in {item.value for item in PhaseStatusCode}
         ]
         goto_target = self._extract_goto_target(response)
@@ -789,7 +807,7 @@ class BlackboardWorkflowRuntime:
                 if goto_target:
                     handoff_next_step, handoff_transition_source = self._resolve_next_step(
                         current_step=current_step,
-                        response=f"{frame.response}\nCAFE_GOTO:{goto_target}",
+                        response=f"{frame.response}\nGOTO:{goto_target}",
                         status_code="",
                     )
                 if handoff_next_step is not None:
@@ -800,7 +818,7 @@ class BlackboardWorkflowRuntime:
                         response=frame.response,
                         explicit_status_code=frame.explicit_status_code,
                     )
-                    invalid_status_codes = sorted(
+                    invalid_intents = sorted(
                         token for token in status_like_tokens if token not in allowed_status_codes
                     )
                     default_next_step, _ = self._resolve_next_step(
@@ -809,10 +827,10 @@ class BlackboardWorkflowRuntime:
                         status_code="",
                     )
                     if default_next_step is not None:
-                        event_name = "status_code_invalid" if invalid_status_codes else "status_code_missing"
+                        event_name = "status_code_invalid" if invalid_intents else "status_code_missing"
                         event_data: Dict[str, Any] = {"step": current_step, "response": frame.response}
-                        if invalid_status_codes:
-                            event_data["invalid_status_codes"] = invalid_status_codes
+                        if invalid_intents:
+                            event_data["invalid_intents"] = invalid_intents
                             event_data["allowed_status_codes"] = sorted(allowed_status_codes)
                         event_data["default_transition"] = default_next_step
                         event_data["runtime"] = runtime_label
@@ -821,13 +839,13 @@ class BlackboardWorkflowRuntime:
                         handoff_transition_source = "default"
                         status_code = "NO_STATUS_CODE"
                         last_status_code = status_code
-                    elif invalid_status_codes:
+                    elif invalid_intents:
                         self.blackboard_store.record_event(
                             self.blackboard,
                             "status_code_invalid",
                             {
                                 "step": current_step,
-                                "invalid_status_codes": invalid_status_codes,
+                                "invalid_intents": invalid_intents,
                                 "allowed_status_codes": sorted(allowed_status_codes),
                                 "response": frame.response,
                                 "runtime": runtime_label,
@@ -943,7 +961,7 @@ class BlackboardWorkflowRuntime:
                 next_step, transition_source = self._resolve_next_step(
                     current_step=current_step,
                     response=(
-                        frame.response if goto_target is None else f"{frame.response}\nCAFE_GOTO:{goto_target}"
+                        frame.response if goto_target is None else f"{frame.response}\nGOTO:{goto_target}"
                     ),
                     status_code=status_code,
                 )

--- a/src/cafe/data/playbooks/default.yaml
+++ b/src/cafe/data/playbooks/default.yaml
@@ -31,10 +31,10 @@ steps:
       prepare_input: [GitHubIssueFetcher, UserInputCollector]
       after_execute: [InteractiveQAHandler]
     "on":
-      CAFE_READY_FOR_REVIEW: spec
-      CAFE_NEED_CLARIFICATION: spec
-      CAFE_NEED_PERMISSION: spec
-      CAFE_CONFIRMED: plan
+      confirm_output: spec
+      need_clarification: spec
+      need_permission: spec
+      await_agent: plan
 
   plan:
     type: skill
@@ -48,7 +48,7 @@ steps:
       prepare_input: [UserInputCollector]
       after_execute:
         - script: sync_github.sh
-          when_status_codes: [CAFE_CONFIRMED]
+          when_intents: [confirmed]
           args:
             phase: plan
             output: "{output_file}"
@@ -63,10 +63,10 @@ steps:
               output:
                 type: string
     "on":
-      CAFE_READY_FOR_REVIEW: plan
-      CAFE_NEED_CLARIFICATION: plan
-      CAFE_NEED_PERMISSION: plan
-      CAFE_CONFIRMED: develop
+      confirm_output: plan
+      need_clarification: plan
+      need_permission: plan
+      await_agent: develop
 
   develop:
     type: skill
@@ -80,11 +80,10 @@ steps:
       prepare_input: [UserInputCollector]
       after_execute: [PermissionRetryHandler]
     "on":
-      CAFE_CONFIRMED: review
-      CAFE_CONFIRMED_SKIP_REVIEW: pr
-      CAFE_NEED_CLARIFICATION: develop
-      CAFE_NEED_PERMISSION: develop
-      CAFE_NO_CHANGES_NEEDED: review
+      await_agent: review
+      manual_handoff: pr
+      need_clarification: develop
+      need_permission: develop
 
   review:
     type: skill
@@ -100,9 +99,9 @@ steps:
       prepare_input: [UserInputCollector]
       before_execute: [NewChangesGate]
     "on":
-      CAFE_CONFIRMED: pr
-      CAFE_NEEDS_CHANGES: develop
-      CAFE_NEED_CLARIFICATION: review
+      await_agent: pr
+      manual_handoff: develop
+      need_clarification: review
 
   pr:
     type: skill
@@ -117,8 +116,8 @@ steps:
       prepare_input: [GitHubPRCreator, UserInputCollector]
       publish_output: [GitHubPRCreator, LocalPRReviewer, PRLinkOpener]
     "on":
-      CAFE_CONFIRMED: _done
-      CAFE_NEED_PERMISSION: pr
-      CAFE_NEEDS_CHANGES: develop
+      await_agent: _done
+      need_permission: pr
+      manual_handoff: develop
 
 entry_point: spec

--- a/src/cafe/data/playbooks/hotfix.yaml
+++ b/src/cafe/data/playbooks/hotfix.yaml
@@ -25,11 +25,10 @@ steps:
       prepare_input: [UserInputCollector]
       after_execute: [PermissionRetryHandler]
     "on":
-      CAFE_CONFIRMED: review
-      CAFE_CONFIRMED_SKIP_REVIEW: pr
-      CAFE_NEED_CLARIFICATION: develop
-      CAFE_NEED_PERMISSION: develop
-      CAFE_NO_CHANGES_NEEDED: review
+      await_agent: review
+      manual_handoff: pr
+      need_clarification: develop
+      need_permission: develop
 
   review:
     type: skill
@@ -45,9 +44,9 @@ steps:
       prepare_input: [UserInputCollector]
       before_execute: [NewChangesGate]
     "on":
-      CAFE_CONFIRMED: pr
-      CAFE_NEEDS_CHANGES: develop
-      CAFE_NEED_CLARIFICATION: review
+      await_agent: pr
+      manual_handoff: develop
+      need_clarification: review
 
   pr:
     type: skill
@@ -62,8 +61,8 @@ steps:
       prepare_input: [GitHubPRCreator, UserInputCollector]
       publish_output: [GitHubPRCreator, LocalPRReviewer, PRLinkOpener]
     "on":
-      CAFE_CONFIRMED: _done
-      CAFE_NEED_PERMISSION: pr
-      CAFE_NEEDS_CHANGES: develop
+      await_agent: _done
+      need_permission: pr
+      manual_handoff: develop
 
 entry_point: develop

--- a/src/cafe/data/playbooks/simple.yaml
+++ b/src/cafe/data/playbooks/simple.yaml
@@ -27,10 +27,10 @@ steps:
       prepare_input: [GitHubIssueFetcher, UserInputCollector]
       after_execute: [InteractiveQAHandler]
     "on":
-      CAFE_READY_FOR_REVIEW: spec
-      CAFE_NEED_CLARIFICATION: spec
-      CAFE_NEED_PERMISSION: spec
-      CAFE_CONFIRMED: develop
+      confirm_output: spec
+      need_clarification: spec
+      need_permission: spec
+      await_agent: develop
 
   develop:
     type: skill
@@ -44,11 +44,9 @@ steps:
       prepare_input: [UserInputCollector]
       after_execute: [PermissionRetryHandler]
     "on":
-      CAFE_CONFIRMED: pr
-      CAFE_CONFIRMED_SKIP_REVIEW: pr
-      CAFE_NEED_CLARIFICATION: develop
-      CAFE_NEED_PERMISSION: develop
-      CAFE_NO_CHANGES_NEEDED: pr
+      await_agent: pr
+      need_clarification: develop
+      need_permission: develop
 
   pr:
     type: skill
@@ -63,8 +61,8 @@ steps:
       prepare_input: [GitHubPRCreator, UserInputCollector]
       publish_output: [GitHubPRCreator, LocalPRReviewer, PRLinkOpener]
     "on":
-      CAFE_CONFIRMED: _done
-      CAFE_NEED_PERMISSION: pr
-      CAFE_NEEDS_CHANGES: develop
+      await_agent: _done
+      need_permission: pr
+      manual_handoff: develop
 
 entry_point: spec

--- a/src/cafe/data/skills/plan/references/xml_questions_instruction.md
+++ b/src/cafe/data/skills/plan/references/xml_questions_instruction.md
@@ -1,7 +1,7 @@
 
 ## Interactive Q&A Questions
 
-[ ] If user clarification is needed: write questions to {questions_xml_file} in the following XML format and hand off to `user` with CAFE_NEED_CLARIFICATION:
+[ ] If user clarification is needed: write questions to {questions_xml_file} in the following XML format and hand off to `user` with need_clarification:
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>

--- a/src/cafe/data/skills/pr/references/execution_steps_iteration_1.md
+++ b/src/cafe/data/skills/pr/references/execution_steps_iteration_1.md
@@ -10,4 +10,4 @@
 [ ] List all major changes and commits in the Changes section
 [ ] Do not query or wait for a remote GitHub branch/PR; host-side publish runs after this phase returns
 [ ] Update blackboard and next-step baton to hand off to the next workflow target
-[ ] Mark this checklist complete before returning CAFE_CONFIRMED
+[ ] Mark this checklist complete before returning confirmed

--- a/src/cafe/data/skills/pr/references/execution_steps_iteration_n.md
+++ b/src/cafe/data/skills/pr/references/execution_steps_iteration_n.md
@@ -6,4 +6,4 @@
 [ ] Edit {current_pr_file} to update PR content based on new changes (NOT in your response)
 [ ] Do not query or wait for a remote GitHub branch/PR; host-side publish runs after this phase returns
 [ ] Update blackboard and next-step baton to hand off to the next workflow target
-[ ] Mark this checklist complete before returning CAFE_CONFIRMED
+[ ] Mark this checklist complete before returning confirmed

--- a/src/cafe/phases/develop_phase.py
+++ b/src/cafe/phases/develop_phase.py
@@ -427,7 +427,7 @@ class DevelopPhase(Phase):
                     data={
                         "iterations": prev_data.get("iteration", self.iteration - 1),
                         "last_response": prev_data.get("response", ""),
-                        "status_code": "CAFE_NO_CHANGES_NEEDED",
+                        "status_code": "no_changes_needed",
                     },
                 )
 
@@ -591,7 +591,7 @@ class DevelopPhase(Phase):
         prev_status = self._context_status_code(prev_data) or ""
 
         # Handle pending NEED_PERMISSION from previous run
-        if prev_status == "CAFE_NEED_PERMISSION":
+        if prev_status == "need_permission":
             recovered_denials = []
             if self.iteration > 1:
                 recovered_denials = self._extract_codex_permission_denials_from_streaming_file(self.iteration - 1)
@@ -621,11 +621,11 @@ class DevelopPhase(Phase):
             # will be done in execute() method when constructing allowed_tools
 
         # Handle NEED_CLARIFICATION - use base class method
-        if prev_status == "CAFE_NEED_CLARIFICATION":
+        if prev_status == "need_clarification":
             return self._handle_need_clarification_input(prev_data, agent_display_name="Developer")
 
         # Handle NO_CHANGES_NEEDED - developer disputes reviewer's feedback
-        if prev_status == "CAFE_NO_CHANGES_NEEDED":
+        if prev_status == "await_agent":
             return self._handle_no_changes_needed_input(prev_data)
 
         # No special handling needed - clear user_input to avoid misuse
@@ -789,7 +789,7 @@ Steps for requesting clarification:
        </options>
      </question>
    </questions>
-3. Return CAFE_NEED_CLARIFICATION only, with no other content
+3. Return need_clarification only, with no other content
 """
 
         if has_review_feedback:
@@ -926,7 +926,7 @@ Read {agent_file} to understand your complete role definition and responsibiliti
             checklist_path = self._get_iteration_dir(self.iteration) / "checklist.md"
 
             # Check for develop clarification file from previous iteration
-            # (only exists if previous iteration returned CAFE_NEED_CLARIFICATION)
+            # (only exists if previous iteration returned need_clarification)
             develop_file = None
             if self.iteration > 1:
                 prev_iteration_dir = self.issue_dir / "develop" / f"iteration_{self.iteration - 1:03d}"
@@ -1055,7 +1055,7 @@ Read {agent_file} to understand your complete role definition and responsibiliti
             result, response = self._execute_and_handle_agent_response(
                 agent_name=self.dev_agent,
                 user_input=current_user_input,
-                valid_status_codes=[
+                valid_intents=[
                     PhaseStatusCode.CONFIRMED,
                     PhaseStatusCode.NEED_PERMISSION,
                     PhaseStatusCode.NEED_CLARIFICATION,
@@ -1107,7 +1107,7 @@ Read {agent_file} to understand your complete role definition and responsibiliti
                         )
                 elif response_status == PhaseStatusCode.NO_CHANGES_NEEDED:
                     # Check if output.md exists and has content
-                    print(f"\n⚠️  Developer returned CAFE_NO_CHANGES_NEEDED, checking for reasoning in output.md...")
+                    print(f"\n⚠️  Developer returned no_changes_needed, checking for reasoning in output.md...")
 
                     iteration_dir = self._get_iteration_dir(self.iteration)
                     output_file = iteration_dir / "output.md"
@@ -1118,13 +1118,13 @@ Read {agent_file} to understand your complete role definition and responsibiliti
                         # No reasoning provided, require agent to write it
                         print(f"⚠️  No reasoning found in output.md. Requesting agent to provide explanation...")
 
-                        continue_prompt = f"""Your response returned CAFE_NO_CHANGES_NEEDED.
+                        continue_prompt = f"""Your response returned no_changes_needed.
 
 You MUST provide your reasoning and explain why the reviewer's feedback is incorrect or unnecessary.
 
 Please:
 1. Write your detailed reasoning to {output_file}
-2. Return CAFE_NO_CHANGES_NEEDED again
+2. Return no_changes_needed again
 
 Do NOT return any other status code until you have written your reasoning."""
 
@@ -1230,7 +1230,7 @@ Do NOT return any other status code until you have written your reasoning."""
                     if not questions_xml_path.exists():
                         return PhaseResult(
                             status=PhaseStatus.FAILED,
-                            message=f"Developer returned CAFE_NEED_CLARIFICATION but did not write questions.xml in iteration {self.iteration}",
+                            message=f"Developer returned need_clarification but did not write questions.xml in iteration {self.iteration}",
                             data={
                                 "iterations": self.iteration,
                                 "last_response": response,
@@ -1286,15 +1286,15 @@ Do NOT return any other status code until you have written your reasoning."""
 
 Based on the following conditions, determine which status code to return:
 
-- CAFE_CONFIRMED: All tasks completed (all items checked in plan.md)
-- CAFE_NEED_PERMISSION: Need to request additional tool usage permissions
+- confirmed: All tasks completed (all items checked in plan.md)
+- need_permission: Need to request additional tool usage permissions
 
-Please return only one status code (example: CAFE_CONFIRMED), with no other content."""
+Please return only one status code (example: confirmed), with no other content."""
 
     def _detect_written_output_files(self) -> List[Path]:
         """Check if develop file was written before failure.
 
-        DevelopPhase uses iteration_XXX/output.md to record CAFE_NEED_CLARIFICATION questions.
+        DevelopPhase uses iteration_XXX/output.md to record need_clarification questions.
 
         Returns:
             List[Path]: Return list containing iteration_XXX/output.md if it exists, otherwise empty list

--- a/src/cafe/phases/generic_phase.py
+++ b/src/cafe/phases/generic_phase.py
@@ -36,7 +36,7 @@ class GenericPhaseExecution:
 class GenericPhase:
     """Build prompts from skill content and run lifecycle hooks."""
 
-    GOTO_PATTERN = re.compile(r"CAFE_GOTO\s*:\s*([a-zA-Z0-9_-]+)")
+    GOTO_PATTERN = re.compile(r"GOTO\s*:\s*([a-zA-Z0-9_-]+)")
     SCRIPT_HOOK_STAGES = {"before_execute", "after_execute"}
 
     def __init__(
@@ -146,9 +146,9 @@ class GenericPhase:
         self,
         *,
         response: str,
-        valid_status_codes: List[PhaseStatusCode],
+        valid_intents: List[PhaseStatusCode],
     ) -> Tuple[Optional[PhaseStatusCode], Optional[str]]:
-        status = StatusCodeParser.extract(response, valid_codes=valid_status_codes)
+        status = StatusCodeParser.extract(response, valid_codes=valid_intents)
         goto_target = self.extract_goto_target(response)
         return status, goto_target
 
@@ -360,13 +360,13 @@ class GenericPhase:
         if stage not in self.SCRIPT_HOOK_STAGES:
             raise ValueError(f"Script hooks are only supported in {sorted(self.SCRIPT_HOOK_STAGES)}")
 
-        script, args_template, schema, when_status_codes, timeout_seconds = self._parse_script_hook_declaration(
+        script, args_template, schema, when_intents, timeout_seconds = self._parse_script_hook_declaration(
             declaration
         )
 
-        if when_status_codes:
+        if when_intents:
             detected_status = self._detect_status_code(response=response or "", step_def=step_def)
-            if detected_status not in when_status_codes:
+            if detected_status not in when_intents:
                 return HookResult(
                     events=[
                         {
@@ -376,9 +376,9 @@ class GenericPhase:
                             "stage": stage,
                             "script": script,
                             "status": "skipped",
-                            "reason": "status_mismatch",
+                            "reason": "intent_mismatch",
                             "detected_status": detected_status,
-                            "when_status_codes": when_status_codes,
+                            "when_intents": when_intents,
                         }
                     ]
                 )
@@ -485,7 +485,7 @@ class GenericPhase:
     def _parse_script_hook_declaration(
         declaration: Dict[str, Any],
     ) -> tuple[str, Dict[str, Any], Optional[Dict[str, Any]], list[str], Optional[float]]:
-        allowed_fields = {"script", "args", "schema", "when_status_codes", "timeout_seconds"}
+        allowed_fields = {"script", "args", "schema", "when_intents", "timeout_seconds"}
         unknown = sorted(set(declaration.keys()) - allowed_fields)
         if unknown:
             raise ValueError(f"Script hook contains unsupported fields: {unknown}")
@@ -505,13 +505,13 @@ class GenericPhase:
         if schema is not None and not isinstance(schema, dict):
             raise ValueError("Script hook 'schema' must be an object")
 
-        when_status_codes_raw = declaration.get("when_status_codes", [])
-        if when_status_codes_raw is None:
-            when_status_codes_raw = []
-        if not isinstance(when_status_codes_raw, list) or not all(
-            isinstance(item, str) for item in when_status_codes_raw
+        when_intents_raw = declaration.get("when_intents", [])
+        if when_intents_raw is None:
+            when_intents_raw = []
+        if not isinstance(when_intents_raw, list) or not all(
+            isinstance(item, str) for item in when_intents_raw
         ):
-            raise ValueError("Script hook 'when_status_codes' must be a list of strings")
+            raise ValueError("Script hook 'when_intents' must be a list of strings")
 
         timeout_seconds_raw = declaration.get("timeout_seconds")
         timeout_seconds: Optional[float] = None
@@ -526,7 +526,7 @@ class GenericPhase:
             script,
             args,
             schema,
-            [item.strip() for item in when_status_codes_raw if item.strip()],
+            [item.strip() for item in when_intents_raw if item.strip()],
             timeout_seconds,
         )
 
@@ -627,7 +627,7 @@ class GenericPhase:
     def _detect_status_code(*, response: str, step_def: Dict[str, Any]) -> Optional[str]:
         valid = [
             PhaseStatusCode(code)
-            for code in step_def.get("valid_status_codes", [])
+            for code in step_def.get("valid_intents", [])
             if code in {item.value for item in PhaseStatusCode}
         ]
         status_code = StatusCodeParser.extract(response, valid_codes=valid or list(PhaseStatusCode))

--- a/src/cafe/phases/generic_workflow_step.py
+++ b/src/cafe/phases/generic_workflow_step.py
@@ -17,7 +17,7 @@ from cafe.core.blackboard import (
 )
 from cafe.core.git import GitOperations
 from cafe.core.phase import Phase
-from cafe.core.status_codes import PhaseStatusCode, StatusCodeParser
+from cafe.core.status_codes import PhaseStatusCode, StatusCodeParser, transition_map_key
 from cafe.core.workflow_models import StepExecutionResult
 from cafe.phases.generic_phase import GenericPhase
 from cafe.utils.checklist_generator import (
@@ -41,7 +41,7 @@ def align_pr_baton_after_execution(
     """If PR feedback needs code changes, ensure the baton leaves the PR step.
 
     Agents should update ``next_step.txt`` themselves, but when they return
-    ``CAFE_NEEDS_CHANGES`` while the baton still targets ``pr``, advance it to
+    ``manual_handoff`` while the baton still targets ``pr``, advance it to
     ``develop`` so ``BlackboardWorkflowRuntime`` can transition.
     """
     if step_name != "pr" or not status_code:
@@ -140,7 +140,7 @@ class GenericWorkflowStepExecutor(Phase):
             )
 
         skill_name = self._resolve_skill_name(step_def, self.iteration)
-        valid_status_codes = self._resolve_valid_status_codes(step_def)
+        valid_intents = self._resolve_valid_intents(step_def)
         agent_name = self._resolve_agent_name(step_def)
         self._apply_step_agent_model(step_name=step_name, step_def=step_def, agent_name=agent_name)
         agent_cli = self.agent_manager.get_agent(agent_name).config.cli
@@ -189,7 +189,7 @@ class GenericWorkflowStepExecutor(Phase):
                 agent_name=agent_name,
                 prompt=prompt,
                 user_input=resolved_user_input,
-                valid_status_codes=valid_status_codes,
+                valid_intents=valid_intents,
                 require_status_code=False,
                 persist_status=False,
                 allowed_tools=allowed_tools,
@@ -223,7 +223,7 @@ class GenericWorkflowStepExecutor(Phase):
         status_code = execution.status_code
         if require_status_code:
             if status_code is None:
-                status_code = StatusCodeParser.extract(response, valid_status_codes)
+                status_code = StatusCodeParser.extract(response, valid_intents)
 
         agent_was_invoked = bool(last_prompt)
         if (
@@ -239,7 +239,7 @@ class GenericWorkflowStepExecutor(Phase):
                 agent_name=agent_name,
                 prompt=last_prompt[0] if last_prompt else "",
                 user_input=resolved_user_input,
-                valid_status_codes=valid_status_codes,
+                valid_intents=valid_intents,
                 allowed_tools=allowed_tools,
                 max_retries=3,
             )
@@ -266,6 +266,7 @@ class GenericWorkflowStepExecutor(Phase):
         if require_status_code and self.interactive and status_code in {
             PhaseStatusCode.NEED_CLARIFICATION,
             PhaseStatusCode.READY_FOR_REVIEW,
+            PhaseStatusCode.CONFIRM_OUTPUT,
         }:
             auto_continue = True
 
@@ -379,10 +380,10 @@ class GenericWorkflowStepExecutor(Phase):
         return str(model) if model else None
 
     @staticmethod
-    def _resolve_valid_status_codes(step_def: Dict[str, Any]) -> List[PhaseStatusCode]:
+    def _resolve_valid_intents(step_def: Dict[str, Any]) -> List[PhaseStatusCode]:
         valid = []
         known_values = {item.value for item in PhaseStatusCode}
-        for code in step_def.get("valid_status_codes", []):
+        for code in step_def.get("valid_intents", []):
             if code in known_values:
                 valid.append(PhaseStatusCode(code))
         return valid or list(PhaseStatusCode)
@@ -636,7 +637,12 @@ class GenericWorkflowStepExecutor(Phase):
 
     @staticmethod
     def _should_validate_checklist(status_code: PhaseStatusCode) -> bool:
-        return status_code in {PhaseStatusCode.CONFIRMED, PhaseStatusCode.READY_FOR_REVIEW}
+        return status_code in {
+            PhaseStatusCode.CONFIRMED,
+            PhaseStatusCode.AWAIT_AGENT,
+            PhaseStatusCode.READY_FOR_REVIEW,
+            PhaseStatusCode.CONFIRM_OUTPUT,
+        }
 
     @staticmethod
     def _event_allows_auto_continue(event: Dict[str, Any]) -> bool:
@@ -645,7 +651,7 @@ class GenericWorkflowStepExecutor(Phase):
         Initial requirement collection also emits ``user_input_collected`` so
         the prompt can receive GitHub/manual issue text. That input is not a
         response to a clarification pause and must not suppress workflow
-        pausing when the agent returns ``CAFE_NEED_CLARIFICATION``.
+        pausing when the agent returns ``need_clarification``.
         """
         event_type = event.get("type")
         if event_type == "review_modification_requested":
@@ -661,6 +667,10 @@ class GenericWorkflowStepExecutor(Phase):
     @staticmethod
     def _resolve_handoff_intent(step_name: str, status_code: PhaseStatusCode) -> Optional[str]:
         if status_code == PhaseStatusCode.READY_FOR_REVIEW:
+            if step_name in {"spec", "plan"}:
+                return "confirm_output"
+            return "manual_handoff"
+        if status_code == PhaseStatusCode.CONFIRM_OUTPUT:
             if step_name in {"spec", "plan"}:
                 return "confirm_output"
             return "manual_handoff"
@@ -692,6 +702,7 @@ class GenericWorkflowStepExecutor(Phase):
         store = BlackboardStore(self.issue_dir)
         if not auto_continue and status_code.value in {
             PhaseStatusCode.READY_FOR_REVIEW.value,
+            PhaseStatusCode.CONFIRM_OUTPUT.value,
             PhaseStatusCode.NEED_CLARIFICATION.value,
             PhaseStatusCode.NEED_PERMISSION.value,
         }:
@@ -770,7 +781,8 @@ class GenericWorkflowStepExecutor(Phase):
         transitions = step_def.get("on", {})
         if not isinstance(transitions, dict):
             return None
-        target = transitions.get(status_code.value)
+        key = transition_map_key(status_code)
+        target = transitions.get(key)
         if target is None:
             target = transitions.get("default")
         return str(target) if target else None

--- a/src/cafe/phases/plan_phase.py
+++ b/src/cafe/phases/plan_phase.py
@@ -291,7 +291,7 @@ class PlanPhase(Phase):
             result, response = self._execute_and_handle_agent_response(
                 agent_name=self.dev_agent,
                 user_input=current_user_input,
-                valid_status_codes=[
+                valid_intents=[
                     PhaseStatusCode.READY_FOR_REVIEW,
                     PhaseStatusCode.NEED_CLARIFICATION,
                     PhaseStatusCode.NEED_PERMISSION,
@@ -456,8 +456,8 @@ Analyze {spec_file_path} and plan implementation steps.
 {rewrite_guardrails}
 
 **Output Format:**
-- **CAFE_NEED_CLARIFICATION**: Append \"## Implementation Plan\" and \"## Questions to Confirm\" sections
-- **CAFE_READY_FOR_REVIEW**: Append complete implementation plan following template structure
+- **need_clarification**: Append \"## Implementation Plan\" and \"## Questions to Confirm\" sections
+- **ready_for_review**: Append complete implementation plan following template structure
 
 {status_code_prompt}
 """
@@ -497,8 +497,8 @@ Continue analyzing the latest version of {spec_file_path}.
 {rewrite_guardrails}
 
 **Output Format:**
-- **CAFE_NEED_CLARIFICATION**: Update relevant sections and list questions in \"## Questions to Confirm\"
-- **CAFE_READY_FOR_REVIEW**: Update sections to meet user's requirements
+- **need_clarification**: Update relevant sections and list questions in \"## Questions to Confirm\"
+- **ready_for_review**: Update sections to meet user's requirements
 
 {status_code_prompt}
 """
@@ -600,7 +600,7 @@ Continue analyzing the latest version of {spec_file_path}.
         prev_status = self._context_status_code(prev_data) or ""
 
         # Get user input based on previous round status
-        if prev_status == "CAFE_READY_FOR_REVIEW":
+        if prev_status == "ready_for_review":
             # Need user choice: confirm/modify
             if self.interactive:
                 # Display delta from previous iteration before asking for decision
@@ -629,7 +629,7 @@ Continue analyzing the latest version of {spec_file_path}.
                         data={
                             "iterations": self.iteration - 1,
                             "last_response": prev_data.get("response", ""),
-                            "status_code": "CAFE_READY_FOR_REVIEW",
+                            "status_code": "ready_for_review",
                         },
                     )
 
@@ -643,7 +643,7 @@ Continue analyzing the latest version of {spec_file_path}.
             
             return result_or_input
 
-        elif prev_status == "CAFE_NEED_CLARIFICATION":
+        elif prev_status == "need_clarification":
             return self._handle_need_clarification_input(prev_data, agent_display_name="Developer")
         else:
             return ""
@@ -716,10 +716,10 @@ Continue analyzing the latest version of {spec_file_path}.
 
 Based on the following conditions, determine which status code to return:
 
-- CAFE_READY_FOR_REVIEW: Implementation plan is complete, ready for user review
-- CAFE_NEED_CLARIFICATION: There are still questions that need confirmation with user
+- ready_for_review: Implementation plan is complete, ready for user review
+- need_clarification: There are still questions that need confirmation with user
 
-Please only return one status code (e.g., CAFE_READY_FOR_REVIEW) without any other content."""
+Please only return one status code (e.g., ready_for_review) without any other content."""
 
     def _detect_written_output_files(self) -> List[Path]:
         """Check if plan file was written before failure.

--- a/src/cafe/phases/pr_phase.py
+++ b/src/cafe/phases/pr_phase.py
@@ -631,7 +631,7 @@ class PRPhase(Phase):
 
         # Only wait if status_code is NEEDS_CHANGES (not READY_FOR_REVIEW or CONFIRMED)
         status_code = pr_iteration_info.get("status_code")
-        if status_code != "CAFE_NEEDS_CHANGES":
+        if status_code != "needs_changes":
             return None
 
         # Latest iteration has NEEDS_CHANGES - check if develop has processed it
@@ -764,7 +764,7 @@ class PRPhase(Phase):
             status_code = pr_iteration_info.get("status_code")
 
             # If CONFIRMED, we're done - nothing more to do
-            if status_code == "CAFE_CONFIRMED":
+            if status_code == "confirmed":
                 console.print()
                 console.print(f"[green]✓ PR #{pr_number} feedback has been fully addressed[/green]")
                 console.print()
@@ -775,7 +775,7 @@ class PRPhase(Phase):
                 )
 
             # If READY_FOR_REVIEW, fetch comments from GitHub
-            if status_code == "CAFE_READY_FOR_REVIEW":
+            if status_code == "ready_for_review":
                 console.print()
                 console.print(f"[dim]Checking for new comments on PR #{pr_number}...[/dim]")
 
@@ -1345,7 +1345,7 @@ The system will verify checklist completion. If unchecked items remain, you will
             agent_name=self.dev_agent,
             prompt=prompt,
             user_input="",
-            valid_status_codes=[PhaseStatusCode.NEEDS_CHANGES, PhaseStatusCode.CONFIRMED],
+            valid_intents=[PhaseStatusCode.NEEDS_CHANGES, PhaseStatusCode.CONFIRMED],
             allowed_tools=allowed_tools,
         )
 
@@ -1434,29 +1434,29 @@ The system will verify checklist completion. If unchecked items remain, you will
             except ValueError:
                 user_input_display_confirm = str(user_input_file)
 
-            confirmation_prompt = f"""You returned CAFE_CONFIRMED for the PR comment organization task.
+            confirmation_prompt = f"""You returned confirmed for the PR comment organization task.
 
 IMPORTANT: This iteration's task is to organize PR review comments from {user_input_display_confirm} into a todo list in {output_display_confirm}.
 
-CAFE_CONFIRMED should ONLY be returned when:
+confirmed should ONLY be returned when:
 - All PR review comments have already been fully addressed/completed (mark them as [x] in the todo list), OR
 - All PR review comments are invalid/not applicable (no action needed)
 
-CAFE_NEEDS_CHANGES should be returned when:
+needs_changes should be returned when:
 - There are PR review comments that need to be addressed by the developer (create unchecked todo items - [ ])
 
 Please re-evaluate the PR comments and confirm:
-- If there are comments that require code changes or actions, return CAFE_NEEDS_CHANGES
-- If all comments are already addressed or not applicable, return CAFE_CONFIRMED
+- If there are comments that require code changes or actions, return needs_changes
+- If all comments are already addressed or not applicable, return confirmed
 
-Return ONLY the status code (CAFE_CONFIRMED or CAFE_NEEDS_CHANGES) with no explanation."""
+Return ONLY the status code (confirmed or needs_changes) with no explanation."""
 
             # Re-execute agent with confirmation prompt
             confirmation_response, confirmation_status_code = self._execute_agent_iteration(
                 agent_name=self.dev_agent,
                 prompt=confirmation_prompt,
                 user_input="",
-                valid_status_codes=[PhaseStatusCode.NEEDS_CHANGES, PhaseStatusCode.CONFIRMED],
+                valid_intents=[PhaseStatusCode.NEEDS_CHANGES, PhaseStatusCode.CONFIRMED],
                 allowed_tools=allowed_tools,
             )
 
@@ -1749,7 +1749,7 @@ Return ONLY the status code (CAFE_CONFIRMED or CAFE_NEEDS_CHANGES) with no expla
             return PhaseResult(
                 status=PhaseStatus.COMPLETED,
                 message=f"Pull Request #{pr_number} updated successfully",
-                data={"pr_number": pr_number, "pr_url": pr_url, "branch": branch_name, "status_code": "CAFE_READY_FOR_REVIEW"},
+                data={"pr_number": pr_number, "pr_url": pr_url, "branch": branch_name, "status_code": "ready_for_review"},
             )
         else:
             # Create new PR
@@ -1798,7 +1798,7 @@ Return ONLY the status code (CAFE_CONFIRMED or CAFE_NEEDS_CHANGES) with no expla
             return PhaseResult(
                 status=PhaseStatus.COMPLETED,
                 message=f"Pull Request #{pr_number} created successfully",
-                data={"pr_number": pr_number, "pr_url": pr_url, "branch": branch_name, "status_code": "CAFE_READY_FOR_REVIEW"},
+                data={"pr_number": pr_number, "pr_url": pr_url, "branch": branch_name, "status_code": "ready_for_review"},
             )
 
     def _generate_pr_content(self) -> PhaseResult | None:
@@ -1964,14 +1964,14 @@ Return ONLY the status code (CAFE_CONFIRMED or CAFE_NEEDS_CHANGES) with no expla
         result, response = self._execute_and_handle_agent_response(
             agent_name=self.dev_agent,
             user_input="",  # No user input for PR generation
-            valid_status_codes=[PhaseStatusCode.CONFIRMED, PhaseStatusCode.NEED_PERMISSION],
+            valid_intents=[PhaseStatusCode.CONFIRMED, PhaseStatusCode.NEED_PERMISSION],
             allowed_tools=allowed_tools,
             complete_codes=[PhaseStatusCode.CONFIRMED, PhaseStatusCode.NEED_PERMISSION],
             # Note: NEED_PERMISSION will be automatically moved to continue_codes by base class
         )
 
         # Check if we should return early (only for NEED_PERMISSION)
-        if result and result.data.get("status_code") == "CAFE_NEED_PERMISSION":
+        if result and result.data.get("status_code") == "need_permission":
             return result
 
         # Verify output file was created
@@ -2095,9 +2095,9 @@ The file should contain:
 
 Based on the following conditions, determine which status code to return:
 
-- CAFE_CONFIRMED: File exists and has complete content (both title and body)
+- confirmed: File exists and has complete content (both title and body)
 
-Please return only one status code (example: CAFE_CONFIRMED), with no other content."""
+Please return only one status code (example: confirmed), with no other content."""
 
     def _rebuild_checklist_for_iteration(self, iteration: int) -> None:
         """Rebuild checklist for current iteration using PR phase rules.

--- a/src/cafe/phases/review_phase.py
+++ b/src/cafe/phases/review_phase.py
@@ -260,7 +260,7 @@ class ReviewPhase(Phase):
             result, response = self._execute_and_handle_agent_response(
                 agent_name=self.review_agent,
                 user_input="",  # Review doesn't need user input
-                valid_status_codes=[
+                valid_intents=[
                     PhaseStatusCode.CONFIRMED,
                     PhaseStatusCode.NEEDS_CHANGES,
                 ],
@@ -503,10 +503,10 @@ git rebase --onto {self.base_branch} {self.base_branch} HEAD --exec '
 
 Based on the following conditions, determine which status code to return:
 
-- CAFE_CONFIRMED: Code review passed, no issues to fix
-- CAFE_NEEDS_CHANGES: Issues need to be fixed
+- confirmed: Code review passed, no issues to fix
+- needs_changes: Issues need to be fixed
 
-Please only return one status code (e.g., CAFE_CONFIRMED) without any other content."""
+Please only return one status code (e.g., confirmed) without any other content."""
 
     def _detect_written_output_files(self) -> List[Path]:
         """Check if review file was written before failure.

--- a/src/cafe/phases/spec_phase.py
+++ b/src/cafe/phases/spec_phase.py
@@ -413,7 +413,7 @@ class SpecPhase(Phase):
             result, response = self._execute_and_handle_agent_response(
                 agent_name=self.pm_agent,
                 user_input=current_user_input,
-                valid_status_codes=[
+                valid_intents=[
                     PhaseStatusCode.READY_FOR_REVIEW,
                     PhaseStatusCode.NEED_CLARIFICATION,
                     PhaseStatusCode.NEED_PERMISSION,
@@ -443,7 +443,7 @@ class SpecPhase(Phase):
             # Save rigor setting to issue.yaml after each iteration
             self._save_issue_config()
 
-            # Validate questions.xml when agent returns CAFE_NEED_CLARIFICATION
+            # Validate questions.xml when agent returns need_clarification
             status_code = self._extract_status_code_from_response(response)
             if status_code == PhaseStatusCode.NEED_CLARIFICATION:
                 self._validate_and_retry_questions_xml(
@@ -554,7 +554,7 @@ class SpecPhase(Phase):
         prev_status = self._context_status_code(prev_data) or ""
 
         # Get user input based on previous round status
-        if prev_status == "CAFE_READY_FOR_REVIEW":
+        if prev_status == "ready_for_review":
             # Need user choice: confirm/modify
             if self.interactive:
                 # Display delta from previous iteration before asking for decision
@@ -583,7 +583,7 @@ class SpecPhase(Phase):
                         data={
                             "iterations": self.iteration - 1,
                             "last_response": prev_data.get("response", ""),
-                            "status_code": "CAFE_READY_FOR_REVIEW",
+                            "status_code": "ready_for_review",
                         },
                     )
 
@@ -597,7 +597,7 @@ class SpecPhase(Phase):
 
             return result_or_input
 
-        elif prev_status == "CAFE_NEED_CLARIFICATION":
+        elif prev_status == "need_clarification":
             return self._handle_need_clarification_input(prev_data, agent_display_name="PM")
         else:
             return ""
@@ -1161,7 +1161,7 @@ class SpecPhase(Phase):
         if not spec_path.is_absolute():
             spec_path = spec_path.resolve()
         
-        return f"""Please use Read tool to read {spec_path}  and analyze current status.\n\nBased on the following conditions, determine which status code to return:\n\n- CAFE_READY_FOR_REVIEW: Requirements specification completed, all necessary information clarified, no pending questions\n- CAFE_NEED_CLARIFICATION: Specification still has issues that need user confirmation, or unclear details\n\nPlease return only one status code (e.g., CAFE_READY_FOR_REVIEW), no other content."""
+        return f"""Please use Read tool to read {spec_path}  and analyze current status.\n\nBased on the following conditions, determine which status code to return:\n\n- ready_for_review: Requirements specification completed, all necessary information clarified, no pending questions\n- need_clarification: Specification still has issues that need user confirmation, or unclear details\n\nPlease return only one status code (e.g., ready_for_review), no other content."""
 
     def _detect_written_output_files(self) -> List[Path]:
         """Check if spec file was written before failure.

--- a/src/cafe/phases/spec_phase.py
+++ b/src/cafe/phases/spec_phase.py
@@ -829,38 +829,45 @@ class SpecPhase(Phase):
         if not backup_path.exists():
             backup_path.write_text(spec_path.read_text())
 
+    @staticmethod
+    def _response_leading_line_is_outcome_token(line: str) -> bool:
+        """Return True when ``line`` is only a legacy ``CAFE_*`` tag or a :class:`PhaseStatusCode` token."""
+        stripped = (line or "").strip()
+        if not stripped:
+            return False
+        if stripped.upper().startswith("CAFE_"):
+            return True
+        parts = stripped.split()
+        if len(parts) != 1:
+            return False
+        token = parts[0].lower()
+        return token in {c.value.lower() for c in PhaseStatusCode}
+
     def _ensure_spec_file_written(self, response: str) -> None:
         """Ensure spec file is written (for mock mode or when agent does not use write tool).
-        
+
         In mock mode, agent will not actually call write tool, so content needs to be extracted from response and written.
-        
+
         Args:
             response: Agent response content
         """
         import os
-        
+
         # Only process in mock mode
         if not os.getenv("CAFE_MOCK_AGENTS"):
             return
-            
-        # Extract content after status code
-        lines = response.strip().split("\n")
-        if not lines:
+
+        raw_lines = response.strip().split("\n")
+        if not raw_lines:
             return
-            
-        # Skip first line (status code) and empty lines
-        content_lines = []
-        skip_first = True
-        for line in lines:
-            if skip_first and line.startswith("CAFE_"):
-                continue
-            skip_first = False
-            content_lines.append(line)
-        
-        content = "\n".join(content_lines).strip()
+
+        if self._response_leading_line_is_outcome_token(raw_lines[0]):
+            raw_lines = raw_lines[1:]
+
+        content = "\n".join(raw_lines).strip()
         if not content:
             return
-            
+
         # Write to file
         spec_path = Path(self.spec_file)
         spec_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/cafe/services/timeline_builder.py
+++ b/src/cafe/services/timeline_builder.py
@@ -174,7 +174,7 @@ class TimelineBuilder:
         end_time = None
         elapsed_time = None
 
-        # Map status - iterations.jsonl has status codes like "CAFE_CONFIRMED", "CAFE_NEEDS_CHANGES"
+        # Map status - iterations.jsonl has status codes like "confirmed", "needs_changes"
         # These should map to "completed" since they represent completed iterations
         status_str = iteration_status.get("status")
         if status_str and status_str.startswith("CAFE_"):

--- a/src/cafe/ui/cli_shared.py
+++ b/src/cafe/ui/cli_shared.py
@@ -887,7 +887,7 @@ def _build_workflow_pause_guidance(*, blackboard: object, final_status_code: str
             if event_type == "baton_missing_transition":
                 return "Agent did not hand off to a new step. Open chat with the current role or update the baton, then run cafe make again."
             if event_type == "status_code_invalid":
-                invalid_codes = data.get("invalid_status_codes")
+                invalid_codes = data.get("invalid_intents")
                 if isinstance(invalid_codes, list) and invalid_codes:
                     rendered = ", ".join(str(code) for code in invalid_codes)
                     return (
@@ -942,19 +942,19 @@ def _alias_pause_intent(alias_result: Dict[str, Any], *intents: str) -> bool:
 
 
 def _alias_is_confirmed_transition(alias_result: Dict[str, Any], step_name: str) -> bool:
-    return _alias_targets(alias_result, step_name) or _alias_status(alias_result) == "CAFE_CONFIRMED"
+    return _alias_targets(alias_result, step_name) or _alias_status(alias_result) == "confirmed"
 
 
 def _alias_needs_clarification(alias_result: Dict[str, Any]) -> bool:
-    return _alias_pause_intent(alias_result, "need_clarification") or _alias_status(alias_result) == "CAFE_NEED_CLARIFICATION"
+    return _alias_pause_intent(alias_result, "need_clarification") or _alias_status(alias_result) == "need_clarification"
 
 
 def _alias_needs_permission(alias_result: Dict[str, Any]) -> bool:
-    return _alias_pause_intent(alias_result, "need_permission") or _alias_status(alias_result) == "CAFE_NEED_PERMISSION"
+    return _alias_pause_intent(alias_result, "need_permission") or _alias_status(alias_result) == "need_permission"
 
 
 def _alias_confirm_output_pause(alias_result: Dict[str, Any]) -> bool:
-    return _alias_pause_intent(alias_result, "confirm_output") or _alias_status(alias_result) == "CAFE_READY_FOR_REVIEW"
+    return _alias_pause_intent(alias_result, "confirm_output") or _alias_status(alias_result) == "ready_for_review"
 
 
 def _reject_unsupported_phase_options(phase_name: str, unsupported_options: Dict[str, bool]) -> None:
@@ -1098,7 +1098,7 @@ def _run_iterative_alias_step(
             return alias_result
 
         console.print()
-        if handoff_intent == "need_clarification" or status_code == "CAFE_NEED_CLARIFICATION":
+        if handoff_intent == "need_clarification" or status_code == "need_clarification":
             console.print("[yellow]💬 Agent needs clarification[/yellow]")
             _display_iteration_questions(issue_name=issue_name, step_name=step_name, alias_result=alias_result)
         else:
@@ -1110,7 +1110,7 @@ def _run_iterative_alias_step(
             console.print("[dim]Stopped by user.[/dim]")
             return alias_result
 
-        if (handoff_intent == "need_clarification" or status_code == "CAFE_NEED_CLARIFICATION") and clarification_prompt:
+        if (handoff_intent == "need_clarification" or status_code == "need_clarification") and clarification_prompt:
             from cafe.ui.cli import prompt_multiline as _pml2
             current_input = _pml2(clarification_prompt).strip() or current_input
         iteration_count += 1

--- a/src/cafe/ui/commands/phases_legacy.py
+++ b/src/cafe/ui/commands/phases_legacy.py
@@ -172,7 +172,7 @@ def spec(
     auto: bool = typer.Option(
         False,
         "--auto",
-        help="Auto mode: automatically continue iterations until CAFE_CONFIRMED",
+        help="Auto mode: automatically continue iterations until confirmed",
     ),
     template: Optional[str] = typer.Option(
         None,
@@ -262,7 +262,7 @@ def spec(
             config_manager=config_manager,
             interactive=is_interactive,
             auto=auto,
-            continuation_statuses=["CAFE_NEED_CLARIFICATION", "CAFE_READY_FOR_REVIEW"],
+            continuation_statuses=["need_clarification", "ready_for_review"],
             role_agent_map_override={"pm": pm_agent} if pm_agent else None,
             user_input=current_input,
             show_prompt=show_prompt,
@@ -344,7 +344,7 @@ def plan(
     auto: bool = typer.Option(
         False,
         "--auto",
-        help="Auto mode: automatically continue iterations until CAFE_CONFIRMED",
+        help="Auto mode: automatically continue iterations until confirmed",
     ),
     sync_github: Optional[bool] = typer.Option(
         None,
@@ -427,7 +427,7 @@ def plan(
             config_manager=config_manager,
             interactive=is_interactive,
             auto=auto,
-            continuation_statuses=["CAFE_NEED_CLARIFICATION", "CAFE_READY_FOR_REVIEW"],
+            continuation_statuses=["need_clarification", "ready_for_review"],
             role_agent_map_override={"developer": dev_agent} if dev_agent else None,
             show_prompt=show_prompt,
             clarification_prompt="Additional planning details:",
@@ -584,9 +584,9 @@ def develop(
         console.print()
         resolved_next_step = _alias_next_step(alias_result)
         if not resolved_next_step:
-            if status_code == "CAFE_CONFIRMED_SKIP_REVIEW":
+            if status_code == "manual_handoff":
                 resolved_next_step = "pr"
-            elif status_code == "CAFE_CONFIRMED":
+            elif status_code == "await_agent":
                 resolved_next_step = "review"
 
         if resolved_next_step in {"review", "pr"}:
@@ -769,7 +769,11 @@ def review(
                 _execute_next_phase_auto("pr", issue_name)
             else:
                 console.print("[dim]Continue the workflow with:[/dim] [bold]cafe make[/bold]")
-        elif _alias_targets(alias_result, "develop") or status_code == "CAFE_NEEDS_CHANGES":
+        elif (
+            _alias_targets(alias_result, "develop")
+            or status_code == "manual_handoff"
+            or status_code == "needs_changes"
+        ):
             console.print(f"[bold yellow]📝 Code review completed with status: {status_code}[/bold yellow]")
             if alias_result.get("output_file"):
                 console.print(f"[dim]Review feedback saved to:[/dim] [dim]{alias_result['output_file']}[/dim]")
@@ -923,14 +927,14 @@ def pr(
         )
         status_code = _alias_status(alias_result)
         console.print()
-        if _alias_is_done(alias_result) or status_code == "CAFE_CONFIRMED":
+        if _alias_is_done(alias_result) or status_code in {"await_agent", "confirmed"}:
             console.print("[bold green]✅ PR content completed![/bold green]")
             console.print(f"Iterations: {alias_result.get('iterations', 'N/A')}")
             if alias_result.get("output_file"):
                 console.print(f"Saved to: {alias_result['output_file']}")
             console.print()
             console.print("[dim]Next step:[/dim] [bold]Review and submit the PR[/bold]")
-        elif _alias_targets(alias_result, "develop") or status_code == "CAFE_NEEDS_CHANGES":
+        elif _alias_targets(alias_result, "develop") or status_code == "manual_handoff":
             console.print(f"[bold yellow]PR step completed with status: {status_code}[/bold yellow]")
             if alias_result.get("output_file"):
                 console.print(f"Saved to: {alias_result['output_file']}")

--- a/src/cafe/ui/commands/workflow.py
+++ b/src/cafe/ui/commands/workflow.py
@@ -485,7 +485,7 @@ def workflow(
             return StepExecutionResult(
                 response="dry-run",
                 artifacts={str(output_key): str(output_path)},
-                status_code="CAFE_CONFIRMED",
+                status_code="confirmed",
             )
         step_executor = None if dry_run else _build_workflow_step_executor(
             config_manager=config_manager,

--- a/src/cafe/utils/checklist_generator.py
+++ b/src/cafe/utils/checklist_generator.py
@@ -277,7 +277,7 @@ def generate_develop_checklist(
         feedback_file_path: Path to feedback todo list file (from review or PR phase, for correction mode)
         basic_principles: Basic principles text in "- item" format (optional)
         output_file: Path to output file (for NO_CHANGES_NEEDED reasoning)
-        questions_xml_file: Path to questions.xml file for CAFE_NEED_CLARIFICATION
+        questions_xml_file: Path to questions.xml file for need_clarification
     """
     # Get agent file path
     agent_file = AgentManager.get_agent_file_path(agent_name, "developer")
@@ -378,7 +378,7 @@ def generate_review_checklist(
         pr_todo_list_section = f"""
 ## PR Todo List Check
 [ ] Read {pr_todo_list_file_path} - this is the todo list from the PR phase
-[ ] Check that ALL todo items are marked as completed [x]. If any unchecked items [ ] remain, return CAFE_NEEDS_CHANGES
+[ ] Check that ALL todo items are marked as completed [x]. If any unchecked items [ ] remain, return needs_changes
 """
 
     # Get agent guidelines checklist

--- a/src/cafe/utils/checklist_templates.py
+++ b/src/cafe/utils/checklist_templates.py
@@ -42,7 +42,7 @@ SPEC_EXECUTION_STEPS_ITERATION_N = """## Checklist
 XML_QUESTIONS_INSTRUCTION = """
 ## Interactive Q&A Questions
 
-[ ] If returning CAFE_NEED_CLARIFICATION: Write questions to {questions_xml_file} in the following XML format:
+[ ] If returning need_clarification: Write questions to {questions_xml_file} in the following XML format:
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -155,8 +155,8 @@ DEVELOP_EXECUTION_STEPS_CORRECTION = """## Checklist
 
 ## Status Codes
 
-- CAFE_CONFIRMED: All issues fixed, ready for review
-- CAFE_NO_CHANGES_NEEDED: You believe reviewer's feedback is incorrect/unnecessary. Write your reasoning to {output_file} then return this code.
+- confirmed: All issues fixed, ready for review
+- no_changes_needed: You believe reviewer's feedback is incorrect/unnecessary. Write your reasoning to {output_file} then return this code.
 {xml_questions_instruction}"""
 
 
@@ -171,7 +171,7 @@ REVIEW_EXECUTION_STEPS = """## Checklist
 [ ] Prioritize user feedback from PR comments over spec requirements if there are conflicts
 
 ## Git Status and Security Check
-[ ] Check if there are new commits (use `git log {base_branch}..HEAD`). If no commits exist, development is incomplete - return CAFE_NEEDS_CHANGES
+[ ] Check if there are new commits (use `git log {base_branch}..HEAD`). If no commits exist, development is incomplete - return needs_changes
 [ ] Check for uncommitted changes (if any, development is incomplete)
 [ ] Check for sensitive info in committed files (passwords, API keys, credentials)
 [ ] If sensitive info found: treat as critical issue, require immediate removal from commit history
@@ -233,7 +233,7 @@ PR_EXECUTION_STEPS_ITERATION_1 = """## Checklist
 [ ] Include reference to original requirements
 [ ] List all major changes and commits in the Changes section
 [ ] Do not query or wait for a remote GitHub branch/PR; host-side publish runs after this phase returns
-[ ] Mark this checklist complete before returning CAFE_CONFIRMED
+[ ] Mark this checklist complete before returning confirmed
 """
 
 PR_EXECUTION_STEPS_ITERATION_N = """## Checklist
@@ -243,7 +243,7 @@ PR_EXECUTION_STEPS_ITERATION_N = """## Checklist
 [ ] Review unpushed commits to identify new changes
 [ ] Edit {current_pr_file} to update PR content based on new changes (NOT in your response)
 [ ] Do not query or wait for a remote GitHub branch/PR; host-side publish runs after this phase returns
-[ ] Mark this checklist complete before returning CAFE_CONFIRMED
+[ ] Mark this checklist complete before returning confirmed
 """
 
 PR_COMMENTS_ORGANIZATION_STEPS = """## Checklist

--- a/tests/integration/test_pr_command_non_interactive.py
+++ b/tests/integration/test_pr_command_non_interactive.py
@@ -228,7 +228,7 @@ class TestPRCommandCustomTitleAndBody:
 
         # Enable mock agent mode
         monkeypatch.setenv("CAFE_MOCK_AGENTS", "true")
-        monkeypatch.setenv("CAFE_MOCK_RESPONSE", "CAFE_CONFIRMED\n\nPR content generated")
+        monkeypatch.setenv("CAFE_MOCK_RESPONSE", "confirmed\n\nPR content generated")
 
         # Override mock to return specific PR URL
         mock_github_ops.create_pr.return_value = "https://github.com/user/repo/pull/4"

--- a/tests/integration/test_pr_e2e_with_mock.py
+++ b/tests/integration/test_pr_e2e_with_mock.py
@@ -188,7 +188,7 @@ class TestPRE2EMockCustomTitleAndBody:
         result = run_cafe_pr(
             tmp_path,
             issue_name,
-            mock_response="CAFE_CONFIRMED\n\n# Auto-generated title"
+            mock_response="confirmed\n\n# Auto-generated title"
         )
 
         output = result.stdout + result.stderr
@@ -291,7 +291,7 @@ class TestPRE2EMockExistingFiles:
         result = run_cafe_pr(
             tmp_path,
             issue_name,
-            mock_response="CAFE_CONFIRMED\n\n# New Generated Title",
+            mock_response="confirmed\n\n# New Generated Title",
             extra_args=["--update"]
         )
 

--- a/tests/integration/test_workflow_e2e.py
+++ b/tests/integration/test_workflow_e2e.py
@@ -39,7 +39,7 @@ def _write_pr_done_baton(issue_dir: Path) -> None:
         to_owner=HandoffOwner.DONE,
         to_step="done",
         intent=HandoffIntent.WORKFLOW_COMPLETE,
-        status_code="CAFE_CONFIRMED",
+        status_code="confirmed",
         source="test.executor",
     )
 
@@ -108,9 +108,9 @@ class TestHappyPath:
                 _write_pr_done_baton(issue_dir)
                 events.append({"type": "pr_synced", "url": "https://example.com/pr/1"})
             return StepExecutionResult(
-                response="CAFE_CONFIRMED",
+                response="confirmed",
                 artifacts={str(step_def.get("output_artifact", step_name)): f"{step_name}/output.md"},
-                status_code="CAFE_CONFIRMED",
+                status_code="confirmed",
                 events=events,
             )
 
@@ -144,9 +144,9 @@ class TestHappyPath:
                 _write_pr_done_baton(issue_dir)
                 events.append({"type": "pr_synced", "url": "https://example.com/pr/1"})
             return StepExecutionResult(
-                response="CAFE_CONFIRMED",
+                response="confirmed",
                 artifacts={artifact_key: f"{step_name}/iteration_001/output.md"},
-                status_code="CAFE_CONFIRMED",
+                status_code="confirmed",
                 events=events,
             )
 
@@ -208,9 +208,9 @@ class TestSelfLoop:
                 _write_pr_done_baton(issue_dir)
                 events.append({"type": "pr_synced", "url": "https://example.com/pr/1"})
             return StepExecutionResult(
-                response="CAFE_CONFIRMED",
+                response="confirmed",
                 artifacts={str(step_def.get("output_artifact", step_name)): f"{step_name}/output.md"},
-                status_code="CAFE_CONFIRMED",
+                status_code="confirmed",
                 events=events,
             )
 
@@ -223,13 +223,13 @@ class TestSelfLoop:
         return result, call_counts, subsequent_calls
 
     def test_spec_self_loop_then_confirms(self, tmp_path: Path) -> None:
-        """spec CAFE_NEED_CLARIFICATION×2 後 CAFE_CONFIRMED，最終流向 plan。"""
+        """spec need_clarification×2 後 confirmed，最終流向 plan。"""
         result, calls, subsequent = self._run_single_step_loop(
             tmp_path,
             start_step="spec",
-            loop_status="CAFE_NEED_CLARIFICATION",
+            loop_status="need_clarification",
             loop_count=2,
-            final_status="CAFE_CONFIRMED",
+            final_status="confirmed",
             expected_next_step="plan",
         )
         assert calls["spec"] == 3  # 2 loop + 1 confirm
@@ -237,13 +237,13 @@ class TestSelfLoop:
         assert result.completed is True
 
     def test_plan_self_loop_then_confirms(self, tmp_path: Path) -> None:
-        """plan CAFE_READY_FOR_REVIEW×2 後 CAFE_CONFIRMED，最終流向 develop。"""
+        """plan ready_for_review×2 後 confirmed，最終流向 develop。"""
         result, calls, subsequent = self._run_single_step_loop(
             tmp_path,
             start_step="plan",
-            loop_status="CAFE_READY_FOR_REVIEW",
+            loop_status="ready_for_review",
             loop_count=2,
-            final_status="CAFE_CONFIRMED",
+            final_status="confirmed",
             expected_next_step="develop",
         )
         assert calls["plan"] == 3
@@ -251,13 +251,13 @@ class TestSelfLoop:
         assert result.completed is True
 
     def test_develop_self_loop_then_confirms(self, tmp_path: Path) -> None:
-        """develop CAFE_NEED_CLARIFICATION×2 後 CAFE_CONFIRMED，最終流向 review。"""
+        """develop need_clarification×2 後 confirmed，最終流向 review。"""
         result, calls, subsequent = self._run_single_step_loop(
             tmp_path,
             start_step="develop",
-            loop_status="CAFE_NEED_CLARIFICATION",
+            loop_status="need_clarification",
             loop_count=2,
-            final_status="CAFE_CONFIRMED",
+            final_status="confirmed",
             expected_next_step="review",
         )
         assert calls["develop"] == 3
@@ -265,13 +265,13 @@ class TestSelfLoop:
         assert result.completed is True
 
     def test_review_self_loop_then_confirms(self, tmp_path: Path) -> None:
-        """review CAFE_NEED_CLARIFICATION×2 後 CAFE_CONFIRMED，在 max_iterations=3 限制內。"""
+        """review need_clarification×2 後 confirmed，在 max_iterations=3 限制內。"""
         result, calls, subsequent = self._run_single_step_loop(
             tmp_path,
             start_step="review",
-            loop_status="CAFE_NEED_CLARIFICATION",
+            loop_status="need_clarification",
             loop_count=2,
-            final_status="CAFE_CONFIRMED",
+            final_status="confirmed",
             expected_next_step="pr",
         )
         assert calls["review"] == 3  # 2 loop + 1 confirm，恰好在限制內
@@ -288,14 +288,14 @@ class TestSelfLoop:
             call_counts[step_name] = call_counts.get(step_name, 0) + 1
             if step_name == "review":
                 return StepExecutionResult(
-                    response="CAFE_NEEDS_CHANGES",
+                    response="needs_changes",
                     artifacts={},
-                    status_code="CAFE_NEEDS_CHANGES",
+                    status_code="needs_changes",
                 )
             return StepExecutionResult(
-                response="CAFE_CONFIRMED",
+                response="confirmed",
                 artifacts={str(step_def.get("output_artifact", step_name)): f"{step_name}/output.md"},
-                status_code="CAFE_CONFIRMED",
+                status_code="confirmed",
             )
 
         runner = BlackboardWorkflowRuntime(
@@ -321,15 +321,15 @@ class TestSelfLoop:
                 spec_calls += 1
                 if spec_calls < 3:
                     return StepExecutionResult(
-                        response="CAFE_NEED_CLARIFICATION",
+                        response="need_clarification",
                         artifacts={},
-                        status_code="CAFE_NEED_CLARIFICATION",
+                        status_code="need_clarification",
                         auto_continue=True,
                     )
             return StepExecutionResult(
-                response="CAFE_CONFIRMED",
+                response="confirmed",
                 artifacts={str(step_def.get("output_artifact", step_name)): f"{step_name}/output.md"},
-                status_code="CAFE_CONFIRMED",
+                status_code="confirmed",
             )
 
         runner = BlackboardWorkflowRuntime(
@@ -354,15 +354,15 @@ class TestSelfLoop:
 
 class TestUserHandoff:
     def test_user_handoff_pauses_workflow(self, tmp_path: Path) -> None:
-        """spec 回傳 CAFE_NEED_CLARIFICATION（auto_continue=False）→ workflow 應暫停。"""
+        """spec 回傳 need_clarification（auto_continue=False）→ workflow 應暫停。"""
         issue_dir = tmp_path / ".cafe" / "issues" / "issue-handoff-pause"
         playbook = _load_default_playbook()
 
         def executor(step_name: str, step_def: dict, state: BlackboardState) -> StepExecutionResult:
             return StepExecutionResult(
-                response="CAFE_NEED_CLARIFICATION",
+                response="need_clarification",
                 artifacts={},
-                status_code="CAFE_NEED_CLARIFICATION",
+                status_code="need_clarification",
                 auto_continue=False,
             )
 
@@ -380,7 +380,7 @@ class TestUserHandoff:
         assert pause_events, "workflow_paused event should be recorded"
 
     def test_user_handoff_auto_continue_resumes_in_same_run(self, tmp_path: Path) -> None:
-        """spec 先 CAFE_NEED_CLARIFICATION（auto_continue=True），再 CAFE_CONFIRMED → 不暫停，直接流向 plan。"""
+        """spec 先 need_clarification（auto_continue=True），再 confirmed → 不暫停，直接流向 plan。"""
         issue_dir = tmp_path / ".cafe" / "issues" / "issue-handoff-resume"
         playbook = _load_default_playbook()
         spec_calls = 0
@@ -391,9 +391,9 @@ class TestUserHandoff:
                 spec_calls += 1
                 if spec_calls == 1:
                     return StepExecutionResult(
-                        response="CAFE_NEED_CLARIFICATION",
+                        response="need_clarification",
                         artifacts={},
-                        status_code="CAFE_NEED_CLARIFICATION",
+                        status_code="need_clarification",
                         auto_continue=True,
                     )
             events = []
@@ -401,9 +401,9 @@ class TestUserHandoff:
                 _write_pr_done_baton(issue_dir)
                 events.append({"type": "pr_synced", "url": "https://example.com/pr/1"})
             return StepExecutionResult(
-                response="CAFE_CONFIRMED",
+                response="confirmed",
                 artifacts={str(step_def.get("output_artifact", step_name)): f"{step_name}/output.md"},
-                status_code="CAFE_CONFIRMED",
+                status_code="confirmed",
                 events=events,
             )
 
@@ -440,15 +440,15 @@ class TestUserHandoff:
                     if spec_calls == 1:
                         # 第一次呼叫：暫停（auto_continue=False）
                         return StepExecutionResult(
-                            response="CAFE_NEED_CLARIFICATION",
+                            response="need_clarification",
                             artifacts={},
-                            status_code="CAFE_NEED_CLARIFICATION",
+                            status_code="need_clarification",
                             auto_continue=False,
                         )
                 return StepExecutionResult(
-                    response="CAFE_CONFIRMED",
+                    response="confirmed",
                     artifacts={str(step_def.get("output_artifact", step_name)): f"{step_name}/output.md"},
-                    status_code="CAFE_CONFIRMED",
+                    status_code="confirmed",
                 )
 
         cli_runner = CliRunner()
@@ -510,7 +510,7 @@ class TestNextStepLifecycle:
                 self, step_name: str, step_def: dict, blackboard_state: object
             ) -> tuple[str, dict[str, str]]:
                 return (
-                    "CAFE_CONFIRMED",
+                    "confirmed",
                     {str(step_def.get("output_artifact", step_name)): f"{step_name}/output.md"},
                 )
 

--- a/tests/unit/test_agent_manager_mock_mode.py
+++ b/tests/unit/test_agent_manager_mock_mode.py
@@ -80,7 +80,7 @@ class TestAgentManagerMockMode:
         agent_response = executor.execute("test prompt")
 
         # Assert
-        assert "CAFE_READY_FOR_REVIEW" in agent_response.response
+        assert "ready_for_review" in agent_response.response
 
     def test_mock_executor_uses_custom_response_from_env(self, monkeypatch):
         """測試 mock executor 可以從環境變數自訂回應"""

--- a/tests/unit/test_checklist_generator.py
+++ b/tests/unit/test_checklist_generator.py
@@ -574,7 +574,7 @@ class TestSpecDodInstruction:
 
         The status code parser (extract_all) scans the entire agent response for
         CAFE_ prefixed codes. If the DoD instruction contains a literal status code
-        like CAFE_READY_FOR_REVIEW, and the agent also returns CAFE_NEED_CLARIFICATION,
+        like ready_for_review, and the agent also returns need_clarification,
         the parser finds two different codes and returns None, causing the phase to fail.
         """
         instruction = checklist_templates.SPEC_DOD_INSTRUCTION

--- a/tests/unit/test_checklist_validation_status_code.py
+++ b/tests/unit/test_checklist_validation_status_code.py
@@ -58,14 +58,14 @@ class TestChecklistValidationPreservesStatusCode:
         # context.json has response WITH status code
         context = iteration_dir / "context.json"
         context.write_text(json.dumps({
-            "response": "Done.\n\nCAFE_NEED_CLARIFICATION",
+            "response": "Done.\n\nneed_clarification",
         }))
 
         response, status_code, passed = phase._validate_and_retry_checklist_completion(
             agent_name="Roger",
             prompt="test prompt",
             user_input="",
-            valid_status_codes=[PhaseStatusCode.READY_FOR_REVIEW, PhaseStatusCode.NEED_CLARIFICATION],
+            valid_intents=[PhaseStatusCode.READY_FOR_REVIEW, PhaseStatusCode.NEED_CLARIFICATION],
         )
 
         assert passed is True
@@ -93,7 +93,7 @@ class TestChecklistValidationPreservesStatusCode:
             agent_name="Roger",
             prompt="test prompt",
             user_input="",
-            valid_status_codes=[PhaseStatusCode.READY_FOR_REVIEW, PhaseStatusCode.NEED_CLARIFICATION],
+            valid_intents=[PhaseStatusCode.READY_FOR_REVIEW, PhaseStatusCode.NEED_CLARIFICATION],
         )
 
         assert passed is True

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -267,7 +267,7 @@ class TestPlanCommand:
         mock_select_template.return_value = "default"
 
         mock_execute_alias.return_value = {
-            "status_code": "CAFE_CONFIRMED",
+            "status_code": "confirmed",
             "iterations": 2,
             "output_file": str(spec_file),
         }
@@ -470,7 +470,7 @@ class TestPlanCommand:
         mock_git_ops.return_value = mock_git_instance
 
         mock_execute_alias.return_value = {
-            "status_code": "CAFE_CONFIRMED",
+            "status_code": "confirmed",
             "iterations": 1,
             "output_file": str(spec_file),
         }
@@ -536,7 +536,7 @@ class TestPlanCommand:
         mock_isatty.return_value = True
 
         mock_execute_alias.return_value = {
-            "status_code": "CAFE_CONFIRMED",
+            "status_code": "confirmed",
             "iterations": 1,
             "output_file": str(spec_file),
         }

--- a/tests/unit/test_cli_auto_mode.py
+++ b/tests/unit/test_cli_auto_mode.py
@@ -68,12 +68,12 @@ class TestAutoModeVariableScope:
             mock_run.return_value = MagicMock(returncode=0)
             mock_execute_alias.side_effect = [
                 {
-                    "status_code": "CAFE_READY_FOR_REVIEW",
+                    "status_code": "ready_for_review",
                     "iterations": 1,
                     "output_file": str(prepared_issue / "spec" / "iteration_001" / "output.md"),
                 },
                 {
-                    "status_code": "CAFE_CONFIRMED",
+                    "status_code": "confirmed",
                     "iterations": 2,
                     "output_file": str(prepared_issue / "spec" / "iteration_001" / "output.md"),
                 },
@@ -130,7 +130,7 @@ class TestAutoModeConfigPreservation:
         (spec_iter_dir / "output.md").write_text("# Test Spec")
         with patch('cafe.ui.cli._execute_single_step_alias') as mock_execute_alias:
             mock_execute_alias.return_value = {
-                "status_code": "CAFE_CONFIRMED",
+                "status_code": "confirmed",
                 "iterations": 2,
                 "output_file": str(prepared_issue / "plan" / "iteration_002" / "output.md"),
             }
@@ -243,7 +243,7 @@ class TestReviewMaxIterationsConfig:
              patch('cafe.ui.cli.subprocess.run') as mock_run:
             mock_run.return_value = MagicMock(returncode=0)
             mock_execute_alias.return_value = {
-                "status_code": "CAFE_CONFIRMED",
+                "status_code": "confirmed",
                 "iterations": 1,
                 "output_file": str(prepared_issue / "review" / "iteration_001" / "output.md"),
             }
@@ -269,7 +269,7 @@ class TestReviewMaxIterationsConfig:
         (review_iter_dir / "output.md").write_text("# Test Review")
         with patch('cafe.ui.cli._execute_single_step_alias') as mock_execute_alias:
             mock_execute_alias.return_value = {
-                "status_code": "CAFE_NEEDS_CHANGES",
+                "status_code": "needs_changes",
                 "iterations": 1,
                 "output_file": str(review_iter_dir / "output.md"),
             }

--- a/tests/unit/test_cli_catalog_commands.py
+++ b/tests/unit/test_cli_catalog_commands.py
@@ -34,9 +34,9 @@ steps:
   develop:
     skill: develop
     role: developer
-    valid_status_codes: [CAFE_CONFIRMED]
+    valid_intents: [confirmed]
     on:
-      CAFE_CONFIRMED: _done
+      await_agent: _done
 """.strip(),
         encoding="utf-8",
     )
@@ -67,9 +67,9 @@ steps:
     skill: develop
     role: developer
     allowed_tools: [Bash, "Bash(git:*)"]
-    valid_status_codes: [CAFE_CONFIRMED]
+    valid_intents: [confirmed]
     on:
-      CAFE_CONFIRMED: _done
+      await_agent: _done
 """.strip(),
         encoding="utf-8",
     )
@@ -384,9 +384,9 @@ steps:
   qa:
     skill: review
     role: reviewer
-    valid_status_codes: [CAFE_CONFIRMED]
+    valid_intents: [confirmed]
     on:
-      CAFE_CONFIRMED: _done
+      await_agent: _done
 """.strip(),
         encoding="utf-8",
     )

--- a/tests/unit/test_cli_dynamic_steps.py
+++ b/tests/unit/test_cli_dynamic_steps.py
@@ -26,9 +26,9 @@ steps:
   qa:
     skill: review
     role: reviewer
-    valid_status_codes: [CAFE_CONFIRMED]
+    valid_intents: [confirmed]
     on:
-      CAFE_CONFIRMED: _done
+      await_agent: _done
 """.strip(),
         encoding="utf-8",
     )
@@ -41,7 +41,7 @@ steps:
         git.get_current_branch.return_value = "issue-205"
         mock_git_cls.return_value = git
         executor = MagicMock()
-        executor.execute_step.return_value = ("CAFE_CONFIRMED", {})
+        executor.execute_step.return_value = ("confirmed", {})
         mock_builder.return_value = executor
 
         result = runner.invoke(app, ["qa"])

--- a/tests/unit/test_cli_phase_commands.py
+++ b/tests/unit/test_cli_phase_commands.py
@@ -37,7 +37,7 @@ def mock_dependencies():
         mock_agent_manager.get_agent.return_value = mock_agent_executor
         mock_setup_agents.return_value = mock_agent_manager
         
-        mock_execute_alias.return_value = {"status_code": "CAFE_CONFIRMED", "iterations": 1}
+        mock_execute_alias.return_value = {"status_code": "confirmed", "iterations": 1}
         
         yield {
             "setup_agents": mock_setup_agents,
@@ -154,8 +154,8 @@ def test_spec_command_shows_questions_before_next_iteration(tmp_path, monkeypatc
         mock_setup_agents.return_value = mock_agent_manager
 
         mock_execute_alias.side_effect = [
-            {"status_code": "CAFE_NEED_CLARIFICATION", "iterations": 1},
-            {"status_code": "CAFE_CONFIRMED", "iterations": 2},
+            {"status_code": "need_clarification", "iterations": 1},
+            {"status_code": "confirmed", "iterations": 2},
         ]
 
         result = runner.invoke(app, ["spec", "--interactive"])

--- a/tests/unit/test_cli_pr_command.py
+++ b/tests/unit/test_cli_pr_command.py
@@ -48,7 +48,7 @@ class TestPRCommand:
     def test_pr_uses_workflow_alias(self, mock_git_cls, mock_execute_alias, temp_repo_dir):
         _mock_git(mock_git_cls)
         mock_execute_alias.return_value = {
-            "status_code": "CAFE_CONFIRMED",
+            "status_code": "confirmed",
             "iterations": 1,
             "output_file": ".cafe/issues/test-issue/pr/iteration_001/output.md",
         }

--- a/tests/unit/test_cli_show.py
+++ b/tests/unit/test_cli_show.py
@@ -219,9 +219,9 @@ steps:
   qa:
     skill: review
     role: reviewer
-    valid_status_codes: [CAFE_CONFIRMED]
+    valid_intents: [confirmed]
     on:
-      CAFE_CONFIRMED: _done
+      await_agent: _done
 """.strip(),
             encoding="utf-8",
         )

--- a/tests/unit/test_cli_spec_auto.py
+++ b/tests/unit/test_cli_spec_auto.py
@@ -61,7 +61,7 @@ class TestSpecAutoMode:
     
     @pytest.mark.skip(reason="Complex CLI mocking - covered by integration tests")
     def test_auto_mode_continues_until_confirmed(self, mock_env):
-        """測試 auto 模式會自動循環直到 CAFE_CONFIRMED"""
+        """測試 auto 模式會自動循環直到 confirmed"""
         # Need to patch sys.stdin before importing
         import sys
         original_isatty = sys.stdin.isatty
@@ -110,15 +110,15 @@ class TestSpecAutoMode:
                 results = [
                     PhaseResult(
                         status=PhaseStatus.COMPLETED,
-                        data={"status_code": "CAFE_NEED_CLARIFICATION", "iterations": 1}
+                        data={"status_code": "need_clarification", "iterations": 1}
                     ),
                     PhaseResult(
                         status=PhaseStatus.COMPLETED,
-                        data={"status_code": "CAFE_READY_FOR_REVIEW", "iterations": 2}
+                        data={"status_code": "ready_for_review", "iterations": 2}
                     ),
                     PhaseResult(
                         status=PhaseStatus.COMPLETED,
-                        data={"status_code": "CAFE_CONFIRMED", "iterations": 3}
+                        data={"status_code": "confirmed", "iterations": 3}
                     ),
                 ]
                 mock_phase.execute.side_effect = results
@@ -185,11 +185,11 @@ class TestSpecAutoMode:
             results = [
                 PhaseResult(
                     status=PhaseStatus.COMPLETED,
-                    data={"status_code": "CAFE_NEED_CLARIFICATION", "iterations": 1}
+                    data={"status_code": "need_clarification", "iterations": 1}
                 ),
                 PhaseResult(
                     status=PhaseStatus.COMPLETED,
-                    data={"status_code": "CAFE_CONFIRMED", "iterations": 2}
+                    data={"status_code": "confirmed", "iterations": 2}
                 ),
             ]
             mock_phase.execute.side_effect = results
@@ -248,11 +248,11 @@ class TestSpecAutoMode:
             results = [
                 PhaseResult(
                     status=PhaseStatus.COMPLETED,
-                    data={"status_code": "CAFE_NEED_CLARIFICATION", "iterations": 1}
+                    data={"status_code": "need_clarification", "iterations": 1}
                 ),
                 PhaseResult(
                     status=PhaseStatus.COMPLETED,
-                    data={"status_code": "CAFE_CONFIRMED", "iterations": 2}
+                    data={"status_code": "confirmed", "iterations": 2}
                 ),
             ]
             mock_phase.execute.side_effect = results
@@ -309,7 +309,7 @@ class TestSpecAutoMode:
             
             mock_phase.execute.return_value = PhaseResult(
                 status=PhaseStatus.COMPLETED,
-                data={"status_code": "CAFE_NEED_CLARIFICATION", "iterations": 1}
+                data={"status_code": "need_clarification", "iterations": 1}
             )
             mock_phase_cls.return_value = mock_phase
             

--- a/tests/unit/test_cli_spec_output.py
+++ b/tests/unit/test_cli_spec_output.py
@@ -84,7 +84,7 @@ class TestSpecCommandOutputWithReadyForReview:
         """READY_FOR_REVIEW 狀態應提示使用者回到 workflow 主入口."""
         mock_execute_alias.return_value = {
             "iterations": 2,
-            "status_code": "CAFE_READY_FOR_REVIEW",
+            "status_code": "ready_for_review",
         }
 
         # Execute with interactive mode and user input
@@ -103,7 +103,7 @@ class TestSpecCommandOutputWithReadyForReview:
         """READY_FOR_REVIEW 狀態應顯示 spec 儲存位置."""
         mock_execute_alias.return_value = {
             "iterations": 1,
-            "status_code": "CAFE_READY_FOR_REVIEW",
+            "status_code": "ready_for_review",
             "output_file": ".cafe/issues/test-branch/spec/iteration_001/output.md",
         }
 
@@ -138,7 +138,7 @@ class TestSpecCommandOutputWithConfirmed:
         """CONFIRMED 狀態應提示使用者回到 workflow 主入口."""
         mock_execute_alias.return_value = {
             "iterations": 3,
-            "status_code": "CAFE_CONFIRMED",
+            "status_code": "confirmed",
         }
 
         # Execute
@@ -157,7 +157,7 @@ class TestSpecCommandOutputWithConfirmed:
         """CONFIRMED 狀態應顯示 iteration 次數."""
         mock_execute_alias.return_value = {
             "iterations": 5,
-            "status_code": "CAFE_CONFIRMED",
+            "status_code": "confirmed",
         }
 
         result = runner.invoke(app, ["spec", "--interactive", "--user-input", "test"])
@@ -190,7 +190,7 @@ class TestSpecCommandOutputWithNeedClarification:
         """NEED_CLARIFICATION 狀態應提示使用者回到 workflow 主入口."""
         mock_execute_alias.return_value = {
             "iterations": 1,
-            "status_code": "CAFE_NEED_CLARIFICATION",
+            "status_code": "need_clarification",
         }
 
         result = runner.invoke(app, ["spec", "--interactive", "--user-input", "test"])
@@ -209,12 +209,12 @@ class TestSpecCommandOutputComparison:
     ):
         """確認 READY_FOR_REVIEW and CONFIRMED 訊息確實不同."""
         # Test READY_FOR_REVIEW
-        mock_execute_alias.return_value = {"iterations": 1, "status_code": "CAFE_READY_FOR_REVIEW"}
+        mock_execute_alias.return_value = {"iterations": 1, "status_code": "ready_for_review"}
 
         result_ready = runner.invoke(app, ["spec", "--interactive", "--user-input", "test"])
 
         # Test CONFIRMED
-        mock_execute_alias.return_value = {"iterations": 1, "status_code": "CAFE_CONFIRMED"}
+        mock_execute_alias.return_value = {"iterations": 1, "status_code": "confirmed"}
 
         result_confirmed = runner.invoke(app, ["spec", "--interactive", "--user-input", "test"])
 
@@ -233,7 +233,7 @@ class TestSpecCommandLegacyNotice:
     ):
         mock_execute_alias.return_value = {
             "iterations": 1,
-            "status_code": "CAFE_CONFIRMED",
+            "status_code": "confirmed",
         }
 
         result = runner.invoke(app, ["spec", "--interactive", "--user-input", "test"])

--- a/tests/unit/test_cli_workflow_command.py
+++ b/tests/unit/test_cli_workflow_command.py
@@ -78,7 +78,7 @@ def test_single_step_alias_updates_workflow_pointer_to_requested_step(tmp_path: 
             self.agent_manager = MagicMock()
 
         def execute_step(self, step_name: str, step_def: dict, blackboard_state: object) -> StepExecutionResult:
-            return _result(status_code="CAFE_NO_CHANGES_NEEDED", step_name=step_name, step_def=step_def, artifacts={})
+            return _result(status_code="no_changes_needed", step_name=step_name, step_def=step_def, artifacts={})
 
     with patch("cafe.ui.cli._build_workflow_step_executor", return_value=FakeExecutor()):
         result = _execute_single_step_alias(
@@ -87,7 +87,7 @@ def test_single_step_alias_updates_workflow_pointer_to_requested_step(tmp_path: 
             config_manager=config_manager,
         )
 
-    assert result["status_code"] == "CAFE_NO_CHANGES_NEEDED"
+    assert result["status_code"] == "no_changes_needed"
     blackboard_data = json.loads((issue_dir / "blackboard.json").read_text(encoding="utf-8"))
     assert blackboard_data["current_step"] == "review"
 
@@ -123,10 +123,10 @@ def test_workflow_command_runs_execute_mode(tmp_path: Path, monkeypatch) -> None
                     state=blackboard_state,
                     from_step="pr",
                     to_step="user",
-                    status_code="CAFE_CONFIRMED",
+                    status_code="confirmed",
                     intent=HandoffIntent.MANUAL_HANDOFF,
                 )
-            return _result(status_code="CAFE_CONFIRMED", step_name=step_name, step_def=step_def)
+            return _result(status_code="confirmed", step_name=step_name, step_def=step_def)
 
     with (
         patch("cafe.ui.cli.GitOperations") as mock_git_cls,
@@ -155,7 +155,7 @@ def test_workflow_command_passes_initial_user_input_to_spec_step(tmp_path: Path,
 
     class FakeExecutor:
         def execute_step(self, step_name: str, step_def: dict, blackboard_state: object) -> StepExecutionResult:
-            return _result(status_code="CAFE_CONFIRMED", step_name=step_name, step_def=step_def)
+            return _result(status_code="confirmed", step_name=step_name, step_def=step_def)
 
     with (
         patch("cafe.ui.cli.GitOperations") as mock_git_cls,
@@ -195,9 +195,9 @@ def test_workflow_command_prints_pr_url_when_pr_step_reports_sync_event(tmp_path
             if step_name == "pr":
                 events = [{"type": "pr_synced", "url": "https://github.com/test/repo/pull/238"}]
             return StepExecutionResult(
-                response="CAFE_CONFIRMED",
+                response="confirmed",
                 artifacts={str(step_def.get("output_artifact", step_name)): f"{step_name}/output.md"},
-                status_code="CAFE_CONFIRMED",
+                status_code="confirmed",
                 events=events,
             )
 
@@ -248,10 +248,10 @@ def test_workflow_command_consumes_chat_baton_before_execution(tmp_path: Path, m
                     state=blackboard_state,
                     from_step="pr",
                     to_step="user",
-                    status_code="CAFE_CONFIRMED",
+                    status_code="confirmed",
                     intent=HandoffIntent.MANUAL_HANDOFF,
                 )
-            return _result(status_code="CAFE_CONFIRMED", step_name=step_name, step_def=step_def)
+            return _result(status_code="confirmed", step_name=step_name, step_def=step_def)
 
     with (
         patch("cafe.ui.cli.GitOperations") as mock_git_cls,
@@ -299,7 +299,7 @@ def test_workflow_command_does_not_consume_chat_baton_with_uncommitted_changes(t
     class FakeExecutor:
         def execute_step(self, step_name: str, step_def: dict, blackboard_state: object) -> StepExecutionResult:
             executed_steps.append(step_name)
-            return _result(status_code="CAFE_CONFIRMED", step_name=step_name, step_def=step_def, artifacts={})
+            return _result(status_code="confirmed", step_name=step_name, step_def=step_def, artifacts={})
 
     with (
         patch("cafe.ui.cli.GitOperations") as mock_git_cls,
@@ -384,7 +384,7 @@ def test_workflow_command_start_step_rebuilds_stale_text_baton(tmp_path: Path, m
             blackboard_state: object,
         ) -> StepExecutionResult:
             return _result(
-                status_code="CAFE_NEED_CLARIFICATION",
+                status_code="need_clarification",
                 step_name=step_name,
                 step_def=step_def,
                 artifacts={},
@@ -436,7 +436,7 @@ def test_workflow_command_prints_guidance_for_invalid_runtime_baton(
             blackboard_state: object,
         ) -> StepExecutionResult:
             return _result(
-                status_code="CAFE_NEED_CLARIFICATION",
+                status_code="need_clarification",
                 step_name=step_name,
                 step_def=step_def,
                 artifacts={},
@@ -472,7 +472,7 @@ def test_workflow_command_prints_paused_when_human_input_is_needed(tmp_path: Pat
 
     class FakeExecutor:
         def execute_step(self, step_name: str, step_def: dict, blackboard_state: object) -> StepExecutionResult:
-            return _result(status_code="CAFE_NEED_CLARIFICATION", step_name=step_name, step_def=step_def, artifacts={})
+            return _result(status_code="need_clarification", step_name=step_name, step_def=step_def, artifacts={})
 
     with (
         patch("cafe.ui.cli.GitOperations") as mock_git_cls,
@@ -596,10 +596,10 @@ def test_workflow_command_user_owner_can_set_next_phase(tmp_path: Path, monkeypa
                     state=blackboard_state,
                     from_step="pr",
                     to_step="user",
-                    status_code="CAFE_CONFIRMED",
+                    status_code="confirmed",
                     intent=HandoffIntent.MANUAL_HANDOFF,
                 )
-            return _result(status_code="CAFE_CONFIRMED", step_name=step_name, step_def=step_def, artifacts={})
+            return _result(status_code="confirmed", step_name=step_name, step_def=step_def, artifacts={})
 
     with (
         patch("cafe.ui.cli.GitOperations") as mock_git_cls,
@@ -698,10 +698,10 @@ def test_workflow_command_user_owner_can_chat_and_resume_from_baton(tmp_path: Pa
                     state=blackboard_state,
                     from_step="pr",
                     to_step="user",
-                    status_code="CAFE_CONFIRMED",
+                    status_code="confirmed",
                     intent=HandoffIntent.MANUAL_HANDOFF,
                 )
-            return _result(status_code="CAFE_CONFIRMED", step_name=step_name, step_def=step_def, artifacts={})
+            return _result(status_code="confirmed", step_name=step_name, step_def=step_def, artifacts={})
 
     def fake_launch_chat(role: str, issue_name: str) -> int:
         assert role == "developer"
@@ -756,10 +756,10 @@ def test_workflow_command_enters_user_phase_immediately_after_agent_handoff(tmp_
                 state=blackboard_state,
                 from_step="pr",
                 to_step="user",
-                status_code="CAFE_CONFIRMED",
+                status_code="confirmed",
                 intent=HandoffIntent.MANUAL_HANDOFF,
             )
-            return _result(status_code="CAFE_CONFIRMED", step_name=step_name, step_def=step_def, artifacts={})
+            return _result(status_code="confirmed", step_name=step_name, step_def=step_def, artifacts={})
 
     with (
         patch("cafe.ui.cli.GitOperations") as mock_git_cls,
@@ -808,10 +808,10 @@ def test_workflow_command_noninteractive_stops_after_agent_handoff_to_user(tmp_p
                 state=blackboard_state,
                 from_step="pr",
                 to_step="user",
-                status_code="CAFE_CONFIRMED",
+                status_code="confirmed",
                 intent=HandoffIntent.MANUAL_HANDOFF,
             )
-            return _result(status_code="CAFE_CONFIRMED", step_name=step_name, step_def=step_def, artifacts={})
+            return _result(status_code="confirmed", step_name=step_name, step_def=step_def, artifacts={})
 
     with (
         patch("cafe.ui.cli.GitOperations") as mock_git_cls,
@@ -861,10 +861,10 @@ def test_workflow_command_done_phase_can_restart_workflow(tmp_path: Path, monkey
                     state=blackboard_state,
                     from_step="pr",
                     to_step="user",
-                    status_code="CAFE_CONFIRMED",
+                    status_code="confirmed",
                     intent=HandoffIntent.MANUAL_HANDOFF,
                 )
-            return _result(status_code="CAFE_CONFIRMED", step_name=step_name, step_def=step_def, artifacts={})
+            return _result(status_code="confirmed", step_name=step_name, step_def=step_def, artifacts={})
 
     with (
         patch("cafe.ui.cli.GitOperations") as mock_git_cls,
@@ -937,13 +937,13 @@ def test_workflow_command_resumes_incomplete_iteration_before_user_phase(tmp_pat
                     {
                         "iteration": 3,
                         "step_name": "spec",
-                        "status_code": "CAFE_READY_FOR_REVIEW",
+                        "status_code": "ready_for_review",
                         "end_time": "2026-04-14T10:05:00+08:00",
                     }
                 ),
                 encoding="utf-8",
             )
-            return _result(status_code="CAFE_READY_FOR_REVIEW", step_name=step_name, step_def=step_def, artifacts={})
+            return _result(status_code="ready_for_review", step_name=step_name, step_def=step_def, artifacts={})
 
     with (
         patch("cafe.ui.cli.GitOperations") as mock_git_cls,
@@ -1139,7 +1139,7 @@ def test_workflow_command_resumes_pr_when_external_feedback_arrives_while_done(t
     class FakeExecutor:
         def execute_step(self, step_name: str, step_def: dict, blackboard_state: object) -> StepExecutionResult:
             executed_steps.append(step_name)
-            return _result(status_code="CAFE_CONFIRMED", step_name=step_name, step_def=step_def, artifacts={})
+            return _result(status_code="confirmed", step_name=step_name, step_def=step_def, artifacts={})
 
     with (
         patch("cafe.ui.cli.GitOperations") as mock_git_cls,
@@ -1174,20 +1174,20 @@ steps:
     skill: spec_first
     role: pm
     allowed_goto: [develop]
-    valid_status_codes: [CAFE_CONFIRMED, CAFE_NEED_CLARIFICATION]
+    valid_intents: [confirmed, need_clarification]
     on:
-      CAFE_CONFIRMED: plan
-      CAFE_NEED_CLARIFICATION: develop
+      await_agent: plan
+      need_clarification: develop
   plan:
     skill: plan
     role: developer
-    valid_status_codes: [CAFE_CONFIRMED]
+    valid_intents: [confirmed]
     on:
-      CAFE_CONFIRMED: _done
+      await_agent: _done
   develop:
     skill: develop
     role: developer
-    valid_status_codes: [CAFE_CONFIRMED]
+    valid_intents: [confirmed]
     on: {}
 """.strip(),
         encoding="utf-8",
@@ -1210,9 +1210,9 @@ steps:
                     state=blackboard_state,
                     from_step="spec",
                     to_step="develop",
-                    status_code="CAFE_CONFIRMED",
+                    status_code="confirmed",
                 )
-            return _result(status_code="CAFE_CONFIRMED", step_name=step_name, step_def=step_def, artifacts={})
+            return _result(status_code="confirmed", step_name=step_name, step_def=step_def, artifacts={})
         executor.execute_step.side_effect = _execute
         mock_builder.return_value = executor
 
@@ -1235,15 +1235,15 @@ steps:
   plan:
     skill: plan
     role: developer
-    valid_status_codes: [CAFE_CONFIRMED]
+    valid_intents: [confirmed]
     on:
-      CAFE_CONFIRMED: develop
+      await_agent: develop
   develop:
     skill: develop
     role: developer
-    valid_status_codes: [CAFE_CONFIRMED]
+    valid_intents: [confirmed]
     on:
-      CAFE_CONFIRMED: _done
+      await_agent: _done
 """.strip(),
         encoding="utf-8",
     )
@@ -1257,7 +1257,7 @@ steps:
         mock_git_cls.return_value = git
         executor = MagicMock()
         executor.execute_step.side_effect = lambda step_name, step_def, blackboard_state: (
-            executed_steps.append(step_name) or _result(status_code="CAFE_CONFIRMED", step_name=step_name, step_def=step_def, artifacts={})
+            executed_steps.append(step_name) or _result(status_code="confirmed", step_name=step_name, step_def=step_def, artifacts={})
         )
         mock_builder.return_value = executor
 
@@ -1282,7 +1282,7 @@ def test_workflow_command_runs_hotfix_playbook(tmp_path: Path, monkeypatch) -> N
         mock_git_cls.return_value = git
         executor = MagicMock()
         executor.execute_step.side_effect = lambda step_name, step_def, blackboard_state: (
-            executed_steps.append(step_name) or _result(status_code="CAFE_CONFIRMED", step_name=step_name, step_def=step_def, artifacts={})
+            executed_steps.append(step_name) or _result(status_code="confirmed", step_name=step_name, step_def=step_def, artifacts={})
         )
         mock_builder.return_value = executor
 
@@ -1307,15 +1307,15 @@ steps:
   develop:
     skill: develop
     role: developer
-    valid_status_codes: [CAFE_CONFIRMED]
+    valid_intents: [confirmed]
     on:
-      CAFE_CONFIRMED: pr
+      await_agent: pr
   pr:
     skill: pr
     role: developer
-    valid_status_codes: [CAFE_CONFIRMED]
+    valid_intents: [confirmed]
     on:
-      CAFE_CONFIRMED: _done
+      await_agent: _done
 """.strip(),
         encoding="utf-8",
     )
@@ -1329,7 +1329,7 @@ steps:
         mock_git_cls.return_value = git
         executor = MagicMock()
         executor.execute_step.side_effect = lambda step_name, step_def, blackboard_state: (
-            executed_steps.append(step_name) or _result(status_code="CAFE_CONFIRMED", step_name=step_name, step_def=step_def, artifacts={})
+            executed_steps.append(step_name) or _result(status_code="confirmed", step_name=step_name, step_def=step_def, artifacts={})
         )
         mock_builder.return_value = executor
 

--- a/tests/unit/test_context_endtime.py
+++ b/tests/unit/test_context_endtime.py
@@ -77,7 +77,7 @@ class TestContextJsonEndTime:
         # Call _update_iteration_history
         phase._update_iteration_history(
             phase_specific_data=phase_specific_data,
-            status_code=MagicMock(value="CAFE_CONFIRMED"),
+            status_code=MagicMock(value="confirmed"),
         )
 
         # Verify context.json contains end_time field
@@ -108,7 +108,7 @@ class TestContextJsonEndTime:
                 "response": "done without status",
                 "status_code": "stale",
             },
-            status_code=MagicMock(value="CAFE_CONFIRMED"),
+            status_code=MagicMock(value="confirmed"),
             persist_status=False,
         )
 

--- a/tests/unit/test_context_session_id_update.py
+++ b/tests/unit/test_context_session_id_update.py
@@ -32,7 +32,7 @@ class TestContextSessionIDUpdate:
             executor.config.session_id = "new-session-123"
 
             return (
-                "CAFE_READY_FOR_REVIEW",
+                "ready_for_review",
                 TokenUsage(),
                 [],  # permission_denials
                 ["--model", "claude-sonnet-4.5"],  # cli_command_args

--- a/tests/unit/test_develop_clarification.py
+++ b/tests/unit/test_develop_clarification.py
@@ -1,4 +1,4 @@
-"""Tests for develop phase CAFE_NEED_CLARIFICATION handling with questions.xml."""
+"""Tests for develop phase need_clarification handling with questions.xml."""
 import json
 import pytest
 from pathlib import Path
@@ -62,10 +62,10 @@ def interactive_phase(tmp_path, mock_deps):
 
 
 class TestDevelopClarificationQuestionsXml:
-    """Tests that CAFE_NEED_CLARIFICATION requires questions.xml."""
+    """Tests that need_clarification requires questions.xml."""
 
     def test_need_clarification_without_questions_xml_returns_failed(self, phase, tmp_path, monkeypatch):
-        """CAFE_NEED_CLARIFICATION with no questions.xml should return FAILED."""
+        """need_clarification with no questions.xml should return FAILED."""
         monkeypatch.chdir(tmp_path)
         # questions_xml_path won't exist since no file is created
         with patch.object(phase, "_check_if_already_completed_with_review", return_value=None):
@@ -75,7 +75,7 @@ class TestDevelopClarificationQuestionsXml:
                         with patch.object(
                             phase,
                             "_execute_and_handle_agent_response",
-                            return_value=(None, "CAFE_NEED_CLARIFICATION"),
+                            return_value=(None, "need_clarification"),
                         ):
                             # _validate_and_retry_questions_xml does nothing (xml still doesn't exist)
                             with patch.object(phase, "_validate_and_retry_questions_xml", return_value=False):
@@ -86,7 +86,7 @@ class TestDevelopClarificationQuestionsXml:
         assert "questions.xml" in result.message
 
     def test_need_clarification_with_valid_questions_xml_returns_in_progress(self, phase, tmp_path, monkeypatch):
-        """CAFE_NEED_CLARIFICATION with valid questions.xml should return IN_PROGRESS."""
+        """need_clarification with valid questions.xml should return IN_PROGRESS."""
         monkeypatch.chdir(tmp_path)
         # Pre-create the questions.xml in the iteration directory
         issue_dir = phase.issue_dir
@@ -111,7 +111,7 @@ class TestDevelopClarificationQuestionsXml:
                         with patch.object(
                             phase,
                             "_execute_and_handle_agent_response",
-                            return_value=(None, "CAFE_NEED_CLARIFICATION"),
+                            return_value=(None, "need_clarification"),
                         ):
                             with patch.object(phase, "_validate_and_retry_questions_xml", return_value=True):
                                 with patch("cafe.utils.checklist_generator.generate_develop_checklist"):
@@ -132,7 +132,7 @@ class TestDevelopClarificationQuestionsXml:
                         with patch.object(
                             interactive_phase,
                             "_execute_and_handle_agent_response",
-                            return_value=(None, "CAFE_NEED_PERMISSION"),
+                            return_value=(None, "need_permission"),
                         ):
                             with patch("cafe.utils.checklist_generator.generate_develop_checklist"):
                                 result = interactive_phase.execute()
@@ -167,7 +167,7 @@ class TestDevelopClarificationQuestionsXml:
                         with patch.object(
                             interactive_phase,
                             "_execute_and_handle_agent_response",
-                            return_value=(None, "CAFE_NEED_CLARIFICATION"),
+                            return_value=(None, "need_clarification"),
                         ):
                             with patch.object(
                                 interactive_phase, "_validate_and_retry_questions_xml", return_value=True
@@ -271,7 +271,7 @@ class TestDevelopNeedPermissionFallback:
         with patch.object(
             phase,
             "_load_previous_iteration_data",
-            return_value={"iteration": 1, "status_code": "CAFE_NEED_PERMISSION", "response": "CAFE_NEED_PERMISSION"},
+            return_value={"iteration": 1, "status_code": "need_permission", "response": "need_permission"},
         ):
             result = phase._prepare_user_input_for_iteration()
 
@@ -287,7 +287,7 @@ class TestDevelopNeedPermissionFallback:
         with patch.object(
             phase,
             "_load_previous_iteration_data",
-            return_value={"iteration": 1, "response": "CAFE_NEED_PERMISSION"},
+            return_value={"iteration": 1, "response": "need_permission"},
         ):
             result = phase._prepare_user_input_for_iteration()
 
@@ -303,13 +303,13 @@ class TestDevelopNeedPermissionFallback:
         with patch.object(
             phase,
             "_load_previous_iteration_data",
-            return_value={"iteration": 1, "status_code": "CAFE_NEED_PERMISSION", "response": "CAFE_NEED_PERMISSION"},
+            return_value={"iteration": 1, "status_code": "need_permission", "response": "need_permission"},
         ):
             result = phase._prepare_user_input_for_iteration()
 
         assert isinstance(result, PhaseResult)
         assert result.status == PhaseStatus.FAILED
-        assert result.data.get("status_code") == "CAFE_NEED_PERMISSION"
+        assert result.data.get("status_code") == "need_permission"
 
     def test_prepare_user_input_uses_host_execution_failure_followup(self, phase, monkeypatch, tmp_path):
         """Should reuse failed host execution context instead of asking for permission again."""
@@ -336,7 +336,7 @@ class TestDevelopNeedPermissionFallback:
         with patch.object(
             phase,
             "_load_previous_iteration_data",
-            return_value={"iteration": 1, "status_code": "CAFE_NEED_PERMISSION", "response": "CAFE_NEED_PERMISSION"},
+            return_value={"iteration": 1, "status_code": "need_permission", "response": "need_permission"},
         ):
             result = phase._prepare_user_input_for_iteration()
 
@@ -359,7 +359,7 @@ class TestDevelopNeedPermissionFallback:
         with patch.object(
             phase,
             "_load_previous_iteration_data",
-            return_value={"iteration": 1, "status_code": "CAFE_NEED_PERMISSION", "response": "CAFE_NEED_PERMISSION"},
+            return_value={"iteration": 1, "status_code": "need_permission", "response": "need_permission"},
         ):
             approved_tools, user_input = phase._handle_previous_permission_denials()
 
@@ -381,7 +381,7 @@ class TestDevelopNeedPermissionFallback:
         with patch.object(
             phase,
             "_load_previous_iteration_data",
-            return_value={"iteration": 1, "response": "CAFE_NEED_PERMISSION"},
+            return_value={"iteration": 1, "response": "need_permission"},
         ):
             approved_tools, user_input = phase._handle_previous_permission_denials()
 
@@ -404,8 +404,8 @@ class TestCodexPermissionRules:
             "_load_previous_iteration_data",
             return_value={
                 "iteration": 1,
-                "status_code": "CAFE_NEED_PERMISSION",
-                "response": "CAFE_NEED_PERMISSION",
+                "status_code": "need_permission",
+                "response": "need_permission",
                 "cli": "codex",
                 "permission_denials": [
                     {
@@ -441,8 +441,8 @@ class TestCodexPermissionRules:
             "_load_previous_iteration_data",
             return_value={
                 "iteration": 1,
-                "status_code": "CAFE_NEED_PERMISSION",
-                "response": "CAFE_NEED_PERMISSION",
+                "status_code": "need_permission",
+                "response": "need_permission",
                 "cli": "codex",
                 "permission_denials": [
                     {
@@ -508,7 +508,7 @@ class TestCodexPermissionRules:
             with patch("cafe.utils.git_utils.get_git_toplevel", return_value=repo_root):
                 result = phase._handle_standard_status_codes(
                     status_code=PhaseStatusCode.CONFIRMED,
-                    response="CAFE_CONFIRMED",
+                    response="confirmed",
                     continue_codes=[],
                     complete_codes=[],
                 )

--- a/tests/unit/test_develop_no_changes_needed.py
+++ b/tests/unit/test_develop_no_changes_needed.py
@@ -57,8 +57,8 @@ class TestNoChangesNeededReasoningValidation:
         # Create context.json with NO_CHANGES_NEEDED response
         context_data = {
             "iteration": 1,
-            "response": "CAFE_NO_CHANGES_NEEDED\n\nThe reviewer is wrong.",
-            "status_code": "CAFE_NO_CHANGES_NEEDED",
+            "response": "no_changes_needed\n\nThe reviewer is wrong.",
+            "status_code": "no_changes_needed",
             "streaming_log": [],
             "prompt": "Test prompt"
         }
@@ -74,7 +74,7 @@ class TestNoChangesNeededReasoningValidation:
             # Agent should have written to output.md
             output_file.write_text("The reviewer's feedback is incorrect because...")
             return (
-                "CAFE_NO_CHANGES_NEEDED\n\n[reasoning written to output.md]",
+                "no_changes_needed\n\n[reasoning written to output.md]",
                 TokenUsage(),
                 [],
                 [],
@@ -126,8 +126,8 @@ class TestNoChangesNeededReasoningValidation:
         # Create context.json
         context_data = {
             "iteration": 1,
-            "response": "CAFE_NO_CHANGES_NEEDED",
-            "status_code": "CAFE_NO_CHANGES_NEEDED",
+            "response": "no_changes_needed",
+            "status_code": "no_changes_needed",
             "streaming_log": [],
             "prompt": "Test prompt"
         }
@@ -140,7 +140,7 @@ class TestNoChangesNeededReasoningValidation:
         # Mock agent to NOT create output.md
         phase.agent_manager.execute = MagicMock(
             return_value=(
-                "CAFE_NO_CHANGES_NEEDED",
+                "no_changes_needed",
                 TokenUsage(),
                 [],
                 [],
@@ -166,7 +166,7 @@ class TestNoChangesNeededReasoningValidation:
 
         # Should mention writing to {output_file}
         assert "{output_file}" in checklist_content
-        assert "NO_CHANGES_NEEDED" in checklist_content or "CAFE_NO_CHANGES_NEEDED" in checklist_content
+        assert "NO_CHANGES_NEEDED" in checklist_content or "no_changes_needed" in checklist_content
 
     def test_checklist_generator_resolves_output_file_placeholder(self):
         """Test that checklist generator properly resolves output_file placeholder"""
@@ -258,7 +258,7 @@ class TestConfirmedSkipReviewResumeFlag:
 
         assert result is not None
         assert result.data.get("skip_review") is True
-        assert result.data.get("status_code") == "CAFE_CONFIRMED_SKIP_REVIEW"
+        assert result.data.get("status_code") == "skip_review"
 
     def test_resume_with_confirmed_status_does_not_include_skip_review_flag(self, setup_develop_phase):
         """Test that resuming with CONFIRMED status does not include skip_review=True"""
@@ -318,7 +318,7 @@ class TestConfirmedSkipReviewSaveProgress:
         import json
         data = json.loads(status_file.read_text())
         assert data["status"] == PhaseStatus.COMPLETED.value
-        assert data["status_code"] == "CAFE_CONFIRMED_SKIP_REVIEW"
+        assert data["status_code"] == "skip_review"
 
     def test_save_progress_confirmed_status_saves_as_completed(self, setup_develop_phase):
         """Test that _save_progress(CONFIRMED) still saves status as COMPLETED"""

--- a/tests/unit/test_develop_phase_prompt.py
+++ b/tests/unit/test_develop_phase_prompt.py
@@ -14,7 +14,7 @@ def _write_review_iteration(
     issue_dir: Path,
     *,
     iteration: int = 1,
-    status_code: str = "CAFE_NEEDS_CHANGES",
+    status_code: str = "needs_changes",
     timestamp: str = "2026-01-07T11:39:41+08:00",
     end_time: str | None = None,
     output: str = "## Todo List\n\n- [ ] Review issue",
@@ -73,7 +73,7 @@ class TestDevelopPhasePromptGeneration:
         _write_review_iteration(
             issue_dir,
             iteration=1,
-            status_code="CAFE_NEEDS_CHANGES",
+            status_code="needs_changes",
             timestamp="2026-01-07T11:39:41+08:00",
             output="Please fix commit message format",
         )
@@ -130,7 +130,7 @@ class TestDevelopPhasePromptGeneration:
         _write_review_iteration(
             issue_dir,
             iteration=1,
-            status_code="CAFE_NEEDS_CHANGES",
+            status_code="needs_changes",
             end_time="2026-01-07T11:40:00+08:00",
             output="Please fix review issue from iteration context",
         )
@@ -191,7 +191,7 @@ class TestDevelopPhasePromptGeneration:
         pr_context_file.write_text(json.dumps({
             "iteration": 1,
             "timestamp": datetime.now(timezone.utc).isoformat(),
-            "status_code": "CAFE_NEEDS_CHANGES"
+            "status_code": "needs_changes"
         }))
 
         # Mock get_agent_file_path
@@ -237,7 +237,7 @@ class TestDevelopPhasePromptGeneration:
         _write_review_iteration(
             issue_dir,
             iteration=1,
-            status_code="CAFE_CONFIRMED",
+            status_code="confirmed",
             timestamp="2026-01-07T11:39:41+08:00",
             output="Looks good!",
         )
@@ -262,7 +262,7 @@ class TestDevelopPhasePromptGeneration:
         pr_context_file.write_text(json.dumps({
             "iteration": 1,
             "timestamp": datetime.now(timezone.utc).isoformat(),
-            "status_code": "CAFE_NEEDS_CHANGES"
+            "status_code": "needs_changes"
         }))
 
         # Mock get_agent_file_path
@@ -308,7 +308,7 @@ class TestDevelopPhasePromptGeneration:
         _write_review_iteration(
             issue_dir,
             iteration=1,
-            status_code="CAFE_NEEDS_CHANGES",
+            status_code="needs_changes",
             timestamp="2026-01-07T11:39:41+08:00",
             output="## Todo List\n\n- [ ] Fix issue",
         )
@@ -322,7 +322,7 @@ class TestDevelopPhasePromptGeneration:
         # Mock get_agent_file_path and generate_develop_checklist
         with patch('cafe.agents.manager.AgentManager.get_agent_file_path', return_value=str(agent_file)), \
              patch('cafe.utils.checklist_generator.generate_develop_checklist') as mock_gen_checklist, \
-             patch.object(DevelopPhase, '_execute_and_handle_agent_response', return_value=(None, "CAFE_CONFIRMED")):
+             patch.object(DevelopPhase, '_execute_and_handle_agent_response', return_value=(None, "confirmed")):
 
             # Create phase
             phase = DevelopPhase(
@@ -372,7 +372,7 @@ class TestDevelopPhasePromptGeneration:
         _write_review_iteration(
             issue_dir,
             iteration=1,
-            status_code="CAFE_NEEDS_CHANGES",
+            status_code="needs_changes",
             timestamp="2026-01-07T11:39:41+08:00",
             end_time="2026-01-07T11:40:00+08:00",
             output="## Todo List\n\n- [ ] Review issue",
@@ -390,7 +390,7 @@ class TestDevelopPhasePromptGeneration:
         pr_context_file.write_text(json.dumps({
             "iteration": 1,
             "timestamp": datetime.now(timezone.utc).isoformat(),
-            "status_code": "CAFE_NEEDS_CHANGES",
+            "status_code": "needs_changes",
             "end_time": "2026-01-07T11:50:00+08:00",
         }))
 
@@ -403,7 +403,7 @@ class TestDevelopPhasePromptGeneration:
         # Mock get_agent_file_path and generate_develop_checklist
         with patch('cafe.agents.manager.AgentManager.get_agent_file_path', return_value=str(agent_file)), \
              patch('cafe.utils.checklist_generator.generate_develop_checklist') as mock_gen_checklist, \
-             patch.object(DevelopPhase, '_execute_and_handle_agent_response', return_value=(None, "CAFE_CONFIRMED")):
+             patch.object(DevelopPhase, '_execute_and_handle_agent_response', return_value=(None, "confirmed")):
 
             # Create phase
             phase = DevelopPhase(
@@ -454,7 +454,7 @@ class TestDevelopPhasePromptGeneration:
         _write_review_iteration(
             issue_dir,
             iteration=1,
-            status_code="CAFE_NEEDS_CHANGES",
+            status_code="needs_changes",
             timestamp="2026-01-07T11:58:24+08:00",
             end_time="2026-01-07T11:58:24+08:00",
             output="## Todo List\n\n- [ ] Review issue",
@@ -472,13 +472,13 @@ class TestDevelopPhasePromptGeneration:
         pr_context_file.write_text(json.dumps({
             "iteration": 1,
             "timestamp": datetime.now(timezone.utc).isoformat(),
-            "status_code": "CAFE_NEEDS_CHANGES"
+            "status_code": "needs_changes"
         }))
 
         # Create PR status.json with older end_time
         pr_status_file = pr_dir / "status.json"
         pr_status_file.write_text(json.dumps({
-            "status_code": "CAFE_NEEDS_CHANGES",
+            "status_code": "needs_changes",
             "end_time": "2026-01-07T11:42:12+08:00"
         }))
 
@@ -491,7 +491,7 @@ class TestDevelopPhasePromptGeneration:
         # Mock get_agent_file_path and generate_develop_checklist
         with patch('cafe.agents.manager.AgentManager.get_agent_file_path', return_value=str(agent_file)), \
              patch('cafe.utils.checklist_generator.generate_develop_checklist') as mock_gen_checklist, \
-             patch.object(DevelopPhase, '_execute_and_handle_agent_response', return_value=(None, "CAFE_CONFIRMED")):
+             patch.object(DevelopPhase, '_execute_and_handle_agent_response', return_value=(None, "confirmed")):
 
             # Create phase
             phase = DevelopPhase(
@@ -541,7 +541,7 @@ class TestDevelopPhasePromptGeneration:
         _write_review_iteration(
             issue_dir,
             iteration=1,
-            status_code="CAFE_NEEDS_CHANGES",
+            status_code="needs_changes",
             timestamp="2026-01-07T11:39:41+08:00",
             output="## Todo List\n\n- [ ] Review issue",
         )
@@ -557,7 +557,7 @@ class TestDevelopPhasePromptGeneration:
         # Mock get_agent_file_path and generate_develop_checklist
         with patch('cafe.agents.manager.AgentManager.get_agent_file_path', return_value=str(agent_file)), \
              patch('cafe.utils.checklist_generator.generate_develop_checklist') as mock_gen_checklist, \
-             patch.object(DevelopPhase, '_execute_and_handle_agent_response', return_value=(None, "CAFE_CONFIRMED")):
+             patch.object(DevelopPhase, '_execute_and_handle_agent_response', return_value=(None, "confirmed")):
 
             # Create phase
             phase = DevelopPhase(
@@ -658,7 +658,7 @@ class TestReviewFeedbackDetectionByEndTime:
         _write_review_iteration(
             issue_dir,
             iteration=1,
-            status_code="CAFE_NEEDS_CHANGES",
+            status_code="needs_changes",
             timestamp="2026-01-07T10:00:00+08:00",
             end_time="2026-01-07T10:05:00+08:00",
         )
@@ -670,10 +670,10 @@ class TestReviewFeedbackDetectionByEndTime:
         develop_status_file.write_text(json.dumps({
             "phase": "develop",
             "status": "completed",
-            "status_code": "CAFE_CONFIRMED",
+            "status_code": "confirmed",
             "timestamp": "2026-01-07T10:10:00+08:00",
             "iteration": 3,
-            "message": "Phase completed with CAFE_CONFIRMED",
+            "message": "Phase completed with confirmed",
             "end_time": "2026-01-07T10:15:00+08:00",
         }))
 
@@ -696,7 +696,7 @@ class TestReviewFeedbackDetectionByEndTime:
         _write_review_iteration(
             issue_dir,
             iteration=1,
-            status_code="CAFE_NEEDS_CHANGES",
+            status_code="needs_changes",
             timestamp="2026-01-07T10:20:00+08:00",
             end_time="2026-01-07T10:25:00+08:00",
         )
@@ -708,10 +708,10 @@ class TestReviewFeedbackDetectionByEndTime:
         develop_status_file.write_text(json.dumps({
             "phase": "develop",
             "status": "completed",
-            "status_code": "CAFE_CONFIRMED",
+            "status_code": "confirmed",
             "timestamp": "2026-01-07T10:10:00+08:00",
             "iteration": 3,
-            "message": "Phase completed with CAFE_CONFIRMED",
+            "message": "Phase completed with confirmed",
             "end_time": "2026-01-07T10:15:00+08:00",
         }))
 
@@ -732,7 +732,7 @@ class TestReviewFeedbackDetectionByEndTime:
         _write_review_iteration(
             issue_dir,
             iteration=1,
-            status_code="CAFE_NEEDS_CHANGES",
+            status_code="needs_changes",
             timestamp="2026-01-07T10:20:00+08:00",
             end_time="2026-01-07T10:25:00+08:00",
         )
@@ -743,10 +743,10 @@ class TestReviewFeedbackDetectionByEndTime:
         develop_status_file.write_text(json.dumps({
             "phase": "develop",
             "status": "completed",
-            "status_code": "CAFE_CONFIRMED",
+            "status_code": "confirmed",
             "timestamp": "2026-01-07T10:10:00+08:00",
             "iteration": 3,
-            "message": "Phase completed with CAFE_CONFIRMED",
+            "message": "Phase completed with confirmed",
             "end_time": "2026-01-07T10:15:00+08:00",
         }))
 
@@ -768,7 +768,7 @@ class TestReviewFeedbackDetectionByEndTime:
         _write_review_iteration(
             issue_dir,
             iteration=1,
-            status_code="CAFE_NEEDS_CHANGES",
+            status_code="needs_changes",
             timestamp="2026-01-07T10:20:00+08:00",
             end_time="2026-01-07T10:25:00+08:00",
         )
@@ -780,10 +780,10 @@ class TestReviewFeedbackDetectionByEndTime:
         develop_status_file.write_text(json.dumps({
             "phase": "develop",
             "status": "completed",
-            "status_code": "CAFE_CONFIRMED",
+            "status_code": "confirmed",
             "timestamp": "2026-01-07T10:10:00+08:00",
             "iteration": 3,
-            "message": "Phase completed with CAFE_CONFIRMED",
+            "message": "Phase completed with confirmed",
         }))
 
         with patch('cafe.agents.manager.AgentManager.get_agent_file_path', return_value=str(setup["agent_file"])):
@@ -804,7 +804,7 @@ class TestReviewFeedbackDetectionByEndTime:
         _write_review_iteration(
             issue_dir,
             iteration=1,
-            status_code="CAFE_NEEDS_CHANGES",
+            status_code="needs_changes",
             timestamp="2026-01-07T10:20:00+08:00",
         )
 
@@ -815,10 +815,10 @@ class TestReviewFeedbackDetectionByEndTime:
         develop_status_file.write_text(json.dumps({
             "phase": "develop",
             "status": "completed",
-            "status_code": "CAFE_CONFIRMED",
+            "status_code": "confirmed",
             "timestamp": "2026-01-07T10:10:00+08:00",
             "iteration": 3,
-            "message": "Phase completed with CAFE_CONFIRMED",
+            "message": "Phase completed with confirmed",
             "end_time": "2026-01-07T10:15:00+08:00",
         }))
 

--- a/tests/unit/test_generic_phase.py
+++ b/tests/unit/test_generic_phase.py
@@ -194,8 +194,8 @@ def test_build_prompt_contract_covers_shared_skills_files_context_and_gate(tmp_p
 def test_parse_response_extracts_status_and_goto(tmp_path: Path) -> None:
     phase = GenericPhase(_setup_loader(tmp_path))
     status, goto_target = phase.parse_response(
-        response="CAFE_CONFIRMED\nCAFE_GOTO:review",
-        valid_status_codes=[PhaseStatusCode.CONFIRMED],
+        response="confirmed\nGOTO:review",
+        valid_intents=[PhaseStatusCode.CONFIRMED],
     )
     assert status == PhaseStatusCode.CONFIRMED
     assert goto_target == "review"
@@ -274,9 +274,9 @@ def test_execute_short_circuits_when_before_execute_stops(tmp_path: Path) -> Non
         shared_skill_invocations=["/workflow-common"],
         step_def={
             "hooks": {"before_execute": ["StopHook"]},
-            "valid_status_codes": ["CAFE_NEED_CLARIFICATION"],
+            "valid_intents": ["need_clarification"],
         },
-        agent_executor=lambda prompt: calls.append(prompt) or "CAFE_CONFIRMED",
+        agent_executor=lambda prompt: calls.append(prompt) or "confirmed",
     )
 
     assert calls == []
@@ -291,7 +291,7 @@ def test_execute_runs_prepare_input_and_after_execute_retry(tmp_path: Path) -> N
         hook_registry={"PrepareHook": PrepareHook, "RetryHook": RetryHook},
     )
     prompts: list[str] = []
-    responses = iter(["CAFE_CONFIRMED", "CAFE_CONFIRMED"])
+    responses = iter(["confirmed", "confirmed"])
 
     result = phase.execute(
         skill_name="plan",
@@ -302,7 +302,7 @@ def test_execute_runs_prepare_input_and_after_execute_retry(tmp_path: Path) -> N
                 "prepare_input": ["PrepareHook"],
                 "after_execute": ["RetryHook"],
             },
-            "valid_status_codes": ["CAFE_CONFIRMED"],
+            "valid_intents": ["confirmed"],
         },
         agent_executor=lambda prompt: prompts.append(prompt) or next(responses),
     )
@@ -330,9 +330,9 @@ def test_execute_skips_publish_when_artifact_not_ready(tmp_path: Path) -> None:
                 "after_execute": ["NoArtifactHook"],
                 "publish_output": ["PublishHook"],
             },
-            "valid_status_codes": ["CAFE_CONFIRMED"],
+            "valid_intents": ["confirmed"],
         },
-        agent_executor=lambda prompt: "CAFE_CONFIRMED",
+        agent_executor=lambda prompt: "confirmed",
     )
 
     assert result.artifact_ready is False
@@ -354,10 +354,10 @@ def test_execute_applies_publish_output_status_override(tmp_path: Path) -> None:
             "hooks": {
                 "publish_output": ["PublishOverrideHook"],
             },
-            "valid_status_codes": ["CAFE_CONFIRMED", "CAFE_READY_FOR_REVIEW"],
+            "valid_intents": ["confirmed", "ready_for_review"],
         },
         output_file=tmp_path / "out.md",
-        agent_executor=lambda prompt: "CAFE_CONFIRMED",
+        agent_executor=lambda prompt: "confirmed",
     )
 
     assert result.status_code == PhaseStatusCode.READY_FOR_REVIEW
@@ -515,10 +515,10 @@ def test_execute_runs_script_hook_with_schema_and_interpolation(tmp_path: Path) 
                     }
                 ]
             },
-            "valid_status_codes": ["CAFE_CONFIRMED"],
+            "valid_intents": ["confirmed"],
         },
         output_file=output_file,
-        agent_executor=lambda prompt: "CAFE_CONFIRMED",
+        agent_executor=lambda prompt: "confirmed",
     )
 
     event = next(item for item in result.events if item.get("type") == "script_hook")
@@ -546,9 +546,9 @@ def test_execute_rejects_script_hook_path_traversal(tmp_path: Path) -> None:
                         }
                     ]
                 },
-                "valid_status_codes": ["CAFE_CONFIRMED"],
+                "valid_intents": ["confirmed"],
             },
-            agent_executor=lambda prompt: "CAFE_CONFIRMED",
+            agent_executor=lambda prompt: "confirmed",
         )
 
 
@@ -581,9 +581,9 @@ def test_execute_rejects_script_hook_symlink_outside_scripts_dir(tmp_path: Path)
                         }
                     ]
                 },
-                "valid_status_codes": ["CAFE_CONFIRMED"],
+                "valid_intents": ["confirmed"],
             },
-            agent_executor=lambda prompt: "CAFE_CONFIRMED",
+            agent_executor=lambda prompt: "confirmed",
         )
 
 
@@ -621,9 +621,9 @@ def test_execute_script_hook_validation_failure_stops_pipeline(tmp_path: Path) -
                     }
                 ]
             },
-            "valid_status_codes": ["CAFE_NEED_PERMISSION", "CAFE_CONFIRMED"],
+            "valid_intents": ["need_permission", "confirmed"],
         },
-        agent_executor=lambda prompt: "CAFE_CONFIRMED",
+        agent_executor=lambda prompt: "confirmed",
     )
 
     assert not marker.exists()
@@ -658,13 +658,13 @@ def test_execute_script_hook_failure_stops_pipeline(tmp_path: Path) -> None:
                     {
                         "script": "fail.sh",
                         "args": {},
-                        "when_status_codes": ["CAFE_CONFIRMED"],
+                        "when_intents": ["confirmed"],
                     }
                 ]
             },
-            "valid_status_codes": ["CAFE_CONFIRMED", "CAFE_NEED_PERMISSION"],
+            "valid_intents": ["confirmed", "need_permission"],
         },
-        agent_executor=lambda prompt: "CAFE_CONFIRMED",
+        agent_executor=lambda prompt: "confirmed",
     )
 
     assert result.status_code == PhaseStatusCode.NEED_PERMISSION
@@ -698,18 +698,18 @@ def test_execute_script_hook_can_skip_when_status_mismatch(tmp_path: Path) -> No
                     {
                         "script": "noop.sh",
                         "args": {},
-                        "when_status_codes": ["CAFE_CONFIRMED"],
+                        "when_intents": ["confirmed"],
                     }
                 ]
             },
-            "valid_status_codes": ["CAFE_READY_FOR_REVIEW", "CAFE_CONFIRMED"],
+            "valid_intents": ["ready_for_review", "confirmed"],
         },
-        agent_executor=lambda prompt: "CAFE_READY_FOR_REVIEW",
+        agent_executor=lambda prompt: "ready_for_review",
     )
 
     event = next(item for item in result.events if item.get("type") == "script_hook")
     assert event["status"] == "skipped"
-    assert event["reason"] == "status_mismatch"
+    assert event["reason"] == "intent_mismatch"
 
 
 def test_execute_script_hook_passes_timeout_to_subprocess(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -743,9 +743,9 @@ def test_execute_script_hook_passes_timeout_to_subprocess(tmp_path: Path, monkey
                     }
                 ]
             },
-            "valid_status_codes": ["CAFE_CONFIRMED"],
+            "valid_intents": ["confirmed"],
         },
-        agent_executor=lambda prompt: "CAFE_CONFIRMED",
+        agent_executor=lambda prompt: "confirmed",
     )
 
     assert captured["timeout"] == 2.5
@@ -782,9 +782,9 @@ def test_execute_script_hook_timeout_stops_pipeline(tmp_path: Path, monkeypatch:
                     }
                 ]
             },
-            "valid_status_codes": ["CAFE_CONFIRMED", "CAFE_NEED_PERMISSION"],
+            "valid_intents": ["confirmed", "need_permission"],
         },
-        agent_executor=lambda prompt: "CAFE_CONFIRMED",
+        agent_executor=lambda prompt: "confirmed",
     )
 
     assert result.status_code == PhaseStatusCode.NEED_PERMISSION
@@ -826,9 +826,9 @@ def test_execute_script_hook_timeout_decodes_bytes_output(
                     }
                 ]
             },
-            "valid_status_codes": ["CAFE_CONFIRMED", "CAFE_NEED_PERMISSION"],
+            "valid_intents": ["confirmed", "need_permission"],
         },
-        agent_executor=lambda prompt: "CAFE_CONFIRMED",
+        agent_executor=lambda prompt: "confirmed",
     )
 
     assert result.status_code == PhaseStatusCode.NEED_PERMISSION

--- a/tests/unit/test_generic_workflow_step.py
+++ b/tests/unit/test_generic_workflow_step.py
@@ -127,8 +127,8 @@ def test_generic_workflow_step_executor_writes_iteration_files(tmp_path: Path, m
                 "role": "pm",
                 "output_artifact": "spec",
                 "allowed_tools": ["Read"],
-                "valid_status_codes": ["CAFE_CONFIRMED"],
-                "on": {"CAFE_CONFIRMED": "_done"},
+                "valid_intents": ["confirmed"],
+                "on": {"await_agent": "_done"},
             }
         },
     }
@@ -140,14 +140,14 @@ def test_generic_workflow_step_executor_writes_iteration_files(tmp_path: Path, m
         issue_name="issue-1",
         playbook=playbook,
         generic_phase=_build_loader(tmp_path),
-        agent_manager=FakeAgentManager("CAFE_CONFIRMED"),
+        agent_manager=FakeAgentManager("confirmed"),
         git_ops=FakeGitOperations(),
         role_agent_map={"pm": "Roger"},
     )
 
     result = executor.execute_step("spec", playbook["steps"]["spec"], state)
 
-    assert result.response == "CAFE_CONFIRMED"
+    assert result.response == "confirmed"
     assert "spec" in result.artifacts
     iteration_dir = issue_dir / "spec" / "iteration_001"
     assert (iteration_dir / "context.json").exists()
@@ -161,7 +161,7 @@ def test_generic_workflow_step_executor_writes_iteration_files(tmp_path: Path, m
     assert reloaded.handoff_contract.to_owner == HandoffOwner.DONE
     assert reloaded.handoff_contract.to_step == "done"
     assert reloaded.handoff_contract.intent == HandoffIntent.WORKFLOW_COMPLETE
-    assert reloaded.handoff_contract.status_code == "CAFE_CONFIRMED"
+    assert reloaded.handoff_contract.status_code == "confirmed"
     assert reloaded.handoff_contract.source == "workflow.status_transition_adapter"
 
 
@@ -177,8 +177,8 @@ def test_generic_workflow_step_writes_review_pause_contract(tmp_path: Path, monk
                 "role": "pm",
                 "output_artifact": "spec",
                 "allowed_tools": ["Read"],
-                "valid_status_codes": ["CAFE_READY_FOR_REVIEW", "CAFE_CONFIRMED"],
-                "on": {"CAFE_READY_FOR_REVIEW": "spec", "CAFE_CONFIRMED": "_done"},
+                "valid_intents": ["ready_for_review", "confirmed"],
+                "on": {"confirm_output": "spec", "await_agent": "_done"},
             }
         },
     }
@@ -188,14 +188,14 @@ def test_generic_workflow_step_writes_review_pause_contract(tmp_path: Path, monk
         issue_name="issue-review-pause",
         playbook=playbook,
         generic_phase=_build_loader(tmp_path),
-        agent_manager=FakeAgentManager("CAFE_READY_FOR_REVIEW"),
+        agent_manager=FakeAgentManager("ready_for_review"),
         git_ops=FakeGitOperations(),
         role_agent_map={"pm": "Roger"},
     )
 
     result = executor.execute_step("spec", playbook["steps"]["spec"], state)
 
-    assert result.status_code == "CAFE_READY_FOR_REVIEW"
+    assert result.status_code == "ready_for_review"
     reloaded = BlackboardStore(issue_dir).load_or_create("spec")
     assert reloaded.handoff_contract is not None
     assert reloaded.handoff_contract.to_owner == HandoffOwner.USER
@@ -216,13 +216,13 @@ def test_generic_workflow_step_does_not_retry_for_legacy_status_tokens(tmp_path:
                 "role": "pm",
                 "output_artifact": "spec",
                 "allowed_tools": ["Read"],
-                "valid_status_codes": ["CAFE_CONFIRMED"],
-                "on": {"CAFE_CONFIRMED": "_done"},
+                "valid_intents": ["confirmed"],
+                "on": {"await_agent": "_done"},
             }
         },
     }
     state = BlackboardStore(issue_dir).load_or_create("spec")
-    agent_manager = FakeAgentManager(["CAFE_SPEC_READY", "CAFE_CONFIRMED"])
+    agent_manager = FakeAgentManager(["ready_for_review", "confirmed"])
     executor = GenericWorkflowStepExecutor(
         issue_dir=issue_dir,
         issue_name="issue-status-retry",
@@ -245,7 +245,7 @@ def test_generic_workflow_step_executor_uses_iteration_specific_skill_mapping(tm
     phase_dir = issue_dir / "spec" / "iteration_001"
     phase_dir.mkdir(parents=True, exist_ok=True)
     (phase_dir / "context.json").write_text(
-        '{"iteration": 1, "response": "CAFE_CONFIRMED", "end_time": "2026-04-09T00:00:00+08:00"}',
+        '{"iteration": 1, "response": "confirmed", "end_time": "2026-04-09T00:00:00+08:00"}',
         encoding="utf-8",
     )
 
@@ -258,8 +258,8 @@ def test_generic_workflow_step_executor_uses_iteration_specific_skill_mapping(tm
                 "role": "pm",
                 "output_artifact": "spec",
                 "allowed_tools": ["Read"],
-                "valid_status_codes": ["CAFE_CONFIRMED"],
-                "on": {"CAFE_CONFIRMED": "_done"},
+                "valid_intents": ["confirmed"],
+                "on": {"await_agent": "_done"},
             }
         },
     }
@@ -281,7 +281,7 @@ def test_generic_workflow_step_executor_uses_iteration_specific_skill_mapping(tm
         issue_name="issue-2",
         playbook=playbook,
         generic_phase=generic_phase,
-        agent_manager=FakeAgentManager("CAFE_CONFIRMED"),
+        agent_manager=FakeAgentManager("confirmed"),
         git_ops=FakeGitOperations(),
         role_agent_map={"pm": "Roger"},
     )
@@ -303,8 +303,8 @@ def test_generic_workflow_step_executor_installs_workflow_common_and_phase_skill
                 "role": "reviewer",
                 "output_artifact": "review_feedback",
                 "allowed_tools": ["Read"],
-                "valid_status_codes": ["CAFE_CONFIRMED"],
-                "on": {"CAFE_CONFIRMED": "_done"},
+                "valid_intents": ["confirmed"],
+                "on": {"await_agent": "_done"},
             }
         },
     }
@@ -324,7 +324,7 @@ def test_generic_workflow_step_executor_installs_workflow_common_and_phase_skill
         issue_name="issue-review-skill",
         playbook=playbook,
         generic_phase=generic_phase,
-        agent_manager=FakeAgentManager("CAFE_CONFIRMED"),
+        agent_manager=FakeAgentManager("confirmed"),
         git_ops=FakeGitOperations(),
         role_agent_map={"reviewer": "Richard"},
     )
@@ -348,8 +348,8 @@ def test_generic_workflow_step_prompt_includes_latest_blackboard_handoff(tmp_pat
                 "role": "developer",
                 "output_artifact": "code",
                 "allowed_tools": ["Read"],
-                "valid_status_codes": ["CAFE_CONFIRMED"],
-                "on": {"CAFE_CONFIRMED": "_done"},
+                "valid_intents": ["confirmed"],
+                "on": {"await_agent": "_done"},
             }
         },
     }
@@ -367,7 +367,7 @@ def test_generic_workflow_step_prompt_includes_latest_blackboard_handoff(tmp_pat
         state,
         "還要再實作 cafe skill rm，支援批次刪除、interactive 多選與 confirm。",
     )
-    agent_manager = FakeAgentManager("CAFE_CONFIRMED")
+    agent_manager = FakeAgentManager("confirmed")
     executor = GenericWorkflowStepExecutor(
         issue_dir=issue_dir,
         issue_name="issue-handoff",
@@ -396,8 +396,8 @@ def test_generic_workflow_step_prompt_keeps_skill_invocations_only(tmp_path: Pat
                 "role": "developer",
                 "output_artifact": "pr",
                 "allowed_tools": ["Read"],
-                "valid_status_codes": ["CAFE_CONFIRMED"],
-                "on": {"CAFE_CONFIRMED": "_done"},
+                "valid_intents": ["confirmed"],
+                "on": {"await_agent": "_done"},
             }
         },
     }
@@ -411,7 +411,7 @@ def test_generic_workflow_step_prompt_keeps_skill_invocations_only(tmp_path: Pat
     plan_file.write_text("# Plan\n", encoding="utf-8")
     store.set_artifact(state, "spec", str(spec_file))
     store.set_artifact(state, "plan", str(plan_file))
-    agent_manager = FakeAgentManager("CAFE_CONFIRMED")
+    agent_manager = FakeAgentManager("confirmed")
     executor = GenericWorkflowStepExecutor(
         issue_dir=issue_dir,
         issue_name="issue-pr-skill-body",
@@ -445,8 +445,8 @@ def test_generic_workflow_step_pr_prompt_overrides_external_state_guardrail(tmp_
                 "role": "developer",
                 "output_artifact": "pr",
                 "allowed_tools": ["Read"],
-                "valid_status_codes": ["CAFE_CONFIRMED"],
-                "on": {"CAFE_CONFIRMED": "_done"},
+                "valid_intents": ["confirmed"],
+                "on": {"await_agent": "_done"},
             }
         },
     }
@@ -461,7 +461,7 @@ def test_generic_workflow_step_pr_prompt_overrides_external_state_guardrail(tmp_
     store.set_artifact(state, "spec", str(spec_file))
     store.set_artifact(state, "plan", str(plan_file))
     store.set_handoff_summary(state, "原本的 pr script 有問題，我把 pr 砍掉了麻煩重發一次")
-    agent_manager = FakeAgentManager("CAFE_CONFIRMED")
+    agent_manager = FakeAgentManager("confirmed")
     executor = GenericWorkflowStepExecutor(
         issue_dir=issue_dir,
         issue_name="issue-pr-guardrail",
@@ -492,8 +492,8 @@ def test_generic_workflow_step_writes_pr_publish_request_contract(tmp_path: Path
                 "role": "developer",
                 "output_artifact": "pr",
                 "allowed_tools": ["Read"],
-                "valid_status_codes": ["CAFE_CONFIRMED"],
-                "on": {"CAFE_CONFIRMED": "_done"},
+                "valid_intents": ["confirmed"],
+                "on": {"await_agent": "_done"},
             }
         },
     }
@@ -509,7 +509,7 @@ def test_generic_workflow_step_writes_pr_publish_request_contract(tmp_path: Path
     issue_yaml.write_text("base_branch: v02\n", encoding="utf-8")
     store.set_artifact(state, "spec", str(spec_file))
     store.set_artifact(state, "plan", str(plan_file))
-    agent_manager = FakeAgentManager("CAFE_CONFIRMED")
+    agent_manager = FakeAgentManager("confirmed")
     executor = GenericWorkflowStepExecutor(
         issue_dir=issue_dir,
         issue_name="issue-pr-contract",
@@ -550,11 +550,11 @@ def test_generic_workflow_step_collects_clarification_before_next_agent_run(
                 "role": "pm",
                 "output_artifact": "spec",
                 "allowed_tools": ["Read"],
-                "valid_status_codes": ["CAFE_NEED_CLARIFICATION", "CAFE_CONFIRMED"],
+                "valid_intents": ["need_clarification", "confirmed"],
                 "hooks": {"prepare_input": ["UserInputCollector"]},
                 "on": {
-                    "CAFE_NEED_CLARIFICATION": "spec",
-                    "CAFE_CONFIRMED": "_done",
+                    "need_clarification": "spec",
+                    "await_agent": "_done",
                 },
             }
         },
@@ -562,7 +562,7 @@ def test_generic_workflow_step_collects_clarification_before_next_agent_run(
     store = BlackboardStore(issue_dir)
     state = store.load_or_create("spec")
     def _write_questions_xml(*, response: str, streaming_output_file: str | None, **_: object) -> None:
-        if response != "CAFE_NEED_CLARIFICATION" or not streaming_output_file:
+        if response != "need_clarification" or not streaming_output_file:
             return
         iteration_dir = Path(streaming_output_file).parent
         (iteration_dir / "questions.xml").write_text(
@@ -581,7 +581,7 @@ def test_generic_workflow_step_collects_clarification_before_next_agent_run(
         )
 
     agent_manager = FakeAgentManager(
-        ["CAFE_NEED_CLARIFICATION", "CAFE_CONFIRMED"],
+        ["need_clarification", "confirmed"],
         on_execute=_write_questions_xml,
     )
     executor = GenericWorkflowStepExecutor(
@@ -595,7 +595,7 @@ def test_generic_workflow_step_collects_clarification_before_next_agent_run(
     )
 
     first_result = executor.execute_step("spec", playbook["steps"]["spec"], state)
-    assert first_result.response == "CAFE_NEED_CLARIFICATION"
+    assert first_result.response == "need_clarification"
     assert first_result.auto_continue is False
 
     # Mirror the runtime which records a `step_completed` event after each step
@@ -613,7 +613,7 @@ def test_generic_workflow_step_collects_clarification_before_next_agent_run(
     ):
         second_result = executor.execute_step("spec", playbook["steps"]["spec"], state)
 
-    assert second_result.response == "CAFE_CONFIRMED"
+    assert second_result.response == "confirmed"
     assert any(
         "Current user input for this iteration:" in prompt and "A1: CLI only" in prompt
         for prompt in agent_manager.prompts
@@ -635,11 +635,11 @@ def test_initial_requirements_collection_does_not_auto_continue_clarification(
                 "role": "pm",
                 "output_artifact": "spec",
                 "allowed_tools": ["Read"],
-                "valid_status_codes": ["CAFE_NEED_CLARIFICATION", "CAFE_CONFIRMED"],
+                "valid_intents": ["need_clarification", "confirmed"],
                 "hooks": {"prepare_input": ["GitHubIssueFetcher"]},
                 "on": {
-                    "CAFE_NEED_CLARIFICATION": "spec",
-                    "CAFE_CONFIRMED": "_done",
+                    "need_clarification": "spec",
+                    "await_agent": "_done",
                 },
             }
         },
@@ -655,7 +655,7 @@ def test_initial_requirements_collection_does_not_auto_continue_clarification(
         issue_name="issue-initial-input",
         playbook=playbook,
         generic_phase=_build_loader(tmp_path),
-        agent_manager=FakeAgentManager("CAFE_NEED_CLARIFICATION"),
+        agent_manager=FakeAgentManager("need_clarification"),
         git_ops=FakeGitOperations(),
         role_agent_map={"pm": "Roger"},
         step_user_inputs={"spec": "Initial issue text"},
@@ -663,7 +663,7 @@ def test_initial_requirements_collection_does_not_auto_continue_clarification(
 
     result = executor.execute_step("spec", playbook["steps"]["spec"], state)
 
-    assert result.status_code == "CAFE_NEED_CLARIFICATION"
+    assert result.status_code == "need_clarification"
     assert result.auto_continue is False
     reloaded = BlackboardStore(issue_dir).load_or_create("spec")
     assert reloaded.handoff_contract is not None
@@ -685,8 +685,8 @@ def test_generic_workflow_step_records_script_hook_events_to_blackboard(tmp_path
                 "output_artifact": "code",
                 "allowed_tools": ["Read"],
                 "hooks": {"before_execute": ["ScriptHook"]},
-                "valid_status_codes": ["CAFE_CONFIRMED"],
-                "on": {"CAFE_CONFIRMED": "_done"},
+                "valid_intents": ["confirmed"],
+                "on": {"await_agent": "_done"},
             }
         },
     }
@@ -734,14 +734,14 @@ def test_generic_workflow_step_records_script_hook_events_to_blackboard(tmp_path
         issue_name="issue-script-event",
         playbook=playbook,
         generic_phase=phase_with_hook,
-        agent_manager=FakeAgentManager("CAFE_CONFIRMED"),
+        agent_manager=FakeAgentManager("confirmed"),
         git_ops=FakeGitOperations(),
         role_agent_map={"developer": "David"},
     )
 
     result = executor.execute_step("develop", playbook["steps"]["develop"], state)
 
-    assert result.status_code == "CAFE_CONFIRMED"
+    assert result.status_code == "confirmed"
     reloaded = BlackboardStore(issue_dir).load_or_create("develop")
     script_event = next(item for item in reloaded.events if item.event_type == "script_hook")
     assert script_event.data["script"] == "demo.sh"
@@ -755,11 +755,11 @@ def test_generic_workflow_step_auto_continues_pause_statuses_in_interactive_mode
     spec_dir.mkdir(parents=True, exist_ok=True)
     (spec_dir / "output.md").write_text("# Spec\n", encoding="utf-8")
     (spec_dir / "context.json").write_text(
-        '{"iteration":1,"status_code":"CAFE_CONFIRMED"}',
+        '{"iteration":1,"status_code":"confirmed"}',
         encoding="utf-8",
     )
     (issue_dir / "spec" / "status.json").write_text(
-        '{"phase":"spec","status":"completed","status_code":"CAFE_CONFIRMED","iteration":1}',
+        '{"phase":"spec","status":"completed","status_code":"confirmed","iteration":1}',
         encoding="utf-8",
     )
     playbook = {
@@ -771,8 +771,8 @@ def test_generic_workflow_step_auto_continues_pause_statuses_in_interactive_mode
                 "role": "developer",
                 "output_artifact": "plan",
                 "allowed_tools": ["Read"],
-                "valid_status_codes": ["CAFE_READY_FOR_REVIEW"],
-                "on": {"CAFE_READY_FOR_REVIEW": "plan"},
+                "valid_intents": ["ready_for_review"],
+                "on": {"confirm_output": "plan"},
             }
         },
     }
@@ -782,7 +782,7 @@ def test_generic_workflow_step_auto_continues_pause_statuses_in_interactive_mode
         issue_name="issue-review",
         playbook=playbook,
         generic_phase=_build_loader(tmp_path),
-        agent_manager=FakeAgentManager("CAFE_READY_FOR_REVIEW"),
+        agent_manager=FakeAgentManager("ready_for_review"),
         git_ops=FakeGitOperations(),
         role_agent_map={"developer": "David"},
         interactive=True,
@@ -790,7 +790,7 @@ def test_generic_workflow_step_auto_continues_pause_statuses_in_interactive_mode
 
     result = executor.execute_step("plan", playbook["steps"]["plan"], state)
 
-    assert result.response == "CAFE_READY_FOR_REVIEW"
+    assert result.response == "ready_for_review"
     assert result.auto_continue is True
 
 
@@ -806,8 +806,8 @@ def test_generic_workflow_step_keeps_missing_status_without_continue_prompt(tmp_
                 "role": "pm",
                 "output_artifact": "spec",
                 "allowed_tools": ["Read"],
-                "valid_status_codes": ["CAFE_CONFIRMED"],
-                "on": {"CAFE_CONFIRMED": "_done"},
+                "valid_intents": ["confirmed"],
+                "on": {"await_agent": "_done"},
             }
         },
     }
@@ -818,7 +818,7 @@ def test_generic_workflow_step_keeps_missing_status_without_continue_prompt(tmp_
         issue_name="issue-no-status",
         playbook=playbook,
         generic_phase=_build_loader(tmp_path),
-        agent_manager=FakeAgentManager(["done without status", "CAFE_CONFIRMED"]),
+        agent_manager=FakeAgentManager(["done without status", "confirmed"]),
         git_ops=FakeGitOperations(),
         role_agent_map={"pm": "Roger"},
     )
@@ -844,8 +844,8 @@ def test_generic_workflow_step_does_not_recover_from_unchanged_output(tmp_path: 
                 "role": "developer",
                 "output_artifact": "code",
                 "allowed_tools": ["Read"],
-                "valid_status_codes": ["CAFE_CONFIRMED", "CAFE_NO_CHANGES_NEEDED"],
-                "on": {"CAFE_CONFIRMED": "review", "CAFE_NO_CHANGES_NEEDED": "review"},
+                "valid_intents": ["confirmed", "no_changes_needed"],
+                "on": {"await_agent": "review", "await_agent": "review"},
             }
         },
     }
@@ -891,13 +891,13 @@ def test_generic_workflow_step_restores_spec_runtime_allowed_tools(tmp_path: Pat
                 "role": "pm",
                 "output_artifact": "spec",
                 "allowed_tools": ["Read", "Grep", "Glob", "WebFetch", "WebSearch"],
-                "valid_status_codes": ["CAFE_CONFIRMED"],
-                "on": {"CAFE_CONFIRMED": "_done"},
+                "valid_intents": ["confirmed"],
+                "on": {"await_agent": "_done"},
             }
         },
     }
     state = BlackboardStore(issue_dir).load_or_create("spec")
-    agent_manager = FakeAgentManager("CAFE_CONFIRMED")
+    agent_manager = FakeAgentManager("confirmed")
     executor = GenericWorkflowStepExecutor(
         issue_dir=issue_dir,
         issue_name="issue-spec-tools",
@@ -934,8 +934,8 @@ def test_generic_workflow_step_restores_develop_runtime_allowed_tools(tmp_path: 
                 "role": "developer",
                 "output_artifact": "code",
                 "allowed_tools": ["Read", "Edit", "Write", "Grep", "Glob", "Bash", "WebFetch", "WebSearch"],
-                "valid_status_codes": ["CAFE_CONFIRMED"],
-                "on": {"CAFE_CONFIRMED": "_done"},
+                "valid_intents": ["confirmed"],
+                "on": {"await_agent": "_done"},
             }
         },
     }
@@ -949,7 +949,7 @@ def test_generic_workflow_step_restores_develop_runtime_allowed_tools(tmp_path: 
     plan_file.write_text("# Plan\n", encoding="utf-8")
     store.set_artifact(state, "spec", str(spec_file))
     store.set_artifact(state, "plan", str(plan_file))
-    agent_manager = FakeAgentManager("CAFE_CONFIRMED")
+    agent_manager = FakeAgentManager("confirmed")
     executor = GenericWorkflowStepExecutor(
         issue_dir=issue_dir,
         issue_name="issue-develop-tools",
@@ -986,8 +986,8 @@ def test_generic_workflow_step_restores_review_runtime_allowed_tools(tmp_path: P
                 "role": "reviewer",
                 "output_artifact": "review_feedback",
                 "allowed_tools": ["Read", "Grep", "Glob", "Bash(git:*)"],
-                "valid_status_codes": ["CAFE_CONFIRMED"],
-                "on": {"CAFE_CONFIRMED": "_done"},
+                "valid_intents": ["confirmed"],
+                "on": {"await_agent": "_done"},
             }
         },
     }
@@ -1001,7 +1001,7 @@ def test_generic_workflow_step_restores_review_runtime_allowed_tools(tmp_path: P
     plan_file.write_text("# Plan\n", encoding="utf-8")
     store.set_artifact(state, "spec", str(spec_file))
     store.set_artifact(state, "plan", str(plan_file))
-    agent_manager = FakeAgentManager("CAFE_CONFIRMED")
+    agent_manager = FakeAgentManager("confirmed")
     executor = GenericWorkflowStepExecutor(
         issue_dir=issue_dir,
         issue_name="issue-review-tools",
@@ -1043,8 +1043,8 @@ def test_generic_workflow_step_restores_pr_runtime_allowed_tools(tmp_path: Path,
                 "input_artifacts": ["spec", "plan", "review_feedback"],
                 "output_artifact": "pr_result",
                 "allowed_tools": ["Read", "Edit", "Write", "Grep", "Glob", "Bash", "WebFetch", "WebSearch"],
-                "valid_status_codes": ["CAFE_CONFIRMED"],
-                "on": {"CAFE_CONFIRMED": "_done"},
+                "valid_intents": ["confirmed"],
+                "on": {"await_agent": "_done"},
             }
         },
     }
@@ -1062,7 +1062,7 @@ def test_generic_workflow_step_restores_pr_runtime_allowed_tools(tmp_path: Path,
     store.set_artifact(state, "spec", str(spec_file))
     store.set_artifact(state, "plan", str(plan_file))
     store.set_artifact(state, "review_feedback", str(review_file))
-    agent_manager = FakeAgentManager("CAFE_CONFIRMED")
+    agent_manager = FakeAgentManager("confirmed")
     executor = GenericWorkflowStepExecutor(
         issue_dir=issue_dir,
         issue_name="issue-pr-tools",
@@ -1101,7 +1101,7 @@ def test_generic_workflow_step_pr_does_not_require_status_code(tmp_path: Path, m
                 "role": "developer",
                 "output_artifact": "pr_result",
                 "allowed_tools": ["Read"],
-                "on": {"CAFE_CONFIRMED": "_done"},
+                "on": {"await_agent": "_done"},
             }
         },
     }
@@ -1158,8 +1158,8 @@ def test_generic_workflow_step_pr_does_not_parse_status_from_response(tmp_path: 
                 "role": "developer",
                 "output_artifact": "pr_result",
                 "allowed_tools": ["Read"],
-                "valid_status_codes": ["CAFE_CONFIRMED"],
-                "on": {"CAFE_CONFIRMED": "_done"},
+                "valid_intents": ["confirmed"],
+                "on": {"await_agent": "_done"},
             }
         },
     }
@@ -1191,7 +1191,7 @@ def test_generic_workflow_step_pr_does_not_parse_status_from_response(tmp_path: 
 
     def fake_execute(*args, **kwargs):
         return GenericPhaseExecution(
-            response="CAFE_CONFIRMED",
+            response="confirmed",
             status_code=None,
             goto_target=None,
             context_updates={},
@@ -1202,7 +1202,7 @@ def test_generic_workflow_step_pr_does_not_parse_status_from_response(tmp_path: 
 
     result = executor.execute_step("pr", playbook["steps"]["pr"], state)
 
-    assert result.response == "CAFE_CONFIRMED"
+    assert result.response == "confirmed"
     assert result.status_code is None
     assert all(event.get("type") != "handoff_intent" for event in result.events)
 
@@ -1222,7 +1222,7 @@ def test_generic_workflow_step_pr_aligns_baton_when_execute_returns_needs_change
                 "role": "developer",
                 "output_artifact": "pr_result",
                 "allowed_tools": ["Read"],
-                "on": {"CAFE_NEEDS_CHANGES": "develop"},
+                "on": {"manual_handoff": "develop"},
             },
             "develop": {"skill": "develop", "role": "developer", "allowed_tools": ["Read"]},
         },
@@ -1272,7 +1272,7 @@ def test_generic_workflow_step_pr_aligns_baton_when_execute_returns_needs_change
 
     def fake_execute(*args, **kwargs):
         return GenericPhaseExecution(
-            response="CAFE_NEEDS_CHANGES",
+            response="needs_changes",
             status_code=PhaseStatusCode.NEEDS_CHANGES,
             goto_target=None,
             context_updates={},
@@ -1283,7 +1283,7 @@ def test_generic_workflow_step_pr_aligns_baton_when_execute_returns_needs_change
 
     result = executor.execute_step("pr", playbook["steps"]["pr"], state)
 
-    assert result.status_code == "CAFE_NEEDS_CHANGES"
+    assert result.status_code == "needs_changes"
     reloaded = BlackboardStore(issue_dir).load_or_create("pr")
     assert reloaded.handoff_contract is not None
     assert reloaded.handoff_contract.to_step == "develop"
@@ -1303,7 +1303,7 @@ def test_generic_workflow_step_pr_prompt_uses_baton_wording(tmp_path: Path, monk
                 "role": "developer",
                 "output_artifact": "pr_result",
                 "allowed_tools": ["Read"],
-                "on": {"CAFE_CONFIRMED": "_done"},
+                "on": {"await_agent": "_done"},
             }
         },
     }
@@ -1356,8 +1356,8 @@ def test_generic_workflow_step_applies_phase_specific_model_per_step(tmp_path: P
                 "role": "pm",
                 "output_artifact": "spec",
                 "allowed_tools": ["Read"],
-                "valid_status_codes": ["CAFE_CONFIRMED"],
-                "on": {"CAFE_CONFIRMED": "plan"},
+                "valid_intents": ["confirmed"],
+                "on": {"await_agent": "plan"},
             },
             "plan": {
                 "skill": "plan",
@@ -1365,8 +1365,8 @@ def test_generic_workflow_step_applies_phase_specific_model_per_step(tmp_path: P
                 "output_artifact": "plan",
                 "allowed_tools": ["Read"],
                 "input_artifacts": ["spec"],
-                "valid_status_codes": ["CAFE_CONFIRMED"],
-                "on": {"CAFE_CONFIRMED": "_done"},
+                "valid_intents": ["confirmed"],
+                "on": {"await_agent": "_done"},
             },
         },
     }
@@ -1379,7 +1379,7 @@ def test_generic_workflow_step_applies_phase_specific_model_per_step(tmp_path: P
         checklist_file.write_text("- [x] completed\n", encoding="utf-8")
 
     agent_manager = FakeAgentManager(
-        ["CAFE_CONFIRMED", "CAFE_CONFIRMED"],
+        ["confirmed", "confirmed"],
         on_execute=_mark_checklist_complete,
     )
     executor = GenericWorkflowStepExecutor(
@@ -1420,8 +1420,8 @@ def test_generic_workflow_step_develop_confirmed(tmp_path: Path, monkeypatch) ->
                 "role": "developer",
                 "output_artifact": "code",
                 "allowed_tools": ["Read"],
-                "valid_status_codes": ["CAFE_CONFIRMED", "CAFE_NEED_CLARIFICATION"],
-                "on": {"CAFE_CONFIRMED": "review", "CAFE_NEED_CLARIFICATION": "develop"},
+                "valid_intents": ["confirmed", "need_clarification"],
+                "on": {"await_agent": "review", "need_clarification": "develop"},
             },
         },
     }
@@ -1447,7 +1447,7 @@ def test_generic_workflow_step_develop_confirmed(tmp_path: Path, monkeypatch) ->
         playbook=playbook,
         generic_phase=_build_loader(tmp_path),
         agent_manager=FakeAgentManager(
-            "CAFE_CONFIRMED",
+            "confirmed",
             on_execute=_mark_checklist_complete,
         ),
         git_ops=FakeGitOperations(),
@@ -1456,4 +1456,4 @@ def test_generic_workflow_step_develop_confirmed(tmp_path: Path, monkeypatch) ->
 
     result = executor.execute_step("develop", playbook["steps"]["develop"], state)
 
-    assert result.status_code == "CAFE_CONFIRMED"
+    assert result.status_code == "confirmed"

--- a/tests/unit/test_github_pr_comments.py
+++ b/tests/unit/test_github_pr_comments.py
@@ -930,7 +930,7 @@ All tests are passing now.
         from cafe.utils.github import parse_comment_processing_results
 
         agent_response = """
-CAFE_CONFIRMED
+confirmed
 
 ### Processed Comments
 - [#IC_kwDOQCpNoM7hfWZl] Fixed the bug in authentication flow

--- a/tests/unit/test_mock_agent_executor.py
+++ b/tests/unit/test_mock_agent_executor.py
@@ -18,7 +18,7 @@ class TestMockAgentExecutor:
         agent_response = executor.execute("test prompt")
 
         # Assert
-        assert "CAFE_READY_FOR_REVIEW" in agent_response.response
+        assert "ready_for_review" in agent_response.response
         assert isinstance(agent_response.token_usage, TokenUsage)
 
     def test_custom_response(self):

--- a/tests/unit/test_native_user_input_hook.py
+++ b/tests/unit/test_native_user_input_hook.py
@@ -75,7 +75,7 @@ def test_user_input_collector_confirms_ready_for_review_without_running_agent(tm
     prev_iter_dir = phase_dir / "iteration_002"
     prev_iter_dir.mkdir(parents=True, exist_ok=True)
     (prev_iter_dir / "output.md").write_text("# Spec\n", encoding="utf-8")
-    _record_previous_step_status(tmp_path, "spec", "CAFE_READY_FOR_REVIEW")
+    _record_previous_step_status(tmp_path, "spec", "ready_for_review")
 
     phase = _FakePhase(phase_dir=phase_dir, iteration=3)
     phase._ask_user_for_review_decision = MagicMock(return_value="confirm")
@@ -113,7 +113,7 @@ def test_user_input_collector_plan_ready_for_review_skips_full_output_display_wh
     prev_iter_dir = phase_dir / "iteration_002"
     prev_iter_dir.mkdir(parents=True, exist_ok=True)
     (prev_iter_dir / "output.md").write_text("# Plan v2\n", encoding="utf-8")
-    _record_previous_step_status(tmp_path, "plan", "CAFE_READY_FOR_REVIEW")
+    _record_previous_step_status(tmp_path, "plan", "ready_for_review")
 
     phase = _FakePhase(phase_dir=phase_dir, iteration=3)
     phase._ask_user_for_review_decision = MagicMock(return_value="confirm")
@@ -141,7 +141,7 @@ def test_user_input_collector_plan_ready_for_review_falls_back_to_full_output_wi
     prev_iter_dir = phase_dir / "iteration_001"
     prev_iter_dir.mkdir(parents=True, exist_ok=True)
     (prev_iter_dir / "output.md").write_text("# Plan\n", encoding="utf-8")
-    _record_previous_step_status(tmp_path, "plan", "CAFE_READY_FOR_REVIEW")
+    _record_previous_step_status(tmp_path, "plan", "ready_for_review")
 
     phase = _FakePhase(phase_dir=phase_dir, iteration=2)
     phase._ask_user_for_review_decision = MagicMock(return_value="confirm")
@@ -170,7 +170,7 @@ def test_user_input_collector_loads_interactive_qa_for_need_clarification(tmp_pa
     prev_iter_dir = phase_dir / "iteration_001"
     prev_iter_dir.mkdir(parents=True, exist_ok=True)
     (prev_iter_dir / "output.md").write_text("# Spec\n", encoding="utf-8")
-    _record_previous_step_status(tmp_path, "spec", "CAFE_NEED_CLARIFICATION")
+    _record_previous_step_status(tmp_path, "spec", "need_clarification")
     (prev_iter_dir / "questions.xml").write_text(
         """<?xml version="1.0" encoding="UTF-8"?>
 <questions>
@@ -210,7 +210,7 @@ def test_user_input_collector_reuses_existing_user_input_file_without_reasking(t
     prev_iter_dir.mkdir(parents=True, exist_ok=True)
     current_iter_dir.mkdir(parents=True, exist_ok=True)
     (prev_iter_dir / "output.md").write_text("# Spec\n", encoding="utf-8")
-    _record_previous_step_status(tmp_path, "spec", "CAFE_NEED_CLARIFICATION")
+    _record_previous_step_status(tmp_path, "spec", "need_clarification")
     (current_iter_dir / "user_input.md").write_text(
         "Q1: Question?\nA1: Confirmed answer",
         encoding="utf-8",
@@ -380,12 +380,12 @@ def test_execute_step_skips_checklist_validation_when_confirmed_without_agent_ru
 
     result = executor.execute_step(
         "spec",
-        {"role": "pm", "output_artifact": "spec", "valid_status_codes": ["CAFE_CONFIRMED"]},
+        {"role": "pm", "output_artifact": "spec", "valid_intents": ["confirmed"]},
         MagicMock(artifacts={}),
     )
 
     assert isinstance(result, StepExecutionResult)
-    assert result.status_code == "CAFE_CONFIRMED"
+    assert result.status_code == "confirmed"
     executor._validate_and_retry_checklist_completion.assert_not_called()
 
 

--- a/tests/unit/test_phase_cache.py
+++ b/tests/unit/test_phase_cache.py
@@ -41,7 +41,7 @@ class TestCacheEntry:
         data = entry.to_dict()
 
         assert data["phase_name"] == "analysis"
-        assert data["status_code"] == "confirmed"  # Status codes have CAFE_ prefix
+        assert data["status_code"] == "confirmed"  # Serialized as plain outcome token (no CAFE_ prefix)
         assert data["response"] == "Analysis complete"
         assert data["content_hash"] == "def456"
         assert data["timestamp"] == timestamp.isoformat()
@@ -51,7 +51,7 @@ class TestCacheEntry:
         timestamp = datetime.now()
         data = {
             "phase_name": "review",
-            "status_code": "confirmed",  # Status codes have CAFE_ prefix
+            "status_code": "confirmed",  # Plain outcome token in persisted cache entries
             "response": "Code looks good",
             "content_hash": "ghi789",
             "timestamp": timestamp.isoformat()

--- a/tests/unit/test_phase_cache.py
+++ b/tests/unit/test_phase_cache.py
@@ -41,7 +41,7 @@ class TestCacheEntry:
         data = entry.to_dict()
 
         assert data["phase_name"] == "analysis"
-        assert data["status_code"] == "CAFE_CONFIRMED"  # Status codes have CAFE_ prefix
+        assert data["status_code"] == "confirmed"  # Status codes have CAFE_ prefix
         assert data["response"] == "Analysis complete"
         assert data["content_hash"] == "def456"
         assert data["timestamp"] == timestamp.isoformat()
@@ -51,7 +51,7 @@ class TestCacheEntry:
         timestamp = datetime.now()
         data = {
             "phase_name": "review",
-            "status_code": "CAFE_CONFIRMED",  # Status codes have CAFE_ prefix
+            "status_code": "confirmed",  # Status codes have CAFE_ prefix
             "response": "Code looks good",
             "content_hash": "ghi789",
             "timestamp": timestamp.isoformat()

--- a/tests/unit/test_phase_iteration_structure.py
+++ b/tests/unit/test_phase_iteration_structure.py
@@ -53,7 +53,7 @@ class TestAppendIterationIndex:
         iteration_data = {
             "iteration": 1,
             "timestamp": "2025-12-27T10:00:00Z",
-            "status": "CAFE_READY_FOR_REVIEW",
+            "status": "ready_for_review",
             "has_error": False,
         }
 
@@ -71,7 +71,7 @@ class TestAppendIterationIndex:
         iteration_data = {
             "iteration": 1,
             "timestamp": "2025-12-27T10:00:00Z",
-            "status": "CAFE_READY_FOR_REVIEW",
+            "status": "ready_for_review",
             "has_error": False,
         }
 
@@ -96,7 +96,7 @@ class TestAppendIterationIndex:
             {
                 "iteration": 1,
                 "timestamp": "2025-12-27T10:00:00Z",
-                "status": "CAFE_NEED_CLARIFICATION",
+                "status": "need_clarification",
                 "has_error": False,
             }
         )
@@ -106,7 +106,7 @@ class TestAppendIterationIndex:
             {
                 "iteration": 2,
                 "timestamp": "2025-12-27T10:05:00Z",
-                "status": "CAFE_READY_FOR_REVIEW",
+                "status": "ready_for_review",
                 "has_error": False,
             }
         )
@@ -146,7 +146,7 @@ class TestLoadIterationCounter:
             json.dumps(
                 {
                     "iteration": 1,
-                    "response": "CAFE_CONFIRMED",
+                    "response": "confirmed",
                     "end_time": "2026-04-29T10:00:00+08:00",
                 }
             ),
@@ -182,8 +182,8 @@ class TestLoadIterationCounter:
         # 準備測試資料
         iterations_file = phase_dir / "iterations.jsonl"
         iterations_file.write_text(
-            '{"iteration":1,"timestamp":"2025-12-27T10:00:00Z","status":"CAFE_NEED_CLARIFICATION","has_error":false}\n'
-            '{"iteration":2,"timestamp":"2025-12-27T10:05:00Z","status":"CAFE_READY_FOR_REVIEW","has_error":false}\n'
+            '{"iteration":1,"timestamp":"2025-12-27T10:00:00Z","status":"need_clarification","has_error":false}\n'
+            '{"iteration":2,"timestamp":"2025-12-27T10:05:00Z","status":"ready_for_review","has_error":false}\n'
             '{"iteration":3,"timestamp":"2025-12-27T10:10:00Z","status":"CAFE_ERROR","has_error":true}\n'
         )
 
@@ -191,9 +191,9 @@ class TestLoadIterationCounter:
 
         assert len(result) == 3
         assert result[0]["iteration"] == 1
-        assert result[0]["status"] == "CAFE_NEED_CLARIFICATION"
+        assert result[0]["status"] == "need_clarification"
         assert result[1]["iteration"] == 2
-        assert result[1]["status"] == "CAFE_READY_FOR_REVIEW"
+        assert result[1]["status"] == "ready_for_review"
         assert result[2]["iteration"] == 3
         assert result[2]["has_error"] is True
 
@@ -412,7 +412,7 @@ class TestIterationIndexIncludesEndTime:
         iteration_data = {
             "iteration": 1,
             "timestamp": "2026-01-27T10:00:00+08:00",
-            "status": "CAFE_CONFIRMED",
+            "status": "confirmed",
             "has_error": False,
             "end_time": "2026-01-27T10:05:00+08:00"
         }
@@ -431,5 +431,5 @@ class TestIterationIndexIncludesEndTime:
         assert data["iteration"] == 1
         assert data["timestamp"] == "2026-01-27T10:00:00+08:00"
         assert data["end_time"] == "2026-01-27T10:05:00+08:00"
-        assert data["status"] == "CAFE_CONFIRMED"
+        assert data["status"] == "confirmed"
         assert data["has_error"] is False

--- a/tests/unit/test_phase_non_interactive_behavior.py
+++ b/tests/unit/test_phase_non_interactive_behavior.py
@@ -99,7 +99,7 @@ class TestNonInteractiveModeWithNeedClarification:
 
         monkeypatch.setenv(
             "CAFE_MOCK_RESPONSE",
-            "CAFE_NEED_CLARIFICATION\n\n請確認技術選型是否正確？"
+            "need_clarification\n\n請確認技術選型是否正確？"
         )
 
         agent_manager = AgentManager()
@@ -123,7 +123,7 @@ class TestNonInteractiveModeWithNeedClarification:
 
         # 移除 while loop 後, NEED_CLARIFICATION 返回 COMPLETED（不再自動繼續）
         assert result.status == PhaseStatus.COMPLETED
-        assert result.data.get("status_code") == "CAFE_NEED_CLARIFICATION"
+        assert result.data.get("status_code") == "need_clarification"
     
     def test_should_fail_after_first_need_clarification(
         self, mock_env, setup_plan_phase, mock_git_ops, monkeypatch
@@ -137,7 +137,7 @@ class TestNonInteractiveModeWithNeedClarification:
 
         monkeypatch.setenv(
             "CAFE_MOCK_RESPONSE",
-            "CAFE_NEED_CLARIFICATION\n\n請確認技術選型是否正確？"
+            "need_clarification\n\n請確認技術選型是否正確？"
         )
 
         agent_manager = AgentManager()
@@ -161,7 +161,7 @@ class TestNonInteractiveModeWithNeedClarification:
 
         # 移除 while loop 後, 只執行一次, 返回 COMPLETED（不再自動繼續）
         assert result.status == PhaseStatus.COMPLETED
-        assert result.data.get("status_code") == "CAFE_NEED_CLARIFICATION"
+        assert result.data.get("status_code") == "need_clarification"
 
 
 class TestNonInteractiveModeCompleteImmediately:
@@ -179,7 +179,7 @@ class TestNonInteractiveModeCompleteImmediately:
 
         monkeypatch.setenv(
             "CAFE_MOCK_RESPONSE",
-            "CAFE_READY_FOR_REVIEW\n\n# 實作計畫\n\n完整計畫內容."
+            "ready_for_review\n\n# 實作計畫\n\n完整計畫內容."
         )
 
         agent_manager = AgentManager()
@@ -214,4 +214,4 @@ class TestNonInteractiveModeCompleteImmediately:
 
         # Assert - 應該立即完成
         assert result.status == PhaseStatus.COMPLETED
-        assert result.data["status_code"] == "CAFE_READY_FOR_REVIEW"
+        assert result.data["status_code"] == "ready_for_review"

--- a/tests/unit/test_phase_progress.py
+++ b/tests/unit/test_phase_progress.py
@@ -135,7 +135,7 @@ class TestAlreadyCompletedFallback:
             json.dumps(
                 {
                     "iteration": 1,
-                    "response": "CAFE_CONFIRMED",
+                    "response": "confirmed",
                     "end_time": "2026-04-30T00:00:00+08:00",
                 }
             ),

--- a/tests/unit/test_phase_status_analysis_with_tools.py
+++ b/tests/unit/test_phase_status_analysis_with_tools.py
@@ -40,7 +40,7 @@ class TestPhaseStatusAnalysisWithTools:
         
         # 只設定分析執行返回值（測試只呼叫分析, 不呼叫原始執行）
         mock_agent_manager.execute.return_value = (
-            "CAFE_READY_FOR_REVIEW", None, [], {}, [], None
+            "ready_for_review", None, [], {}, [], None
         )
         
         # Mock other dependencies
@@ -70,12 +70,12 @@ class TestPhaseStatusAnalysisWithTools:
         valid_codes = [PhaseStatusCode.READY_FOR_REVIEW, PhaseStatusCode.NEED_CLARIFICATION]
         response, status_code = phase._analyze_missing_status_code_with_logging(
             agent_name="TestAgent",
-            valid_status_codes=valid_codes,
+            valid_intents=valid_codes,
             original_response="No status code",
         )
         
         # 驗證
-        assert response == "CAFE_READY_FOR_REVIEW"
+        assert response == "ready_for_review"
         assert status_code == PhaseStatusCode.READY_FOR_REVIEW
         
         # 驗證 agent.execute 被呼叫了一次（分析呼叫）
@@ -114,7 +114,7 @@ class TestPhaseStatusAnalysisWithTools:
         # Mock agent manager
         mock_agent_manager = MagicMock(spec=AgentManager)
         mock_agent_manager.execute.return_value = (
-            "CAFE_READY_FOR_REVIEW", None, [], {}, [], None
+            "ready_for_review", None, [], {}, [], None
         )
         
         # Mock other dependencies
@@ -157,7 +157,7 @@ class TestPhaseStatusAnalysisWithTools:
         valid_codes = [PhaseStatusCode.READY_FOR_REVIEW]
         response, status_code = phase._analyze_missing_status_code_with_logging(
             agent_name="TestAgent",
-            valid_status_codes=valid_codes,
+            valid_intents=valid_codes,
             original_response="No status code",
         )
         
@@ -218,7 +218,7 @@ class TestPhaseStatusAnalysisWithTools:
         valid_codes = [PhaseStatusCode.READY_FOR_REVIEW]
         response, status_code = phase._analyze_missing_status_code_with_logging(
             agent_name="TestAgent",
-            valid_status_codes=valid_codes,
+            valid_intents=valid_codes,
             original_response="No status code",
         )
         
@@ -249,7 +249,7 @@ class TestPhaseStatusAnalysisWithTools:
         # Mock agent manager
         mock_agent_manager = MagicMock(spec=AgentManager)
         mock_agent_manager.execute.return_value = (
-            "CAFE_NEED_CLARIFICATION\n\nThis spec needs more details.",
+            "need_clarification\n\nThis spec needs more details.",
             None, [], {}, [], None
         )
         
@@ -281,10 +281,10 @@ class TestPhaseStatusAnalysisWithTools:
         ]
         response, status_code = phase._analyze_missing_status_code_with_logging(
             agent_name="TestAgent",
-            valid_status_codes=valid_codes,
+            valid_intents=valid_codes,
             original_response="No status code",
         )
         
         # 驗證
-        assert "CAFE_NEED_CLARIFICATION" in response
+        assert "need_clarification" in response
         assert status_code == PhaseStatusCode.NEED_CLARIFICATION

--- a/tests/unit/test_plan_checklist_xml.py
+++ b/tests/unit/test_plan_checklist_xml.py
@@ -25,7 +25,7 @@ def test_generate_plan_checklist_includes_xml_instruction_when_path_provided(tmp
     # Verify XML schema and file path are included
     assert str(questions_xml_file) in content
     assert "<questions>" in content
-    assert "CAFE_NEED_CLARIFICATION" in content
+    assert "need_clarification" in content
 
 
 def test_generate_plan_checklist_without_xml_file_omits_instruction(tmp_path):
@@ -46,7 +46,7 @@ def test_generate_plan_checklist_without_xml_file_omits_instruction(tmp_path):
     content = checklist_path.read_text()
 
     assert "<questions>" not in content
-    assert "CAFE_NEED_CLARIFICATION" not in content
+    assert "need_clarification" not in content
 
 
 def test_generate_plan_checklist_iteration_n_includes_xml_instruction(tmp_path):

--- a/tests/unit/test_plan_phase_qa.py
+++ b/tests/unit/test_plan_phase_qa.py
@@ -244,7 +244,7 @@ class TestReviewDecisionDisplayCallback:
 
         with patch.object(plan_phase, "_display_current_plan"), \
              patch.object(plan_phase, "_display_iteration_delta") as mock_display_delta, \
-             patch.object(plan_phase, "_load_previous_iteration_data", return_value={"status_code": "CAFE_READY_FOR_REVIEW"}), \
+             patch.object(plan_phase, "_load_previous_iteration_data", return_value={"status_code": "ready_for_review"}), \
              patch.object(plan_phase, "_ask_user_for_review_decision", return_value="confirm") as mock_review_decision, \
              patch.object(plan_phase, "_process_review_decision", return_value="confirm"):
 
@@ -269,7 +269,7 @@ class TestReviewDecisionDisplayCallback:
              patch.object(
                  plan_phase,
                  "_load_previous_iteration_data",
-                 return_value={"response": "CAFE_READY_FOR_REVIEW"},
+                 return_value={"response": "ready_for_review"},
              ), \
              patch.object(plan_phase, "_ask_user_for_review_decision", return_value="confirm") as mock_review_decision, \
              patch.object(plan_phase, "_process_review_decision", return_value="confirm"):

--- a/tests/unit/test_plan_phase_status_codes.py
+++ b/tests/unit/test_plan_phase_status_codes.py
@@ -51,7 +51,7 @@ class TestPlanPhaseWithStatusCodes:
         checklist_file.write_text("## Execution Steps Checklist\n\n[x] Step 1\n[x] Step 2\n")
 
         agent_manager = MagicMock(spec=AgentManager)
-        agent_manager.execute.return_value = ("CAFE_READY_FOR_REVIEW\n實作分析已完成.", TokenUsage(), [], None, [], None)
+        agent_manager.execute.return_value = ("ready_for_review\n實作分析已完成.", TokenUsage(), [], None, [], None)
         agent_manager.preview_cli_command_args.return_value = ["--model", "copilot"]
 
         # Mock get_agent to return agent with config
@@ -82,7 +82,7 @@ class TestPlanPhaseWithStatusCodes:
             result = phase.execute()
 
         assert result.status == PhaseStatus.COMPLETED
-        assert result.data.get("status_code") == "CAFE_READY_FOR_REVIEW"  # non-interactive mode completes at READY_FOR_REVIEW
+        assert result.data.get("status_code") == "ready_for_review"  # non-interactive mode completes at READY_FOR_REVIEW
         assert result.data.get("iterations") == 1  # Only 1 iteration in non-interactive mode
 
     def test_need_clarification_continues_iteration(self, tmp_path: Path, mock_git_ops, monkeypatch, mock_multiline_input) -> None:
@@ -99,7 +99,7 @@ class TestPlanPhaseWithStatusCodes:
 
         agent_manager = MagicMock(spec=AgentManager)
         # After removing while loop, only executes once and returns IN_PROGRESS
-        agent_manager.execute.return_value = ("CAFE_NEED_CLARIFICATION\n請補充更多資訊.", TokenUsage(), [], None, [], None)
+        agent_manager.execute.return_value = ("need_clarification\n請補充更多資訊.", TokenUsage(), [], None, [], None)
         agent_manager.preview_cli_command_args.return_value = ["--model", "copilot"]
 
         # Mock get_agent to return agent with config
@@ -129,7 +129,7 @@ class TestPlanPhaseWithStatusCodes:
 
         # After removing while loop, NEED_CLARIFICATION returns COMPLETED (no automatic continuation)
         assert result.status == PhaseStatus.COMPLETED
-        assert result.data.get("status_code") == "CAFE_NEED_CLARIFICATION"
+        assert result.data.get("status_code") == "need_clarification"
         assert result.data.get("iterations") == 1
         assert agent_manager.execute.call_count == 1
 
@@ -152,7 +152,7 @@ class TestPlanPhaseWithStatusCodes:
         checklist_file.write_text("## Execution Steps Checklist\n\n[x] Step 1\n[x] Step 2\n")
 
         agent_manager = MagicMock(spec=AgentManager)
-        agent_manager.execute.return_value = ("分析結果：\nCAFE_READY_FOR_REVIEW\n實作分析已完成.", TokenUsage(), [], None, [], None)
+        agent_manager.execute.return_value = ("分析結果：\nready_for_review\n實作分析已完成.", TokenUsage(), [], None, [], None)
         agent_manager.preview_cli_command_args.return_value = ["--model", "copilot"]
 
         # Mock get_agent to return agent with config
@@ -183,7 +183,7 @@ class TestPlanPhaseWithStatusCodes:
             result = phase.execute()
 
         assert result.status == PhaseStatus.COMPLETED
-        assert result.data.get("status_code") == "CAFE_READY_FOR_REVIEW"  # non-interactive completes at READY_FOR_REVIEW
+        assert result.data.get("status_code") == "ready_for_review"  # non-interactive completes at READY_FOR_REVIEW
 
     def test_no_status_code_continues_iteration(self, tmp_path: Path, mock_git_ops, monkeypatch, mock_multiline_input) -> None:
         """測試沒有狀態碼時繼續迭代"""
@@ -204,7 +204,7 @@ class TestPlanPhaseWithStatusCodes:
         # So when we extract status code from response in plan_phase.py, we get None.
         agent_manager.execute.side_effect = [
             ("這是一般回應, 沒有狀態碼.", TokenUsage(), [], None, [], None),
-            ("CAFE_NEED_CLARIFICATION\n請補充技術選型.", TokenUsage(), [], None, [], None),
+            ("need_clarification\n請補充技術選型.", TokenUsage(), [], None, [], None),
         ]
         agent_manager.preview_cli_command_args.return_value = ["--model", "claude"]
 
@@ -285,7 +285,7 @@ class TestPlanPhaseWithStatusCodes:
             result = phase.execute()
 
         assert result.status == PhaseStatus.COMPLETED
-        assert result.data.get("status_code") == "CAFE_READY_FOR_REVIEW"  # non-interactive completes at READY_FOR_REVIEW
+        assert result.data.get("status_code") == "ready_for_review"  # non-interactive completes at READY_FOR_REVIEW
 
     def test_permission_like_plaintext_response_maps_to_need_permission_without_retry(
         self, tmp_path: Path, mock_git_ops, monkeypatch
@@ -332,7 +332,7 @@ class TestPlanPhaseWithStatusCodes:
             result = phase.execute()
 
         assert result.status == PhaseStatus.COMPLETED
-        assert result.data.get("status_code") == "CAFE_NEED_PERMISSION"
+        assert result.data.get("status_code") == "need_permission"
         assert agent_manager.execute.call_count == 1
 
     def test_structured_permission_denial_maps_to_need_permission_without_retry(
@@ -380,5 +380,5 @@ class TestPlanPhaseWithStatusCodes:
             result = phase.execute()
 
         assert result.status == PhaseStatus.COMPLETED
-        assert result.data.get("status_code") == "CAFE_NEED_PERMISSION"
+        assert result.data.get("status_code") == "need_permission"
         assert agent_manager.execute.call_count == 1

--- a/tests/unit/test_playbook_loader.py
+++ b/tests/unit/test_playbook_loader.py
@@ -36,9 +36,9 @@ steps:
   spec:
     role: pm
     skill: spec_first
-    valid_status_codes: [CAFE_CONFIRMED]
+    valid_intents: [confirmed]
     on:
-      CAFE_CONFIRMED: _done
+      await_agent: _done
 """,
     )
     _write_playbook(
@@ -50,9 +50,9 @@ steps:
   spec:
     role: developer
     skill: spec_first
-    valid_status_codes: [CAFE_CONFIRMED]
+    valid_intents: [confirmed]
     on:
-      CAFE_CONFIRMED: _done
+      await_agent: _done
 """,
     )
     _write_playbook(
@@ -67,9 +67,9 @@ steps:
   spec:
     role: reviewer
     skill: spec_first
-    valid_status_codes: [CAFE_CONFIRMED]
+    valid_intents: [confirmed]
     on:
-      CAFE_CONFIRMED: _done
+      await_agent: _done
 """,
     )
 
@@ -102,9 +102,9 @@ steps:
       1: spec_first
       default: spec_revise
     role: pm
-    valid_status_codes: [CAFE_CONFIRMED]
+    valid_intents: [confirmed]
     on:
-      CAFE_CONFIRMED: _done
+      await_agent: _done
 """,
     )
 
@@ -144,7 +144,7 @@ steps:
     hooks:
       after_execute:
         - script: sync_github.sh
-          when_status_codes: [CAFE_CONFIRMED]
+          when_intents: [confirmed]
           args:
             phase: plan
             output: "{output_file}"
@@ -158,10 +158,10 @@ steps:
                 enum: [spec, plan]
               output:
                 type: string
-    valid_status_codes: [CAFE_READY_FOR_REVIEW, CAFE_CONFIRMED]
+    valid_intents: [ready_for_review, confirmed]
     on:
-      CAFE_READY_FOR_REVIEW: plan
-      CAFE_CONFIRMED: _done
+      confirm_output: plan
+      await_agent: _done
 """,
     )
 
@@ -196,9 +196,9 @@ steps:
     hooks:
       publish_output:
         - script: sync_pr.sh
-    valid_status_codes: [CAFE_CONFIRMED]
+    valid_intents: [confirmed]
     on:
-      CAFE_CONFIRMED: _done
+      await_agent: _done
 """,
     )
 
@@ -223,9 +223,9 @@ steps:
   spec:
     role: pm
     skill: missing_skill
-    valid_status_codes: [CAFE_CONFIRMED]
+    valid_intents: [confirmed]
     on:
-      CAFE_CONFIRMED: _done
+      await_agent: _done
 """,
     )
 
@@ -250,10 +250,10 @@ steps:
   develop:
     role: developer
     skill: develop
-    valid_status_codes: [CAFE_CONFIRMED]
+    valid_intents: [confirmed]
     allowed_goto: [review]
     on:
-      CAFE_CONFIRMED: _done
+      await_agent: _done
 """,
     )
 
@@ -278,9 +278,9 @@ steps:
   review:
     role: reviewer
     skill: review
-    valid_status_codes: [CAFE_CONFIRMED]
+    valid_intents: [confirmed]
     on:
-      CAFE_CONFIRMED: not_exist
+      await_agent: not_exist
 """,
     )
 
@@ -307,9 +307,9 @@ steps:
     role: developer
     skill: develop
     allowed_tools: [Bash, "Bash(git:*)"]
-    valid_status_codes: [CAFE_CONFIRMED]
+    valid_intents: [confirmed]
     on:
-      CAFE_CONFIRMED: _done
+      await_agent: _done
 """,
     )
 
@@ -337,9 +337,9 @@ steps:
     role: developer
     skill: develop
     allowed_tools: [Bash, "Bash(git:*)"]
-    valid_status_codes: [CAFE_CONFIRMED]
+    valid_intents: [confirmed]
     on:
-      CAFE_CONFIRMED: _done
+      await_agent: _done
 """,
     )
 
@@ -374,4 +374,4 @@ def test_builtin_hotfix_and_simple_playbooks_load() -> None:
 
     assert simple.entry_point == "spec"
     assert list(simple.steps.keys()) == ["spec", "develop", "pr"]
-    assert simple.steps["develop"].on["CAFE_CONFIRMED"] == "pr"
+    assert simple.steps["develop"].on["await_agent"] == "pr"

--- a/tests/unit/test_pr_baton_alignment.py
+++ b/tests/unit/test_pr_baton_alignment.py
@@ -56,7 +56,7 @@ def test_align_pr_baton_updates_when_needs_changes_and_stale(tmp_path: Path) -> 
         playbook=playbook,
         blackboard_state=state,
         step_name="pr",
-        status_code="CAFE_NEEDS_CHANGES",
+        status_code="needs_changes",
     )
 
     loaded = BlackboardStore(issue_dir).load_or_create("pr", playbook_id="default")
@@ -97,7 +97,7 @@ def test_align_pr_baton_noop_when_status_not_needs_changes(tmp_path: Path) -> No
         playbook=playbook,
         blackboard_state=state,
         step_name="pr",
-        status_code="CAFE_CONFIRMED",
+        status_code="confirmed",
     )
 
     loaded = BlackboardStore(issue_dir).load_or_create("pr", playbook_id="default")

--- a/tests/unit/test_pr_phase_context.py
+++ b/tests/unit/test_pr_phase_context.py
@@ -107,8 +107,8 @@ class TestPRPhaseContextFields:
         (iter_dir / "context.json").write_text(json.dumps(agent_context))
 
         # Simulate the post-organize status_code update (new behavior: direct JSON update)
-        result_status = "CAFE_NEEDS_CHANGES"
-        result_data = {"pr_number": "42", "status_code": "CAFE_NEEDS_CHANGES"}
+        result_status = "needs_changes"
+        result_data = {"pr_number": "42", "status_code": "needs_changes"}
 
         context_file = iter_dir / "context.json"
         with open(context_file, "r", encoding="utf-8") as f:
@@ -129,7 +129,7 @@ class TestPRPhaseContextFields:
             )
 
         # status_code should be updated
-        assert context["status_code"] == "CAFE_NEEDS_CHANGES"
+        assert context["status_code"] == "needs_changes"
         # phase-specific data should be merged
         assert context["pr_number"] == "42"
 
@@ -181,7 +181,7 @@ class TestPRPhaseContextFields:
         prev_iter_dir.mkdir(parents=True)
         (prev_iter_dir / "context.json").write_text(json.dumps({
             "iteration": 1,
-            "status_code": "CAFE_READY_FOR_REVIEW",
+            "status_code": "ready_for_review",
         }))
         (prev_iter_dir / "output.md").write_text("# Title\n\nBody")
 
@@ -192,7 +192,7 @@ class TestPRPhaseContextFields:
             with patch.object(phase, "_organize_comments_to_todo_list", return_value=PhaseResult(
                 status=PhaseStatus.COMPLETED,
                 message="done",
-                data={"status_code": "CAFE_NEEDS_CHANGES"},
+                data={"status_code": "needs_changes"},
             )):
                 with patch.object(phase, "_save_progress"):
                     with patch.object(phase, "_update_iteration_history") as mock_update:
@@ -310,7 +310,7 @@ class TestPRPhaseContextFields:
             assert field in context, f"Field '{field}' missing from context.json"
 
         # status_code should be set
-        assert context["status_code"] == "CAFE_CONFIRMED"
+        assert context["status_code"] == "confirmed"
 
     def test_second_update_preserves_model_and_stats(
         self, tmp_path, mock_dependencies, setup_issue_dir
@@ -363,6 +363,6 @@ class TestPRPhaseContextFields:
         assert context["cli"] == "claude"
         assert context["prompt"] == "test prompt"
         # status_code should be updated from second call
-        assert context["status_code"] == "CAFE_READY_FOR_REVIEW"
+        assert context["status_code"] == "ready_for_review"
         # phase_specific_data from second call should be merged
         assert context["pr_number"] == "159"

--- a/tests/unit/test_pr_phase_github_mode.py
+++ b/tests/unit/test_pr_phase_github_mode.py
@@ -82,7 +82,7 @@ class TestPRPhaseGitHubMode:
         # Assert
         assert result.status == PhaseStatus.COMPLETED
         assert "created" in result.message.lower()
-        assert result.data.get("status_code") == "CAFE_READY_FOR_REVIEW"
+        assert result.data.get("status_code") == "ready_for_review"
 
         # Verify iteration context.json was created with correct status_code
         iteration_dir = issue_dir / "pr" / "iteration_001"
@@ -90,7 +90,7 @@ class TestPRPhaseGitHubMode:
         assert context_file.exists()
         with open(context_file) as f:
             context = json.load(f)
-        assert context.get("status_code") == "CAFE_READY_FOR_REVIEW"
+        assert context.get("status_code") == "ready_for_review"
 
     # =========================================================================
     # Scenario B: Has new commits, PR exists -> Update PR
@@ -109,7 +109,7 @@ class TestPRPhaseGitHubMode:
             "iteration": 1,
             "timestamp": "2026-01-27T10:00:00+08:00",
             "end_time": "2026-01-27T10:05:00+08:00",
-            "status_code": "CAFE_READY_FOR_REVIEW"
+            "status_code": "ready_for_review"
         }))
 
         # Setup mocks
@@ -136,7 +136,7 @@ class TestPRPhaseGitHubMode:
         # Assert
         assert result.status == PhaseStatus.COMPLETED
         assert "updated" in result.message.lower()
-        assert result.data.get("status_code") == "CAFE_READY_FOR_REVIEW"
+        assert result.data.get("status_code") == "ready_for_review"
 
         # Verify new iteration_002 was created
         iteration_002 = issue_dir / "pr" / "iteration_002"
@@ -144,7 +144,7 @@ class TestPRPhaseGitHubMode:
         assert context_file.exists()
         with open(context_file) as f:
             context = json.load(f)
-        assert context.get("status_code") == "CAFE_READY_FOR_REVIEW"
+        assert context.get("status_code") == "ready_for_review"
 
     # =========================================================================
     # Scenario C: No new commits, no PR -> Return "nothing to do"
@@ -191,7 +191,7 @@ class TestPRPhaseGitHubMode:
             "iteration": 1,
             "timestamp": "2026-01-27T10:00:00+08:00",
             "end_time": "2026-01-27T10:05:00+08:00",
-            "status_code": "CAFE_READY_FOR_REVIEW"
+            "status_code": "ready_for_review"
         }))
 
         # Setup mocks
@@ -212,7 +212,7 @@ class TestPRPhaseGitHubMode:
                     mock_organize.return_value = PhaseResult(
                         status=PhaseStatus.COMPLETED,
                         message="Organized comments",
-                        data={"status_code": "CAFE_NEEDS_CHANGES"}
+                        data={"status_code": "needs_changes"}
                     )
 
                     phase = PRPhase(
@@ -225,7 +225,7 @@ class TestPRPhaseGitHubMode:
 
         # Assert
         assert result.status == PhaseStatus.COMPLETED
-        assert result.data.get("status_code") in ["CAFE_NEEDS_CHANGES", "CAFE_CONFIRMED"]
+        assert result.data.get("status_code") in ["needs_changes", "confirmed"]
 
     def test_scenario_d_comment_fetch_failure_returns_failed(
         self, tmp_path, mock_dependencies, setup_issue_dir
@@ -242,7 +242,7 @@ class TestPRPhaseGitHubMode:
                     "iteration": 1,
                     "timestamp": "2026-01-27T10:00:00+08:00",
                     "end_time": "2026-01-27T10:05:00+08:00",
-                    "status_code": "CAFE_READY_FOR_REVIEW",
+                    "status_code": "ready_for_review",
                 }
             )
         )
@@ -289,7 +289,7 @@ class TestPRPhaseGitHubMode:
             "iteration": 1,
             "timestamp": "2026-01-27T10:00:00+08:00",
             "end_time": "2026-01-27T10:05:00+08:00",
-            "status_code": "CAFE_CONFIRMED"
+            "status_code": "confirmed"
         }))
         (iteration_001 / "user_input.md").write_text("Some feedback")
 
@@ -333,7 +333,7 @@ class TestPRPhaseGitHubMode:
             "iteration": 1,
             "timestamp": "2026-01-27T10:00:00+08:00",
             "end_time": "2026-01-27T10:05:00+08:00",
-            "status_code": "CAFE_NEEDS_CHANGES"
+            "status_code": "needs_changes"
         }))
         (iteration_001 / "user_input.md").write_text("Please fix this")
 
@@ -423,7 +423,7 @@ class TestPRPhaseStep0ResumeIncomplete:
                 mock_organize.return_value = PhaseResult(
                     status=PhaseStatus.COMPLETED,
                     message="Organized",
-                    data={"status_code": "CAFE_NEEDS_CHANGES"}
+                    data={"status_code": "needs_changes"}
                 )
                 with patch.object(PRPhase, "_save_progress") as mock_save_progress:
                     phase = PRPhase(
@@ -480,7 +480,7 @@ class TestPRPhaseStep0ResumeIncomplete:
         context_file = iteration_001 / "context.json"
         with open(context_file) as f:
             context = json.load(f)
-        assert context.get("status_code") == "CAFE_READY_FOR_REVIEW"
+        assert context.get("status_code") == "ready_for_review"
 
 
 class TestPRPhaseStep1WaitingForDevelop:
@@ -530,7 +530,7 @@ class TestPRPhaseStep1WaitingForDevelop:
             "iteration": 1,
             "timestamp": "2026-01-27T10:00:00+08:00",
             "end_time": "2026-01-27T10:05:00+08:00",
-            "status_code": "CAFE_NEEDS_CHANGES"
+            "status_code": "needs_changes"
         }))
         # Note: No user_input.md needed - decision should be based on status_code
 
@@ -560,7 +560,7 @@ class TestPRPhaseStep1WaitingForDevelop:
             "iteration": 1,
             "timestamp": "2026-01-27T10:00:00+08:00",
             "end_time": "2026-01-27T10:05:00+08:00",
-            "status_code": "CAFE_READY_FOR_REVIEW"
+            "status_code": "ready_for_review"
         }))
 
         with patch.object(PRPhase, "_get_issue_dir", return_value=issue_dir):
@@ -589,7 +589,7 @@ class TestPRPhaseStep1WaitingForDevelop:
             "iteration": 1,
             "timestamp": "2026-01-27T10:00:00+08:00",
             "end_time": "2026-01-27T10:05:00+08:00",
-            "status_code": "CAFE_CONFIRMED"
+            "status_code": "confirmed"
         }))
 
         with patch.object(PRPhase, "_get_issue_dir", return_value=issue_dir):
@@ -652,7 +652,7 @@ class TestPRPhasePriorityNewCommits:
             "iteration": 1,
             "timestamp": "2026-01-27T10:00:00+08:00",
             "end_time": "2026-01-27T10:05:00+08:00",
-            "status_code": "CAFE_READY_FOR_REVIEW"
+            "status_code": "ready_for_review"
         }))
 
         # Setup mocks - has new commits
@@ -678,7 +678,7 @@ class TestPRPhasePriorityNewCommits:
 
         # Assert - should update PR, not fetch comments
         assert result.status == PhaseStatus.COMPLETED
-        assert result.data.get("status_code") == "CAFE_READY_FOR_REVIEW"
+        assert result.data.get("status_code") == "ready_for_review"
         mock_dependencies["github_ops"].update_pr.assert_called_once()
 
     def test_new_commits_override_confirmed(
@@ -695,7 +695,7 @@ class TestPRPhasePriorityNewCommits:
             "iteration": 1,
             "timestamp": "2026-01-27T10:00:00+08:00",
             "end_time": "2026-01-27T10:05:00+08:00",
-            "status_code": "CAFE_CONFIRMED"
+            "status_code": "confirmed"
         }))
 
         # Setup mocks - has new commits
@@ -721,7 +721,7 @@ class TestPRPhasePriorityNewCommits:
 
         # Assert - should update PR
         assert result.status == PhaseStatus.COMPLETED
-        assert result.data.get("status_code") == "CAFE_READY_FOR_REVIEW"
+        assert result.data.get("status_code") == "ready_for_review"
         mock_dependencies["github_ops"].update_pr.assert_called_once()
 
 
@@ -792,7 +792,7 @@ class TestPRPhaseAgentCalled:
         # Assert agent was called
         mock_generate.assert_called_once()
         assert result.status == PhaseStatus.COMPLETED
-        assert result.data.get("status_code") == "CAFE_READY_FOR_REVIEW"
+        assert result.data.get("status_code") == "ready_for_review"
 
     def test_update_pr_calls_generate_pr_content(
         self, tmp_path, mock_dependencies, setup_issue_dir
@@ -808,7 +808,7 @@ class TestPRPhaseAgentCalled:
             "iteration": 1,
             "timestamp": "2026-01-27T10:00:00+08:00",
             "end_time": "2026-01-27T10:05:00+08:00",
-            "status_code": "CAFE_READY_FOR_REVIEW"
+            "status_code": "ready_for_review"
         }))
         (iteration_001 / "output.md").write_text("# Old PR Title\n\nOld body")
 
@@ -838,7 +838,7 @@ class TestPRPhaseAgentCalled:
         # Assert agent was called for iteration 2
         mock_generate.assert_called_once()
         assert result.status == PhaseStatus.COMPLETED
-        assert result.data.get("status_code") == "CAFE_READY_FOR_REVIEW"
+        assert result.data.get("status_code") == "ready_for_review"
         mock_dependencies["github_ops"].update_pr.assert_called_once()
 
         # Verify iteration_002 directory was created (agent writes to correct iteration)
@@ -859,7 +859,7 @@ class TestPRPhaseAgentCalled:
             "iteration": 1,
             "timestamp": "2026-01-27T10:00:00+08:00",
             "end_time": "2026-01-27T10:05:00+08:00",
-            "status_code": "CAFE_READY_FOR_REVIEW"
+            "status_code": "ready_for_review"
         }))
         (iteration_001 / "output.md").write_text("# Old PR Title\n\nOld body")
 
@@ -1041,7 +1041,7 @@ class TestCreateOrUpdatePRRecordsLastSeenCommentIds:
         iteration_001.mkdir(parents=True)
         (iteration_001 / "context.json").write_text(json.dumps({
             "iteration": 1,
-            "status_code": "CAFE_READY_FOR_REVIEW",
+            "status_code": "ready_for_review",
             "last_seen_comment_ids": ["OLD1"]
         }))
 
@@ -1166,7 +1166,7 @@ class TestSavePRCommentsFiltersLastSeen:
         iter_001.mkdir(parents=True)
         (iter_001 / "context.json").write_text(json.dumps({
             "iteration": 1,
-            "status_code": "CAFE_READY_FOR_REVIEW",
+            "status_code": "ready_for_review",
             "last_seen_comment_ids": ["R1", "T1"]
         }))
 

--- a/tests/unit/test_pr_phase_iteration_logic.py
+++ b/tests/unit/test_pr_phase_iteration_logic.py
@@ -17,7 +17,7 @@ def _write_develop_iteration(
     iteration: int = 1,
     timestamp: str = "2026-01-27T10:00:00+08:00",
     end_time: str | None = None,
-    response: str = "CAFE_CONFIRMED",
+    response: str = "confirmed",
 ) -> None:
     develop_dir = issue_dir / "develop" / f"iteration_{iteration:03d}"
     develop_dir.mkdir(parents=True, exist_ok=True)
@@ -120,7 +120,7 @@ class TestPRPhaseIterationLogic:
             "iteration": 1,
             "timestamp": "2026-01-27T10:00:00+08:00",
             "end_time": "2026-01-27T10:05:00+08:00",
-            "status_code": "CAFE_NEEDS_CHANGES"
+            "status_code": "needs_changes"
         }))
 
         # Create user_input.md
@@ -161,7 +161,7 @@ class TestPRPhaseIterationLogic:
             "iteration": 1,
             "timestamp": "2026-01-27T10:00:00+08:00",
             "end_time": "2026-01-27T10:05:00+08:00",
-            "status_code": "CAFE_CONFIRMED"
+            "status_code": "confirmed"
         }))
 
         with patch.object(PRPhase, "_get_issue_dir", return_value=issue_dir):
@@ -195,7 +195,7 @@ class TestPRPhaseIterationLogic:
             "iteration": 1,
             "timestamp": "2026-01-27T10:00:00+08:00",
             "end_time": "2026-01-27T10:05:00+08:00",
-            "response": "CAFE_READY_FOR_REVIEW"
+            "response": "ready_for_review"
         }))
 
         with patch.object(PRPhase, "_get_issue_dir", return_value=issue_dir):
@@ -209,7 +209,7 @@ class TestPRPhaseIterationLogic:
 
             assert result is not None
             assert result["iteration_number"] == 1
-            assert result["status_code"] == "CAFE_READY_FOR_REVIEW"
+            assert result["status_code"] == "ready_for_review"
 
     def test_should_start_new_iteration_no_iterations(self, tmp_path, mock_dependencies):
         """Test _should_start_new_iteration returns True when no iterations exist."""
@@ -453,7 +453,7 @@ class TestPRPhaseIterationLogic:
             iteration=1,
             timestamp="2026-01-27T10:00:00+08:00",
             end_time="2026-01-27T10:05:00+08:00",
-            response="CAFE_CONFIRMED",
+            response="confirmed",
         )
 
         with patch.object(PRPhase, "_get_issue_dir", return_value=issue_dir):
@@ -483,7 +483,7 @@ class TestPRPhaseIterationLogic:
             iteration=1,
             timestamp="2026-01-27T10:00:00+08:00",
             end_time="2026-01-27T10:05:00+08:00",
-            status_code="CAFE_CONFIRMED",
+            status_code="confirmed",
         )
 
         _write_develop_iteration(
@@ -503,7 +503,7 @@ class TestPRPhaseIterationLogic:
             result = phase._execute_local_review_mode()
 
             assert result.status == PhaseStatus.COMPLETED
-            assert result.data["status_code"] == "CAFE_CONFIRMED"
+            assert result.data["status_code"] == "confirmed"
             mock_dependencies["git_ops"].get_diff.assert_not_called()
 
     def test_execute_local_review_mode_needs_changes_points_back_to_make(
@@ -576,7 +576,7 @@ class TestPRPhaseIterationLogic:
         context_file.write_text(json.dumps({
             "iteration": 1,
             "timestamp": "2026-01-27T10:00:00+08:00",
-            "status_code": "CAFE_CONFIRMED"
+            "status_code": "confirmed"
         }))
 
         with patch.object(PRPhase, "_get_issue_dir", return_value=issue_dir):
@@ -608,7 +608,7 @@ class TestPRPhaseIterationLogic:
             "iteration": 1,
             "timestamp": "2026-01-27T10:00:00+08:00",
             "end_time": "2026-01-27T10:05:00+08:00",
-            "response": "CAFE_CONFIRMED"
+            "response": "confirmed"
         }))
 
         with patch.object(PRPhase, "_get_issue_dir", return_value=issue_dir):
@@ -739,7 +739,7 @@ class TestPRPhaseIterationLogic:
             "iteration": 1,
             "timestamp": "2026-01-27T10:00:00+08:00",
             "end_time": "2026-01-27T10:05:00+08:00",
-            "status_code": "CAFE_CONFIRMED"
+            "status_code": "confirmed"
         }))
 
         with patch.object(PRPhase, "_get_issue_dir", return_value=issue_dir):
@@ -773,7 +773,7 @@ class TestPRPhaseIterationLogic:
             "iteration": 1,
             "timestamp": "2026-01-27T10:00:00+08:00",
             "end_time": "2026-01-27T10:05:00+08:00",
-            "status_code": "CAFE_NEEDS_CHANGES"
+            "status_code": "needs_changes"
         }))
 
         user_input_file = iteration_dir / "user_input.md"
@@ -813,7 +813,7 @@ class TestPRPhaseIterationLogic:
             "iteration": 1,
             "timestamp": "2026-01-27T10:00:00+08:00",
             "end_time": "2026-01-27T10:05:00+08:00",
-            "status_code": "CAFE_NEEDS_CHANGES"
+            "status_code": "needs_changes"
         }))
 
         user_input_file = iteration_dir / "user_input.md"
@@ -907,7 +907,7 @@ class TestPhaseComparisonWithMissingEndTime:
         context_file.write_text(json.dumps({
             "iteration": 1,
             "timestamp": "2026-01-27T10:00:00+08:00",
-            "status_code": "CAFE_NEEDS_CHANGES"
+            "status_code": "needs_changes"
         }))
 
         user_input_file = iteration_dir / "user_input.md"
@@ -944,7 +944,7 @@ class TestPhaseComparisonWithMissingEndTime:
         context_file.write_text(json.dumps({
             "iteration": 1,
             "timestamp": "2026-01-27T10:00:00+08:00",
-            "status_code": "CAFE_NEEDS_CHANGES"
+            "status_code": "needs_changes"
         }))
 
         user_input_file = iteration_dir / "user_input.md"
@@ -988,7 +988,7 @@ class TestPhaseComparisonWithMissingEndTime:
             "iteration": 1,
             "timestamp": "2026-01-27T10:00:00+08:00",
             "end_time": "2026-01-27T10:05:00+08:00",
-            "status_code": "CAFE_NEEDS_CHANGES"
+            "status_code": "needs_changes"
         }))
 
         user_input_file = iteration_dir / "user_input.md"
@@ -1053,7 +1053,7 @@ class TestPhaseComparisonWithMissingEndTime:
             "iteration": 1,
             "timestamp": "2026-01-27T10:00:00+08:00",
             "status_code": None,
-            "response": "CAFE_NEEDS_CHANGES",
+            "response": "needs_changes",
             "cli": "claude",
             "session_id": "test-session",
         }))
@@ -1073,7 +1073,7 @@ class TestPhaseComparisonWithMissingEndTime:
             # (simulates agent processing PR comments and deciding changes are needed)
             with patch.object(phase, "_execute_agent_iteration") as mock_exec:
                 mock_exec.return_value = (
-                    "CAFE_NEEDS_CHANGES",
+                    "needs_changes",
                     PhaseStatusCode.NEEDS_CHANGES,
                 )
                 # Mock _merge_allowed_tools
@@ -1091,12 +1091,12 @@ class TestPhaseComparisonWithMissingEndTime:
 
             # Verify the method returned correctly
             assert result.status == PhaseStatus.COMPLETED
-            assert result.data["status_code"] == "CAFE_NEEDS_CHANGES"
+            assert result.data["status_code"] == "needs_changes"
 
             # THE ACTUAL BUG CHECK: verify status_code was persisted to context.json
             saved_context = json.loads(context_file.read_text())
-            assert saved_context["status_code"] == "CAFE_NEEDS_CHANGES", \
-                f"Bug: status_code in context.json is {saved_context.get('status_code')!r}, expected 'CAFE_NEEDS_CHANGES'"
+            assert saved_context["status_code"] == "needs_changes", \
+                f"Bug: status_code in context.json is {saved_context.get('status_code')!r}, expected 'needs_changes'"
 
     def test_organize_comments_retries_when_output_md_empty(self, tmp_path, mock_dependencies):
         """Test that _organize_comments_to_todo_list retries when output.md is missing todo list markers."""
@@ -1130,7 +1130,7 @@ class TestPhaseComparisonWithMissingEndTime:
             "iteration": 1,
             "timestamp": "2026-01-27T10:00:00+08:00",
             "status_code": None,
-            "response": "CAFE_NEEDS_CHANGES",
+            "response": "needs_changes",
             "cli": "claude",
             "session_id": "test-session",
         }))
@@ -1143,7 +1143,7 @@ class TestPhaseComparisonWithMissingEndTime:
             retry_call_count += 1
             # On first retry, agent writes the todo list to output.md
             output_file.write_text("## Todo List\n- [ ] Fix the bug in line 5\n")
-            return ("CAFE_NEEDS_CHANGES", MagicMock(), [], [], [], None)
+            return ("needs_changes", MagicMock(), [], [], [], None)
 
         with patch.object(PRPhase, "_get_issue_dir", return_value=issue_dir):
             phase = PRPhase(
@@ -1158,7 +1158,7 @@ class TestPhaseComparisonWithMissingEndTime:
 
             with patch.object(phase, "_execute_agent_iteration") as mock_exec:
                 mock_exec.return_value = (
-                    "CAFE_NEEDS_CHANGES",
+                    "needs_changes",
                     PhaseStatusCode.NEEDS_CHANGES,
                 )
                 with patch.object(phase, "_merge_allowed_tools", return_value=["read", "edit"]):
@@ -1175,7 +1175,7 @@ class TestPhaseComparisonWithMissingEndTime:
 
             # Verify: should succeed after retry
             assert result.status == PhaseStatus.COMPLETED
-            assert result.data["status_code"] == "CAFE_NEEDS_CHANGES"
+            assert result.data["status_code"] == "needs_changes"
             # Verify agent_manager.execute was called (retry happened)
             assert retry_call_count == 1
 
@@ -1211,7 +1211,7 @@ class TestPhaseComparisonWithMissingEndTime:
             "iteration": 1,
             "timestamp": "2026-01-27T10:00:00+08:00",
             "status_code": None,
-            "response": "CAFE_NEEDS_CHANGES",
+            "response": "needs_changes",
             "cli": "claude",
             "session_id": "test-session",
         }))
@@ -1222,7 +1222,7 @@ class TestPhaseComparisonWithMissingEndTime:
             nonlocal retry_call_count
             retry_call_count += 1
             # Agent never fixes output.md - returns but doesn't write todo list
-            return ("CAFE_NEEDS_CHANGES", MagicMock(), [], [], [], None)
+            return ("needs_changes", MagicMock(), [], [], [], None)
 
         with patch.object(PRPhase, "_get_issue_dir", return_value=issue_dir):
             phase = PRPhase(
@@ -1237,7 +1237,7 @@ class TestPhaseComparisonWithMissingEndTime:
 
             with patch.object(phase, "_execute_agent_iteration") as mock_exec:
                 mock_exec.return_value = (
-                    "CAFE_NEEDS_CHANGES",
+                    "needs_changes",
                     PhaseStatusCode.NEEDS_CHANGES,
                 )
                 with patch.object(phase, "_merge_allowed_tools", return_value=["read", "edit"]):
@@ -1333,7 +1333,7 @@ class TestGetLastSeenCommentIds:
             json.dumps(
                 {
                     "iteration": 1,
-                    "status_code": "CAFE_READY_FOR_REVIEW",
+                    "status_code": "ready_for_review",
                     "last_seen_comment_ids": ["OLD_CONTEXT"],
                 }
             )
@@ -1365,7 +1365,7 @@ class TestGetLastSeenCommentIds:
         context_file = iter_dir / "context.json"
         context_file.write_text(json.dumps({
             "iteration": 1,
-            "status_code": "CAFE_READY_FOR_REVIEW",
+            "status_code": "ready_for_review",
             "last_seen_comment_ids": ["123456", "IC_kwDOQCpNoM111", "789012"]
         }))
 
@@ -1390,7 +1390,7 @@ class TestGetLastSeenCommentIds:
         iter_001.mkdir(parents=True)
         (iter_001 / "context.json").write_text(json.dumps({
             "iteration": 1,
-            "status_code": "CAFE_READY_FOR_REVIEW",
+            "status_code": "ready_for_review",
             "last_seen_comment_ids": ["R1", "T1"]
         }))
 
@@ -1399,7 +1399,7 @@ class TestGetLastSeenCommentIds:
         iter_002.mkdir(parents=True)
         (iter_002 / "context.json").write_text(json.dumps({
             "iteration": 2,
-            "status_code": "CAFE_NEEDS_CHANGES"
+            "status_code": "needs_changes"
             # last_seen_comment_ids 欄位不存在
         }))
 
@@ -1422,7 +1422,7 @@ class TestGetLastSeenCommentIds:
         iter_001.mkdir(parents=True)
         (iter_001 / "context.json").write_text(json.dumps({
             "iteration": 1,
-            "status_code": "CAFE_READY_FOR_REVIEW"
+            "status_code": "ready_for_review"
             # 沒有 last_seen_comment_ids（舊版本）
         }))
 

--- a/tests/unit/test_pr_phase_status_analysis.py
+++ b/tests/unit/test_pr_phase_status_analysis.py
@@ -79,7 +79,7 @@ class TestStatusAnalysisPrompt:
                 assert "PR title" in prompt or "title" in prompt.lower()
                 assert "PR body" in prompt or "body" in prompt.lower()
                 assert "H1 heading" in prompt or "#" in prompt
-                assert "CAFE_CONFIRMED" in prompt
+                assert "confirmed" in prompt
 
     def test_status_analysis_prompt_format(self, tmp_path):
         """Test that prompt has correct structure"""

--- a/tests/unit/test_reset_command.py
+++ b/tests/unit/test_reset_command.py
@@ -246,10 +246,10 @@ class TestIterationRemovalAndStatusUpdate:
         status_data = {
             "phase": "spec",
             "status": "completed",
-            "status_code": "CAFE_CONFIRMED",
+            "status_code": "confirmed",
             "timestamp": "2024-01-03T00:00:00+00:00",
             "iteration": 3,
-            "message": "Phase completed with CAFE_CONFIRMED",
+            "message": "Phase completed with confirmed",
             "end_time": "2024-01-03T00:00:00+00:00",
         }
         status_path.write_text(json.dumps(status_data))
@@ -283,7 +283,7 @@ class TestIterationRemovalAndStatusUpdate:
             "iteration": 3,
             "timestamp": "2024-01-03T10:00:00+00:00",
             "end_time": "2024-01-03T10:30:00+00:00",
-            "status_code": "CAFE_CONFIRMED",
+            "status_code": "confirmed",
         }
         iter3_context.write_text(json.dumps(context_data))
 
@@ -298,7 +298,7 @@ class TestIterationRemovalAndStatusUpdate:
             "status_code": loaded_context.get("status_code"),
             "timestamp": target_timestamp,
             "iteration": 3,
-            "message": "Phase completed with CAFE_CONFIRMED",
+            "message": "Phase completed with confirmed",
             "end_time": target_end_time or target_timestamp,
         }
 
@@ -316,7 +316,7 @@ class TestIterationRemovalAndStatusUpdate:
         context_data = {
             "iteration": 3,
             "timestamp": "2024-01-03T10:00:00+00:00",
-            "status_code": "CAFE_CONFIRMED",
+            "status_code": "confirmed",
             # No end_time field
         }
         iter3_context.write_text(json.dumps(context_data))
@@ -332,7 +332,7 @@ class TestIterationRemovalAndStatusUpdate:
             "status_code": loaded_context.get("status_code"),
             "timestamp": target_timestamp,
             "iteration": 3,
-            "message": "Phase completed with CAFE_CONFIRMED",
+            "message": "Phase completed with confirmed",
             "end_time": target_end_time or target_timestamp,  # Fallback to timestamp
         }
 

--- a/tests/unit/test_review_phase_iteration_context.py
+++ b/tests/unit/test_review_phase_iteration_context.py
@@ -44,7 +44,7 @@ def test_get_phase_end_time_uses_iteration_context_without_status_file(tmp_path:
         "develop",
         iteration=1,
         end_time="2026-04-29T10:00:00+08:00",
-        response="CAFE_CONFIRMED",
+        response="confirmed",
     )
     phase = _make_review_phase(issue_dir)
 
@@ -58,14 +58,14 @@ def test_check_if_develop_is_newer_uses_iteration_context_without_status_file(tm
         "develop",
         iteration=1,
         end_time="2026-04-29T10:00:00+08:00",
-        response="CAFE_CONFIRMED",
+        response="confirmed",
     )
     _write_iteration_context(
         issue_dir,
         "review",
         iteration=1,
         end_time="2026-04-29T09:00:00+08:00",
-        response="CAFE_NEEDS_CHANGES",
+        response="needs_changes",
     )
     phase = _make_review_phase(issue_dir)
 
@@ -79,14 +79,14 @@ def test_check_if_develop_is_newer_returns_false_when_review_is_latest(tmp_path:
         "develop",
         iteration=1,
         end_time="2026-04-29T09:00:00+08:00",
-        response="CAFE_CONFIRMED",
+        response="confirmed",
     )
     _write_iteration_context(
         issue_dir,
         "review",
         iteration=1,
         end_time="2026-04-29T10:00:00+08:00",
-        response="CAFE_NEEDS_CHANGES",
+        response="needs_changes",
     )
     phase = _make_review_phase(issue_dir)
 
@@ -100,14 +100,14 @@ def test_execute_completed_review_points_back_to_make(tmp_path: Path, capsys) ->
         "develop",
         iteration=1,
         end_time="2026-04-29T09:00:00+08:00",
-        response="CAFE_CONFIRMED",
+        response="confirmed",
     )
     _write_iteration_context(
         issue_dir,
         "review",
         iteration=1,
         end_time="2026-04-29T10:00:00+08:00",
-        response="CAFE_CONFIRMED",
+        response="confirmed",
     )
     phase = _make_review_phase(issue_dir)
     phase.git_ops = MagicMock()

--- a/tests/unit/test_skill_sync_github_script.py
+++ b/tests/unit/test_skill_sync_github_script.py
@@ -82,4 +82,4 @@ def test_default_playbook_migrates_plan_sync_to_script_hook() -> None:
     assert script_hook["script"] == "sync_github.sh"
     assert script_hook["args"]["phase"] == "plan"
     assert script_hook["args"]["output"] == "{output_file}"
-    assert script_hook["when_status_codes"] == ["CAFE_CONFIRMED"]
+    assert script_hook["when_intents"] == ["confirmed"]

--- a/tests/unit/test_spec_github_sync.py
+++ b/tests/unit/test_spec_github_sync.py
@@ -65,7 +65,7 @@ class TestConfirmedSyncInWorkflow:
         prev_context = {
             "user_input": "Initial requirements",
             "response": "Spec is ready",
-            "status_code": "CAFE_READY_FOR_REVIEW",
+            "status_code": "ready_for_review",
             "phase_specific_data": {"pm_agent": "Roger"}
         }
         (prev_iteration_dir / "context.json").write_text(json.dumps(prev_context))
@@ -103,7 +103,7 @@ class TestConfirmedSyncInWorkflow:
         prev_context = {
             "user_input": "Initial requirements",
             "response": "Spec is ready",
-            "status_code": "CAFE_READY_FOR_REVIEW",
+            "status_code": "ready_for_review",
             "phase_specific_data": {"pm_agent": "Roger"}
         }
         (prev_iteration_dir / "context.json").write_text(json.dumps(prev_context))

--- a/tests/unit/test_spec_phase_qa.py
+++ b/tests/unit/test_spec_phase_qa.py
@@ -311,7 +311,7 @@ class TestReviewDecisionDisplayCallback:
 
         with patch.object(spec_phase, "_display_current_spec"), \
              patch.object(spec_phase, "_display_iteration_delta") as mock_display_delta, \
-             patch.object(spec_phase, "_load_previous_iteration_data", return_value={"status_code": "CAFE_READY_FOR_REVIEW"}), \
+             patch.object(spec_phase, "_load_previous_iteration_data", return_value={"status_code": "ready_for_review"}), \
              patch.object(spec_phase, "_ask_user_for_review_decision", return_value="confirm") as mock_review_decision, \
              patch.object(spec_phase, "_process_review_decision", return_value="confirm"):
 
@@ -336,7 +336,7 @@ class TestReviewDecisionDisplayCallback:
              patch.object(
                  spec_phase,
                  "_load_previous_iteration_data",
-                 return_value={"response": "CAFE_READY_FOR_REVIEW"},
+                 return_value={"response": "ready_for_review"},
              ), \
              patch.object(spec_phase, "_ask_user_for_review_decision", return_value="confirm") as mock_review_decision, \
              patch.object(spec_phase, "_process_review_decision", return_value="confirm"):

--- a/tests/unit/test_spec_phase_qa.py
+++ b/tests/unit/test_spec_phase_qa.py
@@ -347,3 +347,28 @@ class TestReviewDecisionDisplayCallback:
         mock_display_delta.assert_called_once()
         assert mock_review_decision.call_args.kwargs["display_callback"] is mock_display_delta
         assert mock_review_decision.call_args.kwargs["output_file"] == prev_spec_file
+
+
+class TestEnsureSpecFileWrittenMockMode:
+    """_ensure_spec_file_written：mock 模式下從 agent 回覆抽出 spec 內容。"""
+
+    def test_strips_plain_outcome_token_first_line(self, spec_phase, tmp_path, monkeypatch):
+        monkeypatch.setenv("CAFE_MOCK_AGENTS", "true")
+        out = tmp_path / "spec.md"
+        spec_phase.spec_file = str(out)
+        spec_phase._ensure_spec_file_written("ready_for_review\n\n# Title\n\nBody")
+        assert out.read_text(encoding="utf-8").startswith("# Title")
+
+    def test_strips_legacy_cafe_prefix_first_line(self, spec_phase, tmp_path, monkeypatch):
+        monkeypatch.setenv("CAFE_MOCK_AGENTS", "true")
+        out = tmp_path / "spec.md"
+        spec_phase.spec_file = str(out)
+        spec_phase._ensure_spec_file_written("CAFE_CONFIRMED\n\n# Spec\n")
+        assert out.read_text(encoding="utf-8").startswith("# Spec")
+
+    def test_keeps_heading_when_first_line_is_not_sole_outcome_token(self, spec_phase, tmp_path, monkeypatch):
+        monkeypatch.setenv("CAFE_MOCK_AGENTS", "true")
+        out = tmp_path / "spec.md"
+        spec_phase.spec_file = str(out)
+        spec_phase._ensure_spec_file_written("# Title\n\nBody\n")
+        assert out.read_text(encoding="utf-8").startswith("# Title")

--- a/tests/unit/test_status_codes.py
+++ b/tests/unit/test_status_codes.py
@@ -7,17 +7,17 @@ from cafe.core.status_codes import PhaseStatusCode
 class TestPhaseStatusCodeEnum:
     """Test PhaseStatusCode enum."""
 
-    def test_all_codes_are_uppercase(self) -> None:
-        """測試所有狀態碼都是大寫"""
+    def test_all_codes_are_snake_case_tokens(self) -> None:
+        """Outcome tokens use snake_case without legacy prefixes."""
         for code in PhaseStatusCode:
-            assert code.value == code.value.upper()
-            assert code.value.startswith("CAFE_")
-            assert all(c.isalpha() or c == "_" for c in code.value)
+            assert code.value == code.value.lower()
+            assert "_" in code.value or code.value.isalpha()
+            assert not code.value.startswith("CAFE_")
 
     def test_enum_can_be_converted_to_string(self) -> None:
         """測試 enum 可以轉成字串"""
         code = PhaseStatusCode.CONFIRMED
-        assert code.value == "CAFE_CONFIRMED"
+        assert code.value == "confirmed"
         assert isinstance(code, str)
 
 
@@ -26,7 +26,7 @@ class TestPhaseStatusExtraction:
 
     def test_extract_status_code_returns_match(self) -> None:
         """測試可從回應中提取狀態碼"""
-        response = "CAFE_CONFIRMED\ndone"
+        response = "confirmed\ndone"
 
         code = Phase._extract_status_code_from_response(
             response,
@@ -37,7 +37,7 @@ class TestPhaseStatusExtraction:
 
     def test_extract_status_code_filters_valid_codes(self) -> None:
         """測試會依 valid_codes 過濾狀態碼"""
-        response = "CAFE_CONFIRMED\ndone"
+        response = "confirmed\ndone"
 
         code = Phase._extract_status_code_from_response(
             response,
@@ -48,7 +48,7 @@ class TestPhaseStatusExtraction:
 
     def test_extract_status_code_returns_none_for_multiple_codes(self) -> None:
         """測試多種狀態碼時回傳 None"""
-        response = "CAFE_CONFIRMED\nCAFE_NEED_CLARIFICATION\ndone"
+        response = "confirmed\nneed_clarification\ndone"
 
         code = Phase._extract_status_code_from_response(
             response,

--- a/tests/unit/test_summary_display.py
+++ b/tests/unit/test_summary_display.py
@@ -177,7 +177,7 @@ class TestRenderTable:
             end_time=datetime(2026, 1, 14, 10, 15, 0, tzinfo=timezone.utc),
             status=PhaseStatus.COMPLETED,
             iteration=1,
-            status_code="CAFE_CONFIRMED"
+            status_code="confirmed"
         )
         # Should render without crashing
         display.render_table([entry])
@@ -194,7 +194,7 @@ class TestRenderTable:
                 end_time=datetime(2026, 1, 14, 10, 15, 0, tzinfo=timezone.utc),
                 status=PhaseStatus.COMPLETED,
                 iteration=1,
-                status_code="CAFE_READY_FOR_REVIEW"
+                status_code="ready_for_review"
             ),
             TimelineEntry(
                 entry_type="iteration",
@@ -204,7 +204,7 @@ class TestRenderTable:
                 end_time=datetime(2026, 1, 14, 11, 10, 0, tzinfo=timezone.utc),
                 status=PhaseStatus.COMPLETED,
                 iteration=2,
-                status_code="CAFE_CONFIRMED"
+                status_code="confirmed"
             ),
         ]
         # Should render multiple entries
@@ -221,7 +221,7 @@ class TestRenderTable:
             end_time=None,  # In progress, no end_time
             status=PhaseStatus.IN_PROGRESS,
             iteration=1,
-            status_code="CAFE_NEED_CLARIFICATION"
+            status_code="need_clarification"
         )
         # Should display "N/A" without crashing
         display.render_table([entry])
@@ -238,7 +238,7 @@ class TestRenderTable:
                 end_time=datetime(2026, 1, 14, 10, 15, 0, tzinfo=timezone.utc),
                 status=PhaseStatus.COMPLETED,
                 iteration=1,
-                status_code="CAFE_CONFIRMED"
+                status_code="confirmed"
             ),
             TimelineEntry(
                 entry_type="iteration",
@@ -248,7 +248,7 @@ class TestRenderTable:
                 end_time=datetime(2026, 1, 14, 11, 20, 0, tzinfo=timezone.utc),
                 status=PhaseStatus.COMPLETED,
                 iteration=1,
-                status_code="CAFE_READY_FOR_REVIEW"
+                status_code="ready_for_review"
             ),
         ]
         # Should display different phases
@@ -269,7 +269,7 @@ class TestRenderTableWithTokenUsage:
             end_time=datetime(2026, 1, 31, 10, 15, 0, tzinfo=timezone.utc),
             status=PhaseStatus.COMPLETED,
             iteration=1,
-            status_code="CAFE_CONFIRMED",
+            status_code="confirmed",
             cli="gemini",
             model="gemini-2.5-flash",
             input_tokens=109260,
@@ -290,7 +290,7 @@ class TestRenderTableWithTokenUsage:
             end_time=datetime(2026, 1, 31, 10, 15, 0, tzinfo=timezone.utc),
             status=PhaseStatus.COMPLETED,
             iteration=1,
-            status_code="CAFE_CONFIRMED",
+            status_code="confirmed",
         )
         # Should render with "--" for missing fields
         display.render_table([entry])
@@ -307,7 +307,7 @@ class TestRenderTableWithTokenUsage:
                 end_time=datetime(2026, 1, 31, 10, 15, 0, tzinfo=timezone.utc),
                 status=PhaseStatus.COMPLETED,
                 iteration=1,
-                status_code="CAFE_CONFIRMED",
+                status_code="confirmed",
                 cli="gemini",
                 model="gemini-2.5-flash",
                 input_tokens=109260,
@@ -322,7 +322,7 @@ class TestRenderTableWithTokenUsage:
                 end_time=datetime(2026, 1, 31, 11, 10, 0, tzinfo=timezone.utc),
                 status=PhaseStatus.COMPLETED,
                 iteration=2,
-                status_code="CAFE_CONFIRMED",
+                status_code="confirmed",
                 # No token usage data
             ),
         ]
@@ -373,7 +373,7 @@ class TestRenderModelSummaryTable:
                 end_time=datetime(2026, 1, 31, 10, 15, 0, tzinfo=timezone.utc),
                 status=PhaseStatus.COMPLETED,
                 iteration=1,
-                status_code="CAFE_CONFIRMED",
+                status_code="confirmed",
                 cli="gemini",
                 model="gemini-2.5-flash",
                 input_tokens=109260,

--- a/tests/unit/test_summary_service.py
+++ b/tests/unit/test_summary_service.py
@@ -106,7 +106,7 @@ class TestLoadPhaseStatus:
                     "iteration": 1,
                     "timestamp": "2026-04-27T10:00:00+08:00",
                     "end_time": "2026-04-27T10:15:00+08:00",
-                    "status_code": "CAFE_CONFIRMED",
+                    "status_code": "confirmed",
                 }
             )
         )
@@ -155,7 +155,7 @@ class TestLoadPhaseStatus:
         assert result["status"] == "completed"
         assert result["timestamp"] == "2026-04-27T10:00:00+08:00"
         assert result["end_time"] == "2026-04-27T10:15:00+08:00"
-        assert result["status_code"] == "CAFE_CONFIRMED"
+        assert result["status_code"] == "confirmed"
 
     def test_load_phase_status_synthesizes_in_progress_from_user_baton(self, tmp_path, monkeypatch):
         """Test paused phases stay in-progress without a phase status file."""
@@ -171,7 +171,7 @@ class TestLoadPhaseStatus:
                 {
                     "iteration": 1,
                     "timestamp": "2026-04-27T09:00:00+08:00",
-                    "status_code": "CAFE_NEED_CLARIFICATION",
+                    "status_code": "need_clarification",
                 }
             )
         )
@@ -181,7 +181,7 @@ class TestLoadPhaseStatus:
             "to_owner": "user",
             "to_step": "user",
             "intent": "confirm_output",
-            "status_code": "CAFE_NEED_CLARIFICATION",
+            "status_code": "need_clarification",
             "created_at": "2026-04-27T09:05:00+08:00",
             "source": "workflow",
         }
@@ -207,7 +207,7 @@ class TestLoadPhaseStatus:
         assert result is not None
         assert result["status"] == "in_progress"
         assert result["timestamp"] == "2026-04-27T09:00:00+08:00"
-        assert result["status_code"] == "CAFE_NEED_CLARIFICATION"
+        assert result["status_code"] == "need_clarification"
         assert "end_time" not in result
 
     def test_load_phase_status_does_not_create_blackboard_files(self, tmp_path, monkeypatch):
@@ -224,7 +224,7 @@ class TestLoadPhaseStatus:
                     "iteration": 1,
                     "timestamp": "2026-04-27T10:00:00+08:00",
                     "end_time": "2026-04-27T10:15:00+08:00",
-                    "status_code": "CAFE_CONFIRMED",
+                    "status_code": "confirmed",
                 }
             )
         )
@@ -287,8 +287,8 @@ class TestLoadIterationStatuses:
         phase_dir = tmp_path / ".cafe/issues/test-issue/spec"
         (phase_dir / "iteration_001").mkdir(parents=True)
         (phase_dir / "iteration_002").mkdir(parents=True)
-        (phase_dir / "iteration_001/context.json").write_text('{"iteration": 1, "status_code": "CAFE_CONFIRMED", "timestamp": "2026-01-14T10:00:00+08:00"}')
-        (phase_dir / "iteration_002/context.json").write_text('{"iteration": 2, "status_code": "CAFE_CONFIRMED", "timestamp": "2026-01-14T11:00:00+08:00"}')
+        (phase_dir / "iteration_001/context.json").write_text('{"iteration": 1, "status_code": "confirmed", "timestamp": "2026-01-14T10:00:00+08:00"}')
+        (phase_dir / "iteration_002/context.json").write_text('{"iteration": 2, "status_code": "confirmed", "timestamp": "2026-01-14T11:00:00+08:00"}')
 
         result = service.load_iteration_statuses("test-issue", "spec")
         assert isinstance(result, list)
@@ -327,7 +327,7 @@ class TestLoadIterationStatuses:
         service = SummaryService()
         phase_dir = tmp_path / ".cafe/issues/test-issue/review"
         (phase_dir / "iteration_001").mkdir(parents=True)
-        context_data = {"iteration": 1, "status_code": "CAFE_NEED_CLARIFICATION", "timestamp": "2025-01-04T14:00:00Z"}
+        context_data = {"iteration": 1, "status_code": "need_clarification", "timestamp": "2025-01-04T14:00:00Z"}
         (phase_dir / "iteration_001/context.json").write_text(json.dumps(context_data))
 
         result = service.load_iteration_statuses("test-issue", "review")
@@ -383,7 +383,7 @@ class TestLoadIterationStatuses:
             context = {
                 "iteration": i,
                 "timestamp": f"2026-01-05T00:{40+i*5:02d}:00.000000",
-                "status_code": "CAFE_CONFIRMED" if i == 4 else "CAFE_NEEDS_CHANGES",
+                "status_code": "confirmed" if i == 4 else "needs_changes",
             }
             (phase_dir / f"iteration_{i:03d}/context.json").write_text(json.dumps(context))
 
@@ -392,7 +392,7 @@ class TestLoadIterationStatuses:
         assert len(result) == 4
         assert result[0]["iteration"] == 1
         assert result[0]["timestamp"] == "2026-01-05T00:45:00.000000"
-        assert result[3]["status_code"] == "CAFE_CONFIRMED"
+        assert result[3]["status_code"] == "confirmed"
 
 
 class TestLoadIterationContexts:
@@ -414,13 +414,13 @@ class TestLoadIterationContexts:
             "iteration": 1,
             "timestamp": "2026-01-14T10:00:00+08:00",
             "end_time": "2026-01-14T10:15:00+08:00",
-            "status_code": "CAFE_READY_FOR_REVIEW"
+            "status_code": "ready_for_review"
         }
         context2 = {
             "iteration": 2,
             "timestamp": "2026-01-14T10:30:00+08:00",
             "end_time": "2026-01-14T10:45:00+08:00",
-            "status_code": "CAFE_CONFIRMED"
+            "status_code": "confirmed"
         }
         (phase_dir / "iteration_001/context.json").write_text(json.dumps(context1))
         (phase_dir / "iteration_002/context.json").write_text(json.dumps(context2))
@@ -431,7 +431,7 @@ class TestLoadIterationContexts:
         assert result[0]["iteration"] == 1
         assert result[0]["timestamp"] == "2026-01-14T10:00:00+08:00"
         assert result[0]["end_time"] == "2026-01-14T10:15:00+08:00"
-        assert result[0]["status_code"] == "CAFE_READY_FOR_REVIEW"
+        assert result[0]["status_code"] == "ready_for_review"
 
     def test_load_iteration_statuses_handles_missing_end_time(self, tmp_path, monkeypatch):
         """Verify handling when end_time is missing"""
@@ -447,7 +447,7 @@ class TestLoadIterationContexts:
         context = {
             "iteration": 1,
             "timestamp": "2026-01-14T11:00:00+08:00",
-            "status_code": "CAFE_NEED_CLARIFICATION"
+            "status_code": "need_clarification"
         }
         (phase_dir / "iteration_001/context.json").write_text(json.dumps(context))
 
@@ -475,7 +475,7 @@ class TestLoadIterationContexts:
                 "iteration": i,
                 "timestamp": f"2026-01-14T{10+i}:00:00+08:00",
                 "end_time": f"2026-01-14T{10+i}:15:00+08:00",
-                "status_code": "CAFE_CONFIRMED"
+                "status_code": "confirmed"
             }
             (phase_dir / f"iteration_{i:03d}/context.json").write_text(json.dumps(context))
 
@@ -506,7 +506,7 @@ class TestLoadTokenUsageData:
             "iteration": 1,
             "timestamp": "2026-01-31T10:00:00+08:00",
             "end_time": "2026-01-31T10:15:00+08:00",
-            "status_code": "CAFE_CONFIRMED",
+            "status_code": "confirmed",
             "cli": "gemini",
             "model": "gemini-2.5-flash",
             "stats": {
@@ -543,7 +543,7 @@ class TestLoadTokenUsageData:
         context = {
             "iteration": 1,
             "timestamp": "2026-01-31T11:00:00+08:00",
-            "status_code": "CAFE_CONFIRMED"
+            "status_code": "confirmed"
         }
         (phase_dir / "iteration_001/context.json").write_text(json.dumps(context))
 
@@ -568,7 +568,7 @@ class TestLoadTokenUsageData:
                 "iteration": 1,
                 "timestamp": "2026-01-31T10:00:00+08:00",
                 "end_time": "2026-01-31T10:15:00+08:00",
-                "status_code": "CAFE_CONFIRMED",
+                "status_code": "confirmed",
                 "cli": "gemini",
                 "model": "gemini-2.5-flash",
                 "stats": {
@@ -582,7 +582,7 @@ class TestLoadTokenUsageData:
                 "iteration": 2,
                 "timestamp": "2026-01-31T11:00:00+08:00",
                 "end_time": "2026-01-31T11:20:00+08:00",
-                "status_code": "CAFE_CONFIRMED",
+                "status_code": "confirmed",
                 "cli": "claude",
                 "model": "claude-3-5-sonnet",
                 "stats": {

--- a/tests/unit/test_timeline_builder.py
+++ b/tests/unit/test_timeline_builder.py
@@ -283,7 +283,7 @@ class TestTimelineEntryWithTokenUsage:
             end_time=datetime.now(timezone.utc),
             status=PhaseStatus.COMPLETED,
             iteration=1,
-            status_code="CAFE_CONFIRMED",
+            status_code="confirmed",
             cli="gemini",
             model="gemini-2.5-flash",
             input_tokens=109260,
@@ -344,7 +344,7 @@ class TestPopulateTokenUsageInIterations:
             "iteration": 1,
             "timestamp": "2026-01-31T10:00:00+08:00",
             "end_time": "2026-01-31T10:15:00+08:00",
-            "status_code": "CAFE_CONFIRMED",
+            "status_code": "confirmed",
             "cli": "gemini",
             "model": "gemini-2.5-flash",
             "stats": {
@@ -371,7 +371,7 @@ class TestPopulateTokenUsageInIterations:
         iteration_status = {
             "iteration": 1,
             "timestamp": "2026-01-31T10:00:00+08:00",
-            "status_code": "CAFE_CONFIRMED"
+            "status_code": "confirmed"
         }
 
         entry = builder._create_iteration_entry("spec", iteration_status)
@@ -390,7 +390,7 @@ class TestPopulateTokenUsageInIterations:
         iteration_status = {
             "iteration": 1,
             "timestamp": "2026-01-31T10:00:00+08:00",
-            "status_code": "CAFE_CONFIRMED",
+            "status_code": "confirmed",
             "cli": "claude",
             "model": "claude-3-5-sonnet",
             "stats": {
@@ -417,7 +417,7 @@ class TestPopulateTokenUsageInIterations:
             "iteration": 1,
             "timestamp": "2026-01-31T10:00:00+08:00",
             "end_time": "2026-01-31T10:15:00+08:00",
-            "status_code": "CAFE_CONFIRMED",
+            "status_code": "confirmed",
             "cli": "claude",
             "model": "claude-3-5-sonnet",
             "stats": {
@@ -460,7 +460,7 @@ class TestPopulateTokenUsageInIterations:
                 "iteration": 1,
                 "timestamp": "2026-01-31T10:00:00+08:00",
                 "end_time": "2026-01-31T10:15:00+08:00",
-                "status_code": "CAFE_CONFIRMED",
+                "status_code": "confirmed",
                 "cli": "gemini",
                 "model": "gemini-2.5-flash",
                 "stats": {

--- a/tests/unit/test_workflow_runtime.py
+++ b/tests/unit/test_workflow_runtime.py
@@ -33,7 +33,7 @@ def test_runtime_blocks_pr_done_without_publish_receipt(tmp_path: Path) -> None:
     playbook = {
         "playbook": {"id": "default"},
         "steps": {
-            "pr": {"skill": "spec_first", "role": "developer", "on": {"CAFE_CONFIRMED": "_done"}},
+            "pr": {"skill": "spec_first", "role": "developer", "on": {"await_agent": "_done"}},
         },
     }
 
@@ -60,7 +60,7 @@ def test_runtime_completes_pr_when_publish_receipt_exists(tmp_path: Path) -> Non
     playbook = {
         "playbook": {"id": "default"},
         "steps": {
-            "pr": {"skill": "spec_first", "role": "developer", "on": {"CAFE_CONFIRMED": "_done"}},
+            "pr": {"skill": "spec_first", "role": "developer", "on": {"await_agent": "_done"}},
         },
     }
 
@@ -92,14 +92,14 @@ def test_runtime_delegates_non_pr_steps_to_legacy_runner(tmp_path: Path) -> None
             "spec": {
                 "skill": "spec_first",
                 "role": "pm",
-                "valid_status_codes": ["CAFE_CONFIRMED"],
-                "on": {"CAFE_CONFIRMED": "_done"},
+                "valid_intents": ["confirmed"],
+                "on": {"await_agent": "_done"},
             },
         },
     }
 
     def executor(step_name: str, step_def: dict, state: object):
-        return ("CAFE_CONFIRMED", {})
+        return ("confirmed", {})
 
     runtime = BlackboardWorkflowRuntime(
         issue_dir=issue_dir,
@@ -110,7 +110,7 @@ def test_runtime_delegates_non_pr_steps_to_legacy_runner(tmp_path: Path) -> None
 
     assert result.completed is True
     assert result.final_step == "spec"
-    assert result.final_status_code == "CAFE_CONFIRMED"
+    assert result.final_status_code == "confirmed"
 
 
 def test_runtime_rejects_legacy_text_baton_in_core_path(tmp_path: Path) -> None:
@@ -136,14 +136,14 @@ def test_runtime_rejects_legacy_text_baton_in_core_path(tmp_path: Path) -> None:
             "spec": {
                 "skill": "spec_first",
                 "role": "pm",
-                "valid_status_codes": ["CAFE_CONFIRMED"],
-                "on": {"CAFE_CONFIRMED": "_done"},
+                "valid_intents": ["confirmed"],
+                "on": {"await_agent": "_done"},
             },
         },
     }
 
     def executor(step_name: str, step_def: dict, state: object):
-        return ("CAFE_CONFIRMED", {})
+        return ("confirmed", {})
 
     with pytest.raises(ValueError, match="Invalid baton contract payload"):
         runtime = BlackboardWorkflowRuntime(
@@ -162,20 +162,20 @@ def test_runtime_hands_off_to_pr_runtime_boundary(tmp_path: Path) -> None:
             "review": {
                 "skill": "spec_first",
                 "role": "reviewer",
-                "valid_status_codes": ["CAFE_CONFIRMED"],
-                "on": {"CAFE_CONFIRMED": "pr"},
+                "valid_intents": ["confirmed"],
+                "on": {"await_agent": "pr"},
             },
             "pr": {
                 "skill": "spec_first",
                 "role": "developer",
-                "on": {"CAFE_CONFIRMED": "_done"},
+                "on": {"await_agent": "_done"},
             },
         },
     }
 
     def executor(step_name: str, step_def: dict, state: object):
         if step_name == "review":
-            return ("CAFE_CONFIRMED", {})
+            return ("confirmed", {})
         raise AssertionError("pr should not execute in the legacy portion")
 
     runtime = BlackboardWorkflowRuntime(
@@ -187,7 +187,7 @@ def test_runtime_hands_off_to_pr_runtime_boundary(tmp_path: Path) -> None:
 
     assert result.completed is False
     assert result.final_step == "review"
-    assert result.final_status_code == "CAFE_CONFIRMED"
+    assert result.final_status_code == "confirmed"
     blackboard = BlackboardStore(issue_dir).load_or_create("review")
     assert blackboard.current_step == "pr"
 
@@ -200,17 +200,17 @@ def test_runtime_single_step_executes_non_pr_locally(tmp_path: Path) -> None:
             "develop": {
                 "skill": "spec_first",
                 "role": "developer",
-                "valid_status_codes": ["CAFE_CONFIRMED"],
-                "on": {"CAFE_CONFIRMED": "_done"},
+                "valid_intents": ["confirmed"],
+                "on": {"await_agent": "_done"},
             },
         },
     }
 
     def executor(step_name: str, step_def: dict, state: object) -> StepExecutionResult:
         return StepExecutionResult(
-            response="CAFE_CONFIRMED",
+            response="confirmed",
             artifacts={"develop_result": "d1"},
-            status_code="CAFE_CONFIRMED",
+            status_code="confirmed",
         )
 
     runtime = BlackboardWorkflowRuntime(
@@ -222,7 +222,7 @@ def test_runtime_single_step_executes_non_pr_locally(tmp_path: Path) -> None:
 
     assert result.completed is True
     assert result.final_step == "develop"
-    assert result.final_status_code == "CAFE_CONFIRMED"
+    assert result.final_status_code == "confirmed"
     blackboard = BlackboardStore(issue_dir).load_or_create("develop")
     assert blackboard.current_step == "done"
     assert blackboard.handoff_contract is not None
@@ -236,7 +236,7 @@ def test_runtime_single_step_executes_pr_without_legacy_runner(tmp_path: Path) -
     playbook = {
         "playbook": {"id": "default"},
         "steps": {
-            "pr": {"skill": "spec_first", "role": "developer", "on": {"CAFE_CONFIRMED": "_done"}},
+            "pr": {"skill": "spec_first", "role": "developer", "on": {"await_agent": "_done"}},
         },
     }
 
@@ -273,14 +273,14 @@ def test_runtime_single_step_legacy_transition_uses_single_step_labels(tmp_path:
             "spec": {
                 "skill": "spec_first",
                 "role": "pm",
-                "valid_status_codes": ["CAFE_CONFIRMED"],
-                "on": {"CAFE_CONFIRMED": "plan"},
+                "valid_intents": ["confirmed"],
+                "on": {"await_agent": "plan"},
             },
             "plan": {
                 "skill": "spec_first",
                 "role": "developer",
-                "valid_status_codes": ["CAFE_CONFIRMED"],
-                "on": {"CAFE_CONFIRMED": "_done"},
+                "valid_intents": ["confirmed"],
+                "on": {"await_agent": "_done"},
             },
         },
     }
@@ -289,9 +289,9 @@ def test_runtime_single_step_legacy_transition_uses_single_step_labels(tmp_path:
         if step_name != "spec":
             raise AssertionError("single-step should only execute one step")
         return StepExecutionResult(
-            response="CAFE_CONFIRMED",
+            response="confirmed",
             artifacts={},
-            status_code="CAFE_CONFIRMED",
+            status_code="confirmed",
         )
 
     runtime = BlackboardWorkflowRuntime(
@@ -303,7 +303,7 @@ def test_runtime_single_step_legacy_transition_uses_single_step_labels(tmp_path:
 
     assert result.completed is False
     assert result.final_step == "spec"
-    assert result.final_status_code == "CAFE_CONFIRMED"
+    assert result.final_status_code == "confirmed"
     blackboard = BlackboardStore(issue_dir).load_or_create("spec")
     assert blackboard.current_step == "plan"
     transition_events = [e for e in blackboard.events if e.event_type == "transition"]
@@ -320,13 +320,13 @@ def test_runtime_single_step_baton_transition_uses_single_step_labels(tmp_path: 
             "pr": {
                 "skill": "spec_first",
                 "role": "developer",
-                "on": {"CAFE_CONFIRMED": "review"},
+                "on": {"await_agent": "review"},
             },
             "review": {
                 "skill": "spec_first",
                 "role": "reviewer",
-                "valid_status_codes": ["CAFE_CONFIRMED"],
-                "on": {"CAFE_CONFIRMED": "_done"},
+                "valid_intents": ["confirmed"],
+                "on": {"await_agent": "_done"},
             },
         },
     }
@@ -360,17 +360,17 @@ def test_runtime_single_step_pause_does_not_emit_workflow_paused_event(tmp_path:
             "spec": {
                 "skill": "spec_first",
                 "role": "pm",
-                "valid_status_codes": ["CAFE_READY_FOR_REVIEW", "CAFE_CONFIRMED"],
-                "on": {"CAFE_READY_FOR_REVIEW": "spec", "CAFE_CONFIRMED": "_done"},
+                "valid_intents": ["ready_for_review", "confirmed"],
+                "on": {"confirm_output": "spec", "await_agent": "_done"},
             },
         },
     }
 
     def executor(step_name: str, step_def: dict, state: object) -> StepExecutionResult:
         return StepExecutionResult(
-            response="CAFE_READY_FOR_REVIEW",
+            response="ready_for_review",
             artifacts={},
-            status_code="CAFE_READY_FOR_REVIEW",
+            status_code="ready_for_review",
             auto_continue=False,
         )
 
@@ -382,7 +382,7 @@ def test_runtime_single_step_pause_does_not_emit_workflow_paused_event(tmp_path:
     result = runtime.run(start_step="spec", single_step=True)
 
     assert result.completed is False
-    assert result.final_status_code == "CAFE_READY_FOR_REVIEW"
+    assert result.final_status_code == "ready_for_review"
     blackboard = BlackboardStore(issue_dir).load_or_create("spec")
     assert blackboard.current_step == "user"
     pause_events = [e for e in blackboard.events if e.event_type == "workflow_paused"]
@@ -397,14 +397,14 @@ def test_runtime_legacy_step_uses_default_transition_when_status_missing(tmp_pat
             "spec": {
                 "skill": "spec_first",
                 "role": "pm",
-                "valid_status_codes": ["CAFE_CONFIRMED"],
+                "valid_intents": ["confirmed"],
                 "on": {"default": "plan"},
             },
             "plan": {
                 "skill": "spec_first",
                 "role": "developer",
-                "valid_status_codes": ["CAFE_CONFIRMED"],
-                "on": {"CAFE_CONFIRMED": "_done"},
+                "valid_intents": ["confirmed"],
+                "on": {"await_agent": "_done"},
             },
         },
     }
@@ -414,7 +414,7 @@ def test_runtime_legacy_step_uses_default_transition_when_status_missing(tmp_pat
         calls.append(step_name)
         if step_name == "spec":
             return ("no explicit cafe code here", {})
-        return ("CAFE_CONFIRMED", {})
+        return ("confirmed", {})
 
     runtime = BlackboardWorkflowRuntime(
         issue_dir=issue_dir,
@@ -425,7 +425,7 @@ def test_runtime_legacy_step_uses_default_transition_when_status_missing(tmp_pat
 
     assert result.completed is True
     assert result.final_step == "plan"
-    assert result.final_status_code == "CAFE_CONFIRMED"
+    assert result.final_status_code == "confirmed"
     assert calls == ["spec", "plan"]
 
 
@@ -437,13 +437,13 @@ def test_runtime_legacy_step_honors_review_confirmed_advance(tmp_path: Path) -> 
             "review": {
                 "skill": "spec_first",
                 "role": "reviewer",
-                "valid_status_codes": ["CAFE_CONFIRMED"],
-                "on": {"CAFE_CONFIRMED": "review", "default": "pr"},
+                "valid_intents": ["confirmed"],
+                "on": {"await_agent": "review", "default": "pr"},
             },
             "pr": {
                 "skill": "spec_first",
                 "role": "developer",
-                "on": {"CAFE_CONFIRMED": "_done"},
+                "on": {"await_agent": "_done"},
             },
         },
     }
@@ -451,9 +451,9 @@ def test_runtime_legacy_step_honors_review_confirmed_advance(tmp_path: Path) -> 
     def executor(step_name: str, step_def: dict, state: object) -> StepExecutionResult:
         if step_name == "review":
             return StepExecutionResult(
-                response="CAFE_CONFIRMED",
+                response="confirmed",
                 artifacts={},
-                status_code="CAFE_CONFIRMED",
+                status_code="confirmed",
                 events=[{"type": "review_confirmed_advance"}],
             )
         _write_baton(issue_dir, from_step="pr", to_owner="done", to_step="done", intent="workflow_complete")
@@ -472,7 +472,7 @@ def test_runtime_legacy_step_honors_review_confirmed_advance(tmp_path: Path) -> 
 
     assert result.completed is False
     assert result.final_step == "review"
-    assert result.final_status_code == "CAFE_CONFIRMED"
+    assert result.final_status_code == "confirmed"
     blackboard = BlackboardStore(issue_dir).load_or_create("review")
     assert blackboard.current_step == "pr"
 
@@ -485,14 +485,14 @@ def test_runtime_resumes_from_blackboard_current_step(tmp_path: Path) -> None:
             "spec": {
                 "skill": "spec_first",
                 "role": "pm",
-                "valid_status_codes": ["CAFE_CONFIRMED"],
-                "on": {"CAFE_CONFIRMED": "plan"},
+                "valid_intents": ["confirmed"],
+                "on": {"await_agent": "plan"},
             },
             "plan": {
                 "skill": "spec_first",
                 "role": "developer",
-                "valid_status_codes": ["CAFE_CONFIRMED"],
-                "on": {"CAFE_CONFIRMED": "_done"},
+                "valid_intents": ["confirmed"],
+                "on": {"await_agent": "_done"},
             },
         },
     }
@@ -501,9 +501,9 @@ def test_runtime_resumes_from_blackboard_current_step(tmp_path: Path) -> None:
     def executor(step_name: str, step_def: dict, state: object) -> StepExecutionResult:
         executed_steps.append(step_name)
         return StepExecutionResult(
-            response="CAFE_CONFIRMED",
+            response="confirmed",
             artifacts={},
-            status_code="CAFE_CONFIRMED",
+            status_code="confirmed",
         )
 
     runtime = BlackboardWorkflowRuntime(
@@ -518,7 +518,7 @@ def test_runtime_resumes_from_blackboard_current_step(tmp_path: Path) -> None:
         to_owner=HandoffOwner.AGENT,
         to_step="plan",
         intent=HandoffIntent.AWAIT_AGENT,
-        status_code="CAFE_CONFIRMED",
+        status_code="confirmed",
         source="test.resume",
     )
     result = runtime.run(max_transitions=5)
@@ -536,14 +536,14 @@ def test_runtime_records_done_handoff_for_non_pr_terminal_transition(tmp_path: P
             "review": {
                 "skill": "spec_first",
                 "role": "reviewer",
-                "valid_status_codes": ["CAFE_CONFIRMED"],
-                "on": {"CAFE_CONFIRMED": "done"},
+                "valid_intents": ["confirmed"],
+                "on": {"await_agent": "done"},
             },
         },
     }
 
     def executor(step_name: str, step_def: dict, state: object):
-        return ("CAFE_CONFIRMED", {})
+        return ("confirmed", {})
 
     runtime = BlackboardWorkflowRuntime(
         issue_dir=issue_dir,
@@ -553,7 +553,7 @@ def test_runtime_records_done_handoff_for_non_pr_terminal_transition(tmp_path: P
     result = runtime.run(start_step="review")
 
     assert result.completed is True
-    assert result.final_status_code == "CAFE_CONFIRMED"
+    assert result.final_status_code == "confirmed"
     blackboard = BlackboardStore(issue_dir).load_or_create("review")
     assert blackboard.current_step == "done"
     assert blackboard.handoff_contract is not None
@@ -570,14 +570,14 @@ def test_runtime_pauses_for_non_pr_transition_to_user(tmp_path: Path) -> None:
             "review": {
                 "skill": "spec_first",
                 "role": "reviewer",
-                "valid_status_codes": ["CAFE_CONFIRMED"],
-                "on": {"CAFE_CONFIRMED": "user"},
+                "valid_intents": ["confirmed"],
+                "on": {"await_agent": "user"},
             },
         },
     }
 
     def executor(step_name: str, step_def: dict, state: object):
-        return ("CAFE_CONFIRMED", {})
+        return ("confirmed", {})
 
     runtime = BlackboardWorkflowRuntime(
         issue_dir=issue_dir,
@@ -587,7 +587,7 @@ def test_runtime_pauses_for_non_pr_transition_to_user(tmp_path: Path) -> None:
     result = runtime.run(start_step="review")
 
     assert result.completed is False
-    assert result.final_status_code == "CAFE_CONFIRMED"
+    assert result.final_status_code == "confirmed"
     blackboard = BlackboardStore(issue_dir).load_or_create("review")
     assert blackboard.current_step == "user"
     assert blackboard.handoff_contract is not None
@@ -605,14 +605,14 @@ def test_runtime_records_status_code_invalid_event(tmp_path: Path) -> None:
             "spec": {
                 "skill": "spec_first",
                 "role": "pm",
-                "valid_status_codes": ["CAFE_CONFIRMED"],
-                "on": {"CAFE_CONFIRMED": "_done"},
+                "valid_intents": ["confirmed"],
+                "on": {"await_agent": "_done"},
             },
         },
     }
 
     def executor(step_name: str, step_def: dict, state: object):
-        return ("CAFE_READY_FOR_REVIEW", {})
+        return ("ready_for_review", {})
 
     runtime = BlackboardWorkflowRuntime(
         issue_dir=issue_dir,
@@ -627,8 +627,8 @@ def test_runtime_records_status_code_invalid_event(tmp_path: Path) -> None:
     invalid_events = [e for e in blackboard.events if e.event_type == "status_code_invalid"]
     assert invalid_events
     latest = invalid_events[-1].data
-    assert latest["invalid_status_codes"] == ["CAFE_READY_FOR_REVIEW"]
-    assert latest["allowed_status_codes"] == ["CAFE_CONFIRMED"]
+    assert latest["invalid_intents"] == ["ready_for_review"]
+    assert latest["allowed_status_codes"] == ["confirmed"]
     assert latest["runtime"] == "legacy_until_boundary"
 
 
@@ -641,8 +641,8 @@ def test_runtime_prefers_step_baton_over_missing_status_text(tmp_path: Path) -> 
             "spec": {
                 "skill": "spec_first",
                 "role": "pm",
-                "valid_status_codes": ["CAFE_CONFIRMED"],
-                "on": {"CAFE_CONFIRMED": "_done"},
+                "valid_intents": ["confirmed"],
+                "on": {"await_agent": "_done"},
             },
         },
     }
@@ -687,14 +687,14 @@ def test_runtime_prefers_step_baton_over_invalid_status_text(tmp_path: Path) -> 
             "spec": {
                 "skill": "spec_first",
                 "role": "pm",
-                "valid_status_codes": ["CAFE_CONFIRMED"],
-                "on": {"CAFE_CONFIRMED": "plan"},
+                "valid_intents": ["confirmed"],
+                "on": {"await_agent": "plan"},
             },
             "plan": {
                 "skill": "plan",
                 "role": "developer",
-                "valid_status_codes": ["CAFE_CONFIRMED"],
-                "on": {"CAFE_CONFIRMED": "_done"},
+                "valid_intents": ["confirmed"],
+                "on": {"await_agent": "_done"},
             },
         },
     }
@@ -708,11 +708,11 @@ def test_runtime_prefers_step_baton_over_invalid_status_text(tmp_path: Path) -> 
                 to_owner=HandoffOwner.AGENT,
                 to_step="plan",
                 intent=HandoffIntent.AWAIT_AGENT,
-                status_code="CAFE_CONFIRMED",
+                status_code="confirmed",
                 source="test.executor",
             )
-            return ("CAFE_READY_FOR_REVIEW", {})
-        return ("CAFE_CONFIRMED", {})
+            return ("ready_for_review", {})
+        return ("confirmed", {})
 
     runtime = BlackboardWorkflowRuntime(
         issue_dir=issue_dir,
@@ -739,8 +739,8 @@ def test_runtime_status_code_missing_no_handoff_contract(tmp_path: Path) -> None
             "spec": {
                 "skill": "spec_first",
                 "role": "pm",
-                "valid_status_codes": ["CAFE_NEED_CLARIFICATION"],
-                "on": {"CAFE_NEED_CLARIFICATION": "spec"},
+                "valid_intents": ["need_clarification"],
+                "on": {"need_clarification": "spec"},
             },
         },
     }
@@ -774,17 +774,17 @@ def test_runtime_pauses_ready_for_review_with_confirm_output_intent(tmp_path: Pa
             "spec": {
                 "skill": "spec_first",
                 "role": "pm",
-                "valid_status_codes": ["CAFE_READY_FOR_REVIEW", "CAFE_CONFIRMED"],
-                "on": {"CAFE_READY_FOR_REVIEW": "spec", "CAFE_CONFIRMED": "_done"},
+                "valid_intents": ["ready_for_review", "confirmed"],
+                "on": {"confirm_output": "spec", "await_agent": "_done"},
             },
         },
     }
 
     def executor(step_name: str, step_def: dict, state: object) -> StepExecutionResult:
         return StepExecutionResult(
-            response="CAFE_READY_FOR_REVIEW",
+            response="ready_for_review",
             artifacts={},
-            status_code="CAFE_READY_FOR_REVIEW",
+            status_code="ready_for_review",
             auto_continue=False,
         )
 
@@ -796,7 +796,7 @@ def test_runtime_pauses_ready_for_review_with_confirm_output_intent(tmp_path: Pa
     result = runtime.run(start_step="spec")
 
     assert result.completed is False
-    assert result.final_status_code == "CAFE_READY_FOR_REVIEW"
+    assert result.final_status_code == "ready_for_review"
     blackboard = BlackboardStore(issue_dir).load_or_create("spec")
     assert blackboard.current_step == "user"
     assert blackboard.handoff_contract is not None
@@ -812,10 +812,10 @@ def test_runtime_continues_when_auto_continue_is_true(tmp_path: Path) -> None:
             "spec": {
                 "skill": "spec_first",
                 "role": "pm",
-                "valid_status_codes": ["CAFE_NEED_CLARIFICATION", "CAFE_CONFIRMED"],
+                "valid_intents": ["need_clarification", "confirmed"],
                 "on": {
-                    "CAFE_NEED_CLARIFICATION": "spec",
-                    "CAFE_CONFIRMED": "_done",
+                    "need_clarification": "spec",
+                    "await_agent": "_done",
                 },
             },
         },
@@ -827,15 +827,15 @@ def test_runtime_continues_when_auto_continue_is_true(tmp_path: Path) -> None:
         call_count += 1
         if call_count == 1:
             return StepExecutionResult(
-                response="CAFE_NEED_CLARIFICATION",
+                response="need_clarification",
                 artifacts={},
-                status_code="CAFE_NEED_CLARIFICATION",
+                status_code="need_clarification",
                 auto_continue=True,
             )
         return StepExecutionResult(
-            response="CAFE_CONFIRMED",
+            response="confirmed",
             artifacts={},
-            status_code="CAFE_CONFIRMED",
+            status_code="confirmed",
         )
 
     runtime = BlackboardWorkflowRuntime(
@@ -861,15 +861,15 @@ def test_runtime_emits_expected_runtime_labels_per_path(tmp_path: Path) -> None:
             "review": {
                 "skill": "spec_first",
                 "role": "reviewer",
-                "valid_status_codes": ["CAFE_CONFIRMED"],
-                "on": {"CAFE_CONFIRMED": "pr"},
+                "valid_intents": ["confirmed"],
+                "on": {"await_agent": "pr"},
             },
-            "pr": {"skill": "spec_first", "role": "developer", "on": {"CAFE_CONFIRMED": "_done"}},
+            "pr": {"skill": "spec_first", "role": "developer", "on": {"await_agent": "_done"}},
         },
     }
 
     def legacy_executor(step_name: str, step_def: dict, state: object):
-        return ("CAFE_CONFIRMED", {})
+        return ("confirmed", {})
 
     legacy_runtime = BlackboardWorkflowRuntime(
         issue_dir=issue_dir_legacy,
@@ -900,7 +900,7 @@ def test_runtime_emits_expected_runtime_labels_per_path(tmp_path: Path) -> None:
     playbook_pr = {
         "playbook": {"id": "default"},
         "steps": {
-            "pr": {"skill": "spec_first", "role": "developer", "on": {"CAFE_CONFIRMED": "_done"}},
+            "pr": {"skill": "spec_first", "role": "developer", "on": {"await_agent": "_done"}},
         },
     }
 
@@ -934,17 +934,17 @@ def test_runtime_emits_expected_runtime_labels_per_path(tmp_path: Path) -> None:
             "develop": {
                 "skill": "spec_first",
                 "role": "developer",
-                "valid_status_codes": ["CAFE_CONFIRMED"],
-                "on": {"CAFE_CONFIRMED": "_done"},
+                "valid_intents": ["confirmed"],
+                "on": {"await_agent": "_done"},
             },
         },
     }
 
     def single_executor(step_name: str, step_def: dict, state: object) -> StepExecutionResult:
         return StepExecutionResult(
-            response="CAFE_CONFIRMED",
+            response="confirmed",
             artifacts={},
-            status_code="CAFE_CONFIRMED",
+            status_code="confirmed",
         )
 
     single_runtime = BlackboardWorkflowRuntime(
@@ -990,15 +990,15 @@ def test_runtime_chains_pr_need_changes_through_develop_to_review(tmp_path: Path
                 "skill": "develop",
                 "role": "developer",
                 "assignee_type": "agent",
-                "valid_status_codes": ["CAFE_CONFIRMED"],
-                "on": {"CAFE_CONFIRMED": "review"},
+                "valid_intents": ["confirmed"],
+                "on": {"await_agent": "review"},
             },
             "review": {
                 "skill": "review",
                 "role": "reviewer",
                 "assignee_type": "agent",
-                "valid_status_codes": ["CAFE_CONFIRMED"],
-                "on": {"CAFE_CONFIRMED": "_done"},
+                "valid_intents": ["confirmed"],
+                "on": {"await_agent": "_done"},
             },
         },
     }
@@ -1015,10 +1015,10 @@ def test_runtime_chains_pr_need_changes_through_develop_to_review(tmp_path: Path
                 to_owner=HandoffOwner.AGENT,
                 to_step="develop",
                 intent=HandoffIntent.AWAIT_AGENT,
-                status_code="CAFE_NEEDS_CHANGES",
+                status_code="needs_changes",
                 source="test",
             )
-            return StepExecutionResult(response="todos", artifacts={}, status_code="CAFE_NEEDS_CHANGES")
+            return StepExecutionResult(response="todos", artifacts={}, status_code="needs_changes")
         if step_name == "develop":
             store.update_handoff_contract(
                 state,
@@ -1026,10 +1026,10 @@ def test_runtime_chains_pr_need_changes_through_develop_to_review(tmp_path: Path
                 to_owner=HandoffOwner.AGENT,
                 to_step="review",
                 intent=HandoffIntent.AWAIT_AGENT,
-                status_code="CAFE_CONFIRMED",
+                status_code="confirmed",
                 source="test",
             )
-            return StepExecutionResult(response="done", artifacts={}, status_code="CAFE_CONFIRMED")
+            return StepExecutionResult(response="done", artifacts={}, status_code="confirmed")
         if step_name == "review":
             store.update_handoff_contract(
                 state,
@@ -1037,10 +1037,10 @@ def test_runtime_chains_pr_need_changes_through_develop_to_review(tmp_path: Path
                 to_owner=HandoffOwner.USER,
                 to_step="user",
                 intent=HandoffIntent.MANUAL_HANDOFF,
-                status_code="CAFE_CONFIRMED",
+                status_code="confirmed",
                 source="test",
             )
-            return StepExecutionResult(response="lgtm", artifacts={}, status_code="CAFE_CONFIRMED")
+            return StepExecutionResult(response="lgtm", artifacts={}, status_code="confirmed")
         raise AssertionError(f"unexpected step {step_name}")
 
     runtime = BlackboardWorkflowRuntime(
@@ -1071,8 +1071,8 @@ def test_runtime_normalizes_legacy_baton_written_by_pr_agent(tmp_path: Path) -> 
                 "skill": "develop",
                 "role": "developer",
                 "assignee_type": "agent",
-                "valid_status_codes": ["CAFE_CONFIRMED"],
-                "on": {"CAFE_CONFIRMED": "_done"},
+                "valid_intents": ["confirmed"],
+                "on": {"await_agent": "_done"},
             },
         },
     }
@@ -1083,7 +1083,7 @@ def test_runtime_normalizes_legacy_baton_written_by_pr_agent(tmp_path: Path) -> 
         calls.append(step_name)
         if step_name == "pr":
             (issue_dir / "next_step.txt").write_text("develop\n", encoding="utf-8")
-            return StepExecutionResult(response="todo", artifacts={}, status_code="CAFE_NEEDS_CHANGES")
+            return StepExecutionResult(response="todo", artifacts={}, status_code="needs_changes")
         if step_name == "develop":
             store = BlackboardStore(issue_dir)
             store.update_handoff_contract(
@@ -1092,10 +1092,10 @@ def test_runtime_normalizes_legacy_baton_written_by_pr_agent(tmp_path: Path) -> 
                 to_owner=HandoffOwner.DONE,
                 to_step="done",
                 intent=HandoffIntent.WORKFLOW_COMPLETE,
-                status_code="CAFE_CONFIRMED",
+                status_code="confirmed",
                 source="test",
             )
-            return StepExecutionResult(response="done", artifacts={}, status_code="CAFE_CONFIRMED")
+            return StepExecutionResult(response="done", artifacts={}, status_code="confirmed")
         raise AssertionError(f"unexpected step {step_name}")
 
     runtime = BlackboardWorkflowRuntime(


### PR DESCRIPTION
## Summary

Closes #256. Migrates the playbook and skill vocabulary from CAFE_* status codes to baton intent keys, and demotes PhaseStatusCode to internal-only compatibility.

## Changes

- Playbook `on:` keys: `CAFE_CONFIRMED` → `await_agent`, `CAFE_READY_FOR_REVIEW` → `confirm_output`, `CAFE_NEED_CLARIFICATION` → `need_clarification`, `CAFE_NEED_PERMISSION` → `need_permission`, `CAFE_NEEDS_CHANGES` → `manual_handoff`, `CAFE_CONFIRMED_SKIP_REVIEW` → `manual_handoff`, `CAFE_NO_CHANGES_NEEDED` → removed (merged into default flow)
- All builtin playbooks (default, hotfix, simple) migrated
- Builtin SKILL.md references updated to use baton intent language
- `GenericWorkflowStepExecutor._write_status_transition_handoff` / `_resolve_next_step_for_status` operate on baton intents
- `PhaseStatusCode` demoted to internal shim with deprecation note
- Playbook schema validator rejects legacy CAFE_* keys
- Full test suite: 1928 passed, 5 skipped, 1 xfailed

No backward compatibility — legacy CAFE_* vocabulary deleted entirely per project direction.