### PR TITLE
Make confirm and clarification handoff handling playbook-driven

### DIFF
--- a/src/cafe/core/hooks/native.py
+++ b/src/cafe/core/hooks/native.py
@@ -14,7 +14,7 @@ from datetime import datetime
 from cafe.core.blackboard import BlackboardState, HandoffContract, HandoffIntent, HandoffOwner
 from cafe.core.hooks import HookResult, NoOpHook
 from cafe.core.questions_schema import parse_questions_xml, validate_questions_xml
-from cafe.core.status_codes import PhaseStatusCode
+from cafe.core.status_codes import PhaseStatusCode, step_on_declares
 from cafe.skills.loader import SkillLoader
 from cafe.ui.interactive_qa import interactive_qa_flow
 from cafe.ui.inquirer_prompts import prompt_multiline
@@ -219,8 +219,9 @@ class UserInputCollector(NoOpHook):
             return HookResult()
 
         step_name = str(kwargs.get("step_name") or kwargs["step_def"].get("name") or "")
+        step_def = kwargs["step_def"]
         agent_name = str(kwargs.get("agent_name") or "")
-        role = str(kwargs["step_def"].get("role", "developer"))
+        role = str(step_def.get("role", "developer"))
 
         # Restore plan phase iteration-1 initial user input (development guide).
         if step_name == "plan" and getattr(phase, "iteration", 0) == 1:
@@ -269,9 +270,9 @@ class UserInputCollector(NoOpHook):
 
         prompt_role = {"pm": "pm", "reviewer": "reviewer"}.get(role, "developer")
         previous_output_file = self._get_previous_output_file(phase, step_name)
-        # For spec/plan READY_FOR_REVIEW flow, delta view is sufficient and less noisy.
+        # Steps that declare confirm_output use delta view on READY_FOR_REVIEW (less noisy).
         if not (
-            step_name in {"spec", "plan"}
+            step_on_declares(step_def, "confirm_output")
             and previous_status == "ready_for_review"
         ):
             self._display_previous_output(phase, step_name, previous_output_file)

--- a/src/cafe/core/status_codes.py
+++ b/src/cafe/core/status_codes.py
@@ -60,6 +60,14 @@ def transition_map_key(code: PhaseStatusCode) -> str:
     return collapsed.get(code, "manual_handoff")
 
 
+def step_on_declares(step_def: dict, intent_key: str) -> bool:
+    """Return whether the playbook step ``on`` map includes *intent_key*."""
+    on_map = step_def.get("on")
+    if not isinstance(on_map, dict):
+        return False
+    return intent_key in on_map
+
+
 class StatusCodeParser:
     """Parser for extracting step outcome tokens from agent responses."""
 

--- a/src/cafe/core/workflow_runtime.py
+++ b/src/cafe/core/workflow_runtime.py
@@ -13,7 +13,12 @@ import re
 from typing import Any, Dict, Optional
 
 from cafe.core.blackboard import BlackboardStore, HandoffIntent, HandoffOwner
-from cafe.core.status_codes import PhaseStatusCode, StatusCodeParser, transition_map_key
+from cafe.core.status_codes import (
+    PhaseStatusCode,
+    StatusCodeParser,
+    step_on_declares,
+    transition_map_key,
+)
 from cafe.core.workflow_models import BatonRejected, PlaybookRunResult, StepExecutionResult, StepInterrupted
 
 
@@ -104,12 +109,12 @@ class BlackboardWorkflowRuntime:
                 return True
         return False
 
-    @staticmethod
-    def _default_pause_intent(current_step: str, status_code: str) -> HandoffIntent:
+    def _default_pause_intent(self, current_step: str, status_code: str) -> HandoffIntent:
+        step_def = self.steps.get(current_step, {})
         if status_code in {
             PhaseStatusCode.READY_FOR_REVIEW.value,
             PhaseStatusCode.CONFIRM_OUTPUT.value,
-        } and current_step in {"spec", "plan"}:
+        } and step_on_declares(step_def, "confirm_output"):
             return HandoffIntent.CONFIRM_OUTPUT
         if status_code == PhaseStatusCode.NEED_CLARIFICATION.value:
             return HandoffIntent.NEED_CLARIFICATION

--- a/src/cafe/phases/generic_workflow_step.py
+++ b/src/cafe/phases/generic_workflow_step.py
@@ -17,7 +17,12 @@ from cafe.core.blackboard import (
 )
 from cafe.core.git import GitOperations
 from cafe.core.phase import Phase
-from cafe.core.status_codes import PhaseStatusCode, StatusCodeParser, transition_map_key
+from cafe.core.status_codes import (
+    PhaseStatusCode,
+    StatusCodeParser,
+    step_on_declares,
+    transition_map_key,
+)
 from cafe.core.workflow_models import StepExecutionResult
 from cafe.phases.generic_phase import GenericPhase
 from cafe.utils.checklist_generator import (
@@ -300,7 +305,7 @@ class GenericWorkflowStepExecutor(Phase):
             store.record_event(blackboard_state, "script_hook", payload)
 
         if require_status_code and effective_status is not None:
-            handoff_intent = self._resolve_handoff_intent(step_name, effective_status)
+            handoff_intent = self._resolve_handoff_intent(step_def, effective_status)
             if handoff_intent is not None:
                 events.append(
                     {
@@ -467,7 +472,7 @@ class GenericWorkflowStepExecutor(Phase):
             add(f"edit({self._display_path(output_file)})")
             add(f"edit({self._display_path(checklist_file)})")
 
-        if step_name in {"spec", "plan"}:
+        if step_on_declares(step_def, "need_clarification"):
             add(f"edit({self._display_path(questions_xml_file)})")
 
         if step_name == "review":
@@ -704,13 +709,12 @@ class GenericWorkflowStepExecutor(Phase):
         return step_name != "pr"
 
     @staticmethod
-    def _resolve_handoff_intent(step_name: str, status_code: PhaseStatusCode) -> Optional[str]:
-        if status_code == PhaseStatusCode.READY_FOR_REVIEW:
-            if step_name in {"spec", "plan"}:
-                return "confirm_output"
-            return "manual_handoff"
-        if status_code == PhaseStatusCode.CONFIRM_OUTPUT:
-            if step_name in {"spec", "plan"}:
+    def _resolve_handoff_intent(step_def: Dict[str, Any], status_code: PhaseStatusCode) -> Optional[str]:
+        if status_code in {
+            PhaseStatusCode.READY_FOR_REVIEW,
+            PhaseStatusCode.CONFIRM_OUTPUT,
+        }:
+            if step_on_declares(step_def, "confirm_output"):
                 return "confirm_output"
             return "manual_handoff"
         if status_code == PhaseStatusCode.NEED_CLARIFICATION:
@@ -767,7 +771,7 @@ class GenericWorkflowStepExecutor(Phase):
             PhaseStatusCode.NEED_CLARIFICATION.value,
             PhaseStatusCode.NEED_PERMISSION.value,
         }:
-            raw_intent = self._resolve_handoff_intent(step_name, status_code) or "manual_handoff"
+            raw_intent = self._resolve_handoff_intent(step_def, status_code) or "manual_handoff"
             store.update_handoff_contract(
                 blackboard_state,
                 from_step=step_name,

--- a/tests/unit/test_cli_workflow_command.py
+++ b/tests/unit/test_cli_workflow_command.py
@@ -850,6 +850,51 @@ def test_confirm_output_chat_uses_playbook_chat_role(tmp_path: Path, monkeypatch
     mock_chat.assert_called_once_with("writer", "editorial-1")
 
 
+def test_brief_confirm_output_routes_to_review_confirmation(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    issue_dir = tmp_path / ".cafe" / "issues" / "editorial-confirm"
+    (issue_dir / "brief" / "iteration_001").mkdir(parents=True, exist_ok=True)
+    (issue_dir / "brief" / "iteration_001" / "output.md").write_text("# Brief\n", encoding="utf-8")
+    store = BlackboardStore(issue_dir)
+    blackboard = store.load_or_create("user", playbook_id="editorial")
+    store.set_current_step(blackboard, "user")
+    store.update_handoff_contract(
+        blackboard,
+        from_step="brief",
+        to_owner=HandoffOwner.USER,
+        to_step="user",
+        intent=HandoffIntent.CONFIRM_OUTPUT,
+        status_code="ready_for_review",
+        source="test",
+    )
+    playbook_data = {
+        "playbook": {"id": "editorial"},
+        "entry_point": "brief",
+        "roles": {"editor": {"default_agent": "Roger"}},
+        "steps": {
+            "brief": {
+                "role": "editor",
+                "on": {"confirm_output": "brief", "await_agent": "draft"},
+            },
+            "draft": {"role": "writer", "on": {"await_agent": "_done"}},
+        },
+    }
+
+    with patch(
+        "cafe.ui.cli_shared._handle_review_confirmation",
+        return_value="draft",
+    ) as mock_confirm:
+        result = _handle_user_phase(
+            issue_name="editorial-confirm",
+            issue_dir=issue_dir,
+            playbook_data=playbook_data,
+            blackboard=blackboard,
+        )
+
+    assert result == "draft"
+    mock_confirm.assert_called_once()
+
+
 def test_workflow_command_user_owner_can_complete_workflow(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("CAFE_FORCE_INTERACTIVE", "1")
@@ -1131,6 +1176,69 @@ def test_user_phase_need_clarification_collects_questions_and_resumes_step(tmp_p
     assert reloaded.handoff_contract is not None
     assert reloaded.handoff_contract.intent == HandoffIntent.AWAIT_AGENT
     assert reloaded.handoff_contract.to_step == "spec"
+
+
+def test_user_phase_question_need_clarification_resumes_question_step(tmp_path: Path, capsys) -> None:
+    issue_dir = tmp_path / ".cafe" / "issues" / "issue-research-clarify"
+    issue_dir.mkdir(parents=True, exist_ok=True)
+    question_iter_dir = issue_dir / "question" / "iteration_001"
+    question_iter_dir.mkdir(parents=True)
+    (question_iter_dir / "output.md").write_text("# Research question\n", encoding="utf-8")
+    (question_iter_dir / "questions.xml").write_text(
+        """<?xml version="1.0" encoding="UTF-8"?>
+<questions>
+  <question id="1">
+    <title>Primary source?</title>
+    <options>
+      <option>Academic papers</option>
+      <option>Industry reports</option>
+    </options>
+  </question>
+</questions>
+""",
+        encoding="utf-8",
+    )
+    playbook_data = {
+        "playbook": {"id": "research"},
+        "roles": {"researcher": {"default_agent": "Morgan"}},
+        "steps": {
+            "question": {
+                "role": "researcher",
+                "on": {"need_clarification": "question", "await_agent": "collect"},
+            },
+            "collect": {"role": "researcher", "on": {}},
+        },
+    }
+    store = BlackboardStore(issue_dir)
+    blackboard = store.load_or_create("user", playbook_id="research")
+    store.set_current_step(blackboard, "user")
+    store.update_handoff_contract(
+        blackboard,
+        from_step="question",
+        to_owner=HandoffOwner.USER,
+        to_step="user",
+        intent=HandoffIntent.NEED_CLARIFICATION,
+        status_code="need_clarification",
+        source="test",
+    )
+
+    with patch(
+        "cafe.ui.interactive_qa.interactive_qa_flow",
+        return_value="Q1: Primary source?\nA1: Academic papers",
+    ):
+        result = _handle_user_phase(
+            issue_name="issue-research-clarify",
+            issue_dir=issue_dir,
+            playbook_data=playbook_data,
+            blackboard=blackboard,
+        )
+
+    assert result == "question"
+    next_input = issue_dir / "question" / "iteration_002" / "user_input.md"
+    assert next_input.read_text(encoding="utf-8") == "Q1: Primary source?\nA1: Academic papers"
+    reloaded = store.load_or_create("question", playbook_id="research")
+    assert reloaded.current_step == "question"
+    assert reloaded.handoff_contract.intent == HandoffIntent.AWAIT_AGENT
 
 
 def test_workflow_command_done_phase_can_restart_workflow(tmp_path: Path, monkeypatch) -> None:

--- a/tests/unit/test_generic_workflow_step.py
+++ b/tests/unit/test_generic_workflow_step.py
@@ -269,6 +269,122 @@ def test_generic_workflow_step_writes_review_pause_contract(tmp_path: Path, monk
     assert reloaded.handoff_contract is not None
     assert reloaded.handoff_contract.to_owner == HandoffOwner.USER
     assert reloaded.handoff_contract.to_step == "user"
+    assert reloaded.handoff_contract.intent == HandoffIntent.CONFIRM_OUTPUT
+
+
+def test_generic_workflow_step_brief_ready_for_review_writes_confirm_output_contract(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    issue_dir = tmp_path / ".cafe" / "issues" / "issue-brief-confirm"
+    playbook = {
+        "playbook": {"id": "editorial"},
+        "roles": {"editor": {"default_agent": "Roger"}},
+        "steps": {
+            "brief": {
+                "skill": "spec_first",
+                "role": "editor",
+                "output_artifact": "brief",
+                "allowed_tools": ["Read"],
+                "valid_intents": ["ready_for_review", "confirmed"],
+                "on": {"confirm_output": "brief", "await_agent": "draft"},
+            }
+        },
+    }
+    state = BlackboardStore(issue_dir).load_or_create("brief")
+    executor = GenericWorkflowStepExecutor(
+        issue_dir=issue_dir,
+        issue_name="issue-brief-confirm",
+        playbook=playbook,
+        generic_phase=_build_loader(tmp_path),
+        agent_manager=FakeAgentManager("ready_for_review"),
+        git_ops=FakeGitOperations(),
+        role_agent_map={"editor": "Roger"},
+        interactive=True,
+    )
+
+    result = executor.execute_step("brief", playbook["steps"]["brief"], state)
+
+    assert result.status_code == "ready_for_review"
+    reloaded = BlackboardStore(issue_dir).load_or_create("brief")
+    assert reloaded.handoff_contract is not None
+    assert reloaded.handoff_contract.intent == HandoffIntent.CONFIRM_OUTPUT
+    assert reloaded.handoff_contract.to_step == "user"
+
+
+def test_generic_workflow_step_question_need_clarification_writes_clarification_contract(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    issue_dir = tmp_path / ".cafe" / "issues" / "issue-question-clarify"
+    playbook = {
+        "playbook": {"id": "research"},
+        "roles": {"researcher": {"default_agent": "Morgan"}},
+        "steps": {
+            "question": {
+                "skill": "spec_first",
+                "role": "researcher",
+                "output_artifact": "research_question_brief",
+                "allowed_tools": ["Read"],
+                "valid_intents": ["need_clarification", "confirmed"],
+                "on": {"need_clarification": "question", "await_agent": "collect"},
+            }
+        },
+    }
+    state = BlackboardStore(issue_dir).load_or_create("question")
+    executor = GenericWorkflowStepExecutor(
+        issue_dir=issue_dir,
+        issue_name="issue-question-clarify",
+        playbook=playbook,
+        generic_phase=_build_loader(tmp_path),
+        agent_manager=FakeAgentManager("need_clarification"),
+        git_ops=FakeGitOperations(),
+        role_agent_map={"researcher": "Morgan"},
+        interactive=True,
+    )
+
+    result = executor.execute_step("question", playbook["steps"]["question"], state)
+
+    assert result.status_code == "need_clarification"
+    reloaded = BlackboardStore(issue_dir).load_or_create("question")
+    assert reloaded.handoff_contract is not None
+    assert reloaded.handoff_contract.intent == HandoffIntent.NEED_CLARIFICATION
+    assert reloaded.handoff_contract.to_step == "user"
+
+
+def test_generic_workflow_step_question_step_allows_questions_xml_edit(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    issue_dir = tmp_path / ".cafe" / "issues" / "issue-question-tools"
+    playbook = {
+        "playbook": {"id": "research"},
+        "roles": {"researcher": {"default_agent": "Morgan"}},
+        "steps": {
+            "question": {
+                "skill": "spec_first",
+                "role": "researcher",
+                "output_artifact": "research_question_brief",
+                "allowed_tools": ["Read"],
+                "valid_intents": ["need_clarification", "confirmed"],
+                "on": {"need_clarification": "question", "await_agent": "collect"},
+            }
+        },
+    }
+    state = BlackboardStore(issue_dir).load_or_create("question")
+    agent_manager = FakeAgentManager("confirmed")
+    executor = GenericWorkflowStepExecutor(
+        issue_dir=issue_dir,
+        issue_name="issue-question-tools",
+        playbook=playbook,
+        generic_phase=_build_loader(tmp_path),
+        agent_manager=agent_manager,
+        git_ops=FakeGitOperations(),
+        role_agent_map={"researcher": "Morgan"},
+    )
+
+    executor.execute_step("question", playbook["steps"]["question"], state)
+
+    allowed_tools = agent_manager.allowed_tools_calls[0] or []
+    assert "edit(./.cafe/issues/issue-question-tools/question/iteration_001/questions.xml)" in allowed_tools
 
 
 def test_generic_workflow_step_auto_confirms_review_in_non_interactive(tmp_path: Path, monkeypatch) -> None:
@@ -1005,7 +1121,7 @@ def test_generic_workflow_step_restores_spec_runtime_allowed_tools(tmp_path: Pat
                 "output_artifact": "spec",
                 "allowed_tools": ["Read", "Grep", "Glob", "WebFetch", "WebSearch"],
                 "valid_intents": ["confirmed"],
-                "on": {"await_agent": "_done"},
+                "on": {"await_agent": "_done", "need_clarification": "spec"},
             }
         },
     }

--- a/tests/unit/test_native_user_input_hook.py
+++ b/tests/unit/test_native_user_input_hook.py
@@ -88,7 +88,7 @@ def test_user_input_collector_confirms_ready_for_review_without_running_agent(tm
             stage="prepare_input",
             phase=phase,
             step_name="spec",
-            step_def={"role": "pm"},
+            step_def={"role": "pm", "on": {"confirm_output": "spec"}},
             agent_name="Roger",
         )
 
@@ -102,6 +102,38 @@ def test_user_input_collector_confirms_ready_for_review_without_running_agent(tm
     mock_display_delta.assert_called_once()
     phase._ask_user_for_review_decision.assert_called_once()
     phase._process_review_decision.assert_called_once()
+
+
+def test_user_input_collector_brief_ready_for_review_uses_delta_when_confirm_output_declared(
+    tmp_path: Path,
+) -> None:
+    phase_dir = tmp_path / "brief"
+    prev_prev_iter_dir = phase_dir / "iteration_001"
+    prev_prev_iter_dir.mkdir(parents=True, exist_ok=True)
+    (prev_prev_iter_dir / "output.md").write_text("# Brief v1\n", encoding="utf-8")
+
+    prev_iter_dir = phase_dir / "iteration_002"
+    prev_iter_dir.mkdir(parents=True, exist_ok=True)
+    (prev_iter_dir / "output.md").write_text("# Brief v2\n", encoding="utf-8")
+    _record_previous_step_status(tmp_path, "brief", "ready_for_review")
+
+    phase = _FakePhase(phase_dir=phase_dir, iteration=3)
+    phase._ask_user_for_review_decision = MagicMock(return_value="confirm")
+    phase._process_review_decision = MagicMock()
+
+    hook = UserInputCollector()
+    with patch.object(hook, "_display_previous_output") as mock_display_output, \
+         patch.object(hook, "_display_previous_iteration_delta") as mock_display_delta:
+        hook.run(
+            stage="prepare_input",
+            phase=phase,
+            step_name="brief",
+            step_def={"role": "editor", "on": {"confirm_output": "brief"}},
+            agent_name="Roger",
+        )
+
+    mock_display_output.assert_not_called()
+    mock_display_delta.assert_called_once()
 
 
 def test_user_input_collector_plan_ready_for_review_skips_full_output_display_when_delta_available(tmp_path: Path) -> None:
@@ -126,7 +158,7 @@ def test_user_input_collector_plan_ready_for_review_skips_full_output_display_wh
             stage="prepare_input",
             phase=phase,
             step_name="plan",
-            step_def={"role": "developer"},
+            step_def={"role": "developer", "on": {"confirm_output": "plan"}},
             agent_name="David",
         )
 
@@ -155,7 +187,7 @@ def test_user_input_collector_plan_ready_for_review_falls_back_to_full_output_wi
             stage="prepare_input",
             phase=phase,
             step_name="plan",
-            step_def={"role": "developer"},
+            step_def={"role": "developer", "on": {"confirm_output": "plan"}},
             agent_name="David",
         )
 

--- a/tests/unit/test_workflow_runtime.py
+++ b/tests/unit/test_workflow_runtime.py
@@ -927,6 +927,78 @@ def test_runtime_pauses_ready_for_review_with_confirm_output_intent(tmp_path: Pa
     assert blackboard.handoff_contract.intent == HandoffIntent.CONFIRM_OUTPUT
 
 
+def test_runtime_pauses_brief_ready_for_review_with_confirm_output_intent(tmp_path: Path) -> None:
+    issue_dir = tmp_path / ".cafe" / "issues" / "brief-confirm-pause"
+    playbook = {
+        "playbook": {"id": "editorial"},
+        "steps": {
+            "brief": {
+                "skill": "brief_first",
+                "role": "editor",
+                "valid_intents": ["ready_for_review", "confirmed"],
+                "on": {"confirm_output": "brief", "await_agent": "draft"},
+            },
+        },
+    }
+
+    def executor(step_name: str, step_def: dict, state: object) -> StepExecutionResult:
+        return StepExecutionResult(
+            response="ready_for_review",
+            artifacts={},
+            status_code="ready_for_review",
+            auto_continue=False,
+        )
+
+    runtime = BlackboardWorkflowRuntime(
+        issue_dir=issue_dir,
+        playbook=playbook,
+        executor=executor,
+    )
+    result = runtime.run(start_step="brief")
+
+    assert result.completed is False
+    assert result.final_status_code == "ready_for_review"
+    blackboard = BlackboardStore(issue_dir).load_or_create("brief")
+    assert blackboard.current_step == "user"
+    assert blackboard.handoff_contract is not None
+    assert blackboard.handoff_contract.intent == HandoffIntent.CONFIRM_OUTPUT
+
+
+def test_runtime_ready_for_review_without_confirm_output_uses_manual_handoff(tmp_path: Path) -> None:
+    issue_dir = tmp_path / ".cafe" / "issues" / "develop-review-no-confirm"
+    playbook = {
+        "playbook": {"id": "default"},
+        "steps": {
+            "develop": {
+                "skill": "develop",
+                "role": "developer",
+                "valid_intents": ["ready_for_review", "confirmed"],
+                "on": {"await_agent": "review", "manual_handoff": "develop"},
+            },
+        },
+    }
+
+    def executor(step_name: str, step_def: dict, state: object) -> StepExecutionResult:
+        return StepExecutionResult(
+            response="ready_for_review",
+            artifacts={},
+            status_code="ready_for_review",
+            auto_continue=False,
+        )
+
+    runtime = BlackboardWorkflowRuntime(
+        issue_dir=issue_dir,
+        playbook=playbook,
+        executor=executor,
+    )
+    result = runtime.run(start_step="develop")
+
+    assert result.completed is False
+    blackboard = BlackboardStore(issue_dir).load_or_create("develop")
+    assert blackboard.handoff_contract is not None
+    assert blackboard.handoff_contract.intent == HandoffIntent.MANUAL_HANDOFF
+
+
 def test_runtime_continues_when_auto_continue_is_true(tmp_path: Path) -> None:
     issue_dir = tmp_path / ".cafe" / "issues" / "auto-continue"
     playbook = {


### PR DESCRIPTION
## Summary

Closes #279. Extends the #278 playbook-driven handoff direction so `confirm_output` and `need_clarification` runtime/UI behavior is driven by playbook step `on` semantics and handoff intent, not hardcoded `spec` / `plan` phase names. Default `spec` and `plan` flows stay unchanged; custom steps such as editorial `brief` and research `question` now get the same confirmation and clarification UX.

## Changes

- **`src/cafe/core/status_codes.py`**: Add shared `step_on_declares()` helper for playbook `on` map checks.
- **`src/cafe/core/workflow_runtime.py`**: `_default_pause_intent` emits `confirm_output` when the current step's `on` map declares `confirm_output`, instead of gating on `spec` / `plan` names.
- **`src/cafe/phases/generic_workflow_step.py`**: Mirror the same rule in `_resolve_handoff_intent()`; allow `questions.xml` edits when the step declares `need_clarification`.
- **`src/cafe/core/hooks/native.py`**: Key delta-only confirmation display off `confirm_output` in step `on`, not step name.
- **Tests**: Add runtime, executor, hook, and CLI coverage for non-default `brief` / `question` steps; keep `spec` / `plan` and PR `ready_for_review` → `manual_handoff` regressions.

### Commits

| SHA | Message |
| --- | --- |
| `ed0cc07` | issue279: derive confirm_output pause from playbook on map |
| `d5c2d1d` | issue279: align executor and hooks with playbook handoff semantics |
| `eaa0bc3` | issue279: add CLI tests for non-default confirm and clarification |

## Test Plan

- [ ] `uv run pytest tests/unit/test_workflow_runtime.py -k "confirm_output or ready_for_review"`
- [ ] `uv run pytest tests/unit/test_generic_workflow_step.py -k "review_pause or clarification or brief or question"`
- [ ] `uv run pytest tests/unit/test_native_user_input_hook.py`
- [ ] `uv run pytest tests/unit/test_cli_workflow_command.py -k "confirm_output or clarification"`
- [ ] `uv run pytest tests/unit/test_workflow_runtime.py tests/unit/test_generic_workflow_step.py tests/unit/test_cli_workflow_command.py tests/unit/test_spec_phase_qa.py tests/unit/test_plan_phase_status_codes.py` (focused regression; 165 passed in develop iteration 002)
- [ ] Manual: run default workflow `spec` / `plan` confirmation and clarification — behavior unchanged
- [ ] Manual: editorial `brief` with `ready_for_review` pauses at user with `confirm_output`; research `question` with `need_clarification` collects answers and resumes