### PR TITLE
issue252: add playbook simulate with static graph diagnostics

### DIFF
--- a/src/cafe/core/playbook.py
+++ b/src/cafe/core/playbook.py
@@ -206,6 +206,10 @@ def validate_playbook(
     warnings: List[str] = []
     steps = model.steps
 
+    entry = model.entry_point
+    if entry is not None and entry not in steps:
+        raise ValueError(f"entry_point {entry!r} is not a defined step")
+
     _report_structural_issue(
         playbook_id=model.playbook.id,
         filename=path.stem,

--- a/src/cafe/playbooks/simulate.py
+++ b/src/cafe/playbooks/simulate.py
@@ -1,0 +1,231 @@
+"""Static transition-graph analysis for ``playbook simulate`` (no agents, no hooks)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Set, Tuple
+
+from cafe.core.playbook import DONE_TARGET, PlaybookDefinition
+from cafe.core.status_codes import PhaseStatusCode, transition_map_key
+
+
+@dataclass(frozen=True)
+class PlaybookSimulationResult:
+    playbook_id: str
+    entry_point: str
+    edges: List[Tuple[str, str, str]]
+    reachable_steps: Set[str]
+    unreachable_steps: Tuple[str, ...]
+    dead_end_steps: Tuple[str, ...]
+    cycles: Tuple[str, ...]
+    missing_intent_handlers: Tuple[str, ...]
+
+
+def validate_entry_point(model: PlaybookDefinition) -> None:
+    ep = model.entry_point
+    if ep is None:
+        return
+    if ep not in model.steps:
+        raise ValueError(f"entry_point {ep!r} is not a defined step")
+
+
+def _iter_edges(model: PlaybookDefinition) -> List[Tuple[str, str, str]]:
+    """(from_step, intent_key, to_target) where to_target is a step id or ``_done``."""
+    edges: List[Tuple[str, str, str]] = []
+    for step_name, step in model.steps.items():
+        for intent_key, target in step.on.items():
+            edges.append((step_name, str(intent_key), str(target)))
+    return edges
+
+
+def _reachable_step_names(model: PlaybookDefinition) -> Set[str]:
+    """Steps reachable from ``entry_point`` following ``on`` targets (``_done`` excluded)."""
+    ep = model.entry_point or next(iter(model.steps.keys()))
+    if ep not in model.steps:
+        return set()
+    seen: Set[str] = {ep}
+    stack = [ep]
+    while stack:
+        cur = stack.pop()
+        step = model.steps.get(cur)
+        if step is None:
+            continue
+        for _intent, tgt in step.on.items():
+            if tgt == DONE_TARGET:
+                continue
+            if tgt in model.steps and tgt not in seen:
+                seen.add(tgt)
+                stack.append(tgt)
+    return seen
+
+
+def _dead_end_steps(model: PlaybookDefinition) -> List[str]:
+    return sorted(name for name, step in model.steps.items() if not step.on)
+
+
+def _missing_intent_handlers(model: PlaybookDefinition) -> List[str]:
+    """When ``valid_intents`` is declared on a step, every mapped transition key must exist in ``on`` (or ``default``)."""
+    findings: List[str] = []
+    for step_name, step in model.steps.items():
+        if not step.valid_intents:
+            continue
+        for raw in step.valid_intents:
+            try:
+                code = PhaseStatusCode(raw)
+            except ValueError:
+                continue
+            key = transition_map_key(code)
+            if key not in step.on and "default" not in step.on:
+                findings.append(
+                    f"step {step_name!r}: outcome {code.value!r} maps to transition key {key!r} "
+                    f"but `on` defines neither that key nor `default`"
+                )
+    return sorted(findings)
+
+
+def _step_adjacency(model: PlaybookDefinition) -> Dict[str, Set[str]]:
+    """Directed edges among defined steps only (``_done`` dropped)."""
+    adj: Dict[str, Set[str]] = {name: set() for name in model.steps}
+    for u, _intent, v in _iter_edges(model):
+        if v != DONE_TARGET and v in model.steps:
+            adj[u].add(v)
+    return adj
+
+
+def _tarjan_sccs(vertices: Set[str], adj: Dict[str, Set[str]]) -> List[List[str]]:
+    index_counter = 0
+    stack: List[str] = []
+    index: Dict[str, int] = {}
+    lowlink: Dict[str, int] = {}
+    onstack: Set[str] = set()
+    components: List[List[str]] = []
+
+    def strongconnect(v: str) -> None:
+        nonlocal index_counter
+        index[v] = index_counter
+        lowlink[v] = index_counter
+        index_counter += 1
+        stack.append(v)
+        onstack.add(v)
+        for w in adj.get(v, set()):
+            if w not in index:
+                strongconnect(w)
+                lowlink[v] = min(lowlink[v], lowlink[w])
+            elif w in onstack:
+                lowlink[v] = min(lowlink[v], index[w])
+        if lowlink[v] == index[v]:
+            comp: List[str] = []
+            while True:
+                w = stack.pop()
+                onstack.remove(w)
+                comp.append(w)
+                if w == v:
+                    break
+            components.append(comp)
+
+    for v in sorted(vertices):
+        if v not in index:
+            strongconnect(v)
+    return components
+
+
+def _multi_step_cycle_summaries(model: PlaybookDefinition) -> List[str]:
+    """Report SCCs with >1 node; single-node SCCs with a self-edge are ignored (self-loops only)."""
+    vertices = set(model.steps.keys())
+    adj = _step_adjacency(model)
+    summaries: List[str] = []
+    for comp in _tarjan_sccs(vertices, adj):
+        if len(comp) > 1:
+            summaries.append("directed cycle among steps: " + ", ".join(sorted(comp)))
+            continue
+        if len(comp) == 1:
+            u = comp[0]
+            if u in adj.get(u, set()):
+                continue
+    return sorted(set(summaries))
+
+
+def analyze_playbook(model: PlaybookDefinition) -> PlaybookSimulationResult:
+    validate_entry_point(model)
+    entry = model.entry_point or next(iter(model.steps.keys()))
+    edges = _iter_edges(model)
+    reachable = _reachable_step_names(model)
+    all_names = set(model.steps.keys())
+    unreachable = tuple(sorted(all_names - reachable))
+    dead = tuple(_dead_end_steps(model))
+    missing = tuple(_missing_intent_handlers(model))
+    cycles = tuple(_multi_step_cycle_summaries(model))
+    return PlaybookSimulationResult(
+        playbook_id=model.playbook.id,
+        entry_point=entry,
+        edges=edges,
+        reachable_steps=reachable,
+        unreachable_steps=unreachable,
+        dead_end_steps=dead,
+        cycles=cycles,
+        missing_intent_handlers=missing,
+    )
+
+
+def _dot_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def format_text_report(result: PlaybookSimulationResult) -> str:
+    lines: List[str] = []
+    lines.append(f"Playbook: {result.playbook_id}")
+    lines.append(f"Entry point: {result.entry_point}")
+    lines.append("")
+    lines.append("Transitions (intent -> next step)")
+    by_from: Dict[str, List[Tuple[str, str]]] = {}
+    for frm, intent, to in result.edges:
+        by_from.setdefault(frm, []).append((intent, to))
+    for step in sorted(by_from.keys()):
+        lines.append(f"  [{step}]")
+        for intent, to in sorted(by_from[step], key=lambda x: (x[0], x[1])):
+            lines.append(f"    {intent} -> {to}")
+    lines.append("")
+    lines.append("Unreachable steps (from entry)")
+    if result.unreachable_steps:
+        for s in result.unreachable_steps:
+            lines.append(f"  - {s}")
+    else:
+        lines.append("  (no findings)")
+    lines.append("")
+    lines.append("Directed cycles (excluding single-step self-loops)")
+    if result.cycles:
+        for c in result.cycles:
+            lines.append(f"  - {c}")
+    else:
+        lines.append("  (no findings)")
+    lines.append("")
+    lines.append("Missing intent handlers and dead-end steps")
+    lines.append("  Intent handlers (from declared valid_intents):")
+    if result.missing_intent_handlers:
+        for m in result.missing_intent_handlers:
+            lines.append(f"    - {m}")
+    else:
+        lines.append("    (no findings)")
+    lines.append("  Dead-end steps (empty on:):")
+    if result.dead_end_steps:
+        for s in result.dead_end_steps:
+            lines.append(f"    - {s}")
+    else:
+        lines.append("    (no findings)")
+    return "\n".join(lines)
+
+
+def format_dot(result: PlaybookSimulationResult) -> str:
+    lines = ["digraph playbook {", "  rankdir=LR;"]
+    nodes: Set[str] = set()
+    for f, _i, t in result.edges:
+        nodes.add(f)
+        nodes.add(t)
+    for n in sorted(nodes):
+        lines.append(f'  "{_dot_escape(n)}";')
+    for f, intent, t in result.edges:
+        lines.append(
+            f'  "{_dot_escape(f)}" -> "{_dot_escape(t)}" [label="{_dot_escape(intent)}"];'
+        )
+    lines.append("}")
+    return "\n".join(lines)

--- a/src/cafe/ui/commands/catalog.py
+++ b/src/cafe/ui/commands/catalog.py
@@ -10,6 +10,7 @@ import yaml
 from rich.console import Console
 
 from cafe.playbooks.loader import PlaybookLoader
+from cafe.playbooks.simulate import analyze_playbook, format_dot, format_text_report
 from cafe.skills.importer import SkillImportSummary, import_skills, preview_importable_skills
 from cafe.skills.loader import SkillLoader
 from cafe.skills.remover import SkillRemoveSummary, remove_skills
@@ -106,6 +107,31 @@ def playbook_validate(
     if loaded.warnings:
         for warning in loaded.warnings:
             console.print(f"[yellow]warning:[/yellow] {warning}")
+
+
+@playbook_app.command(name="simulate")
+def playbook_simulate(
+    name: str = typer.Argument(..., help="Playbook name"),
+    dot: bool = typer.Option(False, "--dot", help="Append a DOT graph of transitions after the summary"),
+) -> None:
+    """Statically trace playbook transitions (read-only; no agents, hooks, or shell helpers)."""
+    loader = _build_playbook_loader()
+    try:
+        loaded = loader.load_model(name, strict=False)
+    except Exception as e:
+        console.print(f"[red]Error: {e}[/red]")
+        raise typer.Exit(1)
+
+    try:
+        result = analyze_playbook(loaded.model)
+    except ValueError as e:
+        console.print(f"[red]Error: {e}[/red]")
+        raise typer.Exit(1)
+
+    console.print(format_text_report(result))
+    if dot:
+        console.print("")
+        console.print(format_dot(result))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_playbook_simulate.py
+++ b/tests/unit/test_playbook_simulate.py
@@ -1,0 +1,238 @@
+"""Tests for ``playbook simulate`` static graph analysis."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from cafe.playbooks.loader import PlaybookLoader
+from cafe.playbooks.simulate import analyze_playbook, format_dot, format_text_report
+from cafe.ui.cli import app
+
+runner = CliRunner()
+
+
+def _write_playbook(root: Path, stem: str, content: str) -> None:
+    pb_dir = root / ".cafe" / "playbooks"
+    pb_dir.mkdir(parents=True, exist_ok=True)
+    (pb_dir / f"{stem}.yaml").write_text(content, encoding="utf-8")
+
+
+def test_simulate_unknown_playbook_no_transition_report(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["playbook", "simulate", "does_not_exist_252"])
+    assert result.exit_code == 1
+    assert "Error:" in result.stdout
+    assert "Transitions (intent -> next step)" not in result.stdout
+
+
+def test_simulate_bad_entry_point_after_load(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _write_playbook(
+        tmp_path,
+        "sim_bad_entry",
+        """
+playbook:
+  id: sim_bad_entry
+  name: Bad entry
+roles:
+  pm:
+    description: PM
+steps:
+  only:
+    type: skill
+    skill: spec_first
+    role: pm
+    on:
+      await_agent: _done
+entry_point: not_a_step
+""".strip()
+        + "\n",
+    )
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["playbook", "simulate", "sim_bad_entry"])
+    assert result.exit_code == 1
+    assert "entry_point" in result.stdout
+    assert "Transitions (intent -> next step)" not in result.stdout
+
+
+def test_simulate_cycle_detection(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _write_playbook(
+        tmp_path,
+        "sim_cycle",
+        """
+playbook:
+  id: sim_cycle
+  name: Sim cycle
+roles:
+  pm:
+    description: PM
+steps:
+  a:
+    type: skill
+    skill: spec_first
+    role: pm
+    on:
+      await_agent: b
+  b:
+    type: skill
+    skill: spec_first
+    role: pm
+    on:
+      await_agent: a
+entry_point: a
+""".strip()
+        + "\n",
+    )
+    monkeypatch.chdir(tmp_path)
+    loader = PlaybookLoader(project_root=tmp_path)
+    res = analyze_playbook(loader.load_model("sim_cycle").model)
+    assert res.cycles
+    assert "a" in res.cycles[0] and "b" in res.cycles[0]
+
+
+def test_simulate_unreachable_step(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _write_playbook(
+        tmp_path,
+        "sim_unreach",
+        """
+playbook:
+  id: sim_unreach
+  name: Sim unreachable
+roles:
+  pm:
+    description: PM
+steps:
+  a:
+    type: skill
+    skill: spec_first
+    role: pm
+    on:
+      await_agent: _done
+  orphan:
+    type: skill
+    skill: spec_first
+    role: pm
+    on:
+      await_agent: orphan
+entry_point: a
+""".strip()
+        + "\n",
+    )
+    monkeypatch.chdir(tmp_path)
+    res = analyze_playbook(PlaybookLoader(project_root=tmp_path).load_model("sim_unreach").model)
+    assert "orphan" in res.unreachable_steps
+
+
+def test_simulate_dead_end_step(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _write_playbook(
+        tmp_path,
+        "sim_dead",
+        """
+playbook:
+  id: sim_dead
+  name: Sim dead end
+roles:
+  pm:
+    description: PM
+steps:
+  live:
+    type: skill
+    skill: spec_first
+    role: pm
+    on:
+      await_agent: sink
+  sink:
+    type: skill
+    skill: spec_first
+    role: pm
+    on: {}
+entry_point: live
+""".strip()
+        + "\n",
+    )
+    monkeypatch.chdir(tmp_path)
+    res = analyze_playbook(PlaybookLoader(project_root=tmp_path).load_model("sim_dead").model)
+    assert "sink" in res.dead_end_steps
+
+
+def test_simulate_missing_handler_from_valid_intents(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _write_playbook(
+        tmp_path,
+        "sim_bad_intent",
+        """
+playbook:
+  id: sim_bad_intent
+  name: Sim bad intent
+roles:
+  pm:
+    description: PM
+steps:
+  only:
+    type: skill
+    skill: spec_first
+    role: pm
+    valid_intents: [ready_for_review]
+    on:
+      await_agent: _done
+entry_point: only
+""".strip()
+        + "\n",
+    )
+    monkeypatch.chdir(tmp_path)
+    res = analyze_playbook(PlaybookLoader(project_root=tmp_path).load_model("sim_bad_intent").model)
+    assert res.missing_intent_handlers
+    assert "confirm_output" in res.missing_intent_handlers[0]
+
+
+def test_simulate_builtin_default_and_dot(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    repo = Path(__file__).resolve().parents[2]
+    monkeypatch.chdir(repo)
+    result = runner.invoke(app, ["playbook", "simulate", "default", "--dot"])
+    assert result.exit_code == 0
+    out = result.stdout
+    assert "Transitions (intent -> next step)" in out
+    assert "Unreachable steps (from entry)" in out
+    assert "(no findings)" in out
+    assert "digraph playbook" in out
+
+
+def test_format_dot_edge_count_matches_model(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _write_playbook(
+        tmp_path,
+        "sim_tiny",
+        """
+playbook:
+  id: sim_tiny
+  name: Sim tiny
+roles:
+  pm:
+    description: PM
+steps:
+  only:
+    type: skill
+    skill: spec_first
+    role: pm
+    on:
+      await_agent: _done
+entry_point: only
+""".strip()
+        + "\n",
+    )
+    monkeypatch.chdir(tmp_path)
+    model = PlaybookLoader(project_root=tmp_path).load_model("sim_tiny").model
+    res = analyze_playbook(model)
+    dot = format_dot(res)
+    assert dot.count(" -> ") == len(res.edges)
+    text = format_text_report(res)
+    assert "Dead-end steps" in text
+    assert "_done" in text
+
+
+def test_simulate_simple_builtin(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    repo = Path(__file__).resolve().parents[2]
+    monkeypatch.chdir(repo)
+    r = runner.invoke(app, ["playbook", "simulate", "simple"])
+    assert r.exit_code == 0
+    assert "Entry point: spec" in r.stdout


### PR DESCRIPTION
## Summary

Implements **GitHub issue #252** / CAFE spec: a read-only `cafe playbook simulate <playbook>` command that validates and statically traces the workflow transition graph (`on:` intents → next step or `_done`), reports unreachable steps, multi-step directed cycles (excluding lone self-loops), dead-end steps with empty `on:`, and missing intent handlers when `valid_intents` is declared in YAML. Optional `--dot` emits a Graphviz-compatible digraph with the same edges as the text summary. Playbook loading failures exit before any simulation output.

## Changes

- **`src/cafe/playbooks/simulate.py`** — Core analysis: `analyze_playbook`, `format_text_report`, `format_dot`; reachability from `entry_point`, Tarjan SCC cycles among steps, dead ends, `valid_intents` vs `transition_map_key` gaps.
- **`src/cafe/ui/commands/catalog.py`** — New Typer command `playbook simulate` with `--dot`.
- **`src/cafe/core/playbook.py`** — `validate_playbook` rejects `entry_point` not in `steps` (shared with `validate` / `simulate`).
- **`tests/unit/test_playbook_simulate.py`** — Coverage for unknown playbook (no transition report), bad entry, cycle, unreachable, dead-end, missing handler fixture, built-in `default`/`simple`, DOT edge parity.

**Commits (vs `develop`):**

- `6e177bc` — `issue252: add playbook simulate with static graph diagnostics`

## Test Plan

- `PYTHONPATH=src python3 -m pytest tests/unit/test_playbook_simulate.py -q`
- `PYTHONPATH=src python3 -m pytest tests/unit/test_playbook_loader.py tests/unit/test_skill_sync_pr_script.py -q` (regression after `validate_playbook` change)
- Manual: from repo root, `cafe playbook simulate default` and `cafe playbook simulate default --dot` (expect summary sections and `digraph playbook` when `--dot`).