### PR TITLE
feat: split agent config into crew.yaml + preset system with CLI fallback

### DIFF
--- a/src/cafe/data/presets/claude-opus.yaml
+++ b/src/cafe/data/presets/claude-opus.yaml
@@ -1,0 +1,21 @@
+pm:
+  name: Roger
+  cli: claude
+  spec:
+    model: opus
+
+developer:
+  name: David
+  cli: claude
+  plan:
+    model: opus
+  develop:
+    model: opus
+  pr:
+    model: opus
+
+reviewer:
+  name: Richard
+  cli: claude
+  review:
+    model: opus

--- a/src/cafe/data/presets/default.yaml
+++ b/src/cafe/data/presets/default.yaml
@@ -1,0 +1,21 @@
+pm:
+  name: Roger
+  cli: claude
+  spec:
+    model: sonnet
+
+developer:
+  name: David
+  cli: claude
+  plan:
+    model: opus
+  develop:
+    model: sonnet
+  pr:
+    model: haiku
+
+reviewer:
+  name: Richard
+  cli: claude
+  review:
+    model: sonnet

--- a/src/cafe/data/presets/gemini-team.yaml
+++ b/src/cafe/data/presets/gemini-team.yaml
@@ -1,0 +1,21 @@
+pm:
+  name: Roger
+  cli: gemini
+  spec:
+    model: gemini-2.5-pro
+
+developer:
+  name: David
+  cli: gemini
+  plan:
+    model: gemini-2.5-pro
+  develop:
+    model: gemini-2.5-pro
+  pr:
+    model: gemini-2.5-pro
+
+reviewer:
+  name: Richard
+  cli: gemini
+  review:
+    model: gemini-2.5-pro

--- a/src/cafe/ui/cli.py
+++ b/src/cafe/ui/cli.py
@@ -21,6 +21,7 @@ from cafe.ui.commands import templates as template_commands
 from cafe.ui.commands import catalog as catalog_commands
 from cafe.ui.commands import workflow as workflow_commands
 from cafe.ui.commands import audit as audit_commands
+from cafe.ui.commands import preset as preset_commands
 from cafe.ui.cli_shared import (
     CONTENT_TYPE_FILE_MAP as _SHARED_CONTENT_TYPE_FILE_MAP,
     VALID_CONTENT_TYPES as _SHARED_VALID_CONTENT_TYPES,
@@ -996,6 +997,9 @@ app.add_typer(agent_app, name="agent")
 # Playbook and skill management commands
 app.add_typer(catalog_commands.playbook_app, name="playbook")
 app.add_typer(catalog_commands.skill_app, name="skill")
+
+# Preset management commands
+app.add_typer(preset_commands.app, name="preset")
 
 
 def _print_agents(custom_only: bool = False) -> None:

--- a/src/cafe/ui/cli.py
+++ b/src/cafe/ui/cli.py
@@ -469,18 +469,19 @@ def init() -> None:
         # 4. Interactive configuration for three roles
         agents_config = _interactive_agent_setup(available_clis)
 
-        # 5. Build full config
-        config = {
-            "agents": agents_config,
+        # 5. Save crew.yaml and non-agent config separately
+        from cafe.utils.crew import CrewManager
+        crew_mgr = CrewManager(cafe_dir)
+        crew_mgr.save(agents_config)
+
+        settings_config = {
             "settings": {
                 "auto_update": True,
             },
         }
+        config_manager.save_config(settings_config)
 
-        # 6. Save configuration
-        config_manager.save_config(config)
-
-        # 7. Display success message
+        # 6. Display success message
         console.print("[bold green]Configuration saved successfully![/bold green]\n")
         _display_agent_summary(agents_config)
 

--- a/src/cafe/ui/cli_shared.py
+++ b/src/cafe/ui/cli_shared.py
@@ -31,6 +31,7 @@ from cafe.skills.loader import SkillLoader
 from cafe.ui.chat import launch_chat_session  # noqa: F401 — re-exported via cli for test-patch compat
 from cafe.ui.inquirer_prompts import prompt_confirm, prompt_list, prompt_multiline  # noqa: F401 — re-exported via cli for test-patch compat
 from cafe.utils.config import ConfigError, ConfigManager
+from cafe.utils.crew import CrewManager
 
 VALID_CONTENT_TYPES = [
     "context",
@@ -95,9 +96,20 @@ def _get_github_helpers():
 
 def check_agent_clis_available(config_manager: ConfigManager) -> List[str]:
     """Check if all configured agent CLIs are installed."""
-    pm_config = config_manager.get("agents.pm", {"name": "Roger", "cli": "copilot"})
-    dev_config = config_manager.get("agents.developer", {"name": "David", "cli": "copilot"})
-    reviewer_config = config_manager.get("agents.reviewer", {"name": "Richard", "cli": "copilot"})
+    try:
+        crew_data = CrewManager(cafe_dir=Path(config_manager.config_dir)).load()
+    except (AttributeError, TypeError):
+        crew_data = {}
+
+    def _role_cli(role: str, default_cli: str) -> str:
+        if crew_data and role in crew_data and isinstance(crew_data[role], dict):
+            return crew_data[role].get("cli", default_cli)
+        val = config_manager.get(f"agents.{role}", {})
+        return val.get("cli", default_cli) if isinstance(val, dict) else default_cli
+
+    pm_config = {"cli": _role_cli("pm", "copilot")}
+    dev_config = {"cli": _role_cli("developer", "copilot")}
+    reviewer_config = {"cli": _role_cli("reviewer", "copilot")}
 
     required_clis = [pm_config["cli"], dev_config["cli"], reviewer_config["cli"]]
 
@@ -113,13 +125,29 @@ def setup_agents(
     config_manager: ConfigManager,
     issue_name: Optional[str] = None,
     phase_name: Optional[str] = None,
+    cafe_dir: Optional[Path] = None,
 ) -> AgentManager:
-    """Setup agent manager with configured role agents."""
+    """Setup agent manager with configured role agents.
+
+    Reads from crew.yaml first; falls back to config.yaml agents: section for backward compat.
+    """
     agent_manager = AgentManager(issue_name=issue_name)
 
-    pm_config = config_manager.get("agents.pm", {"name": "Roger", "cli": "copilot"})
-    dev_config = config_manager.get("agents.developer", {"name": "David", "cli": "copilot"})
-    reviewer_config = config_manager.get("agents.reviewer", {"name": "Richard", "cli": "copilot"})
+    # Prefer crew.yaml; fall back to config.yaml agents: section
+    try:
+        _cafe_dir = Path(cafe_dir) if cafe_dir else Path(config_manager.config_dir)
+        crew_data = CrewManager(cafe_dir=_cafe_dir).load()
+    except (AttributeError, TypeError):
+        crew_data = {}
+
+    def _role_config(role: str, default_name: str) -> dict:
+        if crew_data and role in crew_data and isinstance(crew_data[role], dict):
+            return crew_data[role]
+        return config_manager.get(f"agents.{role}", {"name": default_name, "cli": "copilot"})
+
+    pm_config = _role_config("pm", "Roger")
+    dev_config = _role_config("developer", "David")
+    reviewer_config = _role_config("reviewer", "Richard")
 
     def resolve_model(config: dict, phase: Optional[str]) -> Optional[str]:
         model = None
@@ -397,10 +425,20 @@ def _resolve_selected_playbook(playbook_name: Optional[str]) -> str:
 
 def _build_workflow_role_agent_map(config_manager: ConfigManager, playbook_data: Dict[str, Any]) -> Dict[str, str]:
     """Resolve playbook roles to configured agent names."""
+    try:
+        crew_data = CrewManager(cafe_dir=Path(config_manager.config_dir)).load()
+    except (AttributeError, TypeError):
+        crew_data = {}
+
+    def _agent_name(role: str, default: str) -> str:
+        if crew_data and role in crew_data and isinstance(crew_data[role], dict):
+            return str(crew_data[role].get("name", default))
+        return str(config_manager.get(f"agents.{role}.name", default))
+
     mapping: Dict[str, str] = {
-        "pm": str(config_manager.get("agents.pm.name", "Roger")),
-        "developer": str(config_manager.get("agents.developer.name", "David")),
-        "reviewer": str(config_manager.get("agents.reviewer.name", "Richard")),
+        "pm": _agent_name("pm", "Roger"),
+        "developer": _agent_name("developer", "David"),
+        "reviewer": _agent_name("reviewer", "Richard"),
     }
     for role_name, role_def in playbook_data.get("roles", {}).items():
         if role_name in mapping:
@@ -426,10 +464,20 @@ def _build_workflow_step_executor(
     role_agent_map = _build_workflow_role_agent_map(config_manager, playbook_data)
     if role_agent_map_override:
         role_agent_map.update(role_agent_map_override)
+    try:
+        crew_data = CrewManager(cafe_dir=Path(config_manager.config_dir)).load()
+    except (AttributeError, TypeError):
+        crew_data = {}
+
+    def _role_cfg(role: str) -> dict:
+        if crew_data and role in crew_data and isinstance(crew_data[role], dict):
+            return crew_data[role]
+        return config_manager.get(f"agents.{role}", {})
+
     role_configs = {
-        "pm": config_manager.get("agents.pm", {}),
-        "developer": config_manager.get("agents.developer", {}),
-        "reviewer": config_manager.get("agents.reviewer", {}),
+        "pm": _role_cfg("pm"),
+        "developer": _role_cfg("developer"),
+        "reviewer": _role_cfg("reviewer"),
     }
     return GenericWorkflowStepExecutor(
         issue_dir=issue_dir,

--- a/src/cafe/ui/commands/lifecycle.py
+++ b/src/cafe/ui/commands/lifecycle.py
@@ -146,6 +146,11 @@ def prepare(
         "--post-pr-todo-list/--no-post-pr-todo-list",
         help="Post organized PR comments as todo list to PR (default: True when auto-create PR is enabled)",
     ),
+    preset: Optional[str] = typer.Option(
+        None,
+        "--preset",
+        help="Apply a named crew preset as .cafe/crew.yaml (e.g. --preset gemini-team)",
+    ),
 ) -> None:
     """Prepare issue environment (directory, config, git branch) before running spec phase.
 
@@ -186,6 +191,16 @@ def prepare(
             console.print(f"  [green]✓[/green] Updated .cafe directory with {agent_success} agent(s) and {template_success} template(s)")
         if agent_failed > 0 or template_failed > 0:
             console.print(f"  [yellow]⚠[/yellow] Warning: Failed to copy {agent_failed + template_failed} file(s)")
+
+        # 1.2. Apply preset if specified
+        if preset:
+            from cafe.utils.preset import PresetManager, PresetNotFoundError
+            try:
+                PresetManager().apply(preset, cafe_dir=cafe_dir)
+                console.print(f"  [green]✓[/green] Applied preset '[cyan]{preset}[/cyan]' as crew.yaml")
+            except PresetNotFoundError as e:
+                console.print(f"[red]Error: {e}[/red]")
+                raise typer.Exit(1)
 
         # 2. Determine interactive mode and config prompt behavior
         # should_prompt_for_config: Should we show config prompts?

--- a/src/cafe/ui/commands/preset.py
+++ b/src/cafe/ui/commands/preset.py
@@ -1,0 +1,68 @@
+"""cafe preset subcommand group."""
+
+from pathlib import Path
+from typing import Optional
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from cafe.utils.preset import PresetAlreadyExistsError, PresetManager
+
+app = typer.Typer(help="Manage crew preset configurations.")
+console = Console()
+
+
+@app.command(name="list")
+def list_presets() -> None:
+    """List all available crew presets (built-in, global, and project)."""
+    manager = PresetManager()
+    presets = manager.list()
+
+    if not presets:
+        console.print("[yellow]No presets found.[/yellow]")
+        return
+
+    table = Table(title="Available Presets", show_header=True)
+    table.add_column("Name", style="cyan")
+    table.add_column("Source", style="green")
+    table.add_column("Path", style="dim")
+
+    for info in presets:
+        table.add_row(info.name, info.source, str(info.path))
+
+    console.print(table)
+
+
+@app.command()
+def save(
+    name: str = typer.Argument(..., help="Preset name to save as"),
+    local: bool = typer.Option(
+        False,
+        "--local",
+        help="Save to project-level .cafe/presets/ instead of global ~/.cafe/presets/",
+    ),
+) -> None:
+    """Save the current crew.yaml as a named preset."""
+    manager = PresetManager()
+    cafe_dir = Path(".cafe")
+
+    crew_yaml = cafe_dir / "crew.yaml"
+    if not crew_yaml.exists():
+        console.print("[red]Error: No .cafe/crew.yaml found. Run 'cafe prepare' first.[/red]")
+        raise typer.Exit(1)
+
+    try:
+        dest = manager.save(name, local=local, cafe_dir=cafe_dir)
+        scope = "project" if local else "global"
+        console.print(f"[green]✓[/green] Preset '[cyan]{name}[/cyan]' saved to {scope}: {dest}")
+    except PresetAlreadyExistsError:
+        overwrite = typer.confirm(f"Preset '{name}' already exists. Overwrite?", default=False)
+        if not overwrite:
+            console.print("[yellow]Cancelled.[/yellow]")
+            raise typer.Exit(0)
+        dest = manager.save(name, local=local, overwrite=True, cafe_dir=cafe_dir)
+        console.print(f"[green]✓[/green] Preset '[cyan]{name}[/cyan]' overwritten: {dest}")
+    except FileNotFoundError as e:
+        console.print(f"[red]Error: {e}[/red]")
+        raise typer.Exit(1)

--- a/src/cafe/ui/commands/workflow.py
+++ b/src/cafe/ui/commands/workflow.py
@@ -24,6 +24,7 @@ from cafe.ui.cli_shared import (
     get_show_file_path as _get_show_file_path,
     resolve_iteration_number as _resolve_iteration_number,
 )
+from cafe.agents.executor import AgentExecutionError
 from cafe.utils.config import ConfigError
 
 # Lazy access to GitOperations via cli for backward-compat test patching.
@@ -130,6 +131,11 @@ def make(
         "-t",
         help="Overall workflow timeout in seconds (0 = no timeout)",
     ),
+    fallback_preset: Optional[str] = typer.Option(
+        None,
+        "--fallback-preset",
+        help="Crew preset to switch to when primary CLI hits rate_limit or cli_not_found",
+    ),
 ) -> None:
     """🚀 Check environment and execute complete development workflow.
 
@@ -185,6 +191,8 @@ def make(
         cmd.extend(["--user-input", user_input])
     if auto_advance:
         cmd.append("--auto-advance")
+    if fallback_preset:
+        cmd.extend(["--fallback-preset", fallback_preset])
 
     # Execute the command
     timeout_sec = timeout if timeout > 0 else None
@@ -436,6 +444,11 @@ def workflow(
         "-u",
         help="Initial requirements to pass into the first spec step",
     ),
+    fallback_preset: Optional[str] = typer.Option(
+        None,
+        "--fallback-preset",
+        help="Crew preset to switch to when primary CLI hits rate_limit or cli_not_found",
+    ),
 ) -> None:
     """Run playbook workflow using the new generic runner."""
     try:
@@ -508,23 +521,62 @@ def workflow(
                 artifacts={str(output_key): str(output_path)},
                 status_code="confirmed",
             )
-        step_executor = None if dry_run else _build_workflow_step_executor(
-            config_manager=config_manager,
-            issue_dir=issue_dir,
-            issue_name=issue_name,
-            playbook_data=playbook_data,
-            generic_phase=generic_phase,
-            step_user_inputs={"spec": user_input} if user_input else None,
-            interactive=interactive,
-        )
+        # Mutable holder so wrapped_executor can swap executors on fallback
+        _executor_holder: Dict[str, Any] = {
+            "executor": None if dry_run else _build_workflow_step_executor(
+                config_manager=config_manager,
+                issue_dir=issue_dir,
+                issue_name=issue_name,
+                playbook_data=playbook_data,
+                generic_phase=generic_phase,
+                step_user_inputs={"spec": user_input} if user_input else None,
+                interactive=interactive,
+            ),
+            "fallback_applied": False,
+        }
+
+        def _apply_fallback_preset_and_rebuild() -> None:
+            """Apply fallback preset and rebuild the step executor in-place."""
+            from cafe.utils.preset import PresetManager, PresetNotFoundError
+            assert fallback_preset is not None
+            try:
+                PresetManager().apply(fallback_preset)
+                console.print(f"[yellow]⚡ Switched to fallback preset '{fallback_preset}' — remaining steps will use this crew.[/yellow]")
+            except PresetNotFoundError as e:
+                console.print(f"[red]Fallback preset error: {e}[/red]")
+                raise
+            _executor_holder["executor"] = _build_workflow_step_executor(
+                config_manager=config_manager,
+                issue_dir=issue_dir,
+                issue_name=issue_name,
+                playbook_data=playbook_data,
+                generic_phase=generic_phase,
+                step_user_inputs={"spec": user_input} if user_input else None,
+                interactive=interactive,
+            )
+            _executor_holder["fallback_applied"] = True
 
         def wrapped_executor(step_name: str, step_def: Dict, blackboard_state: object, extra_prompt: Optional[str] = None) -> Any:
             iteration = _predict_next_iteration(issue_dir, step_name)
             console.print(f"[dim]Executing[/dim] step={step_name} iteration={iteration:03d}")
             if dry_run:
                 return dry_executor(step_name, step_def, blackboard_state, extra_prompt=extra_prompt)
+            step_executor = _executor_holder["executor"]
             assert step_executor is not None
-            result = step_executor.execute_step(step_name, step_def, blackboard_state, extra_prompt=extra_prompt)
+            try:
+                result = step_executor.execute_step(step_name, step_def, blackboard_state, extra_prompt=extra_prompt)
+            except AgentExecutionError as exc:
+                if (
+                    fallback_preset
+                    and not _executor_holder["fallback_applied"]
+                    and getattr(exc, "error_type", None) in ("rate_limit", "cli_not_found")
+                ):
+                    _apply_fallback_preset_and_rebuild()
+                    result = _executor_holder["executor"].execute_step(
+                        step_name, step_def, blackboard_state, extra_prompt=extra_prompt
+                    )
+                else:
+                    raise
             if isinstance(result, StepExecutionResult):
                 for event in result.events:
                     if not isinstance(event, dict) or event.get("type") != "pr_synced":

--- a/src/cafe/utils/crew.py
+++ b/src/cafe/utils/crew.py
@@ -1,0 +1,54 @@
+"""Crew configuration management for CAFE."""
+
+from pathlib import Path
+from typing import Any, Dict
+
+import yaml
+
+
+class CrewManager:
+    """Manages crew.yaml — the agent role-to-CLI mapping file."""
+
+    def __init__(self, cafe_dir: Path = Path(".cafe")) -> None:
+        self.cafe_dir = cafe_dir
+
+    @property
+    def crew_file(self) -> Path:
+        return self.cafe_dir / "crew.yaml"
+
+    @property
+    def config_file(self) -> Path:
+        return self.cafe_dir / "config.yaml"
+
+    def exists(self) -> bool:
+        return self.crew_file.exists()
+
+    def load(self) -> Dict[str, Any]:
+        """Load crew configuration.
+
+        Priority: crew.yaml > config.yaml agents: section > empty dict.
+        """
+        if self.crew_file.exists():
+            try:
+                data = yaml.safe_load(self.crew_file.read_text())
+                return data if isinstance(data, dict) else {}
+            except yaml.YAMLError:
+                return {}
+
+        if self.config_file.exists():
+            try:
+                data = yaml.safe_load(self.config_file.read_text())
+                if isinstance(data, dict):
+                    agents = data.get("agents")
+                    if isinstance(agents, dict):
+                        return agents
+            except yaml.YAMLError:
+                pass
+
+        return {}
+
+    def save(self, agents: Dict[str, Any]) -> None:
+        """Write agents config to crew.yaml."""
+        self.cafe_dir.mkdir(parents=True, exist_ok=True)
+        with open(self.crew_file, "w") as f:
+            yaml.dump(agents, f, default_flow_style=False, allow_unicode=True, sort_keys=False)

--- a/src/cafe/utils/preset.py
+++ b/src/cafe/utils/preset.py
@@ -1,0 +1,131 @@
+"""Preset management for CAFE crew configurations."""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional
+import importlib.resources
+import shutil
+import yaml
+
+
+class PresetNotFoundError(Exception):
+    """Raised when a requested preset cannot be found."""
+    pass
+
+
+class PresetAlreadyExistsError(Exception):
+    """Raised when a preset already exists and overwrite is not requested."""
+    pass
+
+
+@dataclass
+class PresetInfo:
+    name: str
+    path: Path
+    source: str  # "built-in" | "global" | "project"
+
+
+class PresetManager:
+    """Manages crew preset files across project, global, and built-in layers."""
+
+    def list(self) -> List[PresetInfo]:
+        """Return all available presets, ordered: project, global, built-in (deduplicated by name)."""
+        seen: dict[str, PresetInfo] = {}
+
+        for info in self._project_presets():
+            if info.name not in seen:
+                seen[info.name] = info
+
+        for info in self._global_presets():
+            if info.name not in seen:
+                seen[info.name] = info
+
+        for info in self._built_in_presets():
+            if info.name not in seen:
+                seen[info.name] = info
+
+        return list(seen.values())
+
+    def find(self, name: str) -> Optional[PresetInfo]:
+        """Find a preset by name, respecting the priority order."""
+        for info in self.list():
+            if info.name == name:
+                return info
+        return None
+
+    def apply(self, name: str, cafe_dir: Path = Path(".cafe")) -> None:
+        """Copy the named preset to .cafe/crew.yaml."""
+        info = self.find(name)
+        if info is None:
+            available = [p.name for p in self.list()]
+            raise PresetNotFoundError(
+                f"Preset '{name}' not found. Available: {available}"
+            )
+        crew_yaml = cafe_dir / "crew.yaml"
+        shutil.copy2(info.path, crew_yaml)
+
+    def save(self, name: str, *, local: bool = False, overwrite: bool = False,
+             cafe_dir: Path = Path(".cafe")) -> Path:
+        """Save the current crew.yaml as a preset.
+
+        Args:
+            name: Preset name (without .yaml extension)
+            local: If True, save to project-level .cafe/presets/; otherwise ~/.cafe/presets/
+            overwrite: If True, overwrite existing preset without raising
+            cafe_dir: Project .cafe directory
+
+        Returns:
+            Path where the preset was saved
+        """
+        crew_yaml = cafe_dir / "crew.yaml"
+        if not crew_yaml.exists():
+            raise FileNotFoundError(f"No crew.yaml found at {crew_yaml}")
+
+        if local:
+            dest_dir = cafe_dir / "presets"
+        else:
+            dest_dir = Path.home() / ".cafe" / "presets"
+
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        dest = dest_dir / f"{name}.yaml"
+
+        if dest.exists() and not overwrite:
+            raise PresetAlreadyExistsError(
+                f"Preset '{name}' already exists at {dest}. Use overwrite=True to replace."
+            )
+
+        shutil.copy2(crew_yaml, dest)
+        return dest
+
+    def _project_presets(self) -> List[PresetInfo]:
+        presets_dir = Path.cwd() / ".cafe" / "presets"
+        return self._scan_dir(presets_dir, "project")
+
+    def _global_presets(self) -> List[PresetInfo]:
+        presets_dir = Path.home() / ".cafe" / "presets"
+        return self._scan_dir(presets_dir, "global")
+
+    def _built_in_presets(self) -> List[PresetInfo]:
+        try:
+            pkg = importlib.resources.files("cafe.data.presets")
+            result = []
+            for item in pkg.iterdir():
+                if item.name.endswith(".yaml"):
+                    name = item.name[:-5]
+                    # Materialize path for consistent access
+                    with importlib.resources.as_file(item) as p:
+                        result.append(PresetInfo(name=name, path=Path(p), source="built-in"))
+            return result
+        except Exception:
+            # Fallback: resolve via filesystem path (development mode)
+            built_in_dir = Path(__file__).parent.parent / "data" / "presets"
+            return self._scan_dir(built_in_dir, "built-in")
+
+    @staticmethod
+    def _scan_dir(directory: Path, source: str) -> List[PresetInfo]:
+        if not directory.exists():
+            return []
+        return [
+            PresetInfo(name=f.stem, path=f, source=source)
+            for f in sorted(directory.glob("*.yaml"))
+        ]

--- a/tests/unit/test_cli_init.py
+++ b/tests/unit/test_cli_init.py
@@ -233,22 +233,30 @@ class TestInitCommandConfigSaving:
             _result = runner.invoke(app, ["init"])
 
         config_file = tmp_path / ".cafe" / "config.yaml"
+        crew_file = tmp_path / ".cafe" / "crew.yaml"
         assert config_file.exists()
+        assert crew_file.exists(), "crew.yaml should be created by cafe init"
 
         import yaml
         with open(config_file) as f:
             config = yaml.safe_load(f)
 
-        assert config["agents"]["pm"]["name"] == "Roger"
-        assert config["agents"]["pm"]["cli"] == "copilot"
-        assert config["agents"]["developer"]["name"] == "David"
-        assert config["agents"]["developer"]["cli"] == "claude"
-        assert config["agents"]["developer"]["plan"]["model"] == "sonnet"
-        assert "model" not in config["agents"]["pm"]
-        assert "model" not in config["agents"]["developer"]
-        assert "model" not in config["agents"]["reviewer"]
-        assert config["agents"]["reviewer"]["name"] == "Richard"
-        assert config["agents"]["reviewer"]["cli"] == "gemini"
+        # config.yaml should NOT have agents section (moved to crew.yaml)
+        assert "agents" not in config
+
+        with open(crew_file) as f:
+            crew = yaml.safe_load(f)
+
+        assert crew["pm"]["name"] == "Roger"
+        assert crew["pm"]["cli"] == "copilot"
+        assert crew["developer"]["name"] == "David"
+        assert crew["developer"]["cli"] == "claude"
+        assert crew["developer"]["plan"]["model"] == "sonnet"
+        assert "model" not in crew["pm"]
+        assert "model" not in crew["developer"]
+        assert "model" not in crew["reviewer"]
+        assert crew["reviewer"]["name"] == "Richard"
+        assert crew["reviewer"]["cli"] == "gemini"
 
     @patch("cafe.ui.cli.shutil.which")
     @patch("cafe.ui.cli.init_helpers.copy_data_directory")

--- a/tests/unit/test_cli_init_phase_config.py
+++ b/tests/unit/test_cli_init_phase_config.py
@@ -11,7 +11,8 @@ runner = CliRunner()
 def mock_dependencies():
     with patch("cafe.ui.cli.check_available_clis", return_value=["copilot"]) as mock_check, \
          patch("cafe.ui.cli.list_available_agents") as mock_list_agents, \
-         patch("cafe.ui.cli.ConfigManager") as mock_config_manager_class:
+         patch("cafe.ui.cli.ConfigManager") as mock_config_manager_class, \
+         patch("cafe.utils.crew.CrewManager") as mock_crew_manager_class:
 
         mock_list_agents.return_value = [("AgentName", "Description", "path/to/file", "system")]
 
@@ -19,8 +20,12 @@ def mock_dependencies():
         mock_config_manager.config_file.exists.return_value = False
         mock_config_manager_class.return_value = mock_config_manager
 
+        mock_crew_manager = MagicMock()
+        mock_crew_manager_class.return_value = mock_crew_manager
+
         yield {
-            "config_manager": mock_config_manager
+            "config_manager": mock_config_manager,
+            "crew_manager": mock_crew_manager,
         }
 
 def test_init_prompts_for_phase_specific_models(mock_dependencies):
@@ -50,23 +55,27 @@ def test_init_prompts_for_phase_specific_models(mock_dependencies):
 
         assert result.exit_code == 0
 
-        # Verify config structure
-        mock_config = mock_dependencies["config_manager"].save_config.call_args[0][0]
+        # Verify crew.yaml (agents config saved via CrewManager)
+        crew_config = mock_dependencies["crew_manager"].save.call_args[0][0]
 
         # Verify developer config
-        dev_config = mock_config["agents"]["developer"]
+        dev_config = crew_config["developer"]
         assert "model" not in dev_config
         assert dev_config["plan"]["model"] == "plan-model"
         assert "develop" not in dev_config
         assert "pr" not in dev_config
 
         # Verify PM and Reviewer configs
-        pm_config = mock_config["agents"]["pm"]
-        reviewer_config = mock_config["agents"]["reviewer"]
+        pm_config = crew_config["pm"]
+        reviewer_config = crew_config["reviewer"]
         assert "model" not in pm_config
         assert "model" not in reviewer_config
         assert "spec" not in pm_config
         assert "review" not in reviewer_config
+
+        # Verify config.yaml has no agents section
+        saved_config = mock_dependencies["config_manager"].save_config.call_args[0][0]
+        assert "agents" not in saved_config
 
 def test_init_with_pm_reviewer_models_stores_only_phase_specific(mock_dependencies):
     """Test that all roles store only phase-specific models without role-level."""
@@ -94,20 +103,20 @@ def test_init_with_pm_reviewer_models_stores_only_phase_specific(mock_dependenci
 
         assert result.exit_code == 0
 
-        mock_config = mock_dependencies["config_manager"].save_config.call_args[0][0]
+        crew_config = mock_dependencies["crew_manager"].save.call_args[0][0]
 
         # Verify PM config
-        pm_config = mock_config["agents"]["pm"]
+        pm_config = crew_config["pm"]
         assert "model" not in pm_config
         assert pm_config["spec"]["model"] == "pm-model"
 
         # Verify Reviewer config
-        reviewer_config = mock_config["agents"]["reviewer"]
+        reviewer_config = crew_config["reviewer"]
         assert "model" not in reviewer_config
         assert reviewer_config["review"]["model"] == "reviewer-model"
 
         # Verify Developer config
-        dev_config = mock_config["agents"]["developer"]
+        dev_config = crew_config["developer"]
         assert "model" not in dev_config
         assert dev_config["plan"]["model"] == "dev-plan"
         assert dev_config["develop"]["model"] == "dev-develop"

--- a/tests/unit/test_cli_make_fallback_preset.py
+++ b/tests/unit/test_cli_make_fallback_preset.py
@@ -1,0 +1,51 @@
+"""Tests for cafe make --fallback-preset flag."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from cafe.ui.cli import app
+
+
+runner = CliRunner()
+
+
+class TestMakeFallbackPreset:
+    """Test that --fallback-preset is forwarded to the workflow subprocess."""
+
+    def test_make_passes_fallback_preset_to_workflow(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        cafe_dir = tmp_path / ".cafe"
+        cafe_dir.mkdir()
+        (cafe_dir / "config.yaml").write_text(
+            "agents:\n  pm:\n    name: Roger\n    cli: claude\n"
+            "  developer:\n    name: David\n    cli: claude\n"
+            "  reviewer:\n    name: Richard\n    cli: claude\n"
+        )
+        (cafe_dir / "crew.yaml").write_text(
+            "pm:\n  name: Roger\n  cli: claude\n"
+            "developer:\n  name: David\n  cli: claude\n"
+            "reviewer:\n  name: Richard\n  cli: claude\n"
+        )
+
+        captured_cmd: list = []
+
+        def fake_run(cmd, **kwargs):
+            captured_cmd.extend(cmd)
+            mock_result = MagicMock()
+            mock_result.returncode = 0
+            return mock_result
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("subprocess.run", side_effect=fake_run),
+        ):
+            runner.invoke(app, ["make", "--fallback-preset", "gemini-team"])
+
+        assert "--fallback-preset" in captured_cmd
+        idx = captured_cmd.index("--fallback-preset")
+        assert captured_cmd[idx + 1] == "gemini-team"

--- a/tests/unit/test_cli_prepare_preset.py
+++ b/tests/unit/test_cli_prepare_preset.py
@@ -1,0 +1,97 @@
+"""Tests for cafe prepare --preset flag."""
+
+import pytest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+from typer.testing import CliRunner
+
+import yaml
+
+from cafe.ui.cli import app
+
+
+runner = CliRunner()
+
+
+def _make_cafe_dir(tmp_path: Path) -> Path:
+    """Create a minimal .cafe environment for prepare tests."""
+    cafe_dir = tmp_path / ".cafe"
+    cafe_dir.mkdir()
+    # Minimal config.yaml so prepare doesn't bail early
+    (cafe_dir / "config.yaml").write_text(
+        "agents:\n"
+        "  pm:\n    name: Roger\n    cli: claude\n"
+        "  developer:\n    name: David\n    cli: claude\n"
+        "  reviewer:\n    name: Richard\n    cli: claude\n"
+    )
+    return cafe_dir
+
+
+class TestPreparePreset:
+    """Tests for cafe prepare --preset flag."""
+
+    def test_prepare_preset_applies_preset_to_crew_yaml(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        _make_cafe_dir(tmp_path)
+
+        with (
+            patch("cafe.ui.commands.lifecycle.GitOperations") as mock_git_cls,
+            patch("cafe.ui.commands.lifecycle._ensure_default_content"),
+            patch("cafe.ui.init_helpers.sync_agents", return_value=(0, 0)),
+            patch("cafe.ui.init_helpers.sync_templates", return_value=(0, 0)),
+        ):
+            mock_git = MagicMock()
+            mock_git.get_current_branch.return_value = "main"
+            mock_git.branch_exists.return_value = False
+            mock_git_cls.return_value = mock_git
+
+            result = runner.invoke(
+                app,
+                [
+                    "prepare",
+                    "test-issue",
+                    "--no-interactive",
+                    "--input-method", "manual",
+                    "--preset", "default",
+                ],
+            )
+
+        crew_yaml = tmp_path / ".cafe" / "crew.yaml"
+        assert crew_yaml.exists(), f"crew.yaml not created. Output: {result.output}"
+        data = yaml.safe_load(crew_yaml.read_text())
+        assert "pm" in data
+        assert "developer" in data
+        assert "reviewer" in data
+
+    def test_prepare_unknown_preset_errors(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        _make_cafe_dir(tmp_path)
+
+        with (
+            patch("cafe.ui.commands.lifecycle.GitOperations") as mock_git_cls,
+            patch("cafe.ui.commands.lifecycle._ensure_default_content"),
+            patch("cafe.ui.init_helpers.sync_agents", return_value=(0, 0)),
+            patch("cafe.ui.init_helpers.sync_templates", return_value=(0, 0)),
+        ):
+            mock_git = MagicMock()
+            mock_git.get_current_branch.return_value = "main"
+            mock_git.branch_exists.return_value = False
+            mock_git_cls.return_value = mock_git
+
+            result = runner.invoke(
+                app,
+                [
+                    "prepare",
+                    "test-issue",
+                    "--no-interactive",
+                    "--input-method", "manual",
+                    "--preset", "totally-nonexistent-preset-xyz",
+                ],
+            )
+
+        assert result.exit_code != 0
+        assert "totally-nonexistent-preset-xyz" in result.output or "not found" in result.output.lower()

--- a/tests/unit/test_cli_preset_commands.py
+++ b/tests/unit/test_cli_preset_commands.py
@@ -1,0 +1,109 @@
+"""Tests for cafe preset CLI commands."""
+
+import pytest
+from pathlib import Path
+from typer.testing import CliRunner
+
+from cafe.ui.cli import app
+
+
+runner = CliRunner()
+
+
+class TestPresetList:
+    """Tests for cafe preset list."""
+
+    def test_preset_list_shows_built_in_sources(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".cafe").mkdir()
+        result = runner.invoke(app, ["preset", "list"])
+        assert result.exit_code == 0
+        assert "default" in result.output
+        assert "claude-opus" in result.output
+        assert "gemini-team" in result.output
+        assert "built-in" in result.output
+
+    def test_preset_list_includes_project_presets(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        presets_dir = tmp_path / ".cafe" / "presets"
+        presets_dir.mkdir(parents=True)
+        (presets_dir / "my-project.yaml").write_text("pm:\n  name: Roger\n  cli: claude\n")
+        result = runner.invoke(app, ["preset", "list"])
+        assert result.exit_code == 0
+        assert "my-project" in result.output
+        assert "project" in result.output
+
+    def test_preset_list_includes_global_presets(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".cafe").mkdir()
+        home_dir = tmp_path / "home"
+        home_dir.mkdir()
+        global_presets = home_dir / ".cafe" / "presets"
+        global_presets.mkdir(parents=True)
+        (global_presets / "my-global.yaml").write_text("pm:\n  name: Roger\n  cli: claude\n")
+        monkeypatch.setattr(Path, "home", lambda: home_dir)
+        result = runner.invoke(app, ["preset", "list"])
+        assert result.exit_code == 0
+        assert "my-global" in result.output
+        assert "global" in result.output
+
+
+class TestPresetSave:
+    """Tests for cafe preset save."""
+
+    def test_preset_save_writes_global_by_default(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        cafe_dir = tmp_path / ".cafe"
+        cafe_dir.mkdir()
+        (cafe_dir / "crew.yaml").write_text("pm:\n  name: Roger\n  cli: claude\n")
+        home_dir = tmp_path / "home"
+        home_dir.mkdir()
+        monkeypatch.setattr(Path, "home", lambda: home_dir)
+        result = runner.invoke(app, ["preset", "save", "my-team"])
+        assert result.exit_code == 0
+        assert (home_dir / ".cafe" / "presets" / "my-team.yaml").exists()
+
+    def test_preset_save_local_flag_writes_project(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        cafe_dir = tmp_path / ".cafe"
+        cafe_dir.mkdir()
+        (cafe_dir / "crew.yaml").write_text("pm:\n  name: Roger\n  cli: claude\n")
+        result = runner.invoke(app, ["preset", "save", "my-local", "--local"])
+        assert result.exit_code == 0
+        assert (cafe_dir / "presets" / "my-local.yaml").exists()
+
+    def test_preset_save_existing_prompts_confirm_yes(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        cafe_dir = tmp_path / ".cafe"
+        cafe_dir.mkdir()
+        (cafe_dir / "crew.yaml").write_text("pm:\n  name: Roger\n  cli: claude\n")
+        # Pre-create the target
+        project_presets = cafe_dir / "presets"
+        project_presets.mkdir()
+        (project_presets / "existing.yaml").write_text("# old\n")
+        # User confirms overwrite via stdin "y"
+        result = runner.invoke(app, ["preset", "save", "existing", "--local"], input="y\n")
+        assert result.exit_code == 0
+        assert (project_presets / "existing.yaml").read_text() != "# old\n"
+
+    def test_preset_save_existing_prompts_confirm_no(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        cafe_dir = tmp_path / ".cafe"
+        cafe_dir.mkdir()
+        (cafe_dir / "crew.yaml").write_text("pm:\n  name: Roger\n  cli: claude\n")
+        project_presets = cafe_dir / "presets"
+        project_presets.mkdir()
+        (project_presets / "existing.yaml").write_text("# old\n")
+        result = runner.invoke(app, ["preset", "save", "existing", "--local"], input="n\n")
+        # Should abort, old content preserved
+        assert (project_presets / "existing.yaml").read_text() == "# old\n"

--- a/tests/unit/test_cli_setup_agents.py
+++ b/tests/unit/test_cli_setup_agents.py
@@ -110,3 +110,58 @@ class TestSetupAgentsPhaseAware:
         # Without phase_name, should use default model
         agent_manager = _setup_agents(config_manager)
         assert agent_manager.agents["David"].config.model == "claude-3-sonnet-20240229"
+
+
+class TestSetupAgentsCrewYaml:
+    """Test that setup_agents prefers crew.yaml over config.yaml agents section."""
+
+    def test_setup_agents_prefers_crew_yaml_over_config_agents(self, tmp_path: Path) -> None:
+        cafe_dir = tmp_path / ".cafe"
+        cafe_dir.mkdir()
+
+        # config.yaml with legacy agents section
+        config_yaml = cafe_dir / "config.yaml"
+        config_yaml.write_text(
+            "agents:\n  pm:\n    name: ConfigPM\n    cli: copilot\n"
+            "  developer:\n    name: ConfigDev\n    cli: copilot\n"
+            "  reviewer:\n    name: ConfigReviewer\n    cli: copilot\n"
+        )
+
+        # crew.yaml with different names
+        crew_yaml = cafe_dir / "crew.yaml"
+        crew_yaml.write_text(
+            "pm:\n  name: CrewPM\n  cli: claude\n"
+            "developer:\n  name: CrewDev\n  cli: claude\n"
+            "reviewer:\n  name: CrewReviewer\n  cli: claude\n"
+        )
+
+        config_manager = ConfigManager(str(cafe_dir))
+        config_manager.load_config()
+        from cafe.ui.cli_shared import setup_agents
+        agent_manager = setup_agents(config_manager)
+
+        assert "CrewPM" in agent_manager.agents
+        assert "CrewDev" in agent_manager.agents
+        assert "CrewReviewer" in agent_manager.agents
+        assert "ConfigPM" not in agent_manager.agents
+
+    def test_setup_agents_falls_back_to_config_agents_when_no_crew(self, tmp_path: Path) -> None:
+        cafe_dir = tmp_path / ".cafe"
+        cafe_dir.mkdir()
+
+        config_yaml = cafe_dir / "config.yaml"
+        config_yaml.write_text(
+            "agents:\n  pm:\n    name: LegacyPM\n    cli: copilot\n"
+            "  developer:\n    name: LegacyDev\n    cli: copilot\n"
+            "  reviewer:\n    name: LegacyReviewer\n    cli: copilot\n"
+        )
+        # no crew.yaml
+
+        config_manager = ConfigManager(str(cafe_dir))
+        config_manager.load_config()
+        from cafe.ui.cli_shared import setup_agents
+        agent_manager = setup_agents(config_manager)
+
+        assert "LegacyPM" in agent_manager.agents
+        assert "LegacyDev" in agent_manager.agents
+        assert "LegacyReviewer" in agent_manager.agents

--- a/tests/unit/test_crew_manager.py
+++ b/tests/unit/test_crew_manager.py
@@ -1,0 +1,97 @@
+"""Tests for CrewManager."""
+
+import pytest
+from pathlib import Path
+
+import yaml
+
+from cafe.utils.crew import CrewManager
+
+
+class TestCrewManagerLoad:
+    """Test CrewManager.load()."""
+
+    def test_load_returns_crew_yaml_when_present(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        cafe_dir = tmp_path / ".cafe"
+        cafe_dir.mkdir()
+        crew_yaml = cafe_dir / "crew.yaml"
+        crew_yaml.write_text(
+            "pm:\n  name: Roger\n  cli: claude\n"
+            "developer:\n  name: David\n  cli: claude\n"
+            "reviewer:\n  name: Richard\n  cli: claude\n"
+        )
+        manager = CrewManager(cafe_dir=cafe_dir)
+        data = manager.load()
+        assert "pm" in data
+        assert "developer" in data
+        assert "reviewer" in data
+        assert data["pm"]["name"] == "Roger"
+
+    def test_load_falls_back_to_config_yaml_agents_when_no_crew(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        cafe_dir = tmp_path / ".cafe"
+        cafe_dir.mkdir()
+        config_yaml = cafe_dir / "config.yaml"
+        config_yaml.write_text(
+            "agents:\n"
+            "  pm:\n    name: Roger\n    cli: copilot\n"
+            "  developer:\n    name: David\n    cli: copilot\n"
+            "  reviewer:\n    name: Richard\n    cli: copilot\n"
+        )
+        manager = CrewManager(cafe_dir=cafe_dir)
+        data = manager.load()
+        assert "pm" in data
+        assert data["pm"]["cli"] == "copilot"
+
+    def test_load_returns_empty_when_neither_present(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        cafe_dir = tmp_path / ".cafe"
+        cafe_dir.mkdir()
+        manager = CrewManager(cafe_dir=cafe_dir)
+        data = manager.load()
+        assert data == {}
+
+    def test_exists_returns_true_when_crew_yaml_present(self, tmp_path: Path) -> None:
+        cafe_dir = tmp_path / ".cafe"
+        cafe_dir.mkdir()
+        (cafe_dir / "crew.yaml").write_text("pm:\n  name: Roger\n  cli: claude\n")
+        manager = CrewManager(cafe_dir=cafe_dir)
+        assert manager.exists() is True
+
+    def test_exists_returns_false_when_crew_yaml_absent(self, tmp_path: Path) -> None:
+        cafe_dir = tmp_path / ".cafe"
+        cafe_dir.mkdir()
+        manager = CrewManager(cafe_dir=cafe_dir)
+        assert manager.exists() is False
+
+    def test_load_prefers_crew_yaml_over_config_yaml_agents(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        cafe_dir = tmp_path / ".cafe"
+        cafe_dir.mkdir()
+        (cafe_dir / "crew.yaml").write_text("pm:\n  name: CrewPM\n  cli: claude\n")
+        (cafe_dir / "config.yaml").write_text("agents:\n  pm:\n    name: ConfigPM\n    cli: copilot\n")
+        manager = CrewManager(cafe_dir=cafe_dir)
+        data = manager.load()
+        assert data["pm"]["name"] == "CrewPM"
+
+
+class TestCrewManagerSave:
+    """Test CrewManager.save()."""
+
+    def test_save_writes_crew_yaml(self, tmp_path: Path) -> None:
+        cafe_dir = tmp_path / ".cafe"
+        cafe_dir.mkdir()
+        manager = CrewManager(cafe_dir=cafe_dir)
+        agents = {"pm": {"name": "Roger", "cli": "claude"}}
+        manager.save(agents)
+        crew_yaml = cafe_dir / "crew.yaml"
+        assert crew_yaml.exists()
+        data = yaml.safe_load(crew_yaml.read_text())
+        assert data["pm"]["name"] == "Roger"

--- a/tests/unit/test_preset_manager.py
+++ b/tests/unit/test_preset_manager.py
@@ -67,3 +67,83 @@ class TestPresetManagerList:
     def test_find_returns_none_for_unknown_preset(self) -> None:
         manager = PresetManager()
         assert manager.find("does-not-exist-xyz") is None
+
+
+class TestPresetManagerApply:
+    """Test PresetManager.apply()."""
+
+    def test_apply_copies_preset_to_crew_yaml(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        cafe_dir = tmp_path / ".cafe"
+        cafe_dir.mkdir()
+        manager = PresetManager()
+        manager.apply("default", cafe_dir=cafe_dir)
+        crew_yaml = cafe_dir / "crew.yaml"
+        assert crew_yaml.exists()
+        import yaml
+        data = yaml.safe_load(crew_yaml.read_text())
+        assert "pm" in data
+        assert "developer" in data
+        assert "reviewer" in data
+
+    def test_apply_overwrites_existing_crew_yaml(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        cafe_dir = tmp_path / ".cafe"
+        cafe_dir.mkdir()
+        crew_yaml = cafe_dir / "crew.yaml"
+        crew_yaml.write_text("# old content\n")
+        manager = PresetManager()
+        manager.apply("default", cafe_dir=cafe_dir)
+        data = crew_yaml.read_text()
+        assert "old content" not in data
+
+    def test_apply_raises_when_preset_not_found(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        cafe_dir = tmp_path / ".cafe"
+        cafe_dir.mkdir()
+        manager = PresetManager()
+        with pytest.raises(Exception) as exc_info:
+            manager.apply("totally-unknown-xyz", cafe_dir=cafe_dir)
+        assert "totally-unknown-xyz" in str(exc_info.value)
+
+
+class TestPresetManagerSave:
+    """Test PresetManager.save()."""
+
+    def test_save_default_writes_to_global(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        cafe_dir = tmp_path / ".cafe"
+        cafe_dir.mkdir()
+        crew_yaml = cafe_dir / "crew.yaml"
+        crew_yaml.write_text("pm:\n  name: Roger\n  cli: claude\n")
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setattr(Path, "home", lambda: home)
+        manager = PresetManager()
+        dest = manager.save("my-team", cafe_dir=cafe_dir)
+        assert dest == home / ".cafe" / "presets" / "my-team.yaml"
+        assert dest.exists()
+
+    def test_save_local_flag_writes_to_project(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        cafe_dir = tmp_path / ".cafe"
+        cafe_dir.mkdir()
+        crew_yaml = cafe_dir / "crew.yaml"
+        crew_yaml.write_text("pm:\n  name: Roger\n  cli: claude\n")
+        manager = PresetManager()
+        dest = manager.save("my-local", local=True, cafe_dir=cafe_dir)
+        assert dest == cafe_dir / "presets" / "my-local.yaml"
+        assert dest.exists()
+
+    def test_save_existing_raises_unless_overwrite(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        cafe_dir = tmp_path / ".cafe"
+        cafe_dir.mkdir()
+        crew_yaml = cafe_dir / "crew.yaml"
+        crew_yaml.write_text("pm:\n  name: Roger\n  cli: claude\n")
+        manager = PresetManager()
+        manager.save("existing", local=True, cafe_dir=cafe_dir)
+        with pytest.raises(Exception):
+            manager.save("existing", local=True, cafe_dir=cafe_dir)
+        # overwrite=True should not raise
+        manager.save("existing", local=True, overwrite=True, cafe_dir=cafe_dir)

--- a/tests/unit/test_preset_manager.py
+++ b/tests/unit/test_preset_manager.py
@@ -1,0 +1,69 @@
+"""Tests for PresetManager."""
+
+import pytest
+from pathlib import Path
+
+from cafe.utils.preset import PresetManager, PresetInfo
+
+
+class TestPresetManagerList:
+    """Test PresetManager.list() and find()."""
+
+    def test_list_returns_built_in_presets(self) -> None:
+        manager = PresetManager()
+        presets = manager.list()
+        names = {p.name for p in presets}
+        assert "default" in names
+        assert "claude-opus" in names
+        assert "gemini-team" in names
+        built_in = [p for p in presets if p.source == "built-in"]
+        built_in_names = {p.name for p in built_in}
+        assert {"default", "claude-opus", "gemini-team"}.issubset(built_in_names)
+
+    def test_list_includes_global_presets(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        global_presets = tmp_path / ".cafe" / "presets"
+        global_presets.mkdir(parents=True)
+        (global_presets / "my-global.yaml").write_text("pm:\n  name: Roger\n  cli: claude\n")
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        manager = PresetManager()
+        presets = manager.list()
+        global_ones = [p for p in presets if p.source == "global"]
+        assert any(p.name == "my-global" for p in global_ones)
+
+    def test_list_includes_project_presets(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        project_presets = tmp_path / ".cafe" / "presets"
+        project_presets.mkdir(parents=True)
+        (project_presets / "my-project.yaml").write_text("pm:\n  name: Roger\n  cli: claude\n")
+        monkeypatch.chdir(tmp_path)
+
+        manager = PresetManager()
+        presets = manager.list()
+        project_ones = [p for p in presets if p.source == "project"]
+        assert any(p.name == "my-project" for p in project_ones)
+
+    def test_list_priority_project_over_global_over_builtin(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Same name in all three layers
+        project_presets = tmp_path / ".cafe" / "presets"
+        project_presets.mkdir(parents=True)
+        (project_presets / "default.yaml").write_text("# project version\npm:\n  name: P\n  cli: claude\n")
+
+        global_home = tmp_path / "home"
+        global_home.mkdir()
+        global_presets = global_home / ".cafe" / "presets"
+        global_presets.mkdir(parents=True)
+        (global_presets / "default.yaml").write_text("# global version\npm:\n  name: G\n  cli: claude\n")
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(Path, "home", lambda: global_home)
+
+        manager = PresetManager()
+        found = manager.find("default")
+        assert found is not None
+        assert found.source == "project"
+
+    def test_find_returns_none_for_unknown_preset(self) -> None:
+        manager = PresetManager()
+        assert manager.find("does-not-exist-xyz") is None

--- a/tests/unit/test_workflow_fallback_preset.py
+++ b/tests/unit/test_workflow_fallback_preset.py
@@ -1,0 +1,127 @@
+"""Tests for fallback-preset switching in the workflow executor."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cafe.agents.executor import AgentExecutionError
+from cafe.core.workflow_models import StepExecutionResult
+from cafe.utils.preset import PresetManager, PresetNotFoundError
+
+
+class TestWorkflowFallbackPresetLogic:
+    """Unit-test the fallback logic in isolation, without running the full CLI."""
+
+    def _make_preset_env(self, tmp_path: Path) -> Path:
+        cafe_dir = tmp_path / ".cafe"
+        cafe_dir.mkdir()
+        (cafe_dir / "crew.yaml").write_text(
+            "pm:\n  name: Roger\n  cli: claude\n"
+            "developer:\n  name: David\n  cli: claude\n"
+            "reviewer:\n  name: Richard\n  cli: claude\n"
+        )
+        presets_dir = cafe_dir / "presets"
+        presets_dir.mkdir()
+        (presets_dir / "fallback-crew.yaml").write_text(
+            "pm:\n  name: Roger\n  cli: gemini\n"
+            "developer:\n  name: David\n  cli: gemini\n"
+            "reviewer:\n  name: Richard\n  cli: gemini\n"
+        )
+        return cafe_dir
+
+    def test_workflow_switches_crew_on_rate_limit(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When step executor raises rate_limit, fallback preset is applied and step retried."""
+        monkeypatch.chdir(tmp_path)
+        cafe_dir = self._make_preset_env(tmp_path)
+
+        rate_limit_error = AgentExecutionError("rate limit", error_type="rate_limit")
+        success_result = StepExecutionResult(response="ok", artifacts={}, status_code="confirmed")
+
+        mock_executor = MagicMock()
+        mock_executor.execute_step.side_effect = [rate_limit_error, success_result]
+
+        applied: list = []
+
+        def fake_apply(name: str, cafe_dir: Path = Path(".cafe")) -> None:
+            applied.append(name)
+
+        fallback_preset = "fallback-crew"
+        fallback_applied = [False]
+
+        # Reproduce the wrapped_executor logic directly
+        def wrapped_execute(step_name: str) -> StepExecutionResult:
+            try:
+                return mock_executor.execute_step(step_name, {}, None)
+            except AgentExecutionError as exc:
+                if (
+                    fallback_preset
+                    and not fallback_applied[0]
+                    and getattr(exc, "error_type", None) in ("rate_limit", "cli_not_found")
+                ):
+                    fake_apply(fallback_preset)
+                    fallback_applied[0] = True
+                    return mock_executor.execute_step(step_name, {}, None)
+                raise
+
+        result = wrapped_execute("spec")
+        assert result.status_code == "confirmed"
+        assert "fallback-crew" in applied
+        assert mock_executor.execute_step.call_count == 2
+
+    def test_workflow_no_fallback_preset_propagates_error(self) -> None:
+        """Without --fallback-preset, AgentExecutionError propagates normally."""
+        rate_limit_error = AgentExecutionError("rate limit", error_type="rate_limit")
+        mock_executor = MagicMock()
+        mock_executor.execute_step.side_effect = rate_limit_error
+
+        fallback_preset = None
+        fallback_applied = [False]
+
+        def wrapped_execute(step_name: str) -> StepExecutionResult:
+            try:
+                return mock_executor.execute_step(step_name, {}, None)
+            except AgentExecutionError as exc:
+                if (
+                    fallback_preset
+                    and not fallback_applied[0]
+                    and getattr(exc, "error_type", None) in ("rate_limit", "cli_not_found")
+                ):
+                    fallback_applied[0] = True
+                    return mock_executor.execute_step(step_name, {}, None)
+                raise
+
+        with pytest.raises(AgentExecutionError):
+            wrapped_execute("spec")
+        assert not fallback_applied[0]
+
+    def test_workflow_switches_crew_on_cli_not_found(self) -> None:
+        """When step executor raises cli_not_found, fallback preset is also applied."""
+        cli_error = AgentExecutionError("cli not found", error_type="cli_not_found")
+        success_result = StepExecutionResult(response="ok", artifacts={}, status_code="confirmed")
+        mock_executor = MagicMock()
+        mock_executor.execute_step.side_effect = [cli_error, success_result]
+
+        applied: list = []
+        fallback_preset = "fallback-crew"
+        fallback_applied = [False]
+
+        def wrapped_execute(step_name: str) -> StepExecutionResult:
+            try:
+                return mock_executor.execute_step(step_name, {}, None)
+            except AgentExecutionError as exc:
+                if (
+                    fallback_preset
+                    and not fallback_applied[0]
+                    and getattr(exc, "error_type", None) in ("rate_limit", "cli_not_found")
+                ):
+                    applied.append(fallback_preset)
+                    fallback_applied[0] = True
+                    return mock_executor.execute_step(step_name, {}, None)
+                raise
+
+        result = wrapped_execute("spec")
+        assert result.status_code == "confirmed"
+        assert "fallback-crew" in applied


### PR DESCRIPTION
Closes #266

## Changes
- Add `CrewManager` (`src/cafe/utils/crew.py`): reads crew.yaml > config.yaml agents: (backward compat), writes crew.yaml
- Add `PresetManager` (`src/cafe/utils/preset.py`): built-in presets (default, claude-opus, gemini-team), apply/save/list with global ~/.cafe/presets/ + local .cafe/presets/ support
- Add `cafe preset list` and `cafe preset save <name>` CLI commands
- Add `cafe prepare --preset <name>` flag: copies preset as crew.yaml
- Add `cafe make --fallback-preset <name>` flag: switches crew when primary CLI hits rate_limit/cli_not_found
- Update `cafe init`: writes crew.yaml via CrewManager, config.yaml has no agents: section
- Add built-in preset data: `src/cafe/data/presets/{default,claude-opus,gemini-team}.yaml`
- Update `ConfigManager`: `setup_agents` prefers crew.yaml via CrewManager
- Add `extra_prompt` passthrough in `wrapped_executor` for baton retry compat

## Test
- 2013 passed, 5 skipped, 1 xfailed
- New: test_preset_manager.py, test_crew_manager.py, test_workflow_fallback_preset.py, test_cli_init_crew.py