### PR TITLE
Add baton auto-correction normalization layer

### DIFF
--- a/src/cafe/core/blackboard.py
+++ b/src/cafe/core/blackboard.py
@@ -15,6 +15,54 @@ BLACKBOARD_SCHEMA_VERSION = 1
 NEXT_STEP_FILENAME = "next_step.txt"
 HANDOFF_CONTRACT_VERSION = 1
 
+# to_owner 值：常見 agent 誤用 → 正確值
+_TO_OWNER_ALIASES: Dict[str, str] = {
+    "human": "user",
+    "reviewer": "user",
+    "developer": "user",
+}
+
+# intent 值：to_step=="done" 時需修正的值
+_DONE_INTENT_ALIASES: frozenset = frozenset({"complete", "confirmed", "done"})
+
+
+def _normalize_baton_payload(payload: Dict[str, Any]) -> tuple[Dict[str, Any], List[Dict[str, Any]]]:
+    """將常見 agent 誤用值正規化，回傳 (修正後 payload, corrections 清單)。
+
+    corrections 清單每筆格式：{"field": str, "original": str, "corrected": str}
+    無修正時回傳原 payload 的淺複製與空清單。
+    """
+    corrections: List[Dict[str, Any]] = []
+    result = dict(payload)
+
+    to_step = str(result.get("to_step", ""))
+    to_owner = str(result.get("to_owner", ""))
+    intent = str(result.get("intent", ""))
+
+    # 規則 1：to_owner 通用別名（human/reviewer/developer → user），在 done 規則之前套用
+    if to_step != "done" and to_owner in _TO_OWNER_ALIASES:
+        corrected_owner = _TO_OWNER_ALIASES[to_owner]
+        corrections.append({"field": "to_owner", "original": to_owner, "corrected": corrected_owner})
+        result["to_owner"] = corrected_owner
+
+    # 規則 2：to_step=="done" 時強制 to_owner="done"
+    if to_step == "done":
+        if to_owner != "done":
+            corrections.append({"field": "to_owner", "original": to_owner, "corrected": "done"})
+        result["to_owner"] = "done"
+
+        # 規則 3：to_step=="done" 時修正特定 intent 值
+        if intent in _DONE_INTENT_ALIASES:
+            corrections.append({"field": "intent", "original": intent, "corrected": "workflow_complete"})
+            result["intent"] = "workflow_complete"
+
+    # 規則 4：to_step 為 playbook step（非 user/done）且 intent=="confirmed" → await_agent
+    elif to_step not in {"user", "done"} and intent == "confirmed":
+        corrections.append({"field": "intent", "original": intent, "corrected": "await_agent"})
+        result["intent"] = "await_agent"
+
+    return result, corrections
+
 
 def _now_iso() -> str:
     return datetime.now().astimezone().isoformat()
@@ -405,6 +453,15 @@ class BlackboardStore:
             payload = json.loads(raw)
             if not isinstance(payload, dict):
                 raise ValueError("Baton payload must be a JSON object")
+            payload, corrections = _normalize_baton_payload(payload)
+            if corrections:
+                self.log_event(
+                    state,
+                    state.current_step,
+                    "baton_auto_corrected",
+                    f"baton auto-corrected {len(corrections)} field(s)",
+                    {"corrections": corrections},
+                )
             contract = HandoffContract.from_dict(payload)
         except (json.JSONDecodeError, ValueError) as exc:
             if not allow_legacy_text:

--- a/src/cafe/data/skills/workflow-common/SKILL.md
+++ b/src/cafe/data/skills/workflow-common/SKILL.md
@@ -60,3 +60,109 @@ Follow these in addition to **Shared Rules** whenever you are in **develop** or 
 - **User arbitration:** if you still disagree after the limit (or the issue is product-level), capture both sides in `questions.xml`, record whether the developer or reviewer requested arbitration in blackboard `events`, set `current_step` to `user`, and write the baton target `user`.
 - **Normal completion:** when develop work is done and review should run next, set the baton to `review`. When review approves the default playbook path, set the baton to `pr` unless your playbook says otherwise.
 - Avoid infinite loops on the same unresolved point without new information.
+
+## Baton Schema
+
+The baton contract (`next_step.txt`) is a JSON object with the following fields. Write only valid enum values — the runtime auto-corrects common mistakes but logs a `baton_auto_corrected` warning event every time it does so.
+
+### Valid `to_owner` values
+
+| Value | When to use |
+| --- | --- |
+| `agent` | Next target is an automated workflow step |
+| `user` | Pausing for human input (confirmation, clarification, permission) |
+| `done` | Workflow is complete; no further steps |
+
+### Valid `intent` values
+
+| Value | When to use |
+| --- | --- |
+| `await_agent` | Handing off to the next automated step |
+| `confirm_output` | Asking the user to approve a spec or plan artifact |
+| `need_clarification` | Asking the user a question before proceeding |
+| `need_permission` | Requesting a capability or resource the agent cannot self-authorize |
+| `manual_handoff` | Pausing for the user to take a manual action |
+| `workflow_complete` | Final step finished; workflow ends |
+
+### Example JSON for common transitions
+
+**Agent → next automated step (e.g. develop → review)**
+```json
+{
+  "version": 1,
+  "from_step": "develop",
+  "to_owner": "agent",
+  "to_step": "review",
+  "intent": "await_agent",
+  "status_code": "",
+  "created_at": "2026-05-14T10:00:00+08:00",
+  "source": "develop"
+}
+```
+
+**Agent → user for output confirmation (spec or plan)**
+```json
+{
+  "version": 1,
+  "from_step": "plan",
+  "to_owner": "user",
+  "to_step": "user",
+  "intent": "confirm_output",
+  "status_code": "",
+  "created_at": "2026-05-14T10:00:00+08:00",
+  "source": "plan"
+}
+```
+
+**Agent → user for clarification**
+```json
+{
+  "version": 1,
+  "from_step": "spec",
+  "to_owner": "user",
+  "to_step": "user",
+  "intent": "need_clarification",
+  "status_code": "",
+  "created_at": "2026-05-14T10:00:00+08:00",
+  "source": "spec"
+}
+```
+
+**Agent → user for permission**
+```json
+{
+  "version": 1,
+  "from_step": "develop",
+  "to_owner": "user",
+  "to_step": "user",
+  "intent": "need_permission",
+  "status_code": "",
+  "created_at": "2026-05-14T10:00:00+08:00",
+  "source": "develop"
+}
+```
+
+**Agent → done (workflow complete)**
+```json
+{
+  "version": 1,
+  "from_step": "pr",
+  "to_owner": "done",
+  "to_step": "done",
+  "intent": "workflow_complete",
+  "status_code": "confirmed",
+  "created_at": "2026-05-14T10:00:00+08:00",
+  "source": "pr"
+}
+```
+
+### Auto-correction rules
+
+The runtime normalizes these common mistakes before validation and logs a `baton_auto_corrected` warning event with the original and corrected values:
+
+| Field | Wrong value(s) | Corrected to | Condition |
+| --- | --- | --- | --- |
+| `to_owner` | `human`, `reviewer`, `developer` | `user` | always |
+| `to_owner` | any | `done` | when `to_step == "done"` |
+| `intent` | `complete`, `confirmed`, `done` | `workflow_complete` | when `to_step == "done"` |
+| `intent` | `confirmed` | `await_agent` | when `to_step` is a playbook step |

--- a/tests/integration/test_baton_auto_correction_e2e.py
+++ b/tests/integration/test_baton_auto_correction_e2e.py
@@ -1,0 +1,94 @@
+"""整合測試：baton auto-correction — agent 寫入無效 to_owner 後 runtime 自動修正並繼續推進。"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from cafe.core.blackboard import BlackboardStore, HandoffIntent, HandoffOwner
+from cafe.core.workflow_models import StepExecutionResult
+from cafe.core.workflow_runtime import BlackboardWorkflowRuntime
+from cafe.playbooks.loader import PlaybookLoader
+
+
+def _load_default_playbook() -> dict:
+    return PlaybookLoader().load("default")
+
+
+def _write_raw_baton(issue_dir: Path, payload: dict) -> None:
+    """直接寫入 next_step.txt，模擬 agent 寫出錯誤 baton。"""
+    (issue_dir / "next_step.txt").write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+
+
+class TestBatonAutoCorrectionE2E:
+    def test_agent_writes_to_owner_human_runtime_autocorrects_and_continues(self, tmp_path: Path) -> None:
+        """agent 寫 to_owner='human' 的 baton，runtime 應自動修正為 'user' 並繼續 workflow。
+
+        測試流程：
+        1. 初始化 BlackboardWorkflowRuntime 從 spec 步驟開始
+        2. spec 步驟執行後，模擬 agent 寫入 to_owner='human' 的 baton（應指向 user）
+        3. runtime 下一輪 load_handoff_contract 應自動修正為 to_owner='user'
+        4. blackboard 中應出現 baton_auto_corrected 事件，workflow 不報錯並暫停在 user
+        """
+        issue_dir = tmp_path / ".cafe" / "issues" / "issue-autocorrect-e2e"
+        issue_dir.mkdir(parents=True)
+        playbook = _load_default_playbook()
+
+        spec_executed = []
+
+        def executor(step_name: str, step_def: dict, state) -> StepExecutionResult:
+            if step_name == "spec":
+                spec_executed.append(step_name)
+                # 模擬 agent 在 spec 完成後寫入 to_owner='human' 的錯誤 baton
+                _write_raw_baton(
+                    issue_dir,
+                    {
+                        "version": 1,
+                        "from_step": "spec",
+                        "to_owner": "human",
+                        "to_step": "user",
+                        "intent": "need_clarification",
+                        "status_code": "",
+                        "created_at": "2026-05-14T10:00:00+08:00",
+                        "source": "spec.agent",
+                    },
+                )
+            return StepExecutionResult(
+                response="confirmed",
+                artifacts={str(step_def.get("output_artifact", step_name)): f"{step_name}/output.md"},
+                status_code="confirmed",
+                events=[],
+            )
+
+        runtime = BlackboardWorkflowRuntime(
+            issue_dir=issue_dir,
+            playbook=playbook,
+            executor=executor,
+        )
+
+        # run 應在 user 暫停（不拋出例外）
+        result = runtime.run(start_step="spec", max_transitions=5)
+
+        assert not result.completed, "workflow 應暫停在 user，尚未完成"
+
+        store = BlackboardStore(issue_dir)
+        state = store.load_or_create("spec")
+
+        # 驗證 spec 步驟確實執行過
+        assert "spec" in spec_executed
+
+        # 驗證 baton_auto_corrected 事件已寫入 blackboard
+        auto_events = [e for e in state.events if e.event_type == "baton_auto_corrected"]
+        assert len(auto_events) >= 1, "應至少有一筆 baton_auto_corrected 事件"
+
+        # 驗證事件 data 同時包含 original 與 corrected 值
+        corrections = auto_events[0].data.get("corrections", [])
+        assert any(
+            c.get("field") == "to_owner" and c.get("original") == "human" and c.get("corrected") == "user"
+            for c in corrections
+        ), f"corrections 應包含 to_owner human→user 的修正記錄，實際：{corrections}"

--- a/tests/unit/test_workflow_models.py
+++ b/tests/unit/test_workflow_models.py
@@ -3,7 +3,189 @@
 import json
 from pathlib import Path
 
-from cafe.core.blackboard import ArtifactEntry, ArtifactKind, BlackboardState, BlackboardStore, HandoffOwner
+import pytest
+
+from cafe.core.blackboard import (
+    ArtifactEntry,
+    ArtifactKind,
+    BlackboardState,
+    BlackboardStore,
+    HandoffIntent,
+    HandoffOwner,
+    _normalize_baton_payload,
+)
+
+
+# ---------------------------------------------------------------------------
+# _normalize_baton_payload 單元測試
+# ---------------------------------------------------------------------------
+
+def _base_payload(**overrides) -> dict:
+    """最小合法 payload，方便各測試覆寫特定欄位。"""
+    base = {
+        "version": 1,
+        "from_step": "develop",
+        "to_owner": "agent",
+        "to_step": "review",
+        "intent": "await_agent",
+        "status_code": "",
+        "created_at": "2026-05-14T10:00:00+08:00",
+        "source": "test",
+    }
+    base.update(overrides)
+    return base
+
+
+class TestNormalizeBatonPayload:
+    # --- Task 1: to_owner 通用映射 ---
+
+    def test_to_owner_human_normalized_to_user(self) -> None:
+        """to_owner='human' 應正規化為 'user'。"""
+        payload = _base_payload(to_owner="human", to_step="user")
+        normalized, corrections = _normalize_baton_payload(payload)
+        assert normalized["to_owner"] == "user"
+        assert len(corrections) == 1
+        assert corrections[0]["field"] == "to_owner"
+        assert corrections[0]["original"] == "human"
+        assert corrections[0]["corrected"] == "user"
+
+    def test_to_owner_reviewer_normalized_to_user(self) -> None:
+        """to_owner='reviewer' 應正規化為 'user'。"""
+        payload = _base_payload(to_owner="reviewer", to_step="user")
+        normalized, corrections = _normalize_baton_payload(payload)
+        assert normalized["to_owner"] == "user"
+        assert any(c["field"] == "to_owner" and c["corrected"] == "user" for c in corrections)
+
+    def test_to_owner_developer_normalized_to_user(self) -> None:
+        """to_owner='developer' 應正規化為 'user'。"""
+        payload = _base_payload(to_owner="developer", to_step="user")
+        normalized, corrections = _normalize_baton_payload(payload)
+        assert normalized["to_owner"] == "user"
+        assert any(c["field"] == "to_owner" and c["corrected"] == "user" for c in corrections)
+
+    # --- Task 2: to_step==done 修正 ---
+
+    def test_to_owner_forced_to_done_when_to_step_is_done(self) -> None:
+        """to_step='done' 時，to_owner 應強制改為 'done'。"""
+        payload = _base_payload(to_owner="agent", to_step="done", intent="workflow_complete")
+        normalized, corrections = _normalize_baton_payload(payload)
+        assert normalized["to_owner"] == "done"
+        assert any(c["field"] == "to_owner" and c["corrected"] == "done" for c in corrections)
+
+    def test_intent_complete_corrected_when_to_step_done(self) -> None:
+        """to_step='done' 且 intent='complete' 時，應修正為 'workflow_complete'。"""
+        payload = _base_payload(to_owner="done", to_step="done", intent="complete")
+        normalized, corrections = _normalize_baton_payload(payload)
+        assert normalized["intent"] == "workflow_complete"
+        assert any(c["field"] == "intent" and c["corrected"] == "workflow_complete" for c in corrections)
+
+    def test_intent_confirmed_corrected_when_to_step_done(self) -> None:
+        """to_step='done' 且 intent='confirmed' 時，應修正為 'workflow_complete'。"""
+        payload = _base_payload(to_owner="done", to_step="done", intent="confirmed")
+        normalized, corrections = _normalize_baton_payload(payload)
+        assert normalized["intent"] == "workflow_complete"
+
+    def test_intent_done_corrected_when_to_step_done(self) -> None:
+        """to_step='done' 且 intent='done' 時，應修正為 'workflow_complete'。"""
+        payload = _base_payload(to_owner="done", to_step="done", intent="done")
+        normalized, corrections = _normalize_baton_payload(payload)
+        assert normalized["intent"] == "workflow_complete"
+
+    def test_intent_other_not_corrected_when_to_step_done(self) -> None:
+        """to_step='done' 但 intent 為其他合法值時，不應被修改。"""
+        payload = _base_payload(to_owner="done", to_step="done", intent="manual_handoff")
+        normalized, corrections = _normalize_baton_payload(payload)
+        assert normalized["intent"] == "manual_handoff"
+        assert not any(c["field"] == "intent" for c in corrections)
+
+    # --- Task 3: playbook step intent 修正 ---
+
+    def test_intent_confirmed_corrected_to_await_agent_for_playbook_step(self) -> None:
+        """to_step 為 playbook step 且 intent='confirmed' 時，應修正為 'await_agent'。"""
+        payload = _base_payload(to_owner="agent", to_step="review", intent="confirmed")
+        normalized, corrections = _normalize_baton_payload(payload)
+        assert normalized["intent"] == "await_agent"
+        assert any(c["field"] == "intent" and c["corrected"] == "await_agent" for c in corrections)
+
+    def test_intent_confirmed_not_corrected_when_to_step_user(self) -> None:
+        """to_step='user' 時，intent='confirmed' 不應套用 playbook-step 規則。"""
+        payload = _base_payload(to_owner="user", to_step="user", intent="confirmed")
+        normalized, corrections = _normalize_baton_payload(payload)
+        # to_step='user' 不是 playbook step，不應被 playbook-step 規則修改
+        assert normalized["intent"] == "confirmed"
+        assert not any(c["field"] == "intent" and c["corrected"] == "await_agent" for c in corrections)
+
+    # --- Task 4: 有效 baton 不變動 ---
+
+    def test_valid_baton_passes_through_unchanged(self) -> None:
+        """合法 baton payload 不應被修改，correction 清單應為空。"""
+        payload = _base_payload(to_owner="agent", to_step="review", intent="await_agent")
+        normalized, corrections = _normalize_baton_payload(payload)
+        assert normalized == payload
+        assert corrections == []
+
+    def test_corrections_include_original_and_corrected_values(self) -> None:
+        """每筆 correction 必須同時包含 original 與 corrected 欄位。"""
+        payload = _base_payload(to_owner="human", to_step="user")
+        _, corrections = _normalize_baton_payload(payload)
+        for c in corrections:
+            assert "field" in c
+            assert "original" in c
+            assert "corrected" in c
+
+
+# ---------------------------------------------------------------------------
+# BlackboardStore.load_handoff_contract 整合測試（使用 tmp_path）
+# ---------------------------------------------------------------------------
+
+def _write_baton(issue_dir: Path, payload: dict) -> None:
+    """將 payload 寫入 next_step.txt。"""
+    (issue_dir / "next_step.txt").write_text(
+        json.dumps(payload, ensure_ascii=False), encoding="utf-8"
+    )
+
+
+class TestLoadHandoffContractNormalization:
+    def test_auto_corrects_to_owner_human_and_logs_event(self, tmp_path: Path) -> None:
+        """load_handoff_contract 應自動修正 to_owner=human 並記錄 baton_auto_corrected 事件。"""
+        issue_dir = tmp_path / "issue-norm-1"
+        issue_dir.mkdir(parents=True)
+        store = BlackboardStore(issue_dir)
+        state = store.load_or_create("develop")
+        _write_baton(issue_dir, _base_payload(to_owner="human", to_step="user", intent="need_clarification"))
+
+        contract = store.load_handoff_contract(state, allowed_steps=["develop", "review"])
+
+        assert contract.to_owner == HandoffOwner.USER
+        auto_events = [e for e in state.events if e.event_type == "baton_auto_corrected"]
+        assert len(auto_events) == 1
+        corrections = auto_events[0].data.get("corrections", [])
+        assert any(c["field"] == "to_owner" and c["original"] == "human" and c["corrected"] == "user" for c in corrections)
+
+    def test_valid_baton_no_event_logged(self, tmp_path: Path) -> None:
+        """合法 baton 通過 load_handoff_contract 後不應有 baton_auto_corrected 事件。"""
+        issue_dir = tmp_path / "issue-norm-2"
+        issue_dir.mkdir(parents=True)
+        store = BlackboardStore(issue_dir)
+        state = store.load_or_create("develop")
+        _write_baton(issue_dir, _base_payload(to_owner="agent", to_step="review", intent="await_agent"))
+
+        contract = store.load_handoff_contract(state, allowed_steps=["develop", "review"])
+
+        assert contract.to_owner == HandoffOwner.AGENT
+        assert not any(e.event_type == "baton_auto_corrected" for e in state.events)
+
+    def test_corrected_but_still_invalid_raises(self, tmp_path: Path) -> None:
+        """修正後仍不合法的 baton（to_step 不在 allowed_steps）應拋出 ValueError。"""
+        issue_dir = tmp_path / "issue-norm-3"
+        issue_dir.mkdir(parents=True)
+        store = BlackboardStore(issue_dir)
+        state = store.load_or_create("develop")
+        # to_owner='human' 會被修正為 'user'，但 to_step='nonexistent' 不在 allowed_steps
+        _write_baton(issue_dir, _base_payload(to_owner="human", to_step="nonexistent", intent="await_agent"))
+
+        with pytest.raises(ValueError):
+            store.load_handoff_contract(state, allowed_steps=["develop", "review"])
 
 
 def test_blackboard_load_or_create_persists_current_step_and_playbook(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Workflow batons often contain invalid enum values when agents make common mistakes (e.g. using `human` instead of `user` for `to_owner`). This PR adds a normalization layer inside `BlackboardStore.load_handoff_contract` that auto-corrects these values before validation, logs a `baton_auto_corrected` event with original/corrected values, then still validates the corrected baton. Agents no longer crash the workflow with a simple typo, and operators get visibility into what was fixed via blackboard events.

Alongside the runtime fix, `workflow-common/SKILL.md` gains a formal **Baton Schema** reference section listing valid enum values, example JSON for each common transition type, and the auto-correction rules.

## Changes

- **Normalization helper** (`src/cafe/core/blackboard.py`): Added `_normalize_baton_payload()` implementing four correction rules:
  - `to_owner` alias mapping: `human`/`reviewer`/`developer` → `user`
  - `to_step == "done"`: force `to_owner = "done"`
  - `to_step == "done"`: correct `intent` from `complete`/`confirmed`/`done` → `workflow_complete`
  - Playbook step with `intent == "confirmed"` → `await_agent`
- **Integration with load_handoff_contract**: Calls normalization before `HandoffContract.from_dict`; logs `baton_auto_corrected` event when corrections occur
- **Unit tests** (`tests/unit/test_workflow_models.py`): 15 new tests covering each mapping rule, valid pass-through, post-correction validation, and event logging
- **Integration test** (`tests/integration/test_baton_auto_correction_e2e.py`): E2E verification that agent writes `to_owner: "human"` → runtime auto-corrects → workflow continues without error
- **Baton Schema documentation** (`src/cafe/data/skills/workflow-common/SKILL.md`): New section with valid enum values, example JSON for 5 transition types, auto-correction rule table

## Test Plan

- Unit tests: 1944 passed (existing + 15 new), 5 skipped, 1 xfailed
- Integration test: Confirms `to_owner: "human"` auto-correction and workflow continuation
- All tests pass with no regressions