### PR TITLE
feat: per-role CLI fallback chains in crew.yaml with model config

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,31 +61,47 @@ CAFE supports `git worktree`, enabling parallel development across multiple issu
 CAFE integrates with multiple CLI-based AI agents (e.g., Claude Code, Cursor CLI).
 Different agents and models can be assigned per role, allowing you to balance cost, performance, and reasoning depth.
 
-### Automatic Backup Agent Switching on Rate Limits
+### Automatic Fallback Agent Switching on Rate Limits
 
-When a primary agent hits an API rate limit, CAFE automatically switches to backup agents in configured order—without stopping the workflow. If the backup agent also hits a rate limit, CAFE continues to the next backup until one succeeds or all are exhausted.
+When a primary agent hits an API rate limit (or is not installed), CAFE automatically switches to the next CLI in the configured fallback chain—without stopping the workflow. Each entry in the chain can specify its own model and per-phase model overrides.
 
-You can configure backup agents and their per-phase models in `.cafe/config.yaml`:
+Configure per-role fallback chains in `.cafe/crew.yaml` using the `clis` list:
 
 ```yaml
-agents:
-  developer:
-    name: David
-    cli: claude                    # Primary CLI agent
-    backup:                        # Backup agents (tried in order on rate limit)
-      - gemini
-      - copilot
-    models:                        # Per-CLI, per-phase model configuration
-      claude:
-        plan: opus
-        develop: sonnet
-      gemini:
-        plan: gemini-2.5-pro-preview
-        develop: gemini-2-flash-preview
-      copilot: {}                  # Use CLI default model
+developer:
+  name: David
+  clis:
+    - cli: claude                  # Primary CLI
+      model: opus                  # Default model for this entry
+      plan: sonnet                 # Override model for the plan phase
+      develop: sonnet
+    - cli: gemini                  # First fallback
+      model: gemini-2.5-pro-preview
+    - cli: copilot                 # Second fallback (uses CLI default model)
 ```
 
-If all agents (primary + backups) are exhausted, the workflow stops with a clear error message listing which agents were tried. You can add more backup agents with `cafe config edit`.
+The old format is still fully supported and auto-normalized at runtime:
+
+```yaml
+# Backward-compatible format (auto-normalized to clis list)
+developer:
+  name: David
+  cli: claude
+  model: opus
+  backup:                          # Fallback CLIs (tried in order)
+    - gemini
+    - copilot
+  models:                          # Per-CLI, per-phase model configuration
+    claude:
+      plan: opus
+      develop: sonnet
+    gemini:
+      plan: gemini-2.5-pro-preview
+      develop: gemini-2-flash-preview
+    copilot: {}                    # Use CLI default model
+```
+
+If all entries in the chain are exhausted, the workflow stops with a clear error message listing every CLI that was tried. You can edit your crew with `cafe config edit`.
 
 ---
 

--- a/src/cafe/agents/manager.py
+++ b/src/cafe/agents/manager.py
@@ -63,12 +63,13 @@ class AgentManager:
         session_id = session_data.session_id if session_data else None
         # Note: Don't create session here - let executor handle it on first use
 
-        # Update config with session ID (may be None), preserve backup and models config
+        # Update config with session ID (may be None), preserve clis chain and legacy fields
         config_with_session = AgentConfig(
             name=config.name,
             cli=config.cli,
             session_id=session_id,
             model=config.model,
+            clis=config.clis,
             backup_clis=config.backup_clis,
             models_config=config.models_config,
         )

--- a/src/cafe/agents/manager.py
+++ b/src/cafe/agents/manager.py
@@ -280,43 +280,45 @@ class AgentManager:
             AgentExecutionError: Raised when all agents (primary + backups) fail
         """
         config = primary_executor.config
-        backup_clis = config.backup_clis
-        models_config = config.models_config
 
-        if not backup_clis:
-            # No backup agents configured, re-raise the original error
+        # Use clis chain when available; fall back to legacy backup_clis + models_config
+        chain = config.clis
+        if chain:
+            fallback_entries = chain[1:]
+        else:
+            # Legacy path: reconstruct minimal CliEntry list from backup_clis + models_config
+            from cafe.core.types import CliEntry
+            fallback_entries = []
+            for backup_cli in config.backup_clis:
+                phase_models = {}
+                if config.models_config:
+                    raw = config.models_config.get(backup_cli.value, {})
+                    phase_models = dict(raw) if isinstance(raw, dict) else {}
+                fallback_entries.append(CliEntry(cli=backup_cli, phase_models=phase_models))
+
+        if not fallback_entries:
+            # No fallback entries configured, re-raise the original error
             raise primary_error
 
         primary_cli_name = config.cli.value
         print(f"❌ {primary_cli_name} API rate limit reached, trying backup agent...")
 
-        # Track tried CLIs to avoid duplicates (primary CLI is included from the start)
+        # Track tried CLIs to avoid duplicates
         tried_clis = {config.cli}
         failed_agents: List[str] = [f"{primary_cli_name} ({primary_error})"]
 
-        for backup_cli in backup_clis:
-            # Skip CLIs already tried (e.g. backup_clis contains the same CLI as primary)
-            if backup_cli in tried_clis:
+        for entry in fallback_entries:
+            if entry.cli in tried_clis:
                 continue
-            tried_clis.add(backup_cli)
+            tried_clis.add(entry.cli)
 
-            # Look up the model for this backup CLI in the current phase
-            # e.g. models_config = {"gemini": {"develop": "gemini-2-flash-preview"}}
-            # If not configured or empty string, use None (CLI default model)
-            backup_model: Optional[str] = None
-            if phase_name and models_config:
-                backup_model = models_config.get(backup_cli.value, {}).get(phase_name) or None
+            backup_model = entry.resolve_model(phase_name)
+            print(f"Trying {entry.cli.value}...")
 
-            # Treat empty string as None
-            if backup_model == "":
-                backup_model = None
-
-            print(f"Trying {backup_cli.value}...")
-
-            # Create a new executor for the backup CLI (fresh session to avoid session contamination)
+            # Create a new executor for the fallback CLI (fresh session)
             backup_config = AgentConfig(
                 name=config.name,
-                cli=backup_cli,
+                cli=entry.cli,
                 model=backup_model,
             )
             backup_executor = AgentExecutor(backup_config)
@@ -325,19 +327,17 @@ class AgentManager:
                 agent_response = backup_executor.execute(
                     prompt, allowed_tools, allowed_directories, streaming_output_file
                 )
-                print(f"✅ Successfully completed with {backup_cli.value}")
+                print(f"✅ Successfully completed with {entry.cli.value}")
                 return agent_response
             except AgentExecutionError as backup_error:
                 if hasattr(backup_error, 'error_type') and backup_error.error_type in ("rate_limit", "cli_not_found"):
-                    # rate_limit or cli_not_found: record and continue to next backup
-                    failed_agents.append(f"{backup_cli.value} ({backup_error})")
-                    print(f"❌ {backup_cli.value} also hit rate limit, trying next agent...")
+                    failed_agents.append(f"{entry.cli.value} ({backup_error})")
+                    print(f"❌ {entry.cli.value} also hit rate limit, trying next agent...")
                     continue
                 else:
-                    # Other errors (e.g. invalid prompt format): re-raise immediately
                     raise
 
-        # All agents (primary + all backups) failed, compose error message
+        # All agents (primary + all fallbacks) failed, compose error message
         tried_list = ", ".join(failed_agents)
         raise AgentExecutionError(
             f"All agents failed. Tried: {tried_list}. "

--- a/src/cafe/core/types.py
+++ b/src/cafe/core/types.py
@@ -56,37 +56,74 @@ class PermissionAction(str, Enum):
     SKIP = "s"
 
 
+class CliEntry(BaseModel):
+    """A single CLI entry in a role's fallback chain.
+
+    Each entry carries the CLI identifier, an optional default model, and optional
+    phase-level model overrides stored in phase_models (e.g. {"plan": "sonnet"}).
+    """
+
+    cli: AgentCLI
+    model: Optional[str] = None
+    phase_models: Dict[str, str] = Field(default_factory=dict)
+
+    def resolve_model(self, phase_name: Optional[str]) -> Optional[str]:
+        """Return the effective model for the given phase.
+
+        Priority: phase override → entry model → None (CLI default).
+        Empty-string values are treated as None.
+        """
+        if phase_name:
+            override = self.phase_models.get(phase_name)
+            if override is not None:
+                return override or None
+        return self.model or None
+
+
 class AgentConfig(BaseModel):
     """Configuration for an AI agent.
 
-    backup_clis and models_config support automatic backup agent switching.
-    When the primary CLI hits a rate limit, AgentManager tries each backup CLI in order.
+    Supports a clis list where each entry carries its own CLI, model, and
+    phase-level overrides.  The legacy backup_clis / models_config fields are
+    retained for internal backwards compatibility but new code should populate
+    clis instead (normalize_role_config produces this).
 
-    Example config.yaml::
+    Example crew.yaml (new format)::
 
-        agents:
-          developer:
-            name: David
-            cli: claude                    # Primary CLI
-            backup:                        # Backup CLIs (tried in order)
-              - gemini
-              - copilot
-            models:                        # Per-CLI per-phase model configuration
-              claude:
-                plan: opus
-                develop: sonnet
-              gemini:
-                plan: gemini-2.5-pro-preview
-                develop: gemini-2-flash-preview
-              copilot: {}                  # Use CLI default model
+        developer:
+          name: David
+          clis:
+            - cli: claude
+              model: opus
+              plan: sonnet
+            - cli: gemini
+              model: gemini-2.5-pro-preview
+            - cli: copilot
+
+    Example crew.yaml (old format — auto-normalized)::
+
+        developer:
+          name: David
+          cli: claude
+          model: opus
+          backup:
+            - gemini
+            - copilot
+          models:
+            claude:
+              plan: opus
+              develop: sonnet
+            gemini:
+              plan: gemini-2.5-pro-preview
     """
 
     name: str
     cli: AgentCLI
     session_id: Optional[str] = None
-    model: Optional[str] = None  # Optional model name for CLI (e.g., "sonnet", "opus")
-    backup_clis: List["AgentCLI"] = Field(default_factory=list)  # Ordered list of backup CLIs
-    models_config: Dict[str, Dict[str, str]] = Field(default_factory=dict)  # Per-CLI per-phase model configuration
+    model: Optional[str] = None
+    clis: List["CliEntry"] = Field(default_factory=list)
+    backup_clis: List["AgentCLI"] = Field(default_factory=list)
+    models_config: Dict[str, Dict[str, str]] = Field(default_factory=dict)
 
 
 class TokenUsage(BaseModel):

--- a/src/cafe/ui/cli_shared.py
+++ b/src/cafe/ui/cli_shared.py
@@ -31,7 +31,7 @@ from cafe.skills.loader import SkillLoader
 from cafe.ui.chat import launch_chat_session  # noqa: F401 — re-exported via cli for test-patch compat
 from cafe.ui.inquirer_prompts import prompt_confirm, prompt_list, prompt_multiline  # noqa: F401 — re-exported via cli for test-patch compat
 from cafe.utils.config import ConfigError, ConfigManager
-from cafe.utils.crew import CrewManager
+from cafe.utils.crew import CrewManager, normalize_role_config
 
 VALID_CONTENT_TYPES = [
     "context",
@@ -149,70 +149,45 @@ def setup_agents(
     dev_config = _role_config("developer", "David")
     reviewer_config = _role_config("reviewer", "Richard")
 
-    def resolve_model(config: dict, phase: Optional[str]) -> Optional[str]:
-        model = None
-        if phase and phase in config:
-            phase_config = config[phase]
-            if isinstance(phase_config, dict):
-                model = phase_config.get("model")
-        if model is None:
-            model = config.get("model")
-        return model
+    def _build_agent_config(role_config: dict, default_name: str) -> AgentConfig:
+        chain = normalize_role_config(role_config)
 
-    def resolve_backup_clis(config: dict, primary_cli: AgentCLI) -> List[AgentCLI]:
-        backup_raw = config.get("backup", [])
-        seen = {primary_cli}
-        result = []
-        for cli_str in backup_raw:
-            try:
-                cli = AgentCLI(cli_str)
-            except ValueError:
-                continue
-            if cli not in seen:
-                seen.add(cli)
-                result.append(cli)
-        return result
+        # Seed models_config from raw models: dict for backward compat
+        # (manager._try_backup_agents reads it; callers may also inspect it)
+        raw_models = role_config.get("models", {}) or {}
+        models_config: Dict[str, Dict[str, str]] = {}
+        if isinstance(raw_models, dict):
+            for cli_name, phase_map in raw_models.items():
+                if isinstance(phase_map, dict):
+                    models_config[cli_name] = {k: str(v) for k, v in phase_map.items()}
 
-    def resolve_models_config(config: dict) -> Dict[str, Dict[str, str]]:
-        raw = config.get("models", {})
-        if not isinstance(raw, dict):
-            return {}
-        result: Dict[str, Dict[str, str]] = {}
-        for cli_name, phase_models in raw.items():
-            if isinstance(phase_models, dict):
-                result[cli_name] = {k: str(v) for k, v in phase_models.items()}
-        return result
+        if chain:
+            primary = chain[0]
+            cli = primary.cli
+            model = primary.resolve_model(phase_name)
+            backup_clis = [e.cli for e in chain[1:]]
+            # Merge chain entries into models_config (chain takes priority)
+            for entry in chain:
+                if entry.phase_models:
+                    models_config[entry.cli.value] = dict(entry.phase_models)
+        else:
+            # No valid CLI in role config; fall back to copilot with no model
+            cli = AgentCLI.COPILOT
+            model = None
+            backup_clis = []
 
-    pm_cli = AgentCLI(pm_config["cli"])
-    agent_manager.register_agent(
-        AgentConfig(
-            name=pm_config["name"],
-            cli=pm_cli,
-            model=resolve_model(pm_config, phase_name),
-            backup_clis=resolve_backup_clis(pm_config, pm_cli),
-            models_config=resolve_models_config(pm_config),
+        return AgentConfig(
+            name=role_config.get("name", default_name),
+            cli=cli,
+            model=model,
+            clis=chain,
+            backup_clis=backup_clis,
+            models_config=models_config,
         )
-    )
-    dev_cli = AgentCLI(dev_config["cli"])
-    agent_manager.register_agent(
-        AgentConfig(
-            name=dev_config["name"],
-            cli=dev_cli,
-            model=resolve_model(dev_config, phase_name),
-            backup_clis=resolve_backup_clis(dev_config, dev_cli),
-            models_config=resolve_models_config(dev_config),
-        )
-    )
-    reviewer_cli = AgentCLI(reviewer_config["cli"])
-    agent_manager.register_agent(
-        AgentConfig(
-            name=reviewer_config["name"],
-            cli=reviewer_cli,
-            model=resolve_model(reviewer_config, phase_name),
-            backup_clis=resolve_backup_clis(reviewer_config, reviewer_cli),
-            models_config=resolve_models_config(reviewer_config),
-        )
-    )
+
+    agent_manager.register_agent(_build_agent_config(pm_config, "Roger"))
+    agent_manager.register_agent(_build_agent_config(dev_config, "David"))
+    agent_manager.register_agent(_build_agent_config(reviewer_config, "Richard"))
 
     return agent_manager
 

--- a/src/cafe/utils/crew.py
+++ b/src/cafe/utils/crew.py
@@ -1,9 +1,105 @@
 """Crew configuration management for CAFE."""
 
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 import yaml
+
+from cafe.core.types import AgentCLI, CliEntry
+
+# Keys that are not phase names in a role config dict
+_RESERVED_ROLE_KEYS = frozenset(
+    {"cli", "model", "name", "session_id", "backup", "models", "clis"}
+)
+
+
+def normalize_role_config(role: Dict[str, Any]) -> List[CliEntry]:
+    """Convert any crew.yaml role dict into an ordered CliEntry chain.
+
+    New format (clis list) takes priority over old format (cli/backup/models).
+    Unknown CLI strings are silently ignored.  Duplicate CLIs are deduplicated
+    (first occurrence wins).
+
+    Returns an empty list when no valid primary CLI can be found.
+    """
+    if not isinstance(role, dict):
+        return []
+
+    # New format: use clis list directly
+    raw_clis = role.get("clis")
+    if isinstance(raw_clis, list):
+        seen: set = set()
+        entries: List[CliEntry] = []
+        for item in raw_clis:
+            if not isinstance(item, dict):
+                continue
+            cli_str = item.get("cli")
+            try:
+                cli = AgentCLI(cli_str)
+            except (ValueError, TypeError):
+                continue
+            if cli in seen:
+                continue
+            seen.add(cli)
+            phase_models = {
+                k: str(v)
+                for k, v in item.items()
+                if k not in _RESERVED_ROLE_KEYS and isinstance(v, str)
+            }
+            entries.append(
+                CliEntry(
+                    cli=cli,
+                    model=item.get("model") or None,
+                    phase_models=phase_models,
+                )
+            )
+        return entries
+
+    # Old format: build chain from cli / backup / models
+    primary_cli_str = role.get("cli")
+    if not primary_cli_str:
+        return []
+    try:
+        primary_cli = AgentCLI(primary_cli_str)
+    except ValueError:
+        return []
+
+    models_raw = role.get("models", {}) or {}
+    if not isinstance(models_raw, dict):
+        models_raw = {}
+
+    def _phase_models_for(cli_value: str) -> Dict[str, str]:
+        raw = models_raw.get(cli_value, {}) or {}
+        if not isinstance(raw, dict):
+            return {}
+        return {k: str(v) for k, v in raw.items() if isinstance(v, str)}
+
+    seen_old: set = {primary_cli}
+    chain: List[CliEntry] = [
+        CliEntry(
+            cli=primary_cli,
+            model=role.get("model") or None,
+            phase_models=_phase_models_for(primary_cli.value),
+        )
+    ]
+
+    for cli_str in (role.get("backup") or []):
+        try:
+            cli = AgentCLI(cli_str)
+        except ValueError:
+            continue
+        if cli in seen_old:
+            continue
+        seen_old.add(cli)
+        chain.append(
+            CliEntry(
+                cli=cli,
+                model=None,
+                phase_models=_phase_models_for(cli.value),
+            )
+        )
+
+    return chain
 
 
 class CrewManager:

--- a/src/cafe/utils/crew.py
+++ b/src/cafe/utils/crew.py
@@ -64,22 +64,41 @@ def normalize_role_config(role: Dict[str, Any]) -> List[CliEntry]:
     except ValueError:
         return []
 
+    # Phase overrides from models: dict (per-CLI per-phase)
     models_raw = role.get("models", {}) or {}
     if not isinstance(models_raw, dict):
         models_raw = {}
 
-    def _phase_models_for(cli_value: str) -> Dict[str, str]:
+    def _phase_models_from_models_dict(cli_value: str) -> Dict[str, str]:
         raw = models_raw.get(cli_value, {}) or {}
         if not isinstance(raw, dict):
             return {}
         return {k: str(v) for k, v in raw.items() if isinstance(v, str)}
+
+    # Phase overrides from role-level phase keys: spec: {model: X}
+    # These apply to the primary CLI only (backward compat with existing preset format).
+    def _phase_models_from_role_keys() -> Dict[str, str]:
+        result: Dict[str, str] = {}
+        for key, val in role.items():
+            if key in _RESERVED_ROLE_KEYS:
+                continue
+            if isinstance(val, dict):
+                m = val.get("model")
+                if m and isinstance(m, str):
+                    result[key] = m
+        return result
+
+    primary_phase_models = {
+        **_phase_models_from_role_keys(),
+        **_phase_models_from_models_dict(primary_cli.value),
+    }
 
     seen_old: set = {primary_cli}
     chain: List[CliEntry] = [
         CliEntry(
             cli=primary_cli,
             model=role.get("model") or None,
-            phase_models=_phase_models_for(primary_cli.value),
+            phase_models=primary_phase_models,
         )
     ]
 
@@ -95,7 +114,7 @@ def normalize_role_config(role: Dict[str, Any]) -> List[CliEntry]:
             CliEntry(
                 cli=cli,
                 model=None,
-                phase_models=_phase_models_for(cli.value),
+                phase_models=_phase_models_from_models_dict(cli.value),
             )
         )
 

--- a/tests/unit/test_cli_entry.py
+++ b/tests/unit/test_cli_entry.py
@@ -1,0 +1,62 @@
+"""Tests for CliEntry model."""
+
+import pytest
+
+from cafe.core.types import AgentCLI, CliEntry
+
+
+class TestCliEntryDefaults:
+    """Tests for CliEntry default values."""
+
+    def test_model_defaults_to_none(self) -> None:
+        entry = CliEntry(cli=AgentCLI.CLAUDE)
+        assert entry.model is None
+
+    def test_phase_models_defaults_to_empty_dict(self) -> None:
+        entry = CliEntry(cli=AgentCLI.CLAUDE)
+        assert entry.phase_models == {}
+
+    def test_cli_is_required(self) -> None:
+        with pytest.raises(Exception):
+            CliEntry()  # type: ignore[call-arg]
+
+
+class TestCliEntryResolveModel:
+    """Tests for CliEntry.resolve_model()."""
+
+    def test_returns_phase_override_when_phase_matches(self) -> None:
+        entry = CliEntry(cli=AgentCLI.CLAUDE, model="opus", phase_models={"plan": "sonnet"})
+        assert entry.resolve_model("plan") == "sonnet"
+
+    def test_returns_model_when_phase_not_in_overrides(self) -> None:
+        entry = CliEntry(cli=AgentCLI.CLAUDE, model="opus", phase_models={"plan": "sonnet"})
+        assert entry.resolve_model("develop") == "opus"
+
+    def test_returns_none_when_no_phase_no_model(self) -> None:
+        entry = CliEntry(cli=AgentCLI.CLAUDE)
+        assert entry.resolve_model("plan") is None
+
+    def test_returns_none_when_phase_none(self) -> None:
+        entry = CliEntry(cli=AgentCLI.CLAUDE, model="opus")
+        assert entry.resolve_model(None) == "opus"
+
+    def test_empty_string_phase_override_returns_none(self) -> None:
+        entry = CliEntry(cli=AgentCLI.CLAUDE, model="opus", phase_models={"plan": ""})
+        assert entry.resolve_model("plan") is None
+
+    def test_empty_string_model_returns_none(self) -> None:
+        entry = CliEntry(cli=AgentCLI.CLAUDE, model="")
+        assert entry.resolve_model(None) is None
+
+    def test_returns_phase_override_even_when_model_also_set(self) -> None:
+        entry = CliEntry(
+            cli=AgentCLI.GEMINI,
+            model="gemini-2.5-pro",
+            phase_models={"develop": "gemini-2-flash"},
+        )
+        assert entry.resolve_model("develop") == "gemini-2-flash"
+        assert entry.resolve_model("plan") == "gemini-2.5-pro"
+
+    def test_returns_none_for_unrecognized_phase_with_no_model(self) -> None:
+        entry = CliEntry(cli=AgentCLI.COPILOT, phase_models={"plan": "x"})
+        assert entry.resolve_model("review") is None

--- a/tests/unit/test_cli_setup_agents.py
+++ b/tests/unit/test_cli_setup_agents.py
@@ -112,6 +112,96 @@ class TestSetupAgentsPhaseAware:
         assert agent_manager.agents["David"].config.model == "claude-3-sonnet-20240229"
 
 
+class TestSetupAgentsClisChain:
+    """Test that setup_agents populates clis chain via normalize_role_config."""
+
+    def _write_crew(self, cafe_dir: Path, content: str) -> None:
+        cafe_dir.mkdir(exist_ok=True)
+        (cafe_dir / "crew.yaml").write_text(content)
+
+    def test_new_clis_format_populates_clis_chain(self, tmp_path: Path) -> None:
+        from cafe.core.types import AgentCLI
+        from cafe.ui.cli_shared import setup_agents
+        from cafe.utils.config import ConfigManager
+
+        cafe_dir = tmp_path / ".cafe"
+        self._write_crew(
+            cafe_dir,
+            "pm:\n  name: Roger\n  cli: copilot\n"
+            "developer:\n  name: David\n  clis:\n"
+            "    - cli: claude\n      model: opus\n      plan: sonnet\n"
+            "    - cli: gemini\n      model: gemini-2.5-pro\n"
+            "reviewer:\n  name: Richard\n  cli: copilot\n",
+        )
+        agent_manager = setup_agents(ConfigManager(str(cafe_dir / "config.yaml")), cafe_dir=cafe_dir)
+        david_clis = agent_manager.agents["David"].config.clis
+        assert len(david_clis) == 2
+        assert david_clis[0].cli == AgentCLI.CLAUDE
+        assert david_clis[0].model == "opus"
+        assert david_clis[0].phase_models.get("plan") == "sonnet"
+        assert david_clis[1].cli == AgentCLI.GEMINI
+
+    def test_old_format_crew_yaml_populates_clis_chain(self, tmp_path: Path) -> None:
+        from cafe.core.types import AgentCLI
+        from cafe.ui.cli_shared import setup_agents
+        from cafe.utils.config import ConfigManager
+
+        cafe_dir = tmp_path / ".cafe"
+        self._write_crew(
+            cafe_dir,
+            "pm:\n  name: Roger\n  cli: copilot\n"
+            "developer:\n  name: David\n  cli: claude\n  model: opus\n"
+            "  backup:\n    - gemini\n    - copilot\n"
+            "  models:\n    gemini:\n      plan: gemini-2.5-pro\n"
+            "reviewer:\n  name: Richard\n  cli: copilot\n",
+        )
+        agent_manager = setup_agents(ConfigManager(str(cafe_dir / "config.yaml")), cafe_dir=cafe_dir)
+        david_clis = agent_manager.agents["David"].config.clis
+        assert len(david_clis) == 3
+        assert david_clis[0].cli == AgentCLI.CLAUDE
+        assert david_clis[1].cli == AgentCLI.GEMINI
+        assert david_clis[1].phase_models.get("plan") == "gemini-2.5-pro"
+        assert david_clis[2].cli == AgentCLI.COPILOT
+
+    def test_mixed_format_clis_wins(self, tmp_path: Path) -> None:
+        from cafe.core.types import AgentCLI
+        from cafe.ui.cli_shared import setup_agents
+        from cafe.utils.config import ConfigManager
+
+        cafe_dir = tmp_path / ".cafe"
+        self._write_crew(
+            cafe_dir,
+            "pm:\n  name: Roger\n  cli: copilot\n"
+            "developer:\n  name: David\n  cli: copilot\n  backup: [gemini]\n"
+            "  clis:\n    - cli: claude\n"
+            "reviewer:\n  name: Richard\n  cli: copilot\n",
+        )
+        agent_manager = setup_agents(ConfigManager(str(cafe_dir / "config.yaml")), cafe_dir=cafe_dir)
+        david_clis = agent_manager.agents["David"].config.clis
+        assert len(david_clis) == 1
+        assert david_clis[0].cli == AgentCLI.CLAUDE
+
+    def test_phase_name_resolves_from_clis_chain(self, tmp_path: Path) -> None:
+        """AgentConfig.model reflects clis[0].resolve_model(phase_name)."""
+        from cafe.ui.cli_shared import setup_agents
+        from cafe.utils.config import ConfigManager
+
+        cafe_dir = tmp_path / ".cafe"
+        self._write_crew(
+            cafe_dir,
+            "pm:\n  name: Roger\n  cli: copilot\n"
+            "developer:\n  name: David\n  cli: claude\n  model: opus\n"
+            "  models:\n    claude:\n      develop: sonnet\n"
+            "reviewer:\n  name: Richard\n  cli: copilot\n",
+        )
+        agent_manager = setup_agents(
+            ConfigManager(str(cafe_dir / "config.yaml")),
+            phase_name="develop",
+            cafe_dir=cafe_dir,
+        )
+        assert agent_manager.agents["David"].config.model == "sonnet"
+
+
 class TestSetupAgentsCrewYaml:
     """Test that setup_agents prefers crew.yaml over config.yaml agents section."""
 

--- a/tests/unit/test_clis_chain_fallback.py
+++ b/tests/unit/test_clis_chain_fallback.py
@@ -1,0 +1,212 @@
+"""Tests for clis-chain-based fallback in AgentManager."""
+
+import pytest
+from unittest.mock import patch
+
+from cafe.agents.executor import AgentExecutionError
+from cafe.agents.manager import AgentManager
+from cafe.core.types import AgentCLI, AgentConfig, AgentResponse, CliEntry, TokenUsage
+
+
+def _ok(text: str = "ok") -> AgentResponse:
+    return AgentResponse(response=text, token_usage=TokenUsage())
+
+
+def _rate_limit() -> AgentExecutionError:
+    return AgentExecutionError("rate limit", error_type="rate_limit")
+
+
+def _cli_not_found() -> AgentExecutionError:
+    return AgentExecutionError("cli not found", error_type="cli_not_found")
+
+
+def _make_manager(clis: list) -> AgentManager:
+    manager = AgentManager()
+    config = AgentConfig(
+        name="David",
+        cli=clis[0].cli,
+        model=clis[0].model,
+        clis=clis,
+        backup_clis=[e.cli for e in clis[1:]],
+    )
+    manager.register_agent(config)
+    return manager
+
+
+class TestClisChainFallbackBasic:
+    """Basic fallback scenarios driven by the clis chain."""
+
+    def test_single_entry_chain_rate_limit_reraises(self) -> None:
+        """Chain of length 1 with rate_limit re-raises immediately (no fallback)."""
+        manager = _make_manager([CliEntry(cli=AgentCLI.CLAUDE, model="opus")])
+        with patch("cafe.agents.executor.AgentExecutor.execute", side_effect=_rate_limit()):
+            with pytest.raises(AgentExecutionError) as exc_info:
+                manager.execute("David", "prompt")
+        assert exc_info.value.error_type == "rate_limit"
+
+    def test_two_entry_chain_fallback_succeeds(self) -> None:
+        """Primary rate_limit, second entry succeeds."""
+        manager = _make_manager([
+            CliEntry(cli=AgentCLI.CLAUDE),
+            CliEntry(cli=AgentCLI.GEMINI),
+        ])
+        call_count = 0
+
+        def side_effect(*a, **kw):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise _rate_limit()
+            return _ok("gemini response")
+
+        with patch("cafe.agents.executor.AgentExecutor.execute", side_effect=side_effect):
+            response, *_ = manager.execute("David", "prompt")
+
+        assert response == "gemini response"
+        assert call_count == 2
+
+    def test_three_entry_chain_first_two_fail(self) -> None:
+        """Primary and first fallback fail, second fallback succeeds."""
+        manager = _make_manager([
+            CliEntry(cli=AgentCLI.CLAUDE),
+            CliEntry(cli=AgentCLI.GEMINI),
+            CliEntry(cli=AgentCLI.COPILOT),
+        ])
+        call_count = 0
+
+        def side_effect(*a, **kw):
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 2:
+                raise _rate_limit()
+            return _ok("copilot response")
+
+        with patch("cafe.agents.executor.AgentExecutor.execute", side_effect=side_effect):
+            response, *_ = manager.execute("David", "prompt")
+
+        assert response == "copilot response"
+        assert call_count == 3
+
+    def test_all_chain_entries_fail_raises_error_with_cli_list(self) -> None:
+        """All entries fail; raised error mentions all tried CLIs."""
+        manager = _make_manager([
+            CliEntry(cli=AgentCLI.CLAUDE),
+            CliEntry(cli=AgentCLI.GEMINI),
+        ])
+        with patch("cafe.agents.executor.AgentExecutor.execute", side_effect=_rate_limit()):
+            with pytest.raises(AgentExecutionError) as exc_info:
+                manager.execute("David", "prompt")
+
+        assert exc_info.value.error_type == "rate_limit"
+        msg = str(exc_info.value)
+        assert "claude" in msg.lower()
+        assert "gemini" in msg.lower()
+
+    def test_non_rate_limit_error_not_continued(self) -> None:
+        """Non-rate-limit error on a fallback entry stops the chain immediately."""
+        manager = _make_manager([
+            CliEntry(cli=AgentCLI.CLAUDE),
+            CliEntry(cli=AgentCLI.GEMINI),
+            CliEntry(cli=AgentCLI.COPILOT),
+        ])
+        call_count = 0
+
+        def side_effect(*a, **kw):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise _rate_limit()
+            raise AgentExecutionError("permission denied", error_type="permission_denied")
+
+        with patch("cafe.agents.executor.AgentExecutor.execute", side_effect=side_effect):
+            with pytest.raises(AgentExecutionError) as exc_info:
+                manager.execute("David", "prompt")
+
+        # Stopped at gemini, did not reach copilot
+        assert call_count == 2
+        assert exc_info.value.error_type == "permission_denied"
+
+    def test_cli_not_found_also_triggers_fallback(self) -> None:
+        """cli_not_found is treated the same as rate_limit for chain traversal."""
+        manager = _make_manager([
+            CliEntry(cli=AgentCLI.CLAUDE),
+            CliEntry(cli=AgentCLI.GEMINI),
+        ])
+        call_count = 0
+
+        def side_effect(*a, **kw):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise _cli_not_found()
+            return _ok("gemini ok")
+
+        with patch("cafe.agents.executor.AgentExecutor.execute", side_effect=side_effect):
+            response, *_ = manager.execute("David", "prompt")
+
+        assert response == "gemini ok"
+
+
+class TestClisChainModelResolution:
+    """Tests that verify CliEntry.resolve_model is used for each fallback entry."""
+
+    def _capture_executor_configs(self, chain: list, phase_name: str):
+        """Run a simulated fallback and return configs used per executor call."""
+        manager = _make_manager(chain)
+        created_configs = []
+        original_init = __import__(
+            "cafe.agents.executor", fromlist=["AgentExecutor"]
+        ).AgentExecutor.__init__
+
+        def capture_init(self, config):
+            created_configs.append(config)
+            original_init(self, config)
+
+        call_count = 0
+
+        def side_effect(*a, **kw):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise _rate_limit()
+            return _ok()
+
+        with (
+            patch("cafe.agents.executor.AgentExecutor.__init__", capture_init),
+            patch("cafe.agents.executor.AgentExecutor.execute", side_effect=side_effect),
+        ):
+            manager.execute("David", "prompt", phase_name=phase_name)
+
+        return created_configs
+
+    def test_fallback_entry_uses_phase_model_override(self) -> None:
+        """Fallback executor is built with the phase-specific model from CliEntry."""
+        chain = [
+            CliEntry(cli=AgentCLI.CLAUDE, model="opus"),
+            CliEntry(cli=AgentCLI.GEMINI, model="gemini-2.5-pro",
+                     phase_models={"develop": "gemini-2-flash"}),
+        ]
+        configs = self._capture_executor_configs(chain, phase_name="develop")
+        gemini_configs = [c for c in configs if c.cli == AgentCLI.GEMINI]
+        assert len(gemini_configs) >= 1
+        assert gemini_configs[0].model == "gemini-2-flash"
+
+    def test_fallback_entry_falls_back_to_entry_model_when_no_phase_override(self) -> None:
+        """If no phase override, fallback entry uses its own model."""
+        chain = [
+            CliEntry(cli=AgentCLI.CLAUDE, model="opus"),
+            CliEntry(cli=AgentCLI.GEMINI, model="gemini-2.5-pro"),
+        ]
+        configs = self._capture_executor_configs(chain, phase_name="plan")
+        gemini_configs = [c for c in configs if c.cli == AgentCLI.GEMINI]
+        assert gemini_configs[0].model == "gemini-2.5-pro"
+
+    def test_fallback_entry_uses_none_when_no_model_at_all(self) -> None:
+        """CliEntry with no model and no phase override results in model=None."""
+        chain = [
+            CliEntry(cli=AgentCLI.CLAUDE, model="opus"),
+            CliEntry(cli=AgentCLI.COPILOT),
+        ]
+        configs = self._capture_executor_configs(chain, phase_name="develop")
+        copilot_configs = [c for c in configs if c.cli == AgentCLI.COPILOT]
+        assert copilot_configs[0].model is None

--- a/tests/unit/test_crew_normalize.py
+++ b/tests/unit/test_crew_normalize.py
@@ -1,0 +1,147 @@
+"""Tests for normalize_role_config helper."""
+
+import pytest
+
+from cafe.core.types import AgentCLI, CliEntry
+from cafe.utils.crew import normalize_role_config
+
+
+class TestNormalizeRoleConfigNewFormat:
+    """New clis list format is returned as-is."""
+
+    def test_new_format_single_entry(self) -> None:
+        role = {
+            "name": "David",
+            "clis": [{"cli": "claude", "model": "opus"}],
+        }
+        result = normalize_role_config(role)
+        assert len(result) == 1
+        assert result[0].cli == AgentCLI.CLAUDE
+        assert result[0].model == "opus"
+
+    def test_new_format_with_phase_overrides(self) -> None:
+        role = {
+            "clis": [
+                {"cli": "claude", "model": "opus", "plan": "sonnet", "develop": "sonnet"},
+                {"cli": "gemini", "model": "gemini-2.5-pro"},
+            ]
+        }
+        result = normalize_role_config(role)
+        assert len(result) == 2
+        assert result[0].phase_models == {"plan": "sonnet", "develop": "sonnet"}
+        assert result[1].cli == AgentCLI.GEMINI
+        assert result[1].phase_models == {}
+
+    def test_new_format_entry_without_model(self) -> None:
+        role = {"clis": [{"cli": "copilot"}]}
+        result = normalize_role_config(role)
+        assert result[0].model is None
+        assert result[0].phase_models == {}
+
+    def test_new_format_wins_over_old_fields_when_both_present(self) -> None:
+        """clis takes precedence over cli/backup/models."""
+        role = {
+            "cli": "copilot",
+            "backup": ["gemini"],
+            "clis": [{"cli": "claude", "model": "opus"}],
+        }
+        result = normalize_role_config(role)
+        assert len(result) == 1
+        assert result[0].cli == AgentCLI.CLAUDE
+
+
+class TestNormalizeRoleConfigOldFormat:
+    """Old cli/model/backup/models format is normalized to clis."""
+
+    def test_old_format_cli_only(self) -> None:
+        role = {"name": "David", "cli": "claude"}
+        result = normalize_role_config(role)
+        assert len(result) == 1
+        assert result[0].cli == AgentCLI.CLAUDE
+        assert result[0].model is None
+
+    def test_old_format_cli_with_model(self) -> None:
+        role = {"cli": "claude", "model": "opus"}
+        result = normalize_role_config(role)
+        assert result[0].model == "opus"
+
+    def test_old_format_with_backup(self) -> None:
+        role = {"cli": "claude", "backup": ["gemini", "copilot"]}
+        result = normalize_role_config(role)
+        assert len(result) == 3
+        assert result[0].cli == AgentCLI.CLAUDE
+        assert result[1].cli == AgentCLI.GEMINI
+        assert result[2].cli == AgentCLI.COPILOT
+
+    def test_old_format_with_models_phase_overrides(self) -> None:
+        role = {
+            "cli": "claude",
+            "model": "opus",
+            "backup": ["gemini"],
+            "models": {
+                "claude": {"plan": "opus", "develop": "sonnet"},
+                "gemini": {"plan": "gemini-2.5-pro-preview"},
+            },
+        }
+        result = normalize_role_config(role)
+        assert result[0].phase_models == {"plan": "opus", "develop": "sonnet"}
+        assert result[1].phase_models == {"plan": "gemini-2.5-pro-preview"}
+
+    def test_old_format_models_missing_for_backup_cli(self) -> None:
+        """Backup CLI with no models entry gets empty phase_models."""
+        role = {
+            "cli": "claude",
+            "backup": ["copilot"],
+            "models": {"claude": {"plan": "opus"}},
+        }
+        result = normalize_role_config(role)
+        assert result[1].cli == AgentCLI.COPILOT
+        assert result[1].phase_models == {}
+
+    def test_old_format_empty_models_dict_does_not_raise(self) -> None:
+        role = {"cli": "claude", "models": {"claude": {}}}
+        result = normalize_role_config(role)
+        assert result[0].phase_models == {}
+
+
+class TestNormalizeRoleConfigEdgeCases:
+    """Edge cases: unknown CLIs, duplicates, empty inputs."""
+
+    def test_unknown_cli_string_is_ignored(self) -> None:
+        role = {"cli": "claude", "backup": ["unknown-cli-xyz"]}
+        result = normalize_role_config(role)
+        # Only primary; unknown backup is dropped
+        assert len(result) == 1
+        assert result[0].cli == AgentCLI.CLAUDE
+
+    def test_primary_cli_duplicate_in_backup_is_skipped(self) -> None:
+        role = {"cli": "claude", "backup": ["claude", "gemini"]}
+        result = normalize_role_config(role)
+        clis = [e.cli for e in result]
+        assert clis.count(AgentCLI.CLAUDE) == 1
+        assert AgentCLI.GEMINI in clis
+
+    def test_duplicate_cli_in_backup_list_only_first_kept(self) -> None:
+        role = {"cli": "claude", "backup": ["gemini", "gemini"]}
+        result = normalize_role_config(role)
+        clis = [e.cli for e in result]
+        assert clis.count(AgentCLI.GEMINI) == 1
+
+    def test_new_format_unknown_cli_entry_ignored(self) -> None:
+        role = {"clis": [{"cli": "claude"}, {"cli": "not-a-cli"}]}
+        result = normalize_role_config(role)
+        assert len(result) == 1
+        assert result[0].cli == AgentCLI.CLAUDE
+
+    def test_new_format_duplicate_cli_entries_deduplicated(self) -> None:
+        role = {"clis": [{"cli": "claude"}, {"cli": "claude"}]}
+        result = normalize_role_config(role)
+        assert len(result) == 1
+
+    def test_empty_role_dict_returns_empty_list(self) -> None:
+        result = normalize_role_config({})
+        assert result == []
+
+    def test_role_with_only_name_returns_empty_list(self) -> None:
+        result = normalize_role_config({"name": "David"})
+        assert result == []


### PR DESCRIPTION
Closes #272

## Changes
- Add `CliEntry` model (`workflow_models.py`): cli + model + optional phase-level model overrides
- Add `clis` field to `AgentConfig`: ordered list of CliEntry, first = primary, rest = fallback chain
- Add `normalize_role_config` (`crew.py`): converts old `cli/model` format to `clis` list (backward compat)
- Add `CliEntry.resolve_model(phase)`: returns phase-specific model if set, else entry default
- Rewrite `_try_backup_agents` (`manager.py`): walks `clis` chain on AgentExecutionError, uses `CliEntry.resolve_model` for each attempt
- Wire `setup_agents` (`cli_shared.py`): populates `clis` chain from crew.yaml via normalize_role_config
- Update README: document new `clis` schema and backward-compat format

## Schema example
```yaml
developer:
  name: Nick
  clis:
    - cli: claude
      model: opus
      plan:
        model: opus
      develop:
        model: sonnet
    - cli: codex
      model: o4-mini
    - cli: cursor
      model: gpt-4.1
```

## Rules
- `clis` ordered list: first = primary, rest = fallback chain
- Each entry: `cli` + `model` (default) + optional phase overrides
- On AgentExecutionError: pop next entry from failing role's chain and retry
- Old `cli: X` + `model: Y` still works (auto-normalized to clis)
- Per-role fallback only (developer fallback doesn't affect reviewer)

## Test
- 2054 passed, 5 skipped, 1 xfailed