### PR TITLE
Decouple workflow event display

### DIFF
--- a/src/cafe/core/capabilities.py
+++ b/src/cafe/core/capabilities.py
@@ -371,6 +371,10 @@ def run_pr_publish_capability(
         "pr_number": pr_number,
         "action": action,
         "source": "capability",
+        "display": {
+            "style": "green",
+            "lines": ["PR synced", f"  URL: {pr_url}"],
+        },
     }
     return PrPublishRun(receipt=receipt, pr_synced_event=pr_synced, error_message=None)
 

--- a/src/cafe/core/hooks/native.py
+++ b/src/cafe/core/hooks/native.py
@@ -1070,13 +1070,11 @@ class PRLinkOpener(NoOpHook):
         except Exception:
             return HookResult()
 
-        events = [{"type": "pr_synced", "url": pr_url}]
-
         if sys.stdin.isatty():
             try:
                 webbrowser.open(pr_url)
             except Exception:
-                return HookResult(events=events)
-            events.append({"type": "pr_link_opened", "url": pr_url})
+                return HookResult()
+            return HookResult(events=[{"type": "pr_link_opened", "url": pr_url}])
 
-        return HookResult(events=events)
+        return HookResult()

--- a/src/cafe/ui/commands/workflow.py
+++ b/src/cafe/ui/commands/workflow.py
@@ -447,6 +447,35 @@ def _reset_baton_for_explicit_start_step(
     )
 
 
+def _print_workflow_event_display(event: Any) -> None:
+    """Render generic user-facing event display without coupling to event type."""
+    if not isinstance(event, dict):
+        return
+
+    display = event.get("display")
+    style = None
+    lines: List[str] = []
+    if isinstance(display, str):
+        lines = display.splitlines()
+    elif isinstance(display, dict):
+        raw_style = display.get("style")
+        style = raw_style if isinstance(raw_style, str) and raw_style else None
+        raw_lines = display.get("lines")
+        if isinstance(raw_lines, list):
+            lines = [str(line) for line in raw_lines]
+        else:
+            raw_message = display.get("message")
+            if isinstance(raw_message, str):
+                lines = raw_message.splitlines()
+
+    raw_message = event.get("display_message")
+    if not lines and isinstance(raw_message, str):
+        lines = raw_message.splitlines()
+
+    for index, line in enumerate(lines):
+        console.print(line, style=style if index == 0 else None)
+
+
 def workflow(
     playbook: Optional[str] = typer.Option(None, "--playbook", help="Playbook name"),
     issue: Optional[str] = typer.Option(None, "--issue", help="Issue directory name"),
@@ -540,7 +569,16 @@ def workflow(
                 return StepExecutionResult(
                     response="dry run",
                     artifacts={str(output_key): str(output_path)},
-                    events=[{"type": "pr_synced", "url": "https://example.com/dry-run-pr"}],
+                    events=[
+                        {
+                            "type": "pr_synced",
+                            "url": "https://example.com/dry-run-pr",
+                            "display": {
+                                "style": "green",
+                                "lines": ["PR synced", "  URL: https://example.com/dry-run-pr"],
+                            },
+                        }
+                    ],
                 )
             return StepExecutionResult(
                 response="dry-run",
@@ -607,12 +645,7 @@ def workflow(
                     raise
             if isinstance(result, StepExecutionResult):
                 for event in result.events:
-                    if not isinstance(event, dict) or event.get("type") != "pr_synced":
-                        continue
-                    pr_url = str(event.get("url", "")).strip()
-                    if pr_url:
-                        console.print(f"[green]PR synced[/green]")
-                        console.print(f"  URL: {pr_url}")
+                    _print_workflow_event_display(event)
             return result
 
         pending_start_step = start_step

--- a/tests/unit/test_cli_workflow_command.py
+++ b/tests/unit/test_cli_workflow_command.py
@@ -243,7 +243,7 @@ def test_workflow_accepts_add_dir_and_passes_through(tmp_path: Path, monkeypatch
     assert mock_builder.call_args.kwargs["extra_allowed_directories"] == ["src"]
 
 
-def test_workflow_command_prints_pr_url_when_pr_step_reports_sync_event(tmp_path: Path, monkeypatch) -> None:
+def test_workflow_command_prints_generic_event_display(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.chdir(tmp_path)
     executed_steps: list[str] = []
 
@@ -252,7 +252,18 @@ def test_workflow_command_prints_pr_url_when_pr_step_reports_sync_event(tmp_path
             executed_steps.append(step_name)
             events = []
             if step_name == "pr":
-                events = [{"type": "pr_synced", "url": "https://github.com/test/repo/pull/238"}]
+                events = [
+                    {
+                        "type": "custom_display_event",
+                        "display": {
+                            "style": "green",
+                            "lines": [
+                                "PR synced",
+                                "  URL: https://github.com/test/repo/pull/238",
+                            ],
+                        },
+                    }
+                ]
             return StepExecutionResult(
                 response="confirmed",
                 artifacts={str(step_def.get("output_artifact", step_name)): f"{step_name}/output.md"},
@@ -274,6 +285,52 @@ def test_workflow_command_prints_pr_url_when_pr_step_reports_sync_event(tmp_path
     assert "PR synced" in result.stdout
     assert "https://github.com/test/repo/pull/238" in result.stdout
     assert executed_steps == ["spec", "plan", "develop", "review", "pr"]
+
+
+def test_workflow_command_does_not_duplicate_pr_url_without_display(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    class FakeExecutor:
+        def execute_step(self, step_name: str, step_def: dict, blackboard_state: object, **kwargs):
+            events = []
+            if step_name == "pr":
+                events = [
+                    {
+                        "type": "pr_synced",
+                        "url": "https://github.com/test/repo/pull/277",
+                        "display": {
+                            "style": "green",
+                            "lines": [
+                                "PR synced",
+                                "  URL: https://github.com/test/repo/pull/277",
+                            ],
+                        },
+                    },
+                    {
+                        "type": "pr_link_opened",
+                        "url": "https://github.com/test/repo/pull/277",
+                    },
+                ]
+            return StepExecutionResult(
+                response="confirmed",
+                artifacts={str(step_def.get("output_artifact", step_name)): f"{step_name}/output.md"},
+                status_code="confirmed",
+                events=events,
+            )
+
+    with (
+        patch("cafe.ui.cli.GitOperations") as mock_git_cls,
+        patch("cafe.ui.cli._build_workflow_step_executor", return_value=FakeExecutor()),
+    ):
+        git = MagicMock()
+        git.get_current_branch.return_value = "issue-277"
+        mock_git_cls.return_value = git
+
+        result = runner.invoke(app, ["workflow", "--playbook", "default", "--execute"])
+
+    assert result.exit_code == 0
+    assert result.stdout.count("PR synced") == 1
+    assert result.stdout.count("https://github.com/test/repo/pull/277") == 1
 
 
 def test_workflow_command_consumes_chat_baton_before_execution(tmp_path: Path, monkeypatch) -> None:

--- a/tests/unit/test_native_user_input_hook.py
+++ b/tests/unit/test_native_user_input_hook.py
@@ -401,7 +401,6 @@ def test_pr_link_opener_opens_current_pr_url_when_confirmed() -> None:
 
     mock_open.assert_called_once_with("https://github.com/test/repo/pull/123")
     assert result.events == [
-        {"type": "pr_synced", "url": "https://github.com/test/repo/pull/123"},
         {"type": "pr_link_opened", "url": "https://github.com/test/repo/pull/123"},
     ]
 
@@ -417,9 +416,7 @@ def test_pr_link_opener_skips_browser_in_non_interactive() -> None:
         result = hook.run(stage="publish_output", status_code=PhaseStatusCode.CONFIRMED)
 
     mock_open.assert_not_called()
-    assert result.events == [
-        {"type": "pr_synced", "url": "https://github.com/test/repo/pull/123"},
-    ]
+    assert result.events == []
 
 
 def test_pr_link_opener_noops_when_pr_url_unavailable() -> None:
@@ -435,7 +432,7 @@ def test_pr_link_opener_noops_when_pr_url_unavailable() -> None:
     assert result.events == []
 
 
-def test_pr_link_opener_returns_pr_synced_even_when_browser_open_fails() -> None:
+def test_pr_link_opener_noops_when_browser_open_fails() -> None:
     hook = PRLinkOpener()
 
     with patch("cafe.core.hooks.native.GitHubOps") as mock_github_ops, \
@@ -446,7 +443,7 @@ def test_pr_link_opener_returns_pr_synced_even_when_browser_open_fails() -> None
         result = hook.run(stage="publish_output", status_code=PhaseStatusCode.CONFIRMED)
 
     mock_open.assert_called_once_with("https://github.com/test/repo/pull/123")
-    assert result.events == [{"type": "pr_synced", "url": "https://github.com/test/repo/pull/123"}]
+    assert result.events == []
 
 
 def test_local_pr_reviewer_displays_diff_and_confirms_local_mode(tmp_path: Path) -> None:

--- a/tests/unit/test_native_user_input_hook.py
+++ b/tests/unit/test_native_user_input_hook.py
@@ -634,6 +634,10 @@ def test_github_pr_creator_publish_output_runs_sync_pr_script(tmp_path: Path) ->
         "pr_number": "42",
         "action": "created",
         "source": "capability",
+        "display": {
+            "style": "green",
+            "lines": ["PR synced", "  URL: https://github.com/test/repo/pull/42"],
+        },
     }
     assert result.events[1]["type"] == "capability_receipt"
     assert result.events[1]["capability"] == "cafe.pr.publish"


### PR DESCRIPTION
## Summary

Closes #277.

Removes PR-specific sync rendering from the generic workflow CLI. Workflow events can now carry generic display payloads, while PR publish continues to expose the synced PR URL through that display contract and keeps the existing structural `pr_synced` event for runtime correctness.

## Changes

- Added generic event display rendering in `src/cafe/ui/commands/workflow.py` for `display` and `display_message` payloads.
- Removed the workflow command's `event.get("type") == "pr_synced"` display branch.
- Updated PR publish capability output to include a display payload with `PR synced` and the PR URL.
- Added regression coverage for generic event display and duplicate PR URL suppression.
- Commit: `9535eb3 decouple workflow event display`.

## Test Plan

- `/Users/YO_1/side_projects/cafe/.venv/bin/python -m pytest tests/unit/test_native_user_input_hook.py tests/unit/test_cli_workflow_command.py tests/unit/test_workflow_runtime.py`
- Pre-commit fast suite: 2097 passed, 5 skipped, 30 deselected, 1 xfailed.