### PR TITLE
Move workflow handoff labels into playbook metadata

### DIFF
--- a/src/cafe/core/blackboard.py
+++ b/src/cafe/core/blackboard.py
@@ -237,8 +237,8 @@ class HandoffContract:
         if self.to_owner in {HandoffOwner.USER, HandoffOwner.DONE} and self.to_step not in {"user", "done"}:
             raise ValueError("Baton owner mismatch: user/done owner must target user or done")
 
-        if self.intent == HandoffIntent.CONFIRM_OUTPUT and self.from_step not in {"spec", "plan"}:
-            raise ValueError("intent=confirm_output is only valid when from_step is spec or plan")
+        if self.intent == HandoffIntent.CONFIRM_OUTPUT and self.from_step not in allowed_steps:
+            raise ValueError("intent=confirm_output is only valid when from_step is a playbook step")
 
 
 @dataclass

--- a/src/cafe/core/playbook.py
+++ b/src/cafe/core/playbook.py
@@ -68,6 +68,8 @@ class StepConfig(BaseModel):
     allowed_goto: List[str] = Field(default_factory=list)
     hooks: StepHooks = Field(default_factory=StepHooks)
     auto_snapshot: bool = True
+    handoff_label: Optional[str] = None
+    chat_role: Optional[str] = None
     on: Dict[str, str]
 
     @field_validator("on")
@@ -220,6 +222,7 @@ def validate_playbook(
 
     for step_name, step in steps.items():
         _validate_step_role(step_name, step, model.roles)
+        _validate_step_chat_role(step_name, step, model.roles)
         _validate_step_skills(step_name, step, skill_loader)
         _validate_script_hook_stages(step_name, step.hooks)
         _validate_targets(step_name, step.allowed_goto, steps, "allowed_goto")
@@ -255,6 +258,11 @@ def _report_structural_issue(
 def _validate_step_role(step_name: str, step: StepConfig, roles: Dict[str, PlaybookRole]) -> None:
     if roles and step.role not in roles:
         raise ValueError(f"Step '{step_name}' references unknown role '{step.role}'")
+
+
+def _validate_step_chat_role(step_name: str, step: StepConfig, roles: Dict[str, PlaybookRole]) -> None:
+    if roles and step.chat_role and step.chat_role not in roles:
+        raise ValueError(f"Step '{step_name}' references unknown chat_role '{step.chat_role}'")
 
 
 def _validate_step_skills(step_name: str, step: StepConfig, skill_loader: SkillLoader) -> None:

--- a/src/cafe/data/playbooks/default.yaml
+++ b/src/cafe/data/playbooks/default.yaml
@@ -23,6 +23,8 @@ steps:
       "1": spec_first
       default: spec_revise
     role: pm
+    handoff_label: "Update requirements spec"
+    chat_role: pm
     assignee_type: agent
     input_artifacts: []
     output_artifact: spec
@@ -40,6 +42,8 @@ steps:
     type: skill
     skill: plan
     role: developer
+    handoff_label: "Revise implementation plan"
+    chat_role: developer
     assignee_type: agent
     input_artifacts: [spec]
     output_artifact: plan
@@ -72,6 +76,8 @@ steps:
     type: skill
     skill: develop
     role: developer
+    handoff_label: "Continue implementation"
+    chat_role: developer
     assignee_type: agent
     input_artifacts: [spec, plan]
     output_artifact: code
@@ -89,6 +95,8 @@ steps:
     type: skill
     skill: review
     role: reviewer
+    handoff_label: "Run review again"
+    chat_role: reviewer
     assignee_type: agent
     input_artifacts: [spec, plan, code]
     output_artifact: review_feedback
@@ -107,6 +115,8 @@ steps:
     type: skill
     skill: pr
     role: developer
+    handoff_label: "Refresh PR output"
+    chat_role: developer
     assignee_type: agent
     input_artifacts: [spec, code, review_feedback]
     output_artifact: pr_result

--- a/src/cafe/data/playbooks/editorial.yaml
+++ b/src/cafe/data/playbooks/editorial.yaml
@@ -19,6 +19,8 @@ steps:
       "1": brief_first
       default: brief_revise
     role: editor
+    handoff_label: "Revise editorial brief"
+    chat_role: editor
     assignee_type: agent
     output_artifact: brief
     valid_intents:
@@ -35,6 +37,8 @@ steps:
     type: skill
     skill: draft
     role: writer
+    handoff_label: "Continue manuscript draft"
+    chat_role: writer
     assignee_type: agent
     input_artifacts: [brief]
     output_artifact: manuscript
@@ -50,6 +54,8 @@ steps:
     type: skill
     skill: editorial_review
     role: editor
+    handoff_label: "Run editorial review"
+    chat_role: editor
     assignee_type: agent
     input_artifacts: [brief, manuscript]
     output_artifact: review_feedback
@@ -66,6 +72,8 @@ steps:
     type: skill
     skill: publish
     role: writer
+    handoff_label: "Prepare publication output"
+    chat_role: writer
     assignee_type: agent
     input_artifacts: [brief, manuscript, review_feedback]
     output_artifact: published_piece

--- a/src/cafe/data/playbooks/research.yaml
+++ b/src/cafe/data/playbooks/research.yaml
@@ -13,6 +13,8 @@ steps:
     type: skill
     skill: research_question
     role: researcher
+    handoff_label: "Refine research question"
+    chat_role: researcher
     assignee_type: agent
     output_artifact: research_question_brief
     valid_intents:
@@ -27,6 +29,8 @@ steps:
     type: skill
     skill: research_collect
     role: researcher
+    handoff_label: "Continue evidence collection"
+    chat_role: researcher
     assignee_type: agent
     input_artifacts: [research_question_brief]
     output_artifact: research_notes
@@ -43,6 +47,8 @@ steps:
     type: skill
     skill: research_synthesize
     role: researcher
+    handoff_label: "Revise research synthesis"
+    chat_role: researcher
     assignee_type: agent
     input_artifacts: [research_question_brief, research_notes]
     output_artifact: research_synthesis
@@ -59,6 +65,8 @@ steps:
     type: skill
     skill: research_report
     role: researcher
+    handoff_label: "Update research report"
+    chat_role: researcher
     assignee_type: agent
     input_artifacts: [research_question_brief, research_notes, research_synthesis]
     output_artifact: research_report_doc

--- a/src/cafe/ui/chat.py
+++ b/src/cafe/ui/chat.py
@@ -60,7 +60,7 @@ def get_chat_next_step_path(issue_dir: Path) -> Path:
     return issue_dir / "next_step.txt"
 
 
-def _load_chat_role_config(config_manager: ConfigManager, role: str) -> Optional[dict]:
+def _load_chat_role_config(config_manager: ConfigManager, role: str, issue_dir: Optional[Path] = None) -> Optional[dict]:
     """Load role config from crew.yaml first, then config.yaml."""
     try:
         cafe_dir = Path(getattr(config_manager, "config_dir"))
@@ -72,7 +72,34 @@ def _load_chat_role_config(config_manager: ConfigManager, role: str) -> Optional
         pass
 
     role_config = config_manager.get(f"agents.{role}", None)
-    return role_config if isinstance(role_config, dict) else None
+    if isinstance(role_config, dict):
+        return role_config
+
+    if issue_dir is not None:
+        playbook_role_config = _load_playbook_role_config(issue_dir, role)
+        if playbook_role_config is not None:
+            return playbook_role_config
+    return None
+
+
+def _load_playbook_role_config(issue_dir: Path, role: str) -> Optional[dict]:
+    try:
+        _, _, playbook_id = _load_chat_workflow_context(issue_dir)
+        playbook = PlaybookLoader(project_root=Path.cwd()).load(playbook_id)
+    except Exception:
+        return None
+
+    role_def = playbook.get("roles", {}).get(role, {})
+    if not isinstance(role_def, dict):
+        return None
+
+    agent_name = role_def.get("default_agent")
+    cli = role_def.get("default_cli")
+    if not isinstance(agent_name, str) or not agent_name.strip():
+        return None
+    if not isinstance(cli, str) or not cli.strip():
+        return None
+    return {"name": agent_name.strip(), "cli": cli.strip()}
 
 
 def _configured_cli_values(role_config: dict) -> set[str]:
@@ -362,7 +389,7 @@ def launch_chat_session(role: str, issue_name: str) -> int:
 
     # Load configuration
     config_manager = ConfigManager()
-    agent_config = _load_chat_role_config(config_manager, role)
+    agent_config = _load_chat_role_config(config_manager, role, issue_dir=issue_dir)
 
     if agent_config is None:
         print(f"\n⚠️  No agent configured for role '{role}'. Skipping chat.\n")

--- a/src/cafe/ui/cli.py
+++ b/src/cafe/ui/cli.py
@@ -44,6 +44,7 @@ from cafe.core.git import GitOperations
 from cafe.core.permission import PermissionHandler as _CompatPermissionHandler
 from cafe.core.types import CriticalPhaseError as _CompatCriticalPhaseError
 from cafe.core.workflow_models import StepExecutionResult as _CompatStepExecutionResult
+from cafe.playbooks.loader import PlaybookLoader
 from cafe.templates.manager import TemplateManager
 from cafe.ui import init_helpers as _compat_init_helpers
 from cafe.ui.chat import get_chat_next_step_path as _compat_get_chat_next_step_path, launch_chat_session
@@ -1179,15 +1180,28 @@ def chat_with_agent(
         cafe chat reviewer
     """
     # 1. Validate role parameter
-    valid_roles = ["pm", "developer", "reviewer"]
+    issue_name = _get_and_validate_branch(ctx, "chat")
+    valid_roles = _load_issue_playbook_roles(issue_name)
     if role not in valid_roles:
         console.print(f"[red]Error: Invalid role '{role}'. Must be one of: {', '.join(valid_roles)}[/red]")
         raise typer.Exit(1)
 
-    # 2. Get current branch as issue name
-    issue_name = _get_and_validate_branch(ctx, "chat")
-
     raise typer.Exit(launch_chat_session(role, issue_name))
+
+
+def _load_issue_playbook_roles(issue_name: str) -> list[str]:
+    roles = ["pm", "developer", "reviewer"]
+    try:
+        playbook_name = _resolve_issue_playbook_name(issue_name)
+        playbook_data = PlaybookLoader(project_root=Path.cwd()).load(playbook_name)
+        playbook_roles = playbook_data.get("roles", {})
+        if isinstance(playbook_roles, dict) and playbook_roles:
+            for role in playbook_roles:
+                if role not in roles:
+                    roles.append(str(role))
+    except Exception:
+        pass
+    return roles
 
 
 def main() -> Optional[int]:

--- a/src/cafe/ui/cli_shared.py
+++ b/src/cafe/ui/cli_shared.py
@@ -643,6 +643,41 @@ def _find_external_resume_step(
     return None
 
 
+def _resolve_step_handoff_label(playbook_data: Dict[str, Any], step_name: str) -> str:
+    """Return the user-facing handoff label for a playbook step."""
+    step_def = playbook_data.get("steps", {}).get(step_name, {})
+    if isinstance(step_def, dict):
+        label = step_def.get("handoff_label")
+        if isinstance(label, str) and label.strip():
+            return label.strip()
+    return f"Continue {step_name}"
+
+
+def _resolve_step_chat_role(playbook_data: Dict[str, Any], step_name: str) -> str:
+    """Return the role that should handle chat for a playbook step."""
+    step_def = playbook_data.get("steps", {}).get(step_name, {})
+    roles = playbook_data.get("roles", {})
+    if isinstance(step_def, dict):
+        chat_role = step_def.get("chat_role")
+        if isinstance(chat_role, str) and chat_role.strip():
+            return chat_role.strip()
+        role = step_def.get("role")
+        if isinstance(role, str) and role.strip():
+            return role.strip()
+    if isinstance(roles, dict) and roles:
+        return str(next(iter(roles.keys())))
+    return "developer"
+
+
+def _resolve_role_agent_name(playbook_data: Dict[str, Any], role: str) -> str:
+    role_def = playbook_data.get("roles", {}).get(role, {})
+    if isinstance(role_def, dict):
+        default_agent = role_def.get("default_agent")
+        if isinstance(default_agent, str) and default_agent.strip():
+            return default_agent.strip()
+    return role
+
+
 def _handle_user_phase(
     *,
     issue_name: str,
@@ -651,13 +686,6 @@ def _handle_user_phase(
     blackboard,
     phase_name: str = "user",
 ) -> Optional[str]:
-    phase_labels = {
-        "spec": "Update requirements spec",
-        "plan": "Revise implementation plan",
-        "develop": "Continue implementation",
-        "review": "Run review again",
-        "pr": "Refresh PR output",
-    }
     summary = getattr(blackboard, "handoff_summary", "").strip()
 
     # Check if this is a review-confirmation handoff from spec/plan.
@@ -668,7 +696,7 @@ def _handle_user_phase(
     handoff_intent = getattr(contract, "intent", None) if contract else None
     from_step = getattr(contract, "from_step", None) if contract else None
 
-    if handoff_intent == HandoffIntent.CONFIRM_OUTPUT and from_step in {"spec", "plan"}:
+    if handoff_intent == HandoffIntent.CONFIRM_OUTPUT and from_step in playbook_data.get("steps", {}):
         return _handle_review_confirmation(
             issue_name=issue_name,
             issue_dir=issue_dir,
@@ -676,11 +704,10 @@ def _handle_user_phase(
             blackboard=blackboard,
             store=store,
             from_step=from_step,
-            phase_labels=phase_labels,
             summary=summary,
         )
 
-    if handoff_intent == HandoffIntent.NEED_CLARIFICATION and from_step in {"spec", "plan"}:
+    if handoff_intent == HandoffIntent.NEED_CLARIFICATION and from_step in playbook_data.get("steps", {}):
         return _handle_clarification_handoff(
             issue_name=issue_name,
             issue_dir=issue_dir,
@@ -698,7 +725,6 @@ def _handle_user_phase(
         playbook_data=playbook_data,
         blackboard=blackboard,
         phase_name=phase_name,
-        phase_labels=phase_labels,
         summary=summary,
     )
 
@@ -754,11 +780,8 @@ def _handle_clarification_handoff(
         from cafe.ui.interactive_qa import interactive_qa_flow
 
         if validate_questions_xml(questions_file):
-            step_def = playbook_data.get("steps", {}).get(from_step, {})
-            role = str(step_def.get("role", "developer"))
-            prompt_role = {"pm": "pm", "reviewer": "reviewer"}.get(role, "developer")
-            role_names = playbook_data.get("roles", {})
-            agent_name = role_names.get(role, {}).get("default_agent", role)
+            prompt_role = _resolve_step_chat_role(playbook_data, from_step)
+            agent_name = _resolve_role_agent_name(playbook_data, prompt_role)
             user_input = interactive_qa_flow(
                 parse_questions_xml(questions_file),
                 role=prompt_role,
@@ -812,7 +835,6 @@ def _handle_review_confirmation(
     blackboard,
     store: BlackboardStore,
     from_step: str,
-    phase_labels: Dict[str, str],
     summary: str,
 ) -> Optional[str]:
     """Handle confirm_output handoff: display output and ask for confirmation."""
@@ -848,9 +870,7 @@ def _handle_review_confirmation(
                 confirmed_target = target
                 break
 
-    role_map = {"spec": "pm", "plan": "developer"}.get(from_step, "developer")
-    role_names = playbook_data.get("roles", {})
-    agent_name = role_names.get(role_map, {}).get("default_agent", role_map.capitalize())
+    role_map = _resolve_step_chat_role(playbook_data, from_step)
 
     from cafe.ui.inquirer_prompts import prompt_list, prompt_multiline
 
@@ -951,7 +971,6 @@ def _handle_review_confirmation(
                 playbook_data=playbook_data,
                 blackboard=blackboard,
                 phase_name="user",
-                phase_labels=phase_labels,
                 summary=summary,
             )
 
@@ -976,7 +995,6 @@ def _handle_user_phase_generic(
     playbook_data: Dict[str, Any],
     blackboard,
     phase_name: str,
-    phase_labels: Dict[str, str],
     summary: str,
 ) -> Optional[str]:
     """Generic user-phase menu (original _handle_user_phase behavior)."""
@@ -1011,11 +1029,11 @@ def _handle_user_phase_generic(
 
         step_names = list(playbook_data["steps"].keys())
         step_labels = [
-            f"{phase_labels.get(step_name, step_name)} ({step_name})"
+            f"{_resolve_step_handoff_label(playbook_data, step_name)} ({step_name})"
             for step_name in step_names
         ]
         default_step = str(playbook_data.get("entry_point") or next(iter(playbook_data["steps"].keys())))
-        default_label = f"{phase_labels.get(default_step, default_step)} ({default_step})"
+        default_label = f"{_resolve_step_handoff_label(playbook_data, default_step)} ({default_step})"
         from cafe.ui.cli import prompt_list as _pl2
         selected_label = _pl2(
             "Which phase should continue next?",

--- a/src/cafe/ui/menu.py
+++ b/src/cafe/ui/menu.py
@@ -7,6 +7,7 @@ context-aware menu to guide users through common workflows.
 
 import subprocess
 import sys
+import json
 from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -14,8 +15,10 @@ from typing import Any, Dict, List, Optional
 from rich.console import Console
 
 from cafe.core.git import GitOperations
+from cafe.playbooks.loader import PlaybookLoader
 from cafe.ui.inquirer_prompts import prompt_list, prompt_text
 from cafe.utils.config import ConfigManager
+from cafe.utils.crew import CrewManager
 from cafe.utils.git_utils import is_branch_initialized
 
 
@@ -311,7 +314,7 @@ class InteractiveMenu:
     def _get_available_agents(self) -> List[Dict[str, str]]:
         """Get all configured agents.
 
-        Returns all agents (pm, developer, reviewer) that have been configured,
+        Returns all playbook roles that have a configured or default agent,
         regardless of the current workflow phase.
 
         Returns:
@@ -320,13 +323,71 @@ class InteractiveMenu:
         agents: List[Dict[str, str]] = []
         try:
             config_manager = ConfigManager()
-            for role in ("pm", "developer", "reviewer"):
-                name = config_manager.get(f"agents.{role}.name")
+            role_names = self._get_playbook_role_names()
+            role_defaults = self._get_playbook_role_defaults(role_names)
+            crew_data = self._load_crew_data(config_manager)
+            for role in role_names:
+                name = None
+                if role in crew_data and isinstance(crew_data[role], dict):
+                    raw_name = crew_data[role].get("name")
+                    name = str(raw_name) if raw_name else None
+                if not name:
+                    name = config_manager.get(f"agents.{role}.name")
+                if not name:
+                    name = role_defaults.get(role)
                 if name:
                     agents.append({"role": role, "name": name})
         except Exception:
             pass
         return agents
+
+    def _get_playbook_role_names(self) -> List[str]:
+        issue_name = self._detector.get_current_issue_name()
+        playbook_id = "default"
+        if issue_name:
+            blackboard_file = Path(".cafe") / "issues" / issue_name / "blackboard.json"
+            try:
+                data = json.loads(blackboard_file.read_text(encoding="utf-8"))
+                playbook_id = str(data.get("playbook_id") or "default")
+            except Exception:
+                playbook_id = "default"
+
+        try:
+            playbook = PlaybookLoader(project_root=Path.cwd()).load(playbook_id)
+            roles = playbook.get("roles", {})
+            if isinstance(roles, dict) and roles:
+                return [str(role) for role in roles.keys()]
+        except Exception:
+            pass
+        return ["pm", "developer", "reviewer"]
+
+    def _get_playbook_role_defaults(self, role_names: List[str]) -> Dict[str, str]:
+        defaults: Dict[str, str] = {}
+        issue_name = self._detector.get_current_issue_name()
+        playbook_id = "default"
+        if issue_name:
+            try:
+                data = json.loads((Path(".cafe") / "issues" / issue_name / "blackboard.json").read_text(encoding="utf-8"))
+                playbook_id = str(data.get("playbook_id") or "default")
+            except Exception:
+                playbook_id = "default"
+        try:
+            playbook = PlaybookLoader(project_root=Path.cwd()).load(playbook_id)
+            roles = playbook.get("roles", {})
+            for role in role_names:
+                role_def = roles.get(role, {}) if isinstance(roles, dict) else {}
+                if isinstance(role_def, dict) and role_def.get("default_agent"):
+                    defaults[role] = str(role_def["default_agent"])
+        except Exception:
+            pass
+        return defaults
+
+    @staticmethod
+    def _load_crew_data(config_manager: ConfigManager) -> Dict[str, Any]:
+        try:
+            return CrewManager(cafe_dir=Path(config_manager.config_dir)).load()
+        except Exception:
+            return {}
 
     def _handle_chat(self) -> None:
         """Prompt user to select an agent role then launch cafe chat."""

--- a/tests/unit/test_chat.py
+++ b/tests/unit/test_chat.py
@@ -406,6 +406,52 @@ def test_launch_chat_session_prepares_chat_handoff_directory(
     assert get_chat_next_step_path(tmp_path / ".cafe" / "issues" / "issue123").parent.exists()
 
 
+def test_launch_chat_session_uses_playbook_role_defaults(
+    tmp_path,
+    monkeypatch,
+    mock_chat_environment,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    issue_dir = tmp_path / ".cafe" / "issues" / "research-1"
+    issue_dir.mkdir(parents=True)
+    (issue_dir / "blackboard.json").write_text(
+        '{"schema_version":1,"playbook_id":"research","current_step":"question","artifacts":{},"events":[],"decisions":[]}',
+        encoding="utf-8",
+    )
+
+    with (
+        patch("cafe.ui.chat.subprocess.run", return_value=MagicMock(returncode=0)) as mock_run,
+        patch("cafe.ui.chat.ConfigManager") as mock_config_manager_cls,
+        patch("cafe.ui.chat.AgentManager") as mock_agent_manager_cls,
+        patch("cafe.ui.chat.PlaybookLoader") as mock_loader_cls,
+    ):
+        mock_config = MagicMock()
+        mock_config.config_dir = str(tmp_path / ".cafe")
+        mock_config.get.return_value = None
+        mock_config_manager_cls.return_value = mock_config
+        mock_loader_cls.return_value.load.return_value = {
+            "playbook": {"id": "research"},
+            "roles": {"researcher": {"default_agent": "Morgan", "default_cli": "claude"}},
+            "steps": {"question": {"role": "researcher"}},
+        }
+
+        agent_manager = MagicMock()
+        executor = MagicMock()
+        executor.config = MagicMock(session_id=None, model=None)
+        executor._get_cli_strategy.return_value.build_environment.return_value = dict(os.environ)
+        agent_manager.get_agent.return_value = executor
+        agent_manager.session_manager = MagicMock()
+        mock_agent_manager_cls.return_value = agent_manager
+
+        result = launch_chat_session("researcher", "research-1")
+
+    assert result == 0
+    assert mock_run.call_args.args[0] == ["claude"]
+    registered_config = agent_manager.register_agent.call_args.args[0]
+    assert registered_config.name == "Morgan"
+    assert registered_config.cli == AgentCLI.CLAUDE
+
+
 def test_prepare_chat_handoff_state_creates_blackboard_and_clears_stale_baton(tmp_path, monkeypatch) -> None:
     monkeypatch.chdir(tmp_path)
     issue_dir = tmp_path / ".cafe" / "issues" / "issue123"

--- a/tests/unit/test_cli_invoke_command.py
+++ b/tests/unit/test_cli_invoke_command.py
@@ -83,6 +83,33 @@ class TestChatCommand:
                         assert result.exit_code == 0
                         mock_launch.assert_called_once_with(role, "issue36")
 
+    def test_chat_accepts_custom_playbook_role(self, tmp_path: Path, mock_initialized_branch, config_with_agents):
+        """測試 active issue playbook 定義的自訂 role 可開啟 chat"""
+        issue_dir = tmp_path / ".cafe" / "issues" / "issue36"
+        (issue_dir / "blackboard.json").write_text(
+            '{"schema_version":1,"playbook_id":"research","current_step":"question","artifacts":{},"events":[],"decisions":[]}',
+            encoding="utf-8",
+        )
+
+        with (
+            patch("cafe.ui.cli.GitOperations") as mock_git_class,
+            patch("cafe.ui.cli.is_branch_initialized", return_value=True),
+            patch("cafe.ui.cli.PlaybookLoader") as mock_loader_cls,
+            patch("cafe.ui.cli.launch_chat_session", return_value=0) as mock_launch,
+        ):
+            mock_git = mock_git_class.return_value
+            mock_git.is_valid_branch.return_value = True
+            mock_git.get_current_branch.return_value = "issue36"
+            mock_loader_cls.return_value.load.return_value = {
+                "roles": {"researcher": {"default_agent": "Morgan"}},
+                "steps": {"question": {"role": "researcher"}},
+            }
+
+            result = runner.invoke(app, ["chat", "researcher"])
+
+        assert result.exit_code == 0
+        mock_launch.assert_called_once_with("researcher", "issue36")
+
     def test_chat_gets_issue_from_current_branch(self, tmp_path: Path, mock_initialized_branch, config_with_agents):
         """測試從當前分支取得 issue name"""
         with patch("cafe.ui.cli.GitOperations") as mock_git_class:

--- a/tests/unit/test_cli_workflow_command.py
+++ b/tests/unit/test_cli_workflow_command.py
@@ -694,6 +694,105 @@ def test_workflow_command_user_owner_can_set_next_phase(tmp_path: Path, monkeypa
     assert handoff_event["data"]["note"] == "Please continue implementation with the new handoff context."
 
 
+def test_user_phase_uses_playbook_handoff_labels_and_generic_fallback(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    issue_dir = tmp_path / ".cafe" / "issues" / "research-1"
+    store = BlackboardStore(issue_dir)
+    blackboard = store.load_or_create("user", playbook_id="research")
+    store.set_current_step(blackboard, "user")
+    playbook_data = {
+        "playbook": {"id": "research"},
+        "entry_point": "question",
+        "roles": {"researcher": {"default_agent": "Morgan"}},
+        "steps": {
+            "question": {
+                "role": "researcher",
+                "handoff_label": "Refine research question",
+                "on": {"await_agent": "collect"},
+            },
+            "collect": {"role": "researcher", "on": {"await_agent": "done"}},
+        },
+    }
+    prompts: list[tuple[str, list[str]]] = []
+
+    def prompt_side_effect(message, choices, **kwargs):
+        prompts.append((message, choices))
+        if message == "Select next action":
+            return "Leave a handoff note and continue the workflow"
+        if message == "Which phase should continue next?":
+            return "Continue collect (collect)"
+        return choices[0]
+
+    with (
+        patch("cafe.ui.cli.prompt_list", side_effect=prompt_side_effect),
+        patch("cafe.ui.cli.prompt_multiline", return_value="Continue custom workflow."),
+        patch("cafe.ui.cli.prompt_confirm", return_value=True),
+    ):
+        result = _handle_user_phase(
+            issue_name="research-1",
+            issue_dir=issue_dir,
+            playbook_data=playbook_data,
+            blackboard=blackboard,
+        )
+
+    assert result == "collect"
+    step_prompt = next(choices for message, choices in prompts if message == "Which phase should continue next?")
+    assert "Refine research question (question)" in step_prompt
+    assert "Continue collect (collect)" in step_prompt
+    assert all("implementation" not in choice.lower() for choice in step_prompt)
+
+
+def test_confirm_output_chat_uses_playbook_chat_role(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    issue_dir = tmp_path / ".cafe" / "issues" / "editorial-1"
+    (issue_dir / "brief" / "iteration_001").mkdir(parents=True, exist_ok=True)
+    (issue_dir / "brief" / "iteration_001" / "output.md").write_text("# Brief\n", encoding="utf-8")
+    store = BlackboardStore(issue_dir)
+    blackboard = store.load_or_create("user", playbook_id="editorial")
+    store.set_current_step(blackboard, "user")
+    store.update_handoff_contract(
+        blackboard,
+        from_step="brief",
+        to_owner=HandoffOwner.USER,
+        to_step="user",
+        intent=HandoffIntent.CONFIRM_OUTPUT,
+        status_code="ready_for_review",
+        source="test",
+    )
+    playbook_data = {
+        "playbook": {"id": "editorial"},
+        "entry_point": "brief",
+        "roles": {
+            "editor": {"default_agent": "Roger"},
+            "writer": {"default_agent": "David"},
+        },
+        "steps": {
+            "brief": {
+                "role": "editor",
+                "chat_role": "writer",
+                "on": {"await_agent": "draft", "confirm_output": "brief"},
+            },
+            "draft": {"role": "writer", "on": {"await_agent": "_done"}},
+        },
+    }
+
+    with (
+        patch("cafe.ui.cli.launch_chat_session") as mock_chat,
+        patch("cafe.ui.cli._consume_pending_chat_handoff", return_value="draft"),
+        patch("cafe.ui.cli_shared._print_output_file"),
+        patch("cafe.ui.inquirer_prompts.prompt_list", return_value="chat"),
+    ):
+        result = _handle_user_phase(
+            issue_name="editorial-1",
+            issue_dir=issue_dir,
+            playbook_data=playbook_data,
+            blackboard=blackboard,
+        )
+
+    assert result == "draft"
+    mock_chat.assert_called_once_with("writer", "editorial-1")
+
+
 def test_workflow_command_user_owner_can_complete_workflow(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("CAFE_FORCE_INTERACTIVE", "1")

--- a/tests/unit/test_menu.py
+++ b/tests/unit/test_menu.py
@@ -552,6 +552,41 @@ class TestChatWithAgent:
         assert "developer" in roles
         assert "reviewer" in roles
 
+    def test_get_available_agents_uses_custom_playbook_roles(self, tmp_path, monkeypatch):
+        """測試 custom playbook 角色會出現在 chat role picker"""
+        monkeypatch.chdir(tmp_path)
+        issue_dir = tmp_path / ".cafe" / "issues" / "research-issue"
+        issue_dir.mkdir(parents=True)
+        (issue_dir / "blackboard.json").write_text(
+            '{"schema_version":1,"playbook_id":"research","current_step":"question","artifacts":{},"events":[],"decisions":[]}',
+            encoding="utf-8",
+        )
+
+        detector = MagicMock(spec=MenuStateDetector)
+        detector.get_current_issue_name.return_value = "research-issue"
+
+        mock_config = MagicMock()
+        mock_config.config_dir = str(tmp_path / ".cafe")
+        mock_config.get.return_value = None
+
+        menu = InteractiveMenu(state_detector=detector)
+
+        with (
+            patch("cafe.ui.menu.ConfigManager") as mock_config_cls,
+            patch("cafe.ui.menu.CrewManager") as mock_crew_cls,
+            patch("cafe.ui.menu.PlaybookLoader") as mock_loader_cls,
+        ):
+            mock_config_cls.return_value = mock_config
+            mock_crew_cls.return_value.load.return_value = {}
+            mock_loader_cls.return_value.load.return_value = {
+                "roles": {
+                    "researcher": {"default_agent": "Morgan"},
+                },
+            }
+            agents = menu._get_available_agents()
+
+        assert agents == [{"role": "researcher", "name": "Morgan"}]
+
     def test_get_available_agents_returns_all_in_develop_phase(self, tmp_path, monkeypatch):
         """測試 develop 階段時仍回傳所有已設定的 agents"""
         monkeypatch.chdir(tmp_path)

--- a/tests/unit/test_playbook_loader.py
+++ b/tests/unit/test_playbook_loader.py
@@ -125,6 +125,76 @@ steps:
     }
 
 
+def test_load_supports_step_handoff_label_and_chat_role(tmp_path: Path) -> None:
+    builtin_root = tmp_path / "builtin"
+    _write_skill(builtin_root / "skills", "brief_first")
+    _write_playbook(
+        builtin_root / "playbooks",
+        "editorial",
+        """
+playbook:
+  id: editorial
+roles:
+  editor:
+    description: editor
+  writer:
+    description: writer
+steps:
+  brief:
+    skill: brief_first
+    role: editor
+    handoff_label: Refine editorial brief
+    chat_role: writer
+    valid_intents: [confirmed]
+    on:
+      await_agent: _done
+""",
+    )
+
+    loader = PlaybookLoader(
+        project_root=tmp_path / "project",
+        global_root=tmp_path / "global",
+        builtin_root=builtin_root,
+    )
+    result = loader.load_model("editorial")
+
+    assert result.model.steps["brief"].handoff_label == "Refine editorial brief"
+    assert result.model.steps["brief"].chat_role == "writer"
+
+
+def test_load_rejects_unknown_step_chat_role(tmp_path: Path) -> None:
+    builtin_root = tmp_path / "builtin"
+    _write_skill(builtin_root / "skills", "brief_first")
+    _write_playbook(
+        builtin_root / "playbooks",
+        "editorial",
+        """
+playbook:
+  id: editorial
+roles:
+  editor:
+    description: editor
+steps:
+  brief:
+    skill: brief_first
+    role: editor
+    chat_role: writer
+    valid_intents: [confirmed]
+    on:
+      await_agent: _done
+""",
+    )
+
+    loader = PlaybookLoader(
+        project_root=tmp_path / "project",
+        global_root=tmp_path / "global",
+        builtin_root=builtin_root,
+    )
+
+    with pytest.raises(ValueError, match="unknown chat_role"):
+        loader.load_model("editorial")
+
+
 def test_load_supports_dictionary_script_hook_declarations(tmp_path: Path) -> None:
     builtin_root = tmp_path / "builtin"
     _write_skill(builtin_root / "skills", "plan")
@@ -378,3 +448,17 @@ def test_builtin_hotfix_and_simple_playbooks_load() -> None:
     assert simple.entry_point == "spec"
     assert list(simple.steps.keys()) == ["spec", "develop", "pr"]
     assert simple.steps["develop"].on["await_agent"] == "pr"
+
+
+def test_builtin_non_software_playbooks_define_non_default_handoff_metadata() -> None:
+    loader = PlaybookLoader()
+
+    research = loader.load_model("research").model
+    editorial = loader.load_model("editorial").model
+
+    assert research.steps["question"].handoff_label == "Refine research question"
+    assert research.steps["question"].chat_role == "researcher"
+    assert editorial.steps["draft"].handoff_label == "Continue manuscript draft"
+    assert editorial.steps["draft"].chat_role == "writer"
+    assert "implementation" not in (research.steps["question"].handoff_label or "").lower()
+    assert "requirements" not in (editorial.steps["draft"].handoff_label or "").lower()


### PR DESCRIPTION
## Summary

Implements GitHub issue #278 by moving user handoff menu labels and chat role routing into playbook metadata with neutral generic fallbacks, while preserving the default software workflow behavior.

## Changes

- Added optional `handoff_label` and `chat_role` step metadata plus validation that `chat_role` references a declared playbook role when roles are configured.
- Reworked user handoff menu labels to resolve from playbook metadata and fall back to neutral `Continue <step>` wording instead of default software workflow labels.
- Reworked confirm-output and clarification chat routing to use playbook step metadata, step roles, and playbook role defaults instead of fixed `spec -> pm` / `plan -> developer` assumptions.
- Updated interactive menu and `cafe chat <role>` validation to include active playbook roles while keeping default `pm`, `developer`, and `reviewer` compatibility.
- Added playbook role fallback support in chat launch config so custom roles can use `default_agent` and `default_cli` without legacy agent config entries.
- Added explicit metadata to the default playbook and representative non-software metadata to `research` and `editorial`.
- Added tests covering default workflow compatibility, custom handoff labels, custom chat routing, missing metadata fallback behavior, custom chat roles, and playbook role defaults.
- Commit: `8a1b7fc add playbook handoff metadata`.

## Test Plan

- `uv run pytest tests/unit/test_playbook_loader.py tests/unit/test_cli_workflow_command.py tests/unit/test_menu.py tests/unit/test_chat.py tests/unit/test_cli_invoke_command.py`
- `uv run pytest tests/unit/test_cli_workflow_command.py tests/unit/test_generic_workflow_step.py tests/unit/test_playbook_loader.py tests/unit/test_menu.py tests/unit/test_chat.py tests/unit/test_cli_invoke_command.py`
- Pre-commit fast suite: `2107 passed, 5 skipped, 30 deselected, 1 xfailed`