### PR TITLE
refactor: rename context.json to iteration.json + slim iteration dirs

### DIFF
--- a/src/cafe/core/phase.py
+++ b/src/cafe/core/phase.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import json
+import logging
 from abc import ABC, abstractmethod
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from cafe.core.git import GitOperations
@@ -170,8 +173,8 @@ class Phase(PhaseStateMixin, PhaseCodexMixin, PhaseReviewMixin, PhaseChecklistMi
         if phase_specific_data:
             context_data.update(phase_specific_data)
 
-        # Save as context.json file
-        context_file = iteration_dir / "context.json"
+        # Save as iteration.json file
+        context_file = iteration_dir / "iteration.json"
         with open(context_file, "w", encoding="utf-8") as f:
             json.dump(context_data, f, ensure_ascii=False, indent=2)
 
@@ -232,7 +235,7 @@ class Phase(PhaseStateMixin, PhaseCodexMixin, PhaseReviewMixin, PhaseChecklistMi
         # Get iteration directory and context file
         iteration_dir = self._get_iteration_dir(self.iteration)
         iteration_dir.mkdir(parents=True, exist_ok=True)
-        context_file = iteration_dir / "context.json"
+        context_file = self._resolve_iteration_context_file(iteration_dir)
 
         # Read existing context data
         if context_file.exists():
@@ -302,12 +305,13 @@ class Phase(PhaseStateMixin, PhaseCodexMixin, PhaseReviewMixin, PhaseChecklistMi
         # Save end_time for this iteration
         context_data["end_time"] = datetime.now().astimezone().isoformat()
 
-        # Save updated context.json file
+        # Save updated iteration.json file
+        context_file = iteration_dir / "iteration.json"
         with open(context_file, "w", encoding="utf-8") as f:
             json.dump(context_data, f, ensure_ascii=False, indent=2)
 
         # Note: streaming.jsonl is saved earlier in _execute_agent_iteration
-        # to preserve raw format before context.json processing
+        # to preserve raw format before iteration.json processing
 
         # Append one record to iterations.jsonl
         iteration_index_data = {
@@ -541,9 +545,9 @@ class Phase(PhaseStateMixin, PhaseCodexMixin, PhaseReviewMixin, PhaseChecklistMi
             if key in {"CODEX_HOME", "CLAUDE_CONFIG_DIR", "GEMINI_HOME", "COPILOT_HOME"}
         }
 
-        # 3. Save prompt to context.json (before executing agent)
+        # 3. Save prompt to iteration.json (before executing agent)
         iteration_dir = self._get_iteration_dir(self.iteration)
-        context_file = iteration_dir / "context.json"
+        context_file = self._resolve_iteration_context_file(iteration_dir)
         if context_file.exists():
             with open(context_file, "r", encoding="utf-8") as f:
                 context_data = json.load(f)
@@ -1052,7 +1056,10 @@ class Phase(PhaseStateMixin, PhaseCodexMixin, PhaseReviewMixin, PhaseChecklistMi
         if not phase_dir.exists():
             return None
 
-        for context_file in reversed(sorted(phase_dir.glob("iteration_*/context.json"))):
+        for context_file in reversed(sorted(
+            [self._resolve_iteration_context_file(d) for d in phase_dir.glob("iteration_*") if d.is_dir()],
+            key=lambda p: p.parent.name,
+        )):
             try:
                 with open(context_file, "r", encoding="utf-8") as f:
                     context = json.load(f)
@@ -1135,6 +1142,27 @@ class Phase(PhaseStateMixin, PhaseCodexMixin, PhaseReviewMixin, PhaseChecklistMi
         print("=" * 60)
         print()
 
+    def _resolve_iteration_context_file(self, iteration_dir: Path) -> Path:
+        """Return the iteration context file path, with backward-compatible fallback.
+
+        Prefers iteration.json; falls back to context.json (old name) with a
+        deprecation warning. Returns the iteration.json path even when neither
+        file exists (callers should check .exists() before reading).
+        """
+        new_path = iteration_dir / "iteration.json"
+        if new_path.exists():
+            return new_path
+
+        old_path = iteration_dir / "context.json"
+        if old_path.exists():
+            logger.warning(
+                "[deprecation] context.json found in %s; please rename to iteration.json",
+                iteration_dir,
+            )
+            return old_path
+
+        return new_path
+
     def _load_previous_iteration_data(self) -> Optional[dict]:
         """Load previous round iteration data (common method).
 
@@ -1150,7 +1178,7 @@ class Phase(PhaseStateMixin, PhaseCodexMixin, PhaseReviewMixin, PhaseChecklistMi
             return None
 
         prev_iteration_dir = self._get_iteration_dir(self.iteration - 1)
-        prev_context_file = prev_iteration_dir / "context.json"
+        prev_context_file = self._resolve_iteration_context_file(prev_iteration_dir)
         if not prev_context_file.exists():
             return None
 
@@ -1171,7 +1199,7 @@ class Phase(PhaseStateMixin, PhaseCodexMixin, PhaseReviewMixin, PhaseChecklistMi
             raise AttributeError("Phase must have 'phase_dir' attribute")
 
         current_iteration_dir = self._get_iteration_dir(self.iteration)
-        current_context_file = current_iteration_dir / "context.json"
+        current_context_file = self._resolve_iteration_context_file(current_iteration_dir)
         if not current_context_file.exists():
             return None
 
@@ -1202,14 +1230,14 @@ class Phase(PhaseStateMixin, PhaseCodexMixin, PhaseReviewMixin, PhaseChecklistMi
                 # Return last iteration number
                 return iterations[-1].get("iteration", 0)
 
-        # Fallback: read from iteration_XXX/context.json
+        # Fallback: read from iteration_XXX/iteration.json (or context.json)
         iteration_dirs = sorted(phase_dir.glob("iteration_*"))
         if not iteration_dirs:
             return 0
 
         # Search from back to front for first complete iteration
         for iteration_dir in reversed(iteration_dirs):
-            context_file = iteration_dir / "context.json"
+            context_file = self._resolve_iteration_context_file(iteration_dir)
             if not context_file.exists():
                 continue
 
@@ -1411,9 +1439,9 @@ class Phase(PhaseStateMixin, PhaseCodexMixin, PhaseReviewMixin, PhaseChecklistMi
                 if final_status_code is not None:
                     status_code = final_status_code
 
-                # Checklist validation passed - now we can save status_code to context.json
+                # Checklist validation passed - now we can save status_code to iteration.json
                 iteration_dir = self._get_iteration_dir(self.iteration)
-                context_file = iteration_dir / "context.json"
+                context_file = self._resolve_iteration_context_file(iteration_dir)
                 if context_file.exists():
                     with open(context_file, "r", encoding="utf-8") as f:
                         context_data = json.load(f)
@@ -1429,11 +1457,11 @@ class Phase(PhaseStateMixin, PhaseCodexMixin, PhaseReviewMixin, PhaseChecklistMi
                 print(f"⚠️  Checklist validation failed after maximum retries")
                 # Continue with original response and status_code
         else:
-            # No checklist validation needed - save status_code to context.json directly
+            # No checklist validation needed - save status_code to iteration.json directly
             if status_code is None:
                 raise ValueError(f"Failed to extract status code from agent response in iteration {self.iteration}")
             iteration_dir = self._get_iteration_dir(self.iteration)
-            context_file = iteration_dir / "context.json"
+            context_file = self._resolve_iteration_context_file(iteration_dir)
             if context_file.exists():
                 with open(context_file, "r", encoding="utf-8") as f:
                     context_data = json.load(f)

--- a/src/cafe/core/phase_checklist_mixin.py
+++ b/src/cafe/core/phase_checklist_mixin.py
@@ -78,7 +78,7 @@ class PhaseChecklistMixin:
             # If still not found after rebuild attempt, skip validation
             print(f"⚠️  Checklist file still not found after rebuild, skipping validation")
             # Get current response from context
-            context_file = iteration_dir / "context.json"
+            context_file = self._resolve_iteration_context_file(iteration_dir)
             if context_file.exists():
                 with open(context_file, "r", encoding="utf-8") as f:
                     context_data = json.load(f)
@@ -93,7 +93,7 @@ class PhaseChecklistMixin:
         if result.is_complete:
             print(f"✅ Checklist validation passed - all items completed")
             # Get current response from context
-            context_file = iteration_dir / "context.json"
+            context_file = self._resolve_iteration_context_file(iteration_dir)
             if context_file.exists():
                 with open(context_file, "r", encoding="utf-8") as f:
                     context_data = json.load(f)
@@ -150,7 +150,7 @@ Do NOT return a status code until ALL checklist items are marked as complete [x]
                     print(f"✅ Checklist validation passed after retry {retry_count}")
 
                     # Merge streaming logs
-                    context_file = iteration_dir / "context.json"
+                    context_file = self._resolve_iteration_context_file(iteration_dir)
                     original_streaming_log = []
                     original_response = ""
                     if context_file.exists():
@@ -169,7 +169,7 @@ Do NOT return a status code until ALL checklist items are marked as complete [x]
                             for log_entry in retry_streaming_log:
                                 f.write(json.dumps(log_entry, ensure_ascii=False) + "\n")
 
-                    # Update context.json with final response and merged streaming_log
+                    # Update iteration.json with final response and merged streaming_log
                     # Note: response is NOT merged, only keep the last one
                     if context_file.exists():
                         with open(context_file, "r", encoding="utf-8") as f:
@@ -203,7 +203,7 @@ Do NOT return a status code until ALL checklist items are marked as complete [x]
         print(f"   Please complete the checklist manually and re-run the command.")
 
         # Return the last response and status code
-        context_file = iteration_dir / "context.json"
+        context_file = self._resolve_iteration_context_file(iteration_dir)
         if context_file.exists():
             with open(context_file, "r", encoding="utf-8") as f:
                 context_data = json.load(f)

--- a/src/cafe/core/phase_state_mixin.py
+++ b/src/cafe/core/phase_state_mixin.py
@@ -204,7 +204,11 @@ class PhaseStateMixin:
         if not phase_dir.exists():
             return 1
 
-        existing_iterations = sorted(phase_dir.glob("iteration_*/context.json"))
+        iter_dirs = sorted(d for d in phase_dir.glob("iteration_*") if d.is_dir())
+        existing_iterations = [
+            d for d in iter_dirs
+            if (d / "iteration.json").exists() or (d / "context.json").exists()
+        ]
         if not existing_iterations:
             return 1
 
@@ -213,7 +217,12 @@ class PhaseStateMixin:
         if count >= 999:
             raise ValueError("Cannot exceed 999")
 
-        last_context_file = existing_iterations[-1]
+        last_iter_dir = existing_iterations[-1]
+        last_context_file = (
+            last_iter_dir / "iteration.json"
+            if (last_iter_dir / "iteration.json").exists()
+            else last_iter_dir / "context.json"
+        )
         try:
             with open(last_context_file, "r", encoding="utf-8") as f:
                 last_iteration_data = json.load(f)

--- a/src/cafe/phases/develop_phase.py
+++ b/src/cafe/phases/develop_phase.py
@@ -166,7 +166,7 @@ class DevelopPhase(Phase):
             return None
 
         for iteration_dir in reversed(sorted(review_dir.glob("iteration_*"))):
-            context_file = iteration_dir / "context.json"
+            context_file = self._resolve_iteration_context_file(iteration_dir)
             if not context_file.exists():
                 continue
             try:
@@ -266,7 +266,7 @@ class DevelopPhase(Phase):
             return None
 
         for iteration_dir in reversed(sorted(pr_dir.glob("iteration_*"))):
-            context_file = iteration_dir / "context.json"
+            context_file = self._resolve_iteration_context_file(iteration_dir)
             if not context_file.exists():
                 continue
             try:
@@ -1147,7 +1147,7 @@ Do NOT return any other status code until you have written your reasoning."""
                             merged_response = response + "\n\n[Reasoning Request]\n" + continuation_response
 
                             # Get streaming logs and prompt from context
-                            context_file = iteration_dir / "context.json"
+                            context_file = self._resolve_iteration_context_file(iteration_dir)
                             original_streaming_log = []
                             original_prompt = ""
                             if context_file.exists():

--- a/src/cafe/phases/plan_phase.py
+++ b/src/cafe/phases/plan_phase.py
@@ -122,7 +122,11 @@ class PlanPhase(Phase):
                 )
 
             # Check if this is first iteration (no history files or plan files)
-            has_history = bool(list(self.phase_dir.glob("iteration_*/context.json")))
+            has_history = any(
+                (d / "iteration.json").exists() or (d / "context.json").exists()
+                for d in self.phase_dir.glob("iteration_*")
+                if d.is_dir()
+            )
             is_first_iteration = not has_history
 
             # First iteration requires template (unless template_mode is 'auto')

--- a/src/cafe/phases/pr_phase.py
+++ b/src/cafe/phases/pr_phase.py
@@ -311,7 +311,7 @@ class PRPhase(Phase):
 
         # Check the last iteration - if it has no completion marker, it's incomplete
         last_iter_dir = iteration_dirs[-1]
-        context_file = last_iter_dir / "context.json"
+        context_file = self._resolve_iteration_context_file(last_iter_dir)
 
         if context_file.exists():
             with open(context_file, "r", encoding="utf-8") as f:
@@ -364,7 +364,7 @@ class PRPhase(Phase):
         status_code = None
 
         for iter_dir in reversed(iteration_dirs):
-            context_file = iter_dir / "context.json"
+            context_file = self._resolve_iteration_context_file(iter_dir)
             if context_file.exists():
                 with open(context_file, "r", encoding="utf-8") as f:
                     context = json.load(f)
@@ -420,9 +420,9 @@ class PRPhase(Phase):
         if not iteration_dirs:
             return set()
 
-        # Legacy fallback: search old context.json snapshots
+        # Legacy fallback: search iteration snapshots
         for iter_dir in reversed(iteration_dirs):
-            context_file = iter_dir / "context.json"
+            context_file = self._resolve_iteration_context_file(iter_dir)
             if not context_file.exists():
                 continue
             try:
@@ -447,7 +447,7 @@ class PRPhase(Phase):
 
         iteration_dirs = sorted(develop_dir.glob("iteration_*"))
         for iter_dir in reversed(iteration_dirs):
-            context_file = iter_dir / "context.json"
+            context_file = self._resolve_iteration_context_file(iter_dir)
             if not context_file.exists():
                 continue
             try:

--- a/src/cafe/phases/review_phase.py
+++ b/src/cafe/phases/review_phase.py
@@ -183,7 +183,7 @@ class ReviewPhase(Phase):
                 iteration_dirs = sorted(pr_dir.glob("iteration_*"))
                 # Search backwards for the latest iteration with a completed status_code
                 for iteration_dir_pr in reversed(iteration_dirs):
-                    context_file = iteration_dir_pr / "context.json"
+                    context_file = self._resolve_iteration_context_file(iteration_dir_pr)
                     if not context_file.exists():
                         continue
                     with open(context_file, "r", encoding="utf-8") as f:

--- a/src/cafe/phases/spec_phase.py
+++ b/src/cafe/phases/spec_phase.py
@@ -153,9 +153,14 @@ class SpecPhase(Phase):
 
         # Load phase-specific data from last iteration
         if self.iteration > 0:
-            existing_iterations = sorted(self.phase_dir.glob("iteration_*/context.json"))
+            iter_dirs = sorted(d for d in self.phase_dir.glob("iteration_*") if d.is_dir())
+            existing_iterations = [
+                d for d in iter_dirs
+                if (d / "iteration.json").exists() or (d / "context.json").exists()
+            ]
             if existing_iterations:
-                last_context_file = existing_iterations[-1]
+                last_iter_dir = existing_iterations[-1]
+                last_context_file = self._resolve_iteration_context_file(last_iter_dir)
                 with open(last_context_file, "r", encoding="utf-8") as f:
                     last_data = json.load(f)
                 if "confirmed_requirements" in last_data:

--- a/src/cafe/services/summary_service.py
+++ b/src/cafe/services/summary_service.py
@@ -82,12 +82,16 @@ class SummaryService:
 
         iterations = []
 
-        # Read from context.json files in each iteration directory
+        # Read from iteration.json files (with context.json fallback) in each iteration directory
         for iteration_dir in sorted(phase_dir.glob("iteration_*")):
             if not iteration_dir.is_dir():
                 continue
 
-            context_file = iteration_dir / "context.json"
+            context_file = (
+                iteration_dir / "iteration.json"
+                if (iteration_dir / "iteration.json").exists()
+                else iteration_dir / "context.json"
+            )
             if not context_file.exists():
                 continue
 

--- a/src/cafe/ui/cli_shared.py
+++ b/src/cafe/ui/cli_shared.py
@@ -45,7 +45,7 @@ VALID_CONTENT_TYPES = [
 ]
 
 CONTENT_TYPE_FILE_MAP = {
-    "context": "context.json",
+    "context": "iteration.json",
     "output": "output.md",
     "streaming": "streaming.jsonl",
     "error": "error.json",
@@ -249,13 +249,17 @@ def resolve_iteration_number(phase_dir: Path, iteration_input: int, content_type
     if not filename:
         raise ValueError(f"Unknown content type: {content_type}")
 
-    all_iteration_files = sorted(phase_dir.glob("iteration_*/context.json"))
-    if not all_iteration_files:
+    iter_dirs = sorted(d for d in phase_dir.glob("iteration_*") if d.is_dir())
+    existing_iter_dirs = [
+        d for d in iter_dirs
+        if (d / "iteration.json").exists() or (d / "context.json").exists()
+    ]
+    if not existing_iter_dirs:
         raise ValueError(f"No iterations found in {phase_dir}")
 
     all_iteration_numbers = []
-    for file_path in all_iteration_files:
-        dir_name = file_path.parent.name
+    for iter_dir in existing_iter_dirs:
+        dir_name = iter_dir.name
         if dir_name.startswith("iteration_"):
             try:
                 num = int(dir_name.split("_")[1])
@@ -531,7 +535,12 @@ def _find_incomplete_workflow_step(*, issue_dir: Path, playbook_data: Dict[str, 
         if not iteration_dirs:
             continue
 
-        context_file = iteration_dirs[-1] / "context.json"
+        last_iter_dir = iteration_dirs[-1]
+        context_file = (
+            last_iter_dir / "iteration.json"
+            if (last_iter_dir / "iteration.json").exists()
+            else last_iter_dir / "context.json"
+        )
         if not context_file.exists():
             continue
 

--- a/src/cafe/ui/commands/lifecycle.py
+++ b/src/cafe/ui/commands/lifecycle.py
@@ -1429,8 +1429,13 @@ def reset(
             iterations_file = phase_dir / "iterations.jsonl"
 
             if target_iteration > 0:
-                # Read target iteration's context.json to get status_code
-                target_context_file = phase_dir / f"iteration_{target_iteration:03d}" / "context.json"
+                # Read target iteration's iteration.json (with context.json fallback) to get status_code
+                _iter_dir = phase_dir / f"iteration_{target_iteration:03d}"
+                target_context_file = (
+                    _iter_dir / "iteration.json"
+                    if (_iter_dir / "iteration.json").exists()
+                    else _iter_dir / "context.json"
+                )
                 target_status_code = None
                 target_timestamp = None
                 target_end_time = None

--- a/src/cafe/ui/commands/workflow.py
+++ b/src/cafe/ui/commands/workflow.py
@@ -441,13 +441,23 @@ def workflow(
     try:
         def _predict_next_iteration(issue_root: Path, step_name: str) -> int:
             step_dir = issue_root / step_name
-            existing = sorted(step_dir.glob("iteration_*/context.json"))
+            iter_dirs = sorted(d for d in step_dir.glob("iteration_*") if d.is_dir())
+            existing = [
+                d for d in iter_dirs
+                if (d / "iteration.json").exists() or (d / "context.json").exists()
+            ]
             if not existing:
                 return 1
             count = len(existing)
             try:
                 import json as _json
-                last_data = _json.loads(existing[-1].read_text(encoding="utf-8"))
+                last_dir = existing[-1]
+                last_file = (
+                    last_dir / "iteration.json"
+                    if (last_dir / "iteration.json").exists()
+                    else last_dir / "context.json"
+                )
+                last_data = _json.loads(last_file.read_text(encoding="utf-8"))
                 if not last_data.get("status_code"):
                     return last_data.get("iteration", count)
             except Exception:

--- a/src/cafe/utils/github.py
+++ b/src/cafe/utils/github.py
@@ -1099,7 +1099,11 @@ def load_pr_last_seen_comment_ids(pr_dir: Path) -> Set[str]:
 
     iteration_dirs = sorted(pr_dir.glob("iteration_*"))
     for iter_dir in reversed(iteration_dirs):
-        context_file = iter_dir / "context.json"
+        context_file = (
+            iter_dir / "iteration.json"
+            if (iter_dir / "iteration.json").exists()
+            else iter_dir / "context.json"
+        )
         if not context_file.exists():
             continue
         try:
@@ -1140,7 +1144,11 @@ def get_processed_comment_ids_from_history(phase_dir: "Path") -> set:
         if not item.is_dir() or not item.name.startswith("iteration_"):
             continue
 
-        context_file = item / "context.json"
+        context_file = (
+            item / "iteration.json"
+            if (item / "iteration.json").exists()
+            else item / "context.json"
+        )
         if not context_file.exists():
             continue
 

--- a/tests/unit/test_checklist_validation_status_code.py
+++ b/tests/unit/test_checklist_validation_status_code.py
@@ -1,6 +1,6 @@
 """Test that _validate_and_retry_checklist_completion preserves status code
-when context.json response doesn't contain the status code (e.g., after
-a continue-execution merged the status code into the response but context.json
+when iteration.json response doesn't contain the status code (e.g., after
+a continue-execution merged the status code into the response but iteration.json
 wasn't updated yet).
 """
 
@@ -39,15 +39,15 @@ def phase(tmp_path):
 
 class TestChecklistValidationPreservesStatusCode:
     """Bug: when agent needs a continue-execution to produce a status code,
-    the merged response (with status code) is NOT saved to context.json before
+    the merged response (with status code) is NOT saved to iteration.json before
     checklist validation runs. _validate_and_retry_checklist_completion reads
-    context.json, re-extracts status code from the stale response, gets None,
+    iteration.json, re-extracts status code from the stale response, gets None,
     and returns (response, None, True). This causes the caller to lose the
     status code and ultimately fail with "No valid status code returned".
     """
 
     def test_returns_status_code_when_context_response_has_it(self, phase, tmp_path):
-        """When context.json response contains the status code, it should be extracted."""
+        """When iteration.json response contains the status code, it should be extracted."""
         iteration_dir = phase._get_iteration_dir(1)
         iteration_dir.mkdir(parents=True, exist_ok=True)
 
@@ -55,8 +55,8 @@ class TestChecklistValidationPreservesStatusCode:
         checklist = iteration_dir / "checklist.md"
         checklist.write_text("## Checklist\n\n[x] Task 1\n[x] Task 2\n")
 
-        # context.json has response WITH status code
-        context = iteration_dir / "context.json"
+        # iteration.json has response WITH status code
+        context = iteration_dir / "iteration.json"
         context.write_text(json.dumps({
             "response": "Done.\n\nneed_clarification",
         }))
@@ -72,7 +72,7 @@ class TestChecklistValidationPreservesStatusCode:
         assert status_code == PhaseStatusCode.NEED_CLARIFICATION
 
     def test_returns_none_when_context_response_missing_status_code(self, phase, tmp_path):
-        """When context.json response doesn't contain status code (stale after continue-execution),
+        """When iteration.json response doesn't contain status code (stale after continue-execution),
         _validate_and_retry_checklist_completion returns None for status_code.
         The caller (_execute_and_handle_agent_response) should preserve its own status_code.
         """
@@ -83,8 +83,8 @@ class TestChecklistValidationPreservesStatusCode:
         checklist = iteration_dir / "checklist.md"
         checklist.write_text("## Checklist\n\n[x] Task 1\n[x] Task 2\n")
 
-        # context.json has response WITHOUT status code (stale, pre-continue)
-        context = iteration_dir / "context.json"
+        # iteration.json has response WITHOUT status code (stale, pre-continue)
+        context = iteration_dir / "iteration.json"
         context.write_text(json.dumps({
             "response": "I'm working on the spec analysis...",
         }))
@@ -97,6 +97,6 @@ class TestChecklistValidationPreservesStatusCode:
         )
 
         assert passed is True
-        # Validation can't extract status code from stale context.json — returns None
+        # Validation can't extract status code from stale iteration.json — returns None
         assert status_code is None
         # The fix ensures the caller keeps its own status_code instead of overwriting with None

--- a/tests/unit/test_cli_show.py
+++ b/tests/unit/test_cli_show.py
@@ -22,7 +22,7 @@ class TestResolveIterationNumber:
         for i in [1, 2, 3]:
             iteration_dir = phase_dir / f"iteration_{i:03d}"
             iteration_dir.mkdir()
-            (iteration_dir / "context.json").write_text("{}")
+            (iteration_dir / "iteration.json").write_text("{}")
             (iteration_dir / "output.md").write_text(f"# Output {i}")
 
         # 測試正數迭代號碼
@@ -38,7 +38,7 @@ class TestResolveIterationNumber:
         for i in [1, 2, 3]:
             iteration_dir = phase_dir / f"iteration_{i:03d}"
             iteration_dir.mkdir()
-            (iteration_dir / "context.json").write_text("{}")
+            (iteration_dir / "iteration.json").write_text("{}")
             (iteration_dir / "output.md").write_text(f"# Output {i}")
 
         # 零應該返回最新的有該檔案的迭代號碼（3）
@@ -52,7 +52,7 @@ class TestResolveIterationNumber:
         for i in [1, 2, 3]:
             iteration_dir = phase_dir / f"iteration_{i:03d}"
             iteration_dir.mkdir()
-            (iteration_dir / "context.json").write_text("{}")
+            (iteration_dir / "iteration.json").write_text("{}")
             (iteration_dir / "output.md").write_text(f"# Output {i}")
 
         # -1 應該返回最新迭代的前一個（2）
@@ -68,7 +68,7 @@ class TestResolveIterationNumber:
         for i in [1, 2]:
             iteration_dir = phase_dir / f"iteration_{i:03d}"
             iteration_dir.mkdir()
-            (iteration_dir / "context.json").write_text("{}")
+            (iteration_dir / "iteration.json").write_text("{}")
             (iteration_dir / "output.md").write_text(f"# Output {i}")
 
         # 迭代號碼 5 不存在，應該拋出 ValueError
@@ -83,7 +83,7 @@ class TestResolveIterationNumber:
         for i in [1, 2]:
             iteration_dir = phase_dir / f"iteration_{i:03d}"
             iteration_dir.mkdir()
-            (iteration_dir / "context.json").write_text("{}")
+            (iteration_dir / "iteration.json").write_text("{}")
             (iteration_dir / "output.md").write_text(f"# Output {i}")
 
         # -5 超出範圍，應該拋出 ValueError
@@ -102,13 +102,13 @@ class TestResolveIterationNumber:
 
     def test_resolve_iteration_number_partial_files(self, tmp_path):
         """測試部分迭代有特定檔案的情況"""
-        # 準備測試資料：iteration 1-3 有 output.md，iteration 4 只有 context.json
+        # 準備測試資料：iteration 1-3 有 output.md，iteration 4 只有 iteration.json
         phase_dir = tmp_path / "spec"
         phase_dir.mkdir(parents=True)
         for i in [1, 2, 3, 4]:
             iteration_dir = phase_dir / f"iteration_{i:03d}"
             iteration_dir.mkdir()
-            (iteration_dir / "context.json").write_text("{}")
+            (iteration_dir / "iteration.json").write_text("{}")
             if i <= 3:  # 只有 1-3 有 output.md
                 (iteration_dir / "output.md").write_text(f"# Output {i}")
 
@@ -128,7 +128,7 @@ class TestGetShowFilePath:
         phase_dir = tmp_path / "spec"
 
         # 測試各種內容類型
-        assert _get_show_file_path(phase_dir, 1, "context") == phase_dir / "iteration_001" / "context.json"
+        assert _get_show_file_path(phase_dir, 1, "context") == phase_dir / "iteration_001" / "iteration.json"
         assert _get_show_file_path(phase_dir, 2, "output") == phase_dir / "iteration_002" / "output.md"
         assert _get_show_file_path(phase_dir, 3, "streaming") == phase_dir / "iteration_003" / "streaming.jsonl"
         assert _get_show_file_path(phase_dir, 1, "error") == phase_dir / "iteration_001" / "error.json"
@@ -156,7 +156,7 @@ class TestShowCommand:
         # 建立迭代目錄和檔案
         iteration_dir = issues_dir / "iteration_001"
         iteration_dir.mkdir()
-        (iteration_dir / "context.json").write_text("{}")
+        (iteration_dir / "iteration.json").write_text("{}")
         (iteration_dir / "output.md").write_text("# Test Output")
 
         # Mock git operations 和 config
@@ -184,7 +184,7 @@ class TestShowCommand:
         # 建立迭代目錄和檔案
         iteration_dir = issues_dir / "iteration_001"
         iteration_dir.mkdir()
-        (iteration_dir / "context.json").write_text('{"test": "context"}')
+        (iteration_dir / "iteration.json").write_text('{"test": "context"}')
 
         # Mock git operations 和 config
         with patch("cafe.ui.cli.GitOperations") as mock_git_cls, \
@@ -228,7 +228,7 @@ steps:
 
         iteration_dir = issues_dir / "iteration_001"
         iteration_dir.mkdir()
-        (iteration_dir / "context.json").write_text("{}")
+        (iteration_dir / "iteration.json").write_text("{}")
         (iteration_dir / "output.md").write_text("# QA Output")
 
         with patch("cafe.ui.cli.GitOperations") as mock_git_cls, \
@@ -254,7 +254,7 @@ steps:
         for i in [1, 2]:
             iteration_dir = issues_dir / f"iteration_{i:03d}"
             iteration_dir.mkdir()
-            (iteration_dir / "context.json").write_text("{}")
+            (iteration_dir / "iteration.json").write_text("{}")
             (iteration_dir / "output.md").write_text(f"# Iteration {i}")
 
         # Mock git operations 和 config
@@ -283,7 +283,7 @@ steps:
         for i in [1, 2, 3]:
             iteration_dir = issues_dir / f"iteration_{i:03d}"
             iteration_dir.mkdir()
-            (iteration_dir / "context.json").write_text("{}")
+            (iteration_dir / "iteration.json").write_text("{}")
             (iteration_dir / "output.md").write_text(f"# Iteration {i}")
 
         # Mock git operations 和 config
@@ -311,7 +311,7 @@ steps:
         # 建立迭代目錄但不建立 output.md
         iteration_dir = issues_dir / "iteration_001"
         iteration_dir.mkdir()
-        (iteration_dir / "context.json").write_text("{}")
+        (iteration_dir / "iteration.json").write_text("{}")
 
         # Mock git operations 和 config
         with patch("cafe.ui.cli.GitOperations") as mock_git_cls, \
@@ -337,7 +337,7 @@ steps:
         # 建立一個迭代
         iteration_dir = issues_dir / "iteration_001"
         iteration_dir.mkdir()
-        (iteration_dir / "context.json").write_text("{}")
+        (iteration_dir / "iteration.json").write_text("{}")
 
         # Mock git operations 和 config
         with patch("cafe.ui.cli.GitOperations") as mock_git_cls, \
@@ -393,7 +393,7 @@ class TestShowCommandChecklist:
         # Create iteration with checklist
         iteration_dir = issues_dir / "iteration_001"
         iteration_dir.mkdir()
-        (iteration_dir / "context.json").write_text("{}")
+        (iteration_dir / "iteration.json").write_text("{}")
         checklist_file = iteration_dir / "checklist.md"
         checklist_file.write_text("""## Execution Steps Checklist
 
@@ -428,7 +428,7 @@ class TestShowCommandChecklist:
         # Create iteration with checklist
         iteration_dir = issues_dir / "iteration_001"
         iteration_dir.mkdir()
-        (iteration_dir / "context.json").write_text("{}")
+        (iteration_dir / "iteration.json").write_text("{}")
         checklist_file = iteration_dir / "checklist.md"
         checklist_file.write_text("""## Execution Steps Checklist
 
@@ -462,7 +462,7 @@ class TestShowCommandChecklist:
         for i in [1, 2]:
             iteration_dir = issues_dir / f"iteration_{i:03d}"
             iteration_dir.mkdir()
-            (iteration_dir / "context.json").write_text("{}")
+            (iteration_dir / "iteration.json").write_text("{}")
             checklist_file = iteration_dir / "checklist.md"
             checklist_file.write_text(f"## Checklist for iteration {i}")
 
@@ -491,7 +491,7 @@ class TestShowCommandChecklist:
         # Create iteration WITHOUT checklist
         iteration_dir = issues_dir / "iteration_001"
         iteration_dir.mkdir()
-        (iteration_dir / "context.json").write_text("{}")
+        (iteration_dir / "iteration.json").write_text("{}")
         # No checklist.md file
 
         # Mock git operations and config
@@ -532,7 +532,7 @@ class TestShowCommandUserInput:
         # Create iteration with user_input.md
         iteration_dir = issues_dir / "iteration_001"
         iteration_dir.mkdir()
-        (iteration_dir / "context.json").write_text("{}")
+        (iteration_dir / "iteration.json").write_text("{}")
         user_input_file = iteration_dir / "user_input.md"
         user_input_file.write_text("# Initial Requirements\n\nAdd login feature")
 
@@ -562,7 +562,7 @@ class TestShowCommandUserInput:
         # Create iteration with user_input.md
         iteration_dir = issues_dir / "iteration_001"
         iteration_dir.mkdir()
-        (iteration_dir / "context.json").write_text("{}")
+        (iteration_dir / "iteration.json").write_text("{}")
         user_input_file = iteration_dir / "user_input.md"
         user_input_file.write_text("Please add error handling")
 
@@ -592,7 +592,7 @@ class TestShowCommandUserInput:
         for i in [1, 2]:
             iteration_dir = issues_dir / f"iteration_{i:03d}"
             iteration_dir.mkdir()
-            (iteration_dir / "context.json").write_text("{}")
+            (iteration_dir / "iteration.json").write_text("{}")
             user_input_file = iteration_dir / "user_input.md"
             user_input_file.write_text(f"User input for iteration {i}")
 
@@ -621,7 +621,7 @@ class TestShowCommandUserInput:
         # Create iteration WITHOUT user_input.md
         iteration_dir = issues_dir / "iteration_001"
         iteration_dir.mkdir()
-        (iteration_dir / "context.json").write_text("{}")
+        (iteration_dir / "iteration.json").write_text("{}")
         # No user_input.md file
 
         # Mock git operations and config
@@ -663,7 +663,7 @@ class TestShowCommandQuestions:
         # Create iteration with questions.xml
         iteration_dir = issues_dir / "iteration_001"
         iteration_dir.mkdir()
-        (iteration_dir / "context.json").write_text("{}")
+        (iteration_dir / "iteration.json").write_text("{}")
         questions_file = iteration_dir / "questions.xml"
         questions_file.write_text("""<?xml version="1.0" encoding="UTF-8"?>
 <questions>
@@ -701,7 +701,7 @@ class TestShowCommandQuestions:
         for i in [1, 2]:
             iteration_dir = issues_dir / f"iteration_{i:03d}"
             iteration_dir.mkdir()
-            (iteration_dir / "context.json").write_text("{}")
+            (iteration_dir / "iteration.json").write_text("{}")
             questions_file = iteration_dir / "questions.xml"
             questions_file.write_text(f"""<?xml version="1.0" encoding="UTF-8"?>
 <questions>
@@ -736,7 +736,7 @@ class TestShowCommandQuestions:
         # Create iteration WITHOUT questions.xml
         iteration_dir = issues_dir / "iteration_001"
         iteration_dir.mkdir()
-        (iteration_dir / "context.json").write_text("{}")
+        (iteration_dir / "iteration.json").write_text("{}")
         # No questions.xml file
 
         # Mock git operations and config

--- a/tests/unit/test_cli_workflow_command.py
+++ b/tests/unit/test_cli_workflow_command.py
@@ -914,7 +914,7 @@ def test_workflow_command_resumes_incomplete_iteration_before_user_phase(tmp_pat
         ),
         encoding="utf-8",
     )
-    (spec_iteration / "context.json").write_text(
+    (spec_iteration / "iteration.json").write_text(
         json.dumps(
             {
                 "iteration": 2,
@@ -932,7 +932,7 @@ def test_workflow_command_resumes_incomplete_iteration_before_user_phase(tmp_pat
             executed_steps.append(step_name)
             completed_iteration = issue_dir / "spec" / "iteration_003"
             completed_iteration.mkdir(parents=True, exist_ok=True)
-            (completed_iteration / "context.json").write_text(
+            (completed_iteration / "iteration.json").write_text(
                 json.dumps(
                     {
                         "iteration": 3,
@@ -1002,7 +1002,7 @@ def test_find_external_resume_step_returns_pr_when_new_pr_comments_exist(tmp_pat
 def test_find_external_resume_step_returns_none_when_last_seen_covers_all_comments(
     tmp_path: Path,
 ) -> None:
-    """P2: stale context.json processed fields must not be the only source; last-seen artifact excludes known IDs."""
+    """P2: stale iteration.json processed fields must not be the only source; last-seen artifact excludes known IDs."""
     issue_dir = tmp_path / ".cafe" / "issues" / "issue-241"
     pr_dir = issue_dir / "pr"
     artifact = pr_dir / "artifacts" / "pr_last_seen_comments.json"

--- a/tests/unit/test_context_endtime.py
+++ b/tests/unit/test_context_endtime.py
@@ -1,4 +1,4 @@
-"""Tests for context.json end_time field saving."""
+"""Tests for iteration.json end_time field saving."""
 
 import json
 from pathlib import Path
@@ -24,10 +24,10 @@ class ConcretePhase(Phase):
 
 
 class TestContextEndTime:
-    """Test context.json contains end_time field"""
+    """Test iteration.json contains end_time field"""
 
     def test_context_json_contains_end_time_field(self, tmp_path):
-        """Verify context.json contains end_time field when iteration ends"""
+        """Verify iteration.json contains end_time field when iteration ends"""
         phase_dir = tmp_path / "spec"
         phase_dir.mkdir()
         phase = ConcretePhase(phase_dir=phase_dir)
@@ -42,8 +42,8 @@ class TestContextEndTime:
             status_code=None,
         )
 
-        # Verify context.json contains end_time
-        context_file = phase._get_iteration_dir(1) / "context.json"
+        # Verify iteration.json contains end_time
+        context_file = phase._get_iteration_dir(1) / "iteration.json"
         assert context_file.exists()
 
         with open(context_file, "r", encoding="utf-8") as f:
@@ -58,10 +58,10 @@ class TestContextEndTime:
 
 
 class TestContextJsonEndTime:
-    """Test context.json end_time field"""
+    """Test iteration.json end_time field"""
 
     def test_context_json_contains_end_time_after_update(self, tmp_path):
-        """Verify _update_iteration_history() saves end_time to context.json"""
+        """Verify _update_iteration_history() saves end_time to iteration.json"""
         phase_dir = tmp_path / "spec"
         phase_dir.mkdir()
 
@@ -80,9 +80,9 @@ class TestContextJsonEndTime:
             status_code=MagicMock(value="confirmed"),
         )
 
-        # Verify context.json contains end_time field
+        # Verify iteration.json contains end_time field
         iteration_dir = phase._get_iteration_dir(1)
-        context_file = iteration_dir / "context.json"
+        context_file = iteration_dir / "iteration.json"
         assert context_file.exists()
 
         with open(context_file, "r", encoding="utf-8") as f:
@@ -112,7 +112,7 @@ class TestContextJsonEndTime:
             persist_status=False,
         )
 
-        context_file = phase._get_iteration_dir(1) / "context.json"
+        context_file = phase._get_iteration_dir(1) / "iteration.json"
         context_data = json.loads(context_file.read_text(encoding="utf-8"))
 
         assert context_data["response"] == "done without status"

--- a/tests/unit/test_context_session_id_update.py
+++ b/tests/unit/test_context_session_id_update.py
@@ -1,4 +1,4 @@
-"""Test that context.json captures session_id created during agent execution."""
+"""Test that iteration.json captures session_id created during agent execution."""
 import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -10,7 +10,7 @@ from cafe.core.types import PhaseResult, PhaseStatus, TokenUsage
 
 
 class TestContextSessionIDUpdate:
-    """Verify context.json captures session_id created during agent execution."""
+    """Verify iteration.json captures session_id created during agent execution."""
 
     @pytest.fixture
     def mock_agent_manager(self):
@@ -47,7 +47,7 @@ class TestContextSessionIDUpdate:
     def test_context_json_captures_created_session_id(
         self, tmp_path, mock_agent_manager
     ):
-        """context.json should contain the session_id created during execution, not None."""
+        """iteration.json should contain the session_id created during execution, not None."""
         manager, executor = mock_agent_manager
         
         # Setup issue directory
@@ -77,18 +77,18 @@ class TestContextSessionIDUpdate:
             with patch.object(phase, "_check_if_already_completed", return_value=None):
                 result = phase.execute()
         
-        # Verify context.json exists
-        context_file = spec_dir / "iteration_001" / "context.json"
-        assert context_file.exists(), "context.json should be created"
+        # Verify iteration.json exists
+        context_file = spec_dir / "iteration_001" / "iteration.json"
+        assert context_file.exists(), "iteration.json should be created"
         
-        # Read context.json
+        # Read iteration.json
         with open(context_file) as f:
             context_data = json.load(f)
         
         # Verify session_id is the one created during execution, not None
         assert "session_id" in context_data
         assert context_data["session_id"] == "new-session-123", (
-            "context.json should capture the session_id created during execution"
+            "iteration.json should capture the session_id created during execution"
         )
         assert context_data["session_id"] is not None, (
             "session_id should not be None after agent execution"

--- a/tests/unit/test_develop_no_changes_needed.py
+++ b/tests/unit/test_develop_no_changes_needed.py
@@ -54,7 +54,7 @@ class TestNoChangesNeededReasoningValidation:
         iteration_dir = develop_dir / "iteration_001"
         iteration_dir.mkdir(parents=True, exist_ok=True)
 
-        # Create context.json with NO_CHANGES_NEEDED response
+        # Create iteration.json with NO_CHANGES_NEEDED response
         context_data = {
             "iteration": 1,
             "response": "no_changes_needed\n\nThe reviewer is wrong.",
@@ -62,7 +62,7 @@ class TestNoChangesNeededReasoningValidation:
             "streaming_log": [],
             "prompt": "Test prompt"
         }
-        context_file = iteration_dir / "context.json"
+        context_file = iteration_dir / "iteration.json"
         context_file.write_text(json.dumps(context_data))
 
         # output.md does NOT exist or is empty
@@ -123,7 +123,7 @@ class TestNoChangesNeededReasoningValidation:
         iteration_dir = develop_dir / "iteration_001"
         iteration_dir.mkdir(parents=True, exist_ok=True)
 
-        # Create context.json
+        # Create iteration.json
         context_data = {
             "iteration": 1,
             "response": "no_changes_needed",
@@ -131,7 +131,7 @@ class TestNoChangesNeededReasoningValidation:
             "streaming_log": [],
             "prompt": "Test prompt"
         }
-        context_file = iteration_dir / "context.json"
+        context_file = iteration_dir / "iteration.json"
         context_file.write_text(json.dumps(context_data))
 
         # output.md does NOT exist

--- a/tests/unit/test_develop_phase_prompt.py
+++ b/tests/unit/test_develop_phase_prompt.py
@@ -28,7 +28,7 @@ def _write_review_iteration(
     }
     if end_time is not None:
         payload["end_time"] = end_time
-    (review_dir / "context.json").write_text(json.dumps(payload))
+    (review_dir / "iteration.json").write_text(json.dumps(payload))
     (review_dir / "output.md").write_text(output)
 
 
@@ -186,8 +186,8 @@ class TestDevelopPhasePromptGeneration:
         output_file = pr_iteration_dir / "output.md"
         output_file.write_text("## Todo List\n\n- [ ] Fix issue 1\n- [ ] Fix issue 2")
 
-        # Create context.json for PR iteration with status_code
-        pr_context_file = pr_iteration_dir / "context.json"
+        # Create iteration.json for PR iteration with status_code
+        pr_context_file = pr_iteration_dir / "iteration.json"
         pr_context_file.write_text(json.dumps({
             "iteration": 1,
             "timestamp": datetime.now(timezone.utc).isoformat(),
@@ -257,8 +257,8 @@ class TestDevelopPhasePromptGeneration:
         output_file = pr_iteration_dir / "output.md"
         output_file.write_text("## Todo List\n\n- [ ] Address PR comment 1")
 
-        # Create context.json for PR iteration with status_code
-        pr_context_file = pr_iteration_dir / "context.json"
+        # Create iteration.json for PR iteration with status_code
+        pr_context_file = pr_iteration_dir / "iteration.json"
         pr_context_file.write_text(json.dumps({
             "iteration": 1,
             "timestamp": datetime.now(timezone.utc).isoformat(),
@@ -386,7 +386,7 @@ class TestDevelopPhasePromptGeneration:
         pr_output = pr_iteration_dir / "output.md"
         pr_output.write_text("## Todo List\n\n- [ ] PR issue")
 
-        pr_context_file = pr_iteration_dir / "context.json"
+        pr_context_file = pr_iteration_dir / "iteration.json"
         pr_context_file.write_text(json.dumps({
             "iteration": 1,
             "timestamp": datetime.now(timezone.utc).isoformat(),
@@ -468,7 +468,7 @@ class TestDevelopPhasePromptGeneration:
         pr_output = pr_iteration_dir / "output.md"
         pr_output.write_text("## Todo List\n\n- [ ] PR issue")
 
-        pr_context_file = pr_iteration_dir / "context.json"
+        pr_context_file = pr_iteration_dir / "iteration.json"
         pr_context_file.write_text(json.dumps({
             "iteration": 1,
             "timestamp": datetime.now(timezone.utc).isoformat(),

--- a/tests/unit/test_executor_session_recovery_generic.py
+++ b/tests/unit/test_executor_session_recovery_generic.py
@@ -205,7 +205,7 @@ class TestGenericSessionRecovery:
         assert "creating new session" not in captured.out.lower()
 
     def test_codex_session_recovery_preserves_cli_command_args(self):
-        """Codex stale session errors should still expose CLI args for context.json."""
+        """Codex stale session errors should still expose CLI args for iteration.json."""
         config = AgentConfig(
             name="TestAgent",
             cli=AgentCLI.CODEX,

--- a/tests/unit/test_generic_workflow_step.py
+++ b/tests/unit/test_generic_workflow_step.py
@@ -153,7 +153,7 @@ def test_generic_workflow_step_executor_writes_iteration_files(tmp_path: Path, m
     assert result.response == "confirmed"
     assert "spec" in result.artifacts
     iteration_dir = issue_dir / "spec" / "iteration_001"
-    assert (iteration_dir / "context.json").exists()
+    assert (iteration_dir / "iteration.json").exists()
     assert (iteration_dir / "checklist.md").exists()
     assert (iteration_dir / "output.md").exists()
     assert (iteration_dir / "artifact.json").exists()
@@ -305,7 +305,7 @@ def test_generic_workflow_step_executor_uses_iteration_specific_skill_mapping(tm
     issue_dir = tmp_path / ".cafe" / "issues" / "issue-2"
     phase_dir = issue_dir / "spec" / "iteration_001"
     phase_dir.mkdir(parents=True, exist_ok=True)
-    (phase_dir / "context.json").write_text(
+    (phase_dir / "iteration.json").write_text(
         '{"iteration": 1, "response": "confirmed", "end_time": "2026-04-09T00:00:00+08:00"}',
         encoding="utf-8",
     )
@@ -814,7 +814,7 @@ def test_generic_workflow_step_auto_continues_pause_statuses_in_interactive_mode
     spec_dir = issue_dir / "spec" / "iteration_001"
     spec_dir.mkdir(parents=True, exist_ok=True)
     (spec_dir / "output.md").write_text("# Spec\n", encoding="utf-8")
-    (spec_dir / "context.json").write_text(
+    (spec_dir / "iteration.json").write_text(
         '{"iteration":1,"status_code":"confirmed"}',
         encoding="utf-8",
     )
@@ -888,7 +888,7 @@ def test_generic_workflow_step_keeps_missing_status_without_continue_prompt(tmp_
     assert "done without status" in result.response
     assert result.status_code is None
     assert len(executor.agent_manager.prompts) == 1
-    context_data = json.loads((issue_dir / "spec" / "iteration_001" / "context.json").read_text(encoding="utf-8"))
+    context_data = json.loads((issue_dir / "spec" / "iteration_001" / "iteration.json").read_text(encoding="utf-8"))
     assert "status_code" not in context_data
 
 

--- a/tests/unit/test_github_pr_comments.py
+++ b/tests/unit/test_github_pr_comments.py
@@ -966,7 +966,7 @@ class TestGetProcessedCommentIDs:
         import json
 
         with TemporaryDirectory() as tmpdir:
-            # Create a mock iteration directory with context.json
+            # Create a mock iteration directory with iteration.json
             iteration_dir = Path(tmpdir) / "iteration_001"
             iteration_dir.mkdir(parents=True)
 
@@ -981,7 +981,7 @@ class TestGetProcessedCommentIDs:
                 ]
             }
 
-            with open(iteration_dir / "context.json", "w") as f:
+            with open(iteration_dir / "iteration.json", "w") as f:
                 json.dump(context_data, f)
 
             # Get processed comment IDs
@@ -1013,7 +1013,7 @@ class TestGetProcessedCommentIDs:
                 "pr_comments_processed": [{"id": "111", "description": "Fix 1"}],
                 "pr_comments_skipped": []
             }
-            with open(iter1_dir / "context.json", "w") as f:
+            with open(iter1_dir / "iteration.json", "w") as f:
                 json.dump(context1, f)
 
             # Create iteration 2
@@ -1024,7 +1024,7 @@ class TestGetProcessedCommentIDs:
                 "pr_comments_processed": [{"id": "222", "description": "Fix 2"}],
                 "pr_comments_skipped": [{"id": "333", "reason": "Skip"}]
             }
-            with open(iter2_dir / "context.json", "w") as f:
+            with open(iter2_dir / "iteration.json", "w") as f:
                 json.dump(context2, f)
 
             # Create iteration 3
@@ -1035,7 +1035,7 @@ class TestGetProcessedCommentIDs:
                 "pr_comments_processed": [],
                 "pr_comments_skipped": [{"id": "444", "reason": "Skip 2"}]
             }
-            with open(iter3_dir / "context.json", "w") as f:
+            with open(iter3_dir / "iteration.json", "w") as f:
                 json.dump(context3, f)
 
             # Get processed comment IDs
@@ -1063,9 +1063,9 @@ class TestGetProcessedCommentIDs:
             assert len(result) == 0
 
     def test_get_processed_comment_ids_ignores_malformed_files(self):
-        """測試當某些 context.json 文件格式錯誤時的情況
+        """測試當某些 iteration.json 文件格式錯誤時的情況
 
-        情境：有些 iteration 的 context.json 存在但沒有 comment 數據
+        情境：有些 iteration 的 iteration.json 存在但沒有 comment 數據
         預期：跳過格式錯誤的文件，返回有效的 comment IDs
         """
         from cafe.utils.github import get_processed_comment_ids_from_history
@@ -1081,14 +1081,14 @@ class TestGetProcessedCommentIDs:
                 "iteration": 1,
                 "pr_comments_processed": [{"id": "111", "description": "Fix"}]
             }
-            with open(iter1_dir / "context.json", "w") as f:
+            with open(iter1_dir / "iteration.json", "w") as f:
                 json.dump(context1, f)
 
             # Create iteration 2 with no comment data
             iter2_dir = Path(tmpdir) / "iteration_002"
             iter2_dir.mkdir(parents=True)
             context2 = {"iteration": 2}  # Missing pr_comments_processed
-            with open(iter2_dir / "context.json", "w") as f:
+            with open(iter2_dir / "iteration.json", "w") as f:
                 json.dump(context2, f)
 
             # Get processed comment IDs
@@ -1118,7 +1118,7 @@ def test_load_pr_last_seen_comment_ids_legacy_context(tmp_path: Path) -> None:
     pr_dir = tmp_path / "pr"
     it = pr_dir / "iteration_001"
     it.mkdir(parents=True)
-    (it / "context.json").write_text(
+    (it / "iteration.json").write_text(
         json.dumps({"last_seen_comment_ids": ["x"]}, ensure_ascii=False),
         encoding="utf-8",
     )

--- a/tests/unit/test_iteration_file_fallback.py
+++ b/tests/unit/test_iteration_file_fallback.py
@@ -1,0 +1,83 @@
+"""Tests for backward-compatible iteration context file resolution.
+
+_resolve_iteration_context_file():
+  - Returns iteration.json when it exists.
+  - Falls back to context.json with a deprecation WARNING when only context.json exists.
+  - Returns a path pointing to iteration.json (non-existent) when neither file exists.
+"""
+
+import json
+import logging
+from pathlib import Path
+
+import pytest
+
+from cafe.core.phase import Phase
+
+
+class ConcretePhase(Phase):
+    def __init__(self, phase_dir: Path, **kwargs):
+        super().__init__(**kwargs)
+        self.phase_dir = phase_dir
+        self.iteration = 1
+
+    def execute(self):
+        pass
+
+
+class TestResolveIterationContextFile:
+    def test_returns_iteration_json_when_it_exists(self, tmp_path):
+        iteration_dir = tmp_path / "spec" / "iteration_001"
+        iteration_dir.mkdir(parents=True)
+        (iteration_dir / "iteration.json").write_text("{}", encoding="utf-8")
+
+        phase = ConcretePhase(phase_dir=tmp_path / "spec")
+        result = phase._resolve_iteration_context_file(iteration_dir)
+
+        assert result == iteration_dir / "iteration.json"
+
+    def test_falls_back_to_context_json_with_warning(self, tmp_path, caplog):
+        iteration_dir = tmp_path / "spec" / "iteration_001"
+        iteration_dir.mkdir(parents=True)
+        (iteration_dir / "context.json").write_text("{}", encoding="utf-8")
+
+        phase = ConcretePhase(phase_dir=tmp_path / "spec")
+
+        with caplog.at_level(logging.WARNING):
+            result = phase._resolve_iteration_context_file(iteration_dir)
+
+        assert result == iteration_dir / "context.json"
+        assert any(r.levelno == logging.WARNING for r in caplog.records)
+
+    def test_prefers_iteration_json_over_context_json(self, tmp_path):
+        iteration_dir = tmp_path / "spec" / "iteration_001"
+        iteration_dir.mkdir(parents=True)
+        (iteration_dir / "iteration.json").write_text('{"source": "new"}', encoding="utf-8")
+        (iteration_dir / "context.json").write_text('{"source": "old"}', encoding="utf-8")
+
+        phase = ConcretePhase(phase_dir=tmp_path / "spec")
+        result = phase._resolve_iteration_context_file(iteration_dir)
+
+        assert result == iteration_dir / "iteration.json"
+
+    def test_returns_iteration_json_path_when_neither_exists(self, tmp_path):
+        iteration_dir = tmp_path / "spec" / "iteration_001"
+        iteration_dir.mkdir(parents=True)
+
+        phase = ConcretePhase(phase_dir=tmp_path / "spec")
+        result = phase._resolve_iteration_context_file(iteration_dir)
+
+        assert result == iteration_dir / "iteration.json"
+        assert not result.exists()
+
+    def test_no_warning_when_iteration_json_exists(self, tmp_path, caplog):
+        iteration_dir = tmp_path / "spec" / "iteration_001"
+        iteration_dir.mkdir(parents=True)
+        (iteration_dir / "iteration.json").write_text("{}", encoding="utf-8")
+
+        phase = ConcretePhase(phase_dir=tmp_path / "spec")
+
+        with caplog.at_level(logging.WARNING):
+            phase._resolve_iteration_context_file(iteration_dir)
+
+        assert not any(r.levelno == logging.WARNING for r in caplog.records)

--- a/tests/unit/test_native_user_input_hook.py
+++ b/tests/unit/test_native_user_input_hook.py
@@ -37,7 +37,7 @@ class _FakePhase:
         return phase_dir / f"iteration_{iteration:03d}" / "output.md"
 
     def _load_previous_iteration_data(self) -> dict:
-        context_file = self._get_iteration_dir(self.iteration - 1) / "context.json"
+        context_file = self._get_iteration_dir(self.iteration - 1) / "iteration.json"
         if not context_file.exists():
             return {}
         return json.loads(context_file.read_text(encoding="utf-8"))

--- a/tests/unit/test_phase_iteration_structure.py
+++ b/tests/unit/test_phase_iteration_structure.py
@@ -142,7 +142,7 @@ class TestLoadIterationCounter:
         iteration_dir.mkdir(parents=True)
         phase = ConcretePhase(phase_dir=phase_dir)
 
-        (iteration_dir / "context.json").write_text(
+        (iteration_dir / "iteration.json").write_text(
             json.dumps(
                 {
                     "iteration": 1,
@@ -161,7 +161,7 @@ class TestLoadIterationCounter:
         iteration_dir.mkdir(parents=True)
         phase = ConcretePhase(phase_dir=phase_dir)
 
-        (iteration_dir / "context.json").write_text(
+        (iteration_dir / "iteration.json").write_text(
             json.dumps(
                 {
                     "iteration": 1,
@@ -216,7 +216,7 @@ class TestSaveUserInput:
     """測試重構後的 _save_user_input() 方法"""
 
     def test_creates_iteration_directory_and_context_json(self, tmp_path):
-        """驗證會建立 iteration_XXX/context.json"""
+        """驗證會建立 iteration_XXX/iteration.json"""
         phase_dir = tmp_path / "spec"
         phase_dir.mkdir()
         phase = ConcretePhase(phase_dir=phase_dir)
@@ -229,11 +229,11 @@ class TestSaveUserInput:
         assert iteration_dir.exists()
         assert iteration_dir.is_dir()
 
-        context_file = iteration_dir / "context.json"
+        context_file = iteration_dir / "iteration.json"
         assert context_file.exists()
 
     def test_context_json_contains_required_fields(self, tmp_path):
-        """驗證 context.json 包含所有必要欄位"""
+        """驗證 iteration.json 包含所有必要欄位"""
         phase_dir = tmp_path / "spec"
         phase_dir.mkdir()
         phase = ConcretePhase(phase_dir=phase_dir)
@@ -241,14 +241,14 @@ class TestSaveUserInput:
 
         phase._save_user_input("Test user input")
 
-        context_file = phase_dir / "iteration_001" / "context.json"
+        context_file = phase_dir / "iteration_001" / "iteration.json"
         data = json.loads(context_file.read_text())
 
         # 驗證必要欄位
         assert "iteration" in data
         assert data["iteration"] == 1
         assert "timestamp" in data
-        # user_input is no longer duplicated into context.json;
+        # user_input is no longer duplicated into iteration.json;
         # it lives in user_input.md instead
         assert "user_input" not in data
 
@@ -266,7 +266,7 @@ class TestSaveUserInput:
 
         phase._save_user_input("Test input", phase_specific_data=phase_specific_data)
 
-        context_file = phase_dir / "iteration_002" / "context.json"
+        context_file = phase_dir / "iteration_002" / "iteration.json"
         data = json.loads(context_file.read_text())
 
         assert data["template"] == "default"
@@ -300,7 +300,7 @@ class TestSaveUserInput:
         assert content == user_input_content
 
     def test_user_input_no_longer_in_context_json(self, tmp_path):
-        """驗證 context.json 不再包含 user_input（改用 user_input.md）"""
+        """驗證 iteration.json 不再包含 user_input（改用 user_input.md）"""
         phase_dir = tmp_path / "spec"
         phase_dir.mkdir()
         phase = ConcretePhase(phase_dir=phase_dir)
@@ -310,7 +310,7 @@ class TestSaveUserInput:
         phase._save_user_input(user_input_content)
 
         # user_input is now stored exclusively in user_input.md
-        context_file = phase_dir / "iteration_001" / "context.json"
+        context_file = phase_dir / "iteration_001" / "iteration.json"
         data = json.loads(context_file.read_text())
         assert "user_input" not in data
 
@@ -334,12 +334,12 @@ class TestLoadUserInput:
         user_input_file = iteration_dir / "user_input.md"
         user_input_file.write_text("Content from user_input.md", encoding="utf-8")
 
-        # 同時建立 context.json（但內容不同，以驗證優先讀取 .md）
-        context_file = iteration_dir / "context.json"
+        # 同時建立 iteration.json（但內容不同，以驗證優先讀取 .md）
+        context_file = iteration_dir / "iteration.json"
         context_data = {
             "iteration": 1,
             "timestamp": "2025-12-27T10:00:00Z",
-            "user_input": "Content from context.json",
+            "user_input": "Content from iteration.json",
         }
         context_file.write_text(json.dumps(context_data), encoding="utf-8")
 
@@ -353,18 +353,18 @@ class TestLoadUserInput:
         phase_dir.mkdir()
         phase = ConcretePhase(phase_dir=phase_dir)
 
-        # 只建立 context.json，不建立 user_input.md
+        # 只建立 iteration.json，不建立 user_input.md
         iteration_dir = phase_dir / "iteration_001"
         iteration_dir.mkdir()
-        context_file = iteration_dir / "context.json"
+        context_file = iteration_dir / "iteration.json"
         context_data = {
             "iteration": 1,
             "timestamp": "2025-12-27T10:00:00Z",
-            "user_input": "Content from context.json only",
+            "user_input": "Content from iteration.json only",
         }
         context_file.write_text(json.dumps(context_data), encoding="utf-8")
 
-        # _load_user_input no longer falls back to context.json
+        # _load_user_input no longer falls back to iteration.json
         result = phase._load_user_input(1)
         assert result == ""
 
@@ -379,15 +379,15 @@ class TestLoadUserInput:
         assert result == ""
 
     def test_returns_empty_string_when_user_input_key_missing_in_context(self, tmp_path):
-        """驗證當 context.json 存在但缺少 user_input 欄位時返回空字串"""
+        """驗證當 iteration.json 存在但缺少 user_input 欄位時返回空字串"""
         phase_dir = tmp_path / "spec"
         phase_dir.mkdir()
         phase = ConcretePhase(phase_dir=phase_dir)
 
-        # 建立 context.json 但不包含 user_input 欄位
+        # 建立 iteration.json 但不包含 user_input 欄位
         iteration_dir = phase_dir / "iteration_001"
         iteration_dir.mkdir()
-        context_file = iteration_dir / "context.json"
+        context_file = iteration_dir / "iteration.json"
         context_data = {
             "iteration": 1,
             "timestamp": "2025-12-27T10:00:00Z",

--- a/tests/unit/test_phase_progress.py
+++ b/tests/unit/test_phase_progress.py
@@ -131,7 +131,7 @@ class TestAlreadyCompletedFallback:
         )
         iteration_dir = phase_dir / "iteration_001"
         iteration_dir.mkdir(parents=True)
-        (iteration_dir / "context.json").write_text(
+        (iteration_dir / "iteration.json").write_text(
             json.dumps(
                 {
                     "iteration": 1,

--- a/tests/unit/test_pr_phase_context.py
+++ b/tests/unit/test_pr_phase_context.py
@@ -1,4 +1,4 @@
-"""Test PR phase context.json field population."""
+"""Test PR phase iteration.json field population."""
 import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch, call
@@ -13,7 +13,7 @@ from cafe.utils.github import PRComment
 pytestmark = pytest.mark.slow
 
 
-# Fields that must be present in context.json per issue #142
+# Fields that must be present in iteration.json per issue #142
 AGENT_CONTEXT_FIELDS = [
     "prompt",
     "cli",
@@ -26,7 +26,7 @@ AGENT_CONTEXT_FIELDS = [
 
 
 class TestPRPhaseContextFields:
-    """Verify context.json contains all agent execution context fields."""
+    """Verify iteration.json contains all agent execution context fields."""
 
     @pytest.fixture
     def mock_dependencies(self):
@@ -79,7 +79,7 @@ class TestPRPhaseContextFields:
 
         Regression test: the post-organize code previously called _update_iteration_history()
         with only phase_specific_data and status_code, overwriting agent metadata set by
-        _execute_agent_iteration(). The fix updates status_code directly in context.json.
+        _execute_agent_iteration(). The fix updates status_code directly in iteration.json.
         """
         issue_dir, spec_file = setup_issue_dir
         phase = self._create_phase(mock_dependencies, issue_dir, spec_file)
@@ -87,7 +87,7 @@ class TestPRPhaseContextFields:
         pr_dir = issue_dir / "pr"
         phase.iteration = 2
 
-        # Simulate: agent execution already wrote context.json with all agent fields
+        # Simulate: agent execution already wrote iteration.json with all agent fields
         iter_dir = pr_dir / "iteration_002"
         iter_dir.mkdir(parents=True, exist_ok=True)
         agent_context = {
@@ -104,13 +104,13 @@ class TestPRPhaseContextFields:
             "permission_denials": [],
             "streaming_log": [],
         }
-        (iter_dir / "context.json").write_text(json.dumps(agent_context))
+        (iter_dir / "iteration.json").write_text(json.dumps(agent_context))
 
         # Simulate the post-organize status_code update (new behavior: direct JSON update)
         result_status = "needs_changes"
         result_data = {"pr_number": "42", "status_code": "needs_changes"}
 
-        context_file = iter_dir / "context.json"
+        context_file = iter_dir / "iteration.json"
         with open(context_file, "r", encoding="utf-8") as f:
             context_data = json.load(f)
         context_data.update(result_data)
@@ -118,13 +118,13 @@ class TestPRPhaseContextFields:
         with open(context_file, "w", encoding="utf-8") as f:
             json.dump(context_data, f, ensure_ascii=False, indent=2)
 
-        # Read context.json - agent fields must be preserved
+        # Read iteration.json - agent fields must be preserved
         context = json.loads(context_file.read_text())
 
         for field in AGENT_CONTEXT_FIELDS:
-            assert field in context, f"Field '{field}' missing from context.json"
+            assert field in context, f"Field '{field}' missing from iteration.json"
             assert context[field] is not None, (
-                f"Field '{field}' is None in context.json - "
+                f"Field '{field}' is None in iteration.json - "
                 "agent metadata was erased by post-organize status update"
             )
 
@@ -136,7 +136,7 @@ class TestPRPhaseContextFields:
     def test_save_pr_comments_context_has_all_fields(
         self, tmp_path, mock_dependencies, setup_issue_dir
     ):
-        """_save_pr_comments_to_user_input must produce context.json with all required fields."""
+        """_save_pr_comments_to_user_input must produce iteration.json with all required fields."""
         issue_dir, spec_file = setup_issue_dir
         phase = self._create_phase(mock_dependencies, issue_dir, spec_file)
 
@@ -171,7 +171,7 @@ class TestPRPhaseContextFields:
     def test_local_review_modification_context_has_all_fields(
         self, tmp_path, mock_dependencies, setup_issue_dir
     ):
-        """Local review modification request must produce context.json with all required fields."""
+        """Local review modification request must produce iteration.json with all required fields."""
         issue_dir, spec_file = setup_issue_dir
         phase = self._create_phase(mock_dependencies, issue_dir, spec_file)
 
@@ -179,7 +179,7 @@ class TestPRPhaseContextFields:
         pr_dir = issue_dir / "pr"
         prev_iter_dir = pr_dir / "iteration_001"
         prev_iter_dir.mkdir(parents=True)
-        (prev_iter_dir / "context.json").write_text(json.dumps({
+        (prev_iter_dir / "iteration.json").write_text(json.dumps({
             "iteration": 1,
             "status_code": "ready_for_review",
         }))
@@ -218,7 +218,7 @@ class TestPRPhaseContextFields:
     def test_local_review_confirmation_context_has_all_fields(
         self, tmp_path, mock_dependencies, setup_issue_dir
     ):
-        """Local review confirmation must produce context.json with all required fields."""
+        """Local review confirmation must produce iteration.json with all required fields."""
         issue_dir, spec_file = setup_issue_dir
         phase = self._create_phase(mock_dependencies, issue_dir, spec_file)
 
@@ -248,7 +248,7 @@ class TestPRPhaseContextFields:
     def test_context_json_fields_present_after_save_pr_comments(
         self, tmp_path, mock_dependencies, setup_issue_dir
     ):
-        """Integration: context.json produced by _save_pr_comments_to_user_input has all fields."""
+        """Integration: iteration.json produced by _save_pr_comments_to_user_input has all fields."""
         issue_dir, spec_file = setup_issue_dir
         phase = self._create_phase(mock_dependencies, issue_dir, spec_file)
 
@@ -270,21 +270,21 @@ class TestPRPhaseContextFields:
             with patch.object(phase, "_append_iteration_index"):
                 phase._save_pr_comments_to_user_input(pr_number=42)
 
-        # Read context.json
+        # Read iteration.json
         iter_dir = issue_dir / "pr" / "iteration_001"
-        context_file = iter_dir / "context.json"
-        assert context_file.exists(), "context.json was not created"
+        context_file = iter_dir / "iteration.json"
+        assert context_file.exists(), "iteration.json was not created"
 
         context = json.loads(context_file.read_text())
 
         # All agent context fields must be present (even if None for pre-agent context)
         for field in AGENT_CONTEXT_FIELDS:
-            assert field in context, f"Field '{field}' missing from context.json"
+            assert field in context, f"Field '{field}' missing from iteration.json"
 
     def test_local_review_confirmation_context_fields_present(
         self, tmp_path, mock_dependencies, setup_issue_dir
     ):
-        """Integration: context.json for local review confirmation has all fields."""
+        """Integration: iteration.json for local review confirmation has all fields."""
         issue_dir, spec_file = setup_issue_dir
         phase = self._create_phase(mock_dependencies, issue_dir, spec_file)
 
@@ -303,11 +303,11 @@ class TestPRPhaseContextFields:
                 status_code=PhaseStatusCode.CONFIRMED,
             )
 
-        context = json.loads((iter_dir / "context.json").read_text())
+        context = json.loads((iter_dir / "iteration.json").read_text())
 
         # All agent context fields must be present
         for field in AGENT_CONTEXT_FIELDS:
-            assert field in context, f"Field '{field}' missing from context.json"
+            assert field in context, f"Field '{field}' missing from iteration.json"
 
         # status_code should be set
         assert context["status_code"] == "confirmed"
@@ -350,7 +350,7 @@ class TestPRPhaseContextFields:
                 status_code=PhaseStatusCode.READY_FOR_REVIEW,
             )
 
-        context = json.loads((iter_dir / "context.json").read_text())
+        context = json.loads((iter_dir / "iteration.json").read_text())
 
         # model must be preserved from first call
         assert context["model"] == "claude-haiku-4-5-20251001"

--- a/tests/unit/test_pr_phase_github_mode.py
+++ b/tests/unit/test_pr_phase_github_mode.py
@@ -84,9 +84,9 @@ class TestPRPhaseGitHubMode:
         assert "created" in result.message.lower()
         assert result.data.get("status_code") == "ready_for_review"
 
-        # Verify iteration context.json was created with correct status_code
+        # Verify iteration iteration.json was created with correct status_code
         iteration_dir = issue_dir / "pr" / "iteration_001"
-        context_file = iteration_dir / "context.json"
+        context_file = iteration_dir / "iteration.json"
         assert context_file.exists()
         with open(context_file) as f:
             context = json.load(f)
@@ -105,7 +105,7 @@ class TestPRPhaseGitHubMode:
         pr_dir = issue_dir / "pr"
         iteration_001 = pr_dir / "iteration_001"
         iteration_001.mkdir(parents=True)
-        (iteration_001 / "context.json").write_text(json.dumps({
+        (iteration_001 / "iteration.json").write_text(json.dumps({
             "iteration": 1,
             "timestamp": "2026-01-27T10:00:00+08:00",
             "end_time": "2026-01-27T10:05:00+08:00",
@@ -140,7 +140,7 @@ class TestPRPhaseGitHubMode:
 
         # Verify new iteration_002 was created
         iteration_002 = issue_dir / "pr" / "iteration_002"
-        context_file = iteration_002 / "context.json"
+        context_file = iteration_002 / "iteration.json"
         assert context_file.exists()
         with open(context_file) as f:
             context = json.load(f)
@@ -187,7 +187,7 @@ class TestPRPhaseGitHubMode:
         pr_dir = issue_dir / "pr"
         iteration_001 = pr_dir / "iteration_001"
         iteration_001.mkdir(parents=True)
-        (iteration_001 / "context.json").write_text(json.dumps({
+        (iteration_001 / "iteration.json").write_text(json.dumps({
             "iteration": 1,
             "timestamp": "2026-01-27T10:00:00+08:00",
             "end_time": "2026-01-27T10:05:00+08:00",
@@ -236,7 +236,7 @@ class TestPRPhaseGitHubMode:
         pr_dir = issue_dir / "pr"
         iteration_001 = pr_dir / "iteration_001"
         iteration_001.mkdir(parents=True)
-        (iteration_001 / "context.json").write_text(
+        (iteration_001 / "iteration.json").write_text(
             json.dumps(
                 {
                     "iteration": 1,
@@ -285,7 +285,7 @@ class TestPRPhaseGitHubMode:
         pr_dir = issue_dir / "pr"
         iteration_001 = pr_dir / "iteration_001"
         iteration_001.mkdir(parents=True)
-        (iteration_001 / "context.json").write_text(json.dumps({
+        (iteration_001 / "iteration.json").write_text(json.dumps({
             "iteration": 1,
             "timestamp": "2026-01-27T10:00:00+08:00",
             "end_time": "2026-01-27T10:05:00+08:00",
@@ -329,7 +329,7 @@ class TestPRPhaseGitHubMode:
         pr_dir = issue_dir / "pr"
         iteration_001 = pr_dir / "iteration_001"
         iteration_001.mkdir(parents=True)
-        (iteration_001 / "context.json").write_text(json.dumps({
+        (iteration_001 / "iteration.json").write_text(json.dumps({
             "iteration": 1,
             "timestamp": "2026-01-27T10:00:00+08:00",
             "end_time": "2026-01-27T10:05:00+08:00",
@@ -404,7 +404,7 @@ class TestPRPhaseStep0ResumeIncomplete:
         pr_dir = issue_dir / "pr"
         iteration_001 = pr_dir / "iteration_001"
         iteration_001.mkdir(parents=True)
-        (iteration_001 / "context.json").write_text(json.dumps({
+        (iteration_001 / "iteration.json").write_text(json.dumps({
             "iteration": 1,
             "timestamp": "2026-01-27T10:00:00+08:00"
             # No status_code - incomplete!
@@ -449,7 +449,7 @@ class TestPRPhaseStep0ResumeIncomplete:
         pr_dir = issue_dir / "pr"
         iteration_001 = pr_dir / "iteration_001"
         iteration_001.mkdir(parents=True)
-        (iteration_001 / "context.json").write_text(json.dumps({
+        (iteration_001 / "iteration.json").write_text(json.dumps({
             "iteration": 1,
             "timestamp": "2026-01-27T10:00:00+08:00"
             # No status_code - incomplete!
@@ -477,7 +477,7 @@ class TestPRPhaseStep0ResumeIncomplete:
                 result = phase._execute_github_mode()
 
         # Assert - should have completed the iteration
-        context_file = iteration_001 / "context.json"
+        context_file = iteration_001 / "iteration.json"
         with open(context_file) as f:
             context = json.load(f)
         assert context.get("status_code") == "ready_for_review"
@@ -526,7 +526,7 @@ class TestPRPhaseStep1WaitingForDevelop:
         pr_dir = issue_dir / "pr"
         iteration_001 = pr_dir / "iteration_001"
         iteration_001.mkdir(parents=True)
-        (iteration_001 / "context.json").write_text(json.dumps({
+        (iteration_001 / "iteration.json").write_text(json.dumps({
             "iteration": 1,
             "timestamp": "2026-01-27T10:00:00+08:00",
             "end_time": "2026-01-27T10:05:00+08:00",
@@ -556,7 +556,7 @@ class TestPRPhaseStep1WaitingForDevelop:
         pr_dir = issue_dir / "pr"
         iteration_001 = pr_dir / "iteration_001"
         iteration_001.mkdir(parents=True)
-        (iteration_001 / "context.json").write_text(json.dumps({
+        (iteration_001 / "iteration.json").write_text(json.dumps({
             "iteration": 1,
             "timestamp": "2026-01-27T10:00:00+08:00",
             "end_time": "2026-01-27T10:05:00+08:00",
@@ -585,7 +585,7 @@ class TestPRPhaseStep1WaitingForDevelop:
         pr_dir = issue_dir / "pr"
         iteration_001 = pr_dir / "iteration_001"
         iteration_001.mkdir(parents=True)
-        (iteration_001 / "context.json").write_text(json.dumps({
+        (iteration_001 / "iteration.json").write_text(json.dumps({
             "iteration": 1,
             "timestamp": "2026-01-27T10:00:00+08:00",
             "end_time": "2026-01-27T10:05:00+08:00",
@@ -648,7 +648,7 @@ class TestPRPhasePriorityNewCommits:
         pr_dir = issue_dir / "pr"
         iteration_001 = pr_dir / "iteration_001"
         iteration_001.mkdir(parents=True)
-        (iteration_001 / "context.json").write_text(json.dumps({
+        (iteration_001 / "iteration.json").write_text(json.dumps({
             "iteration": 1,
             "timestamp": "2026-01-27T10:00:00+08:00",
             "end_time": "2026-01-27T10:05:00+08:00",
@@ -691,7 +691,7 @@ class TestPRPhasePriorityNewCommits:
         pr_dir = issue_dir / "pr"
         iteration_001 = pr_dir / "iteration_001"
         iteration_001.mkdir(parents=True)
-        (iteration_001 / "context.json").write_text(json.dumps({
+        (iteration_001 / "iteration.json").write_text(json.dumps({
             "iteration": 1,
             "timestamp": "2026-01-27T10:00:00+08:00",
             "end_time": "2026-01-27T10:05:00+08:00",
@@ -804,7 +804,7 @@ class TestPRPhaseAgentCalled:
         pr_dir = issue_dir / "pr"
         iteration_001 = pr_dir / "iteration_001"
         iteration_001.mkdir(parents=True)
-        (iteration_001 / "context.json").write_text(json.dumps({
+        (iteration_001 / "iteration.json").write_text(json.dumps({
             "iteration": 1,
             "timestamp": "2026-01-27T10:00:00+08:00",
             "end_time": "2026-01-27T10:05:00+08:00",
@@ -855,7 +855,7 @@ class TestPRPhaseAgentCalled:
         pr_dir = issue_dir / "pr"
         iteration_001 = pr_dir / "iteration_001"
         iteration_001.mkdir(parents=True)
-        (iteration_001 / "context.json").write_text(json.dumps({
+        (iteration_001 / "iteration.json").write_text(json.dumps({
             "iteration": 1,
             "timestamp": "2026-01-27T10:00:00+08:00",
             "end_time": "2026-01-27T10:05:00+08:00",
@@ -1039,7 +1039,7 @@ class TestCreateOrUpdatePRRecordsLastSeenCommentIds:
         pr_dir = issue_dir / "pr"
         iteration_001 = pr_dir / "iteration_001"
         iteration_001.mkdir(parents=True)
-        (iteration_001 / "context.json").write_text(json.dumps({
+        (iteration_001 / "iteration.json").write_text(json.dumps({
             "iteration": 1,
             "status_code": "ready_for_review",
             "last_seen_comment_ids": ["OLD1"]
@@ -1164,7 +1164,7 @@ class TestSavePRCommentsFiltersLastSeen:
         pr_dir = issue_dir / "pr"
         iter_001 = pr_dir / "iteration_001"
         iter_001.mkdir(parents=True)
-        (iter_001 / "context.json").write_text(json.dumps({
+        (iter_001 / "iteration.json").write_text(json.dumps({
             "iteration": 1,
             "status_code": "ready_for_review",
             "last_seen_comment_ids": ["R1", "T1"]

--- a/tests/unit/test_pr_phase_iteration_logic.py
+++ b/tests/unit/test_pr_phase_iteration_logic.py
@@ -28,7 +28,7 @@ def _write_develop_iteration(
     }
     if end_time is not None:
         payload["end_time"] = end_time
-    (develop_dir / "context.json").write_text(json.dumps(payload))
+    (develop_dir / "iteration.json").write_text(json.dumps(payload))
 
 
 def _write_pr_iteration(
@@ -53,7 +53,7 @@ def _write_pr_iteration(
         payload["response"] = response
     if status_code is not None:
         payload["status_code"] = status_code
-    (pr_dir / "context.json").write_text(json.dumps(payload))
+    (pr_dir / "iteration.json").write_text(json.dumps(payload))
     if user_input is not None:
         (pr_dir / "user_input.md").write_text(user_input)
 
@@ -114,8 +114,8 @@ class TestPRPhaseIterationLogic:
         spec_file.parent.mkdir(parents=True)
         spec_file.write_text("# Test Spec")
 
-        # Create context.json with status_code (completed iteration)
-        context_file = iteration_dir / "context.json"
+        # Create iteration.json with status_code (completed iteration)
+        context_file = iteration_dir / "iteration.json"
         context_file.write_text(json.dumps({
             "iteration": 1,
             "timestamp": "2026-01-27T10:00:00+08:00",
@@ -155,8 +155,8 @@ class TestPRPhaseIterationLogic:
         spec_file.parent.mkdir(parents=True)
         spec_file.write_text("# Test Spec")
 
-        # Create context.json with status_code (completed iteration, no user_input.md)
-        context_file = iteration_dir / "context.json"
+        # Create iteration.json with status_code (completed iteration, no user_input.md)
+        context_file = iteration_dir / "iteration.json"
         context_file.write_text(json.dumps({
             "iteration": 1,
             "timestamp": "2026-01-27T10:00:00+08:00",
@@ -190,7 +190,7 @@ class TestPRPhaseIterationLogic:
         spec_file.parent.mkdir(parents=True)
         spec_file.write_text("# Test Spec")
 
-        context_file = iteration_dir / "context.json"
+        context_file = iteration_dir / "iteration.json"
         context_file.write_text(json.dumps({
             "iteration": 1,
             "timestamp": "2026-01-27T10:00:00+08:00",
@@ -571,8 +571,8 @@ class TestPRPhaseIterationLogic:
         spec_file.parent.mkdir(parents=True)
         spec_file.write_text("# Test Spec")
 
-        # Create context.json with status_code (complete iteration)
-        context_file = iteration_dir / "context.json"
+        # Create iteration.json with status_code (complete iteration)
+        context_file = iteration_dir / "iteration.json"
         context_file.write_text(json.dumps({
             "iteration": 1,
             "timestamp": "2026-01-27T10:00:00+08:00",
@@ -603,7 +603,7 @@ class TestPRPhaseIterationLogic:
         spec_file.parent.mkdir(parents=True)
         spec_file.write_text("# Test Spec")
 
-        context_file = iteration_dir / "context.json"
+        context_file = iteration_dir / "iteration.json"
         context_file.write_text(json.dumps({
             "iteration": 1,
             "timestamp": "2026-01-27T10:00:00+08:00",
@@ -634,8 +634,8 @@ class TestPRPhaseIterationLogic:
         spec_file.parent.mkdir(parents=True)
         spec_file.write_text("# Test Spec")
 
-        # Create context.json without status_code (incomplete iteration)
-        context_file = iteration_dir / "context.json"
+        # Create iteration.json without status_code (incomplete iteration)
+        context_file = iteration_dir / "iteration.json"
         context_file.write_text(json.dumps({
             "iteration": 1,
             "timestamp": "2026-01-27T10:00:00+08:00"
@@ -673,8 +673,8 @@ class TestPRPhaseIterationLogic:
         spec_file.parent.mkdir(parents=True)
         spec_file.write_text("# Test Spec")
 
-        # Create context.json without status_code (incomplete iteration)
-        context_file = iteration_dir / "context.json"
+        # Create iteration.json without status_code (incomplete iteration)
+        context_file = iteration_dir / "iteration.json"
         context_file.write_text(json.dumps({
             "iteration": 1,
             "timestamp": "2026-01-27T10:00:00+08:00"
@@ -733,8 +733,8 @@ class TestPRPhaseIterationLogic:
         spec_file.parent.mkdir(parents=True)
         spec_file.write_text("# Test Spec")
 
-        # Create context.json with status_code but no user_input
-        context_file = iteration_dir / "context.json"
+        # Create iteration.json with status_code but no user_input
+        context_file = iteration_dir / "iteration.json"
         context_file.write_text(json.dumps({
             "iteration": 1,
             "timestamp": "2026-01-27T10:00:00+08:00",
@@ -768,7 +768,7 @@ class TestPRPhaseIterationLogic:
         spec_file.write_text("# Test Spec")
 
         # Create PR iteration with user_input (NEEDS_CHANGES)
-        pr_context_file = iteration_dir / "context.json"
+        pr_context_file = iteration_dir / "iteration.json"
         pr_context_file.write_text(json.dumps({
             "iteration": 1,
             "timestamp": "2026-01-27T10:00:00+08:00",
@@ -808,7 +808,7 @@ class TestPRPhaseIterationLogic:
         spec_file.write_text("# Test Spec")
 
         # Create PR iteration with user_input at 10:00
-        pr_context_file = iteration_dir / "context.json"
+        pr_context_file = iteration_dir / "iteration.json"
         pr_context_file.write_text(json.dumps({
             "iteration": 1,
             "timestamp": "2026-01-27T10:00:00+08:00",
@@ -902,8 +902,8 @@ class TestPhaseComparisonWithMissingEndTime:
         spec_file.parent.mkdir(parents=True)
         spec_file.write_text("# Test Spec")
 
-        # Create context.json with status_code but no end_time
-        context_file = iteration_dir / "context.json"
+        # Create iteration.json with status_code but no end_time
+        context_file = iteration_dir / "iteration.json"
         context_file.write_text(json.dumps({
             "iteration": 1,
             "timestamp": "2026-01-27T10:00:00+08:00",
@@ -940,7 +940,7 @@ class TestPhaseComparisonWithMissingEndTime:
         spec_file.write_text("# Test Spec")
 
         # Create PR iteration without end_time
-        context_file = iteration_dir / "context.json"
+        context_file = iteration_dir / "iteration.json"
         context_file.write_text(json.dumps({
             "iteration": 1,
             "timestamp": "2026-01-27T10:00:00+08:00",
@@ -983,7 +983,7 @@ class TestPhaseComparisonWithMissingEndTime:
         spec_file.write_text("# Test Spec")
 
         # Create PR iteration with end_time
-        context_file = iteration_dir / "context.json"
+        context_file = iteration_dir / "iteration.json"
         context_file.write_text(json.dumps({
             "iteration": 1,
             "timestamp": "2026-01-27T10:00:00+08:00",
@@ -1016,12 +1016,12 @@ class TestPhaseComparisonWithMissingEndTime:
             assert result is False
 
     def test_organize_comments_saves_status_code_to_context(self, tmp_path, mock_dependencies):
-        """Test that _organize_comments_to_todo_list saves status_code to context.json.
+        """Test that _organize_comments_to_todo_list saves status_code to iteration.json.
 
         Regression test: _execute_agent_iteration intentionally saves status_code=None
-        to context.json (waiting for checklist validation). _organize_comments_to_todo_list
-        must save the final status_code back to context.json before returning.
-        Without this fix, context.json ends up with status_code: null.
+        to iteration.json (waiting for checklist validation). _organize_comments_to_todo_list
+        must save the final status_code back to iteration.json before returning.
+        Without this fix, iteration.json ends up with status_code: null.
         """
         from cafe.core.status_codes import PhaseStatusCode
 
@@ -1047,8 +1047,8 @@ class TestPhaseComparisonWithMissingEndTime:
         checklist_file = iteration_dir / "checklist.md"
         checklist_file.write_text("- [x] Read PR comments\n- [x] Organize into todo list\n")
 
-        # Create context.json as _execute_agent_iteration would leave it (status_code=None)
-        context_file = iteration_dir / "context.json"
+        # Create iteration.json as _execute_agent_iteration would leave it (status_code=None)
+        context_file = iteration_dir / "iteration.json"
         context_file.write_text(json.dumps({
             "iteration": 1,
             "timestamp": "2026-01-27T10:00:00+08:00",
@@ -1093,10 +1093,10 @@ class TestPhaseComparisonWithMissingEndTime:
             assert result.status == PhaseStatus.COMPLETED
             assert result.data["status_code"] == "needs_changes"
 
-            # THE ACTUAL BUG CHECK: verify status_code was persisted to context.json
+            # THE ACTUAL BUG CHECK: verify status_code was persisted to iteration.json
             saved_context = json.loads(context_file.read_text())
             assert saved_context["status_code"] == "needs_changes", \
-                f"Bug: status_code in context.json is {saved_context.get('status_code')!r}, expected 'needs_changes'"
+                f"Bug: status_code in iteration.json is {saved_context.get('status_code')!r}, expected 'needs_changes'"
 
     def test_organize_comments_retries_when_output_md_empty(self, tmp_path, mock_dependencies):
         """Test that _organize_comments_to_todo_list retries when output.md is missing todo list markers."""
@@ -1124,8 +1124,8 @@ class TestPhaseComparisonWithMissingEndTime:
         checklist_file = iteration_dir / "checklist.md"
         checklist_file.write_text("- [x] Read PR comments\n- [x] Organize into todo list\n")
 
-        # Create context.json
-        context_file = iteration_dir / "context.json"
+        # Create iteration.json
+        context_file = iteration_dir / "iteration.json"
         context_file.write_text(json.dumps({
             "iteration": 1,
             "timestamp": "2026-01-27T10:00:00+08:00",
@@ -1205,8 +1205,8 @@ class TestPhaseComparisonWithMissingEndTime:
         checklist_file = iteration_dir / "checklist.md"
         checklist_file.write_text("- [x] Read PR comments\n- [x] Organize into todo list\n")
 
-        # Create context.json
-        context_file = iteration_dir / "context.json"
+        # Create iteration.json
+        context_file = iteration_dir / "iteration.json"
         context_file.write_text(json.dumps({
             "iteration": 1,
             "timestamp": "2026-01-27T10:00:00+08:00",
@@ -1323,13 +1323,13 @@ class TestGetLastSeenCommentIds:
         assert result == {"A1", "B2"}
 
     def test_artifact_takes_precedence_over_legacy_context(self, tmp_path, mock_dependencies):
-        """Artifact data should override older context.json snapshots."""
+        """Artifact data should override older iteration.json snapshots."""
         issue_dir = tmp_path / ".cafe" / "issues" / "test-issue"
         pr_dir = issue_dir / "pr"
 
         iter_dir = pr_dir / "iteration_001"
         iter_dir.mkdir(parents=True)
-        (iter_dir / "context.json").write_text(
+        (iter_dir / "iteration.json").write_text(
             json.dumps(
                 {
                     "iteration": 1,
@@ -1354,7 +1354,7 @@ class TestGetLastSeenCommentIds:
     def test_latest_iteration_has_last_seen_comment_ids(self, tmp_path, mock_dependencies):
         """Test _get_last_seen_comment_ids returns IDs from latest iteration context.
 
-        情境：最新一輪 iteration 的 context.json 包含 last_seen_comment_ids
+        情境：最新一輪 iteration 的 iteration.json 包含 last_seen_comment_ids
         預期：返回該 set
         """
         issue_dir = tmp_path / ".cafe" / "issues" / "test-issue"
@@ -1362,7 +1362,7 @@ class TestGetLastSeenCommentIds:
         iter_dir = pr_dir / "iteration_001"
         iter_dir.mkdir(parents=True)
 
-        context_file = iter_dir / "context.json"
+        context_file = iter_dir / "iteration.json"
         context_file.write_text(json.dumps({
             "iteration": 1,
             "status_code": "ready_for_review",
@@ -1388,7 +1388,7 @@ class TestGetLastSeenCommentIds:
         # iteration_001: push iteration with last_seen_comment_ids
         iter_001 = pr_dir / "iteration_001"
         iter_001.mkdir(parents=True)
-        (iter_001 / "context.json").write_text(json.dumps({
+        (iter_001 / "iteration.json").write_text(json.dumps({
             "iteration": 1,
             "status_code": "ready_for_review",
             "last_seen_comment_ids": ["R1", "T1"]
@@ -1397,7 +1397,7 @@ class TestGetLastSeenCommentIds:
         # iteration_002: comment-fetch iteration without last_seen_comment_ids
         iter_002 = pr_dir / "iteration_002"
         iter_002.mkdir(parents=True)
-        (iter_002 / "context.json").write_text(json.dumps({
+        (iter_002 / "iteration.json").write_text(json.dumps({
             "iteration": 2,
             "status_code": "needs_changes"
             # last_seen_comment_ids 欄位不存在
@@ -1412,7 +1412,7 @@ class TestGetLastSeenCommentIds:
     def test_no_iteration_has_last_seen_comment_ids_returns_empty(self, tmp_path, mock_dependencies):
         """Test _get_last_seen_comment_ids returns empty set when no iteration has the field.
 
-        情境：所有 iteration 都沒有 last_seen_comment_ids（舊版本 context.json）
+        情境：所有 iteration 都沒有 last_seen_comment_ids（舊版本 iteration.json）
         預期：返回空 set（向後兼容）
         """
         issue_dir = tmp_path / ".cafe" / "issues" / "test-issue"
@@ -1420,7 +1420,7 @@ class TestGetLastSeenCommentIds:
 
         iter_001 = pr_dir / "iteration_001"
         iter_001.mkdir(parents=True)
-        (iter_001 / "context.json").write_text(json.dumps({
+        (iter_001 / "iteration.json").write_text(json.dumps({
             "iteration": 1,
             "status_code": "ready_for_review"
             # 沒有 last_seen_comment_ids（舊版本）

--- a/tests/unit/test_reset_command.py
+++ b/tests/unit/test_reset_command.py
@@ -38,8 +38,8 @@ def phase_with_iterations(tmp_issue_dir: Path):
         iter_dir = phase_dir / f"iteration_{i:03d}"
         iter_dir.mkdir(parents=True, exist_ok=True)
 
-        # Create context.json (required for iteration detection)
-        context_file = iter_dir / "context.json"
+        # Create iteration.json (required for iteration detection)
+        context_file = iter_dir / "iteration.json"
         context_file.write_text(json.dumps({"iteration": i}))
 
         # Create output.md
@@ -276,9 +276,9 @@ class TestIterationRemovalAndStatusUpdate:
         assert copied_data == original_data
 
     def test_end_time_from_context_json(self, phase_with_iterations: Path):
-        """Test 5.3b: Read end_time from context.json when updating status.json."""
-        # Update context.json in iteration_003 to include end_time
-        iter3_context = phase_with_iterations / "iteration_003" / "context.json"
+        """Test 5.3b: Read end_time from iteration.json when updating status.json."""
+        # Update iteration.json in iteration_003 to include end_time
+        iter3_context = phase_with_iterations / "iteration_003" / "iteration.json"
         context_data = {
             "iteration": 3,
             "timestamp": "2024-01-03T10:00:00+00:00",
@@ -287,7 +287,7 @@ class TestIterationRemovalAndStatusUpdate:
         }
         iter3_context.write_text(json.dumps(context_data))
 
-        # Simulate what cafe reset does: read context.json and create status.json
+        # Simulate what cafe reset does: read iteration.json and create status.json
         loaded_context = json.loads(iter3_context.read_text())
         target_end_time = loaded_context.get("end_time")
         target_timestamp = loaded_context.get("timestamp")
@@ -310,9 +310,9 @@ class TestIterationRemovalAndStatusUpdate:
         assert loaded_status["end_time"] == "2024-01-03T10:30:00+00:00"
 
     def test_end_time_fallback_to_timestamp(self, phase_with_iterations: Path):
-        """Test 5.3c: Fallback to timestamp when end_time is not in context.json."""
-        # Update context.json in iteration_003 WITHOUT end_time
-        iter3_context = phase_with_iterations / "iteration_003" / "context.json"
+        """Test 5.3c: Fallback to timestamp when end_time is not in iteration.json."""
+        # Update iteration.json in iteration_003 WITHOUT end_time
+        iter3_context = phase_with_iterations / "iteration_003" / "iteration.json"
         context_data = {
             "iteration": 3,
             "timestamp": "2024-01-03T10:00:00+00:00",
@@ -321,7 +321,7 @@ class TestIterationRemovalAndStatusUpdate:
         }
         iter3_context.write_text(json.dumps(context_data))
 
-        # Simulate what cafe reset does: read context.json and create status.json
+        # Simulate what cafe reset does: read iteration.json and create status.json
         loaded_context = json.loads(iter3_context.read_text())
         target_end_time = loaded_context.get("end_time")  # Will be None
         target_timestamp = loaded_context.get("timestamp")
@@ -351,7 +351,7 @@ class TestIterationRemovalAndStatusUpdate:
 
         iter_dir = phase_dir / "iteration_001"
         iter_dir.mkdir(parents=True, exist_ok=True)
-        iter_dir.joinpath("context.json").write_text('{}')
+        iter_dir.joinpath("iteration.json").write_text('{}')
 
         status_path = phase_dir / "status.json"
         status_path.write_text('{"current_iteration": 1}')

--- a/tests/unit/test_review_phase_iteration_context.py
+++ b/tests/unit/test_review_phase_iteration_context.py
@@ -27,7 +27,7 @@ def _write_iteration_context(
         payload["status_code"] = status_code
     if response is not None:
         payload["response"] = response
-    (iteration_dir / "context.json").write_text(json.dumps(payload), encoding="utf-8")
+    (iteration_dir / "iteration.json").write_text(json.dumps(payload), encoding="utf-8")
 
 
 def _make_review_phase(issue_dir: Path) -> ReviewPhase:

--- a/tests/unit/test_spec_github_sync.py
+++ b/tests/unit/test_spec_github_sync.py
@@ -68,7 +68,7 @@ class TestConfirmedSyncInWorkflow:
             "status_code": "ready_for_review",
             "phase_specific_data": {"pm_agent": "Roger"}
         }
-        (prev_iteration_dir / "context.json").write_text(json.dumps(prev_context))
+        (prev_iteration_dir / "iteration.json").write_text(json.dumps(prev_context))
         
         # Create spec file
         spec_content = "# Final Spec\n\nConfirmed requirements"
@@ -106,7 +106,7 @@ class TestConfirmedSyncInWorkflow:
             "status_code": "ready_for_review",
             "phase_specific_data": {"pm_agent": "Roger"}
         }
-        (prev_iteration_dir / "context.json").write_text(json.dumps(prev_context))
+        (prev_iteration_dir / "iteration.json").write_text(json.dumps(prev_context))
         
         spec_phase._config_issue_id = "123"
         spec_phase.iteration = 2

--- a/tests/unit/test_spec_phase_qa.py
+++ b/tests/unit/test_spec_phase_qa.py
@@ -283,12 +283,12 @@ class TestInterruptedIterationUserInput:
     """測試中斷迭代的 user_input 邏輯"""
 
     def test_interrupted_iteration_does_not_fallback_to_context_json_user_input(self, spec_phase):
-        """context.json 的 legacy user_input 不應再作為中斷恢復來源。"""
+        """iteration.json 的 legacy user_input 不應再作為中斷恢復來源。"""
         spec_phase.iteration = 2
 
         iteration_dir = spec_phase._get_iteration_dir(2)
         iteration_dir.mkdir(parents=True, exist_ok=True)
-        (iteration_dir / "context.json").write_text('{"user_input":"legacy only"}', encoding="utf-8")
+        (iteration_dir / "iteration.json").write_text('{"user_input":"legacy only"}', encoding="utf-8")
 
         with patch.object(spec_phase, "_load_current_iteration_data", return_value={"prompt": "x"}), \
              patch.object(spec_phase, "_load_previous_iteration_data", return_value=None):

--- a/tests/unit/test_summary_service.py
+++ b/tests/unit/test_summary_service.py
@@ -100,7 +100,7 @@ class TestLoadPhaseStatus:
         issue_dir = tmp_path / ".cafe/issues/test-issue"
         phase_dir = issue_dir / "pr"
         (phase_dir / "iteration_001").mkdir(parents=True)
-        (phase_dir / "iteration_001/context.json").write_text(
+        (phase_dir / "iteration_001/iteration.json").write_text(
             json.dumps(
                 {
                     "iteration": 1,
@@ -166,7 +166,7 @@ class TestLoadPhaseStatus:
         issue_dir = tmp_path / ".cafe/issues/test-issue"
         phase_dir = issue_dir / "spec"
         (phase_dir / "iteration_001").mkdir(parents=True)
-        (phase_dir / "iteration_001/context.json").write_text(
+        (phase_dir / "iteration_001/iteration.json").write_text(
             json.dumps(
                 {
                     "iteration": 1,
@@ -218,7 +218,7 @@ class TestLoadPhaseStatus:
 
         phase_dir = tmp_path / ".cafe/issues/test-issue/pr"
         (phase_dir / "iteration_001").mkdir(parents=True)
-        (phase_dir / "iteration_001/context.json").write_text(
+        (phase_dir / "iteration_001/iteration.json").write_text(
             json.dumps(
                 {
                     "iteration": 1,
@@ -287,8 +287,8 @@ class TestLoadIterationStatuses:
         phase_dir = tmp_path / ".cafe/issues/test-issue/spec"
         (phase_dir / "iteration_001").mkdir(parents=True)
         (phase_dir / "iteration_002").mkdir(parents=True)
-        (phase_dir / "iteration_001/context.json").write_text('{"iteration": 1, "status_code": "confirmed", "timestamp": "2026-01-14T10:00:00+08:00"}')
-        (phase_dir / "iteration_002/context.json").write_text('{"iteration": 2, "status_code": "confirmed", "timestamp": "2026-01-14T11:00:00+08:00"}')
+        (phase_dir / "iteration_001/iteration.json").write_text('{"iteration": 1, "status_code": "confirmed", "timestamp": "2026-01-14T10:00:00+08:00"}')
+        (phase_dir / "iteration_002/iteration.json").write_text('{"iteration": 2, "status_code": "confirmed", "timestamp": "2026-01-14T11:00:00+08:00"}')
 
         result = service.load_iteration_statuses("test-issue", "spec")
         assert isinstance(result, list)
@@ -319,7 +319,7 @@ class TestLoadIterationStatuses:
         assert result == []
 
     def test_load_iteration_statuses_parses_iteration_info(self, tmp_path, monkeypatch):
-        """Test parsing iteration number and metadata from context.json files."""
+        """Test parsing iteration number and metadata from iteration.json files."""
         from cafe.services.summary_service import SummaryService
 
         monkeypatch.chdir(tmp_path)
@@ -328,7 +328,7 @@ class TestLoadIterationStatuses:
         phase_dir = tmp_path / ".cafe/issues/test-issue/review"
         (phase_dir / "iteration_001").mkdir(parents=True)
         context_data = {"iteration": 1, "status_code": "need_clarification", "timestamp": "2025-01-04T14:00:00Z"}
-        (phase_dir / "iteration_001/context.json").write_text(json.dumps(context_data))
+        (phase_dir / "iteration_001/iteration.json").write_text(json.dumps(context_data))
 
         result = service.load_iteration_statuses("test-issue", "review")
         assert isinstance(result, list)
@@ -336,7 +336,7 @@ class TestLoadIterationStatuses:
         assert result[0]["iteration"] == 1
 
     def test_load_iteration_statuses_handles_malformed_iteration_json(self, tmp_path, monkeypatch):
-        """Test handling of malformed JSON in iteration context.json files."""
+        """Test handling of malformed JSON in iteration iteration.json files."""
         from cafe.services.summary_service import SummaryService
 
         monkeypatch.chdir(tmp_path)
@@ -344,7 +344,7 @@ class TestLoadIterationStatuses:
         service = SummaryService()
         phase_dir = tmp_path / ".cafe/issues/test-issue/pr"
         (phase_dir / "iteration_001").mkdir(parents=True)
-        (phase_dir / "iteration_001/context.json").write_text('{invalid json}')
+        (phase_dir / "iteration_001/iteration.json").write_text('{invalid json}')
 
         result = service.load_iteration_statuses("test-issue", "pr")
         # Should skip malformed file and return empty or populated list
@@ -368,7 +368,7 @@ class TestLoadIterationStatuses:
         assert isinstance(result, list)
 
     def test_load_iteration_statuses_from_context_files(self, tmp_path, monkeypatch):
-        """Test reading iterations from context.json files."""
+        """Test reading iterations from iteration.json files."""
         from cafe.services.summary_service import SummaryService
 
         monkeypatch.chdir(tmp_path)
@@ -377,7 +377,7 @@ class TestLoadIterationStatuses:
         phase_dir = tmp_path / ".cafe/issues/test-issue/review"
         phase_dir.mkdir(parents=True)
 
-        # Create 4 iteration context.json files
+        # Create 4 iteration iteration.json files
         for i in range(1, 5):
             (phase_dir / f"iteration_{i:03d}").mkdir(parents=True)
             context = {
@@ -385,7 +385,7 @@ class TestLoadIterationStatuses:
                 "timestamp": f"2026-01-05T00:{40+i*5:02d}:00.000000",
                 "status_code": "confirmed" if i == 4 else "needs_changes",
             }
-            (phase_dir / f"iteration_{i:03d}/context.json").write_text(json.dumps(context))
+            (phase_dir / f"iteration_{i:03d}/iteration.json").write_text(json.dumps(context))
 
         result = service.load_iteration_statuses("test-issue", "review")
         assert isinstance(result, list)
@@ -396,10 +396,10 @@ class TestLoadIterationStatuses:
 
 
 class TestLoadIterationContexts:
-    """Test loading iteration data from context.json"""
+    """Test loading iteration data from iteration.json"""
 
     def test_load_iteration_statuses_reads_from_context_json(self, tmp_path, monkeypatch):
-        """Verify load_iteration_statuses() reads data from context.json"""
+        """Verify load_iteration_statuses() reads data from iteration.json"""
         from cafe.services.summary_service import SummaryService
 
         monkeypatch.chdir(tmp_path)
@@ -409,7 +409,7 @@ class TestLoadIterationContexts:
         (phase_dir / "iteration_001").mkdir(parents=True)
         (phase_dir / "iteration_002").mkdir(parents=True)
 
-        # Create context.json files (including start_time and end_time)
+        # Create iteration.json files (including start_time and end_time)
         context1 = {
             "iteration": 1,
             "timestamp": "2026-01-14T10:00:00+08:00",
@@ -422,8 +422,8 @@ class TestLoadIterationContexts:
             "end_time": "2026-01-14T10:45:00+08:00",
             "status_code": "confirmed"
         }
-        (phase_dir / "iteration_001/context.json").write_text(json.dumps(context1))
-        (phase_dir / "iteration_002/context.json").write_text(json.dumps(context2))
+        (phase_dir / "iteration_001/iteration.json").write_text(json.dumps(context1))
+        (phase_dir / "iteration_002/iteration.json").write_text(json.dumps(context2))
 
         result = service.load_iteration_statuses("test-issue", "spec")
         assert isinstance(result, list)
@@ -443,13 +443,13 @@ class TestLoadIterationContexts:
         phase_dir = tmp_path / ".cafe/issues/test-issue/plan"
         (phase_dir / "iteration_001").mkdir(parents=True)
 
-        # Create context.json without end_time (simulating in-progress iteration)
+        # Create iteration.json without end_time (simulating in-progress iteration)
         context = {
             "iteration": 1,
             "timestamp": "2026-01-14T11:00:00+08:00",
             "status_code": "need_clarification"
         }
-        (phase_dir / "iteration_001/context.json").write_text(json.dumps(context))
+        (phase_dir / "iteration_001/iteration.json").write_text(json.dumps(context))
 
         result = service.load_iteration_statuses("test-issue", "plan")
         assert isinstance(result, list)
@@ -477,7 +477,7 @@ class TestLoadIterationContexts:
                 "end_time": f"2026-01-14T{10+i}:15:00+08:00",
                 "status_code": "confirmed"
             }
-            (phase_dir / f"iteration_{i:03d}/context.json").write_text(json.dumps(context))
+            (phase_dir / f"iteration_{i:03d}/iteration.json").write_text(json.dumps(context))
 
         result = service.load_iteration_statuses("test-issue", "develop")
         assert isinstance(result, list)
@@ -489,7 +489,7 @@ class TestLoadIterationContexts:
 
 
 class TestLoadTokenUsageData:
-    """Test loading token usage data from context.json"""
+    """Test loading token usage data from iteration.json"""
 
     def test_load_iteration_statuses_extracts_token_usage(self, tmp_path, monkeypatch):
         """Verify load_iteration_statuses() extracts cli, model, and stats fields"""
@@ -501,7 +501,7 @@ class TestLoadTokenUsageData:
         phase_dir = tmp_path / ".cafe/issues/test-issue/spec"
         (phase_dir / "iteration_001").mkdir(parents=True)
 
-        # Create context.json with token usage data
+        # Create iteration.json with token usage data
         context = {
             "iteration": 1,
             "timestamp": "2026-01-31T10:00:00+08:00",
@@ -519,7 +519,7 @@ class TestLoadTokenUsageData:
                 "duration_api_ms": 81850
             }
         }
-        (phase_dir / "iteration_001/context.json").write_text(json.dumps(context))
+        (phase_dir / "iteration_001/iteration.json").write_text(json.dumps(context))
 
         result = service.load_iteration_statuses("test-issue", "spec")
         assert len(result) == 1
@@ -539,13 +539,13 @@ class TestLoadTokenUsageData:
         phase_dir = tmp_path / ".cafe/issues/test-issue/plan"
         (phase_dir / "iteration_001").mkdir(parents=True)
 
-        # Create context.json without token usage data
+        # Create iteration.json without token usage data
         context = {
             "iteration": 1,
             "timestamp": "2026-01-31T11:00:00+08:00",
             "status_code": "confirmed"
         }
-        (phase_dir / "iteration_001/context.json").write_text(json.dumps(context))
+        (phase_dir / "iteration_001/iteration.json").write_text(json.dumps(context))
 
         result = service.load_iteration_statuses("test-issue", "plan")
         assert len(result) == 1
@@ -596,7 +596,7 @@ class TestLoadTokenUsageData:
 
         for i, context in enumerate(contexts, 1):
             (phase_dir / f"iteration_{i:03d}").mkdir(parents=True)
-            (phase_dir / f"iteration_{i:03d}/context.json").write_text(json.dumps(context))
+            (phase_dir / f"iteration_{i:03d}/iteration.json").write_text(json.dumps(context))
 
         result = service.load_iteration_statuses("test-issue", "spec")
         assert len(result) == 2


### PR DESCRIPTION
Closes #265

## Changes
- Rename `context.json` → `iteration.json` across all source and test files
- Backward-compatible read fallback: if `iteration.json` doesn't exist but `context.json` does, read `context.json` with deprecation warning
- Always write new files as `iteration.json`
- Slim iteration directories: delete `streaming.jsonl` and `iterations.jsonl` after phase completion (best-effort)
- Complete `user_input` migration: no new writes to `user_input` field in iteration JSON; content goes to `user_input.md` only

## Test
- 1980 passed, 5 skipped, 1 xfailed
- New `test_iteration_file_fallback.py` — 5 tests for backward-compatible read