### PR TITLE
Route workflow --user-input to playbook entry points

### DIFF
--- a/src/cafe/ui/commands/workflow.py
+++ b/src/cafe/ui/commands/workflow.py
@@ -98,6 +98,30 @@ def _resolve_selected_playbook(*a, **kw):
 
 console = Console()
 
+_USER_INPUT_HELP = (
+    "Initial workflow input, or answer to write when resuming from a user handoff"
+)
+
+
+def _normalize_cli_user_input(user_input: Any) -> Optional[str]:
+    """Return stripped CLI user input, or None when unset or invoked outside Typer."""
+    if not isinstance(user_input, str):
+        return None
+    stripped = user_input.strip()
+    return stripped if stripped else None
+
+
+def _build_initial_step_user_inputs(
+    playbook_data: Dict[str, Any],
+    user_input: Optional[str],
+) -> Optional[Dict[str, str]]:
+    """Map cold-start --user-input to the playbook entry point step."""
+    normalized = _normalize_cli_user_input(user_input)
+    if not normalized:
+        return None
+    entry_point = playbook_data.get("entry_point") or next(iter(playbook_data["steps"].keys()))
+    return {str(entry_point): normalized}
+
 
 def _validate_allowed_directories(config_manager: Any, add_dir: List[str]) -> None:
     """Validate config.yaml and CLI-provided allowed directories."""
@@ -127,7 +151,7 @@ def make(
         None,
         "--user-input",
         "-u",
-        help="Requirements for the spec step, or answer to write when resuming from a user handoff",
+        help=_USER_INPUT_HELP,
     ),
     timeout: int = typer.Option(
         0,
@@ -486,7 +510,7 @@ def workflow(
         None,
         "--user-input",
         "-u",
-        help="Requirements for the spec step, or answer to write when resuming from a user handoff",
+        help=_USER_INPUT_HELP,
     ),
     fallback_preset: Optional[str] = typer.Option(
         None,
@@ -500,6 +524,7 @@ def workflow(
     ),
 ) -> None:
     """Run playbook workflow using the new generic runner."""
+    user_input = _normalize_cli_user_input(user_input)
     try:
         def _predict_next_iteration(issue_root: Path, step_name: str) -> int:
             step_dir = issue_root / step_name
@@ -585,6 +610,19 @@ def workflow(
                 artifacts={str(output_key): str(output_path)},
                 status_code="confirmed",
             )
+        entry_point = str(
+            playbook_data.get("entry_point") or next(iter(playbook_data["steps"].keys()))
+        )
+        resume_blackboard = BlackboardStore(issue_dir).load_or_create(
+            entry_point,
+            playbook_id=str(playbook_data["playbook"]["id"]),
+            allow_legacy_text=True,
+        )
+        if user_input and resume_blackboard.current_step in {"user", "done"}:
+            initial_step_user_inputs = None
+        else:
+            initial_step_user_inputs = _build_initial_step_user_inputs(playbook_data, user_input)
+
         # Mutable holder so wrapped_executor can swap executors on fallback
         _executor_holder: Dict[str, Any] = {
             "executor": None if dry_run else _build_workflow_step_executor(
@@ -593,7 +631,7 @@ def workflow(
                 issue_name=issue_name,
                 playbook_data=playbook_data,
                 generic_phase=generic_phase,
-                step_user_inputs={"spec": user_input} if user_input else None,
+                step_user_inputs=initial_step_user_inputs,
                 interactive=interactive,
                 extra_allowed_directories=add_dir_values,
             ),
@@ -616,7 +654,7 @@ def workflow(
                 issue_name=issue_name,
                 playbook_data=playbook_data,
                 generic_phase=generic_phase,
-                step_user_inputs={"spec": user_input} if user_input else None,
+                step_user_inputs=initial_step_user_inputs,
                 interactive=interactive,
                 extra_allowed_directories=add_dir_values,
             )

--- a/tests/unit/test_cli_workflow_command.py
+++ b/tests/unit/test_cli_workflow_command.py
@@ -6,6 +6,7 @@ from unittest.mock import patch, MagicMock
 
 from typer.testing import CliRunner
 
+from cafe.agents.executor import AgentExecutionError
 from cafe.core.blackboard import BlackboardStore, HandoffIntent, HandoffOwner
 from cafe.core.workflow_models import StepExecutionResult
 from cafe.ui.cli import app, _execute_single_step_alias, _find_external_resume_step, _handle_user_phase
@@ -183,6 +184,245 @@ def test_workflow_command_passes_initial_user_input_to_spec_step(tmp_path: Path,
     assert mock_builder.call_args.kwargs["step_user_inputs"] == {
         "spec": "As a user, I want a smoke-test workflow."
     }
+
+
+def test_workflow_command_passes_initial_user_input_to_question_step(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    class FakeExecutor:
+        def execute_step(self, step_name: str, step_def: dict, blackboard_state: object, **kwargs) -> StepExecutionResult:
+            return _result(status_code="confirmed", step_name=step_name, step_def=step_def)
+
+    with (
+        patch("cafe.ui.cli.GitOperations") as mock_git_cls,
+        patch("cafe.ui.cli._build_workflow_step_executor", return_value=FakeExecutor()) as mock_builder,
+    ):
+        git = MagicMock()
+        git.get_current_branch.return_value = "issue-research-input"
+        mock_git_cls.return_value = git
+
+        result = runner.invoke(
+            app,
+            [
+                "workflow",
+                "--playbook",
+                "research",
+                "--execute",
+                "--user-input",
+                "What is the market size for EV batteries?",
+            ],
+        )
+
+    assert result.exit_code == 0
+    assert mock_builder.call_args.kwargs["step_user_inputs"] == {
+        "question": "What is the market size for EV batteries?"
+    }
+
+
+def test_workflow_command_passes_initial_user_input_to_brief_step(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    class FakeExecutor:
+        def execute_step(self, step_name: str, step_def: dict, blackboard_state: object, **kwargs) -> StepExecutionResult:
+            return _result(status_code="confirmed", step_name=step_name, step_def=step_def)
+
+    with (
+        patch("cafe.ui.cli.GitOperations") as mock_git_cls,
+        patch("cafe.ui.cli._build_workflow_step_executor", return_value=FakeExecutor()) as mock_builder,
+    ):
+        git = MagicMock()
+        git.get_current_branch.return_value = "issue-editorial-input"
+        mock_git_cls.return_value = git
+
+        result = runner.invoke(
+            app,
+            [
+                "workflow",
+                "--playbook",
+                "editorial",
+                "--execute",
+                "--user-input",
+                "Write a blog post about playbook-driven workflows.",
+            ],
+        )
+
+    assert result.exit_code == 0
+    assert mock_builder.call_args.kwargs["step_user_inputs"] == {
+        "brief": "Write a blog post about playbook-driven workflows."
+    }
+
+
+def test_workflow_fallback_rebuild_passes_entry_point_user_input(tmp_path: Path, monkeypatch) -> None:
+    """Fallback executor rebuild should keep entry-point keyed step_user_inputs."""
+    monkeypatch.chdir(tmp_path)
+    cafe_dir = tmp_path / ".cafe"
+    cafe_dir.mkdir()
+    presets_dir = cafe_dir / "presets"
+    presets_dir.mkdir()
+    (presets_dir / "fallback-crew.yaml").write_text(
+        "pm:\n  name: Roger\n  cli: gemini\n",
+        encoding="utf-8",
+    )
+
+    user_text = "Hotfix the login timeout regression."
+    builder_calls: list[dict[str, str] | None] = []
+    execute_calls = {"count": 0}
+
+    class FakeExecutor:
+        def execute_step(self, step_name: str, step_def: dict, blackboard_state: object, **kwargs) -> StepExecutionResult:
+            execute_calls["count"] += 1
+            if execute_calls["count"] == 1:
+                raise AgentExecutionError("rate limit", error_type="rate_limit")
+            return _result(status_code="confirmed", step_name=step_name, step_def=step_def)
+
+    def fake_builder(**kwargs):
+        builder_calls.append(kwargs.get("step_user_inputs"))
+        return FakeExecutor()
+
+    with (
+        patch("cafe.ui.cli.GitOperations") as mock_git_cls,
+        patch("cafe.ui.cli._build_workflow_step_executor", side_effect=fake_builder),
+        patch("cafe.utils.preset.PresetManager.apply"),
+    ):
+        git = MagicMock()
+        git.get_current_branch.return_value = "issue-hotfix-fallback"
+        mock_git_cls.return_value = git
+
+        result = runner.invoke(
+            app,
+            [
+                "workflow",
+                "--playbook",
+                "hotfix",
+                "--execute",
+                "--user-input",
+                user_text,
+                "--fallback-preset",
+                "fallback-crew",
+            ],
+        )
+
+    assert result.exit_code == 0
+    assert builder_calls == [{"develop": user_text}, {"develop": user_text}]
+
+
+def test_workflow_command_resume_user_input_targets_handoff_from_step(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    issue_dir = tmp_path / ".cafe" / "issues" / "issue-resume-plan"
+    issue_dir.mkdir(parents=True, exist_ok=True)
+    store = BlackboardStore(issue_dir)
+    blackboard = store.load_or_create("user", playbook_id="default")
+    store.set_current_step(blackboard, "user")
+    store.update_handoff_contract(
+        blackboard,
+        from_step="plan",
+        to_owner=HandoffOwner.USER,
+        to_step="user",
+        intent=HandoffIntent.NEED_CLARIFICATION,
+        status_code="need_clarification",
+        source="test",
+    )
+
+    class FakeExecutor:
+        def execute_step(self, step_name: str, step_def: dict, blackboard_state: object, **kwargs) -> StepExecutionResult:
+            return _result(status_code="confirmed", step_name=step_name, step_def=step_def)
+
+    with (
+        patch("cafe.ui.cli.GitOperations") as mock_git_cls,
+        patch("cafe.ui.cli._build_workflow_step_executor", return_value=FakeExecutor()) as mock_builder,
+    ):
+        git = MagicMock()
+        git.get_current_branch.return_value = "issue-resume-plan"
+        mock_git_cls.return_value = git
+
+        result = runner.invoke(
+            app,
+            [
+                "workflow",
+                "--playbook",
+                "default",
+                "--execute",
+                "--single-step",
+                "--user-input",
+                "Clarification: include CSV export in scope.",
+            ],
+        )
+
+    assert result.exit_code == 0
+    assert mock_builder.call_args.kwargs["step_user_inputs"] is None
+    resume_input = issue_dir / "plan" / "iteration_001" / "user_input.md"
+    assert resume_input.read_text(encoding="utf-8") == "Clarification: include CSV export in scope."
+    reloaded = store.load_or_create("spec", playbook_id="default")
+    assert "resuming plan" in (reloaded.handoff_summary or "").lower()
+    assert reloaded.current_step == "develop"
+
+
+def test_workflow_command_resume_confirm_output_keeps_await_agent_intent(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    issue_dir = tmp_path / ".cafe" / "issues" / "issue-resume-confirm"
+    issue_dir.mkdir(parents=True, exist_ok=True)
+    store = BlackboardStore(issue_dir)
+    blackboard = store.load_or_create("user", playbook_id="default")
+    store.set_current_step(blackboard, "user")
+    store.update_handoff_contract(
+        blackboard,
+        from_step="spec",
+        to_owner=HandoffOwner.USER,
+        to_step="user",
+        intent=HandoffIntent.CONFIRM_OUTPUT,
+        status_code="ready_for_review",
+        source="test",
+    )
+
+    class FakeExecutor:
+        def execute_step(self, step_name: str, step_def: dict, blackboard_state: object, **kwargs) -> StepExecutionResult:
+            return _result(status_code="confirmed", step_name=step_name, step_def=step_def)
+
+    with (
+        patch("cafe.ui.cli.GitOperations") as mock_git_cls,
+        patch("cafe.ui.cli._build_workflow_step_executor", return_value=FakeExecutor()),
+    ):
+        git = MagicMock()
+        git.get_current_branch.return_value = "issue-resume-confirm"
+        mock_git_cls.return_value = git
+
+        result = runner.invoke(
+            app,
+            [
+                "workflow",
+                "--playbook",
+                "default",
+                "--execute",
+                "--user-input",
+                "Approved with minor wording tweaks.",
+            ],
+        )
+
+    assert result.exit_code == 0
+    resume_input = issue_dir / "spec" / "iteration_001" / "user_input.md"
+    assert resume_input.read_text(encoding="utf-8") == "Approved with minor wording tweaks."
+    reloaded = store.load_or_create("spec", playbook_id="default")
+    assert reloaded.handoff_contract.intent == HandoffIntent.AWAIT_AGENT
+
+
+def test_workflow_help_describes_user_input_without_spec_only_wording() -> None:
+    result = runner.invoke(app, ["workflow", "--help"])
+    assert result.exit_code == 0
+    help_text = result.stdout.lower()
+    assert "spec step" not in help_text
+    assert "initial workflow input" in help_text
+    assert "resuming from a user" in help_text
+    assert "handoff" in help_text
+
+
+def test_make_help_describes_user_input_without_spec_only_wording() -> None:
+    result = runner.invoke(app, ["make", "--help"])
+    assert result.exit_code == 0
+    help_text = result.stdout.lower()
+    assert "spec step" not in help_text
+    assert "initial workflow input" in help_text
+    assert "resuming from a user" in help_text
+    assert "handoff" in help_text
 
 
 def test_build_workflow_step_executor_passes_allowed_directories(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary
Generalizes workflow cold-start `--user-input` routing so the input is delivered to the active playbook entry point instead of always being assigned to `spec`.

This addresses issue 280: custom playbooks such as research and editorial can now receive initial input on their first declared step, while the default playbook still routes initial requirements to `spec`. Resume-from-user-handoff behavior remains contract-driven.

## Changes
- Commit `58270bf`: `issue280: route --user-input to playbook entry_point on cold start`
- Added `_USER_INPUT_HELP`, `_normalize_cli_user_input()`, and `_build_initial_step_user_inputs()` in `src/cafe/ui/commands/workflow.py`.
- Updated initial executor creation and fallback executor rebuild to pass `step_user_inputs` keyed by the playbook `entry_point`.
- Prevented resume answers from being duplicated into cold-start `step_user_inputs` when the blackboard is paused at `user` or `done`.
- Updated `cafe workflow --user-input` and `cafe make --user-input` help text to use playbook-neutral wording.
- Added workflow CLI regression coverage for default, research, editorial, hotfix fallback rebuild, user-handoff resume, confirm-output resume, and help text behavior.

## Test Plan
- `pytest tests/unit/test_cli_workflow_command.py -q`
- `pytest tests/unit/test_cli_make.py -q`
- `pytest tests/unit/test_cli_workflow_command.py tests/unit/test_cli_make.py -q`