### PR TITLE
Reconcile blackboard when agent dies after valid handoff

### DIFF
--- a/src/cafe/core/workflow_runtime.py
+++ b/src/cafe/core/workflow_runtime.py
@@ -974,6 +974,18 @@ class BlackboardWorkflowRuntime:
             reason=reason,
         )
 
+    def _should_attempt_resume_reconciliation(self, *, start_step: Optional[str]) -> bool:
+        if start_step is None:
+            return True
+        try:
+            contract = self.blackboard_store.load_handoff_contract(
+                self.blackboard,
+                allowed_steps=list(self.steps.keys()),
+            )
+        except Exception:
+            return False
+        return contract.source == "workflow.consume_handoff" and contract.to_step == start_step
+
     def _run_baton_driven_pr(
         self,
         *,
@@ -1664,7 +1676,7 @@ class BlackboardWorkflowRuntime:
                 )
             return self._run_single_step(current_step=current_step)
 
-        if start_step is None:
+        if self._should_attempt_resume_reconciliation(start_step=start_step):
             reconciled = self._try_resume_reconcile_interrupted_handoff(
                 runtime_label="resume_reconciliation",
             )

--- a/src/cafe/core/workflow_runtime.py
+++ b/src/cafe/core/workflow_runtime.py
@@ -7,12 +7,15 @@ primary source of truth for step transitions.
 from __future__ import annotations
 
 from collections import Counter
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from datetime import datetime
+import json
 from pathlib import Path
 import re
 from typing import Any, Dict, Optional
 
-from cafe.core.blackboard import BlackboardStore, HandoffIntent, HandoffOwner
+from cafe.core.blackboard import BlackboardStore, HandoffContract, HandoffIntent, HandoffOwner
+from cafe.core.questions_schema import validate_questions_xml
 from cafe.core.status_codes import (
     PhaseStatusCode,
     StatusCodeParser,
@@ -20,6 +23,7 @@ from cafe.core.status_codes import (
     transition_map_key,
 )
 from cafe.core.workflow_models import BatonRejected, PlaybookRunResult, StepExecutionResult, StepInterrupted
+from cafe.utils.checklist_validator import validate_checklist
 
 
 STATUS_TOKEN_PATTERN = re.compile(r"\bCAFE_[A-Z0-9_]+\b")
@@ -46,6 +50,16 @@ class PostContractResult:
     status_code: str
     next_step: Optional[str] = None
     terminal_result: Optional[PlaybookRunResult] = None
+
+
+@dataclass
+class HandoffReconciliationResult:
+    reconciled: bool
+    status_code: str = ""
+    contract: Optional[HandoffContract] = None
+    iteration_dir: Optional[Path] = None
+    missing_evidence: list[str] = field(default_factory=list)
+    validated_evidence: list[str] = field(default_factory=list)
 
 
 class BlackboardWorkflowRuntime:
@@ -667,6 +681,299 @@ class BlackboardWorkflowRuntime:
         )
         return PostContractResult(status_code=resolved_status_code, next_step=next_step)
 
+    @staticmethod
+    def _now_iso() -> str:
+        return datetime.now().astimezone().isoformat()
+
+    def _latest_iteration_dir(self, current_step: str) -> Optional[Path]:
+        step_dir = self.issue_dir / current_step
+        if not step_dir.exists():
+            return None
+        iteration_dirs = sorted(path for path in step_dir.glob("iteration_*") if path.is_dir())
+        return iteration_dirs[-1] if iteration_dirs else None
+
+    @staticmethod
+    def _questions_required_for_reconciliation(contract: HandoffContract, status_code: str) -> bool:
+        return (
+            contract.intent == HandoffIntent.NEED_CLARIFICATION
+            or contract.status_code == PhaseStatusCode.NEED_CLARIFICATION.value
+            or status_code == PhaseStatusCode.NEED_CLARIFICATION.value
+        )
+
+    def _pr_publish_receipt_recorded(self) -> bool:
+        for receipt in getattr(self.blackboard, "capability_receipts", []):
+            if (
+                isinstance(receipt, dict)
+                and receipt.get("capability") == "cafe.pr.publish"
+                and receipt.get("success") is True
+            ):
+                return True
+        for event in getattr(self.blackboard, "events", []):
+            data = getattr(event, "data", {})
+            if getattr(event, "event_type", "") == "pr_synced":
+                return True
+            if (
+                getattr(event, "event_type", "") == "capability_receipt"
+                and isinstance(data, dict)
+                and data.get("capability") == "cafe.pr.publish"
+                and data.get("success") is True
+            ):
+                return True
+        return False
+
+    def _validate_reconciled_handoff(self, *, current_step: str) -> HandoffReconciliationResult:
+        missing: list[str] = []
+        validated: list[str] = []
+        contract: Optional[HandoffContract] = None
+
+        try:
+            contract = self.blackboard_store.load_handoff_contract(
+                self.blackboard,
+                allowed_steps=list(self.steps.keys()),
+            )
+        except Exception:
+            missing.append("baton_valid")
+
+        status_code = ""
+        if contract is not None:
+            status_code = contract.status_code or f"BATON_{contract.intent.value.upper()}"
+            if contract.from_step != current_step:
+                missing.append("baton_from_step")
+
+            downstream = False
+            if contract.to_owner == HandoffOwner.AGENT:
+                downstream = contract.to_step in self.steps and contract.to_step != current_step
+            elif contract.to_owner == HandoffOwner.USER:
+                downstream = contract.to_step == "user"
+            elif contract.to_owner == HandoffOwner.DONE:
+                downstream = contract.to_step == "done"
+
+            if not downstream:
+                missing.append("baton_downstream")
+            else:
+                validated.append("baton")
+
+            if (
+                current_step == "pr"
+                and contract.to_owner == HandoffOwner.DONE
+                and self._pr_step_requires_publish_receipt(current_step)
+                and not self._pr_publish_receipt_recorded()
+            ):
+                missing.append("capability_receipt")
+
+        iteration_dir = self._latest_iteration_dir(current_step)
+        if iteration_dir is None:
+            missing.append("iteration_dir")
+        else:
+            output_path = iteration_dir / "output.md"
+            if not output_path.exists() or not output_path.read_text(encoding="utf-8").strip():
+                missing.append("output_non_empty")
+            else:
+                validated.append("output")
+
+            checklist_path = iteration_dir / "checklist.md"
+            try:
+                checklist_result = validate_checklist(checklist_path)
+                if checklist_result.is_complete:
+                    validated.append("checklist")
+                else:
+                    missing.append("checklist_complete")
+            except FileNotFoundError:
+                missing.append("checklist_complete")
+
+            if contract is not None and self._questions_required_for_reconciliation(contract, status_code):
+                questions_path = iteration_dir / "questions.xml"
+                if validate_questions_xml(questions_path):
+                    validated.append("questions")
+                else:
+                    missing.append("questions_valid")
+
+        return HandoffReconciliationResult(
+            reconciled=not missing,
+            status_code=status_code,
+            contract=contract,
+            iteration_dir=iteration_dir,
+            missing_evidence=missing,
+            validated_evidence=validated,
+        )
+
+    def _reconciliation_event_exists(
+        self,
+        *,
+        current_step: str,
+        status_code: str,
+        contract: HandoffContract,
+    ) -> bool:
+        for event in self.blackboard.events:
+            if event.event_type != "step_reconciled":
+                continue
+            data = event.data
+            if (
+                data.get("step") == current_step
+                and data.get("status_code") == status_code
+                and data.get("to_owner") == contract.to_owner.value
+                and data.get("to_step") == contract.to_step
+            ):
+                return True
+        return False
+
+    def _record_reconciliation_failed(
+        self,
+        *,
+        current_step: str,
+        runtime: str,
+        missing_evidence: list[str],
+    ) -> None:
+        self.blackboard_store.record_event(
+            self.blackboard,
+            "step_reconciliation_failed",
+            {
+                "step": current_step,
+                "runtime": runtime,
+                "reason": "incomplete_handoff",
+                "missing_evidence": list(missing_evidence),
+            },
+        )
+
+    def _patch_reconciled_iteration_metadata(self, result: HandoffReconciliationResult) -> None:
+        if result.iteration_dir is None:
+            return
+        iteration_file = result.iteration_dir / "iteration.json"
+        if not iteration_file.exists():
+            return
+        try:
+            data = json.loads(iteration_file.read_text(encoding="utf-8"))
+        except Exception:
+            return
+        changed = False
+        if not data.get("status_code"):
+            data["status_code"] = result.status_code
+            changed = True
+        if not data.get("end_time"):
+            data["end_time"] = self._now_iso()
+            changed = True
+        if changed:
+            iteration_file.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    def _apply_reconciled_handoff(
+        self,
+        *,
+        current_step: str,
+        runtime: str,
+        result: HandoffReconciliationResult,
+    ) -> PlaybookRunResult:
+        if result.contract is None:
+            raise RuntimeError("Cannot apply reconciliation without a valid handoff contract")
+
+        contract = result.contract
+        status_code = result.status_code
+        self._patch_reconciled_iteration_metadata(result)
+
+        if not self._reconciliation_event_exists(
+            current_step=current_step,
+            status_code=status_code,
+            contract=contract,
+        ):
+            self.blackboard_store.record_event(
+                self.blackboard,
+                "step_reconciled",
+                {
+                    "step": current_step,
+                    "status_code": status_code,
+                    "to_owner": contract.to_owner.value,
+                    "to_step": contract.to_step,
+                    "runtime": runtime,
+                    "reason": "post_interrupt_completed_handoff",
+                    "validated_evidence": list(result.validated_evidence),
+                },
+            )
+
+        if contract.to_owner == HandoffOwner.USER:
+            return self._emit_pause(
+                current_step=current_step,
+                status_code=status_code,
+                runtime=runtime,
+                reason="reconciled_handoff",
+                update_contract=False,
+            )
+
+        if contract.to_owner == HandoffOwner.DONE:
+            return self._emit_complete(
+                current_step=current_step,
+                status_code=status_code,
+                next_step=contract.to_step,
+                runtime=runtime,
+                reason="reconciled_handoff",
+                update_contract=False,
+            )
+
+        self._emit_transition(
+            current_step=current_step,
+            next_step=contract.to_step,
+            status_code=status_code,
+            source="reconciled_baton",
+            runtime=runtime,
+            update_contract=False,
+        )
+        return PlaybookRunResult(
+            final_step=current_step,
+            final_status_code=status_code,
+            completed=False,
+        )
+
+    def _try_reconcile_interrupted_step(
+        self,
+        *,
+        current_step: str,
+        runtime: str,
+        reason: str,
+    ) -> Optional[PlaybookRunResult]:
+        if reason in {"interrupted", "keyboard_interrupt", "publish_error"}:
+            return None
+
+        result = self._validate_reconciled_handoff(current_step=current_step)
+        if not result.reconciled:
+            self._record_reconciliation_failed(
+                current_step=current_step,
+                runtime=runtime,
+                missing_evidence=result.missing_evidence,
+            )
+            return None
+
+        return self._apply_reconciled_handoff(
+            current_step=current_step,
+            runtime=runtime,
+            result=result,
+        )
+
+    def _latest_unreconciled_interrupted_step(self) -> Optional[tuple[str, str]]:
+        for event in reversed(self.blackboard.events):
+            if event.event_type == "step_reconciled":
+                return None
+            if event.event_type != "step_interrupted":
+                continue
+            step = str(event.data.get("step", event.step))
+            reason = str(event.data.get("reason", "interrupted"))
+            if reason in {"interrupted", "keyboard_interrupt", "publish_error"}:
+                return None
+            return step, reason
+        return None
+
+    def _try_resume_reconcile_interrupted_handoff(
+        self,
+        *,
+        runtime_label: str,
+    ) -> Optional[PlaybookRunResult]:
+        interrupted = self._latest_unreconciled_interrupted_step()
+        if interrupted is None:
+            return None
+        step, reason = interrupted
+        return self._try_reconcile_interrupted_step(
+            current_step=step,
+            runtime=runtime_label,
+            reason=reason,
+        )
+
     def _run_baton_driven_pr(
         self,
         *,
@@ -715,6 +1022,13 @@ class BlackboardWorkflowRuntime:
                         extra_prompt=_baton_retry_extra_prompt,
                     )
                 except StepInterrupted as si:
+                    reconciled = self._try_reconcile_interrupted_step(
+                        current_step=current_step,
+                        runtime=runtime_label,
+                        reason=si.reason,
+                    )
+                    if reconciled is not None:
+                        return reconciled
                     self.blackboard_store.record_event(
                         self.blackboard,
                         "workflow_paused",
@@ -940,6 +1254,13 @@ class BlackboardWorkflowRuntime:
                         extra_prompt=_baton_retry_extra_prompt,
                     )
                 except StepInterrupted as si:
+                    reconciled = self._try_reconcile_interrupted_step(
+                        current_step=current_step,
+                        runtime=runtime_label,
+                        reason=si.reason,
+                    )
+                    if reconciled is not None:
+                        return reconciled
                     if pause_record_event:
                         self.blackboard_store.record_event(
                             self.blackboard,
@@ -1342,6 +1663,13 @@ class BlackboardWorkflowRuntime:
                     source="workflow.start_step_override",
                 )
             return self._run_single_step(current_step=current_step)
+
+        if start_step is None:
+            reconciled = self._try_resume_reconcile_interrupted_handoff(
+                runtime_label="resume_reconciliation",
+            )
+            if reconciled is not None and self.blackboard.current_step not in self.steps:
+                return reconciled
 
         current_step = start_step or self.blackboard.current_step
         if current_step not in self.steps:

--- a/src/cafe/services/summary_service.py
+++ b/src/cafe/services/summary_service.py
@@ -13,13 +13,15 @@ from cafe.core.types import PhaseStatus
 class SummaryService:
     """Service for building workflow summary timeline data."""
 
-    def __init__(self, git_ops: Optional[GitOperations] = None):
+    def __init__(self, git_ops: Optional[GitOperations] = None, issues_root: Optional[Path] = None):
         """Initialize summary service.
 
         Args:
             git_ops: GitOperations instance for git context detection
+            issues_root: Root directory containing issue workflow data
         """
         self.git_ops = git_ops or GitOperations()
+        self.issues_root = issues_root or Path(".cafe/issues")
         self._load_errors: List[Dict[str, str]] = []
 
     def get_current_issue(self) -> str:
@@ -49,7 +51,7 @@ class SummaryService:
         Returns:
             Dictionary containing phase status information, or None if no phase data exists
         """
-        status_file = Path(".cafe/issues") / issue_name / phase_name / "status.json"
+        status_file = self.issues_root / issue_name / phase_name / "status.json"
 
         if status_file.exists():
             try:
@@ -75,7 +77,7 @@ class SummaryService:
             List of iteration context dictionaries with timestamp (start_time),
             end_time, status_code, cli, model, and stats, ordered by iteration number
         """
-        phase_dir = Path(".cafe/issues") / issue_name / phase_name
+        phase_dir = self.issues_root / issue_name / phase_name
 
         if not phase_dir.exists():
             return []
@@ -130,7 +132,7 @@ class SummaryService:
 
     def _load_workflow_state(self, issue_name: str) -> tuple[Optional[str], Optional[Dict[str, Any]]]:
         """Load the current workflow pointer and baton contract if available."""
-        issue_dir = Path(".cafe/issues") / issue_name
+        issue_dir = self.issues_root / issue_name
         blackboard_file = issue_dir / "blackboard.json"
         next_step_file = issue_dir / "next_step.txt"
 

--- a/src/cafe/ui/commands/workflow.py
+++ b/src/cafe/ui/commands/workflow.py
@@ -304,6 +304,13 @@ def show(
 
         # Check if file exists
         if not file_path.exists():
+            if content_type == "status":
+                from cafe.services.summary_service import SummaryService
+
+                status = SummaryService(issues_root=cafe_dir / "issues").load_phase_status(issue_name, phase_name)
+                if status:
+                    console.print_json(data=status)
+                    return
             # Special error message for user_input content type
             if content_type == "user_input":
                 console.print("[red]No user input markdown file found for this iteration.[/red]")

--- a/tests/unit/test_cli_show.py
+++ b/tests/unit/test_cli_show.py
@@ -1,5 +1,6 @@
 """Tests for cafe show command."""
 
+import json
 import pytest
 from pathlib import Path
 from typer.testing import CliRunner
@@ -242,6 +243,63 @@ steps:
 
             assert result.exit_code == 0
             assert "QA Output" in result.stdout
+
+    def test_show_status_synthesizes_when_status_file_missing(self, tmp_path):
+        """status view falls back to synthesized workflow state."""
+        cafe_dir = tmp_path / ".cafe"
+        issue_dir = cafe_dir / "issues" / "test-issue"
+        phase_dir = issue_dir / "develop"
+        iteration_dir = phase_dir / "iteration_001"
+        iteration_dir.mkdir(parents=True)
+        (iteration_dir / "iteration.json").write_text(
+            json.dumps(
+                {
+                    "iteration": 1,
+                    "timestamp": "2026-04-27T10:00:00+08:00",
+                    "end_time": "2026-04-27T10:05:00+08:00",
+                    "status_code": "confirmed",
+                }
+            ),
+            encoding="utf-8",
+        )
+        baton = {
+            "version": 1,
+            "from_step": "develop",
+            "to_owner": "agent",
+            "to_step": "review",
+            "intent": "await_agent",
+            "status_code": "confirmed",
+            "created_at": "2026-04-27T10:05:00+08:00",
+            "source": "test",
+        }
+        (issue_dir / "blackboard.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "current_step": "review",
+                    "playbook_id": "default",
+                    "artifacts": {},
+                    "events": [],
+                    "decisions": [],
+                    "handoff_contract": baton,
+                }
+            ),
+            encoding="utf-8",
+        )
+        (issue_dir / "next_step.txt").write_text(json.dumps(baton), encoding="utf-8")
+
+        with patch("cafe.ui.cli.GitOperations") as mock_git_cls, \
+             patch("cafe.ui.cli.ConfigManager") as mock_config_cls, \
+             patch("cafe.ui.cli.Path.cwd", return_value=tmp_path):
+
+            mock_git = mock_git_cls.return_value
+            mock_git.get_current_branch.return_value = "test-issue"
+
+            result = runner.invoke(app, ["show", "develop", "status"])
+
+            assert result.exit_code == 0
+            assert "confirmed" in result.stdout
+            assert "completed" in result.stdout
 
     def test_show_command_with_iteration(self, tmp_path):
         """測試指定迭代號碼"""

--- a/tests/unit/test_workflow_runtime.py
+++ b/tests/unit/test_workflow_runtime.py
@@ -10,7 +10,15 @@ from cafe.core.workflow_models import BatonRejected, StepExecutionResult, StepIn
 from cafe.core.workflow_runtime import BlackboardWorkflowRuntime
 
 
-def _write_baton(issue_dir: Path, *, from_step: str, to_owner: str, to_step: str, intent: str) -> None:
+def _write_baton(
+    issue_dir: Path,
+    *,
+    from_step: str,
+    to_owner: str,
+    to_step: str,
+    intent: str,
+    status_code: str = "",
+) -> None:
     (issue_dir / "next_step.txt").write_text(
         json.dumps(
             {
@@ -19,13 +27,34 @@ def _write_baton(issue_dir: Path, *, from_step: str, to_owner: str, to_step: str
                 "to_owner": to_owner,
                 "to_step": to_step,
                 "intent": intent,
-                "status_code": "",
+                "status_code": status_code,
                 "created_at": "2026-04-26T23:00:00+08:00",
                 "source": "test",
             }
         ),
         encoding="utf-8",
     )
+
+
+def _write_iteration_evidence(
+    issue_dir: Path,
+    step: str,
+    *,
+    output: str = "# done\n",
+    checklist: str = "- [x] done\n",
+    questions: str | None = None,
+) -> Path:
+    iteration_dir = issue_dir / step / "iteration_001"
+    iteration_dir.mkdir(parents=True, exist_ok=True)
+    (iteration_dir / "iteration.json").write_text(
+        json.dumps({"iteration": 1, "timestamp": "2026-04-26T23:00:00+08:00"}),
+        encoding="utf-8",
+    )
+    (iteration_dir / "output.md").write_text(output, encoding="utf-8")
+    (iteration_dir / "checklist.md").write_text(checklist, encoding="utf-8")
+    if questions is not None:
+        (iteration_dir / "questions.xml").write_text(questions, encoding="utf-8")
+    return iteration_dir
 
 
 def test_runtime_blocks_pr_done_without_publish_receipt(tmp_path: Path) -> None:
@@ -1388,6 +1417,165 @@ def test_runtime_handles_agent_execution_error(tmp_path: Path) -> None:
     msg = json.loads(interrupted_events[0].message) if isinstance(interrupted_events[0].message, str) else interrupted_events[0].message
     assert msg["step"] == "spec"
     assert msg["reason"] == "agent_rate_limit"
+
+
+def test_runtime_reconciles_agent_error_after_valid_handoff(tmp_path: Path) -> None:
+    """Agent failure after a complete on-disk handoff records a reconciled transition."""
+    from cafe.agents.executor import AgentExecutionError
+
+    issue_dir = tmp_path / ".cafe" / "issues" / "demo-reconcile-agent-error"
+    playbook = {
+        "playbook": {"id": "default"},
+        "steps": {
+            "spec": {"skill": "spec_first", "role": "developer", "on": {"await_agent": "plan"}},
+            "plan": {"skill": "plan", "role": "developer", "on": {"await_agent": "_done"}},
+        },
+    }
+
+    def executor(step_name: str, step_def: dict, state: object) -> StepExecutionResult:
+        if step_name == "spec":
+            _write_baton(
+                issue_dir,
+                from_step="spec",
+                to_owner="agent",
+                to_step="plan",
+                intent="await_agent",
+                status_code="confirmed",
+            )
+            _write_iteration_evidence(issue_dir, "spec")
+            raise AgentExecutionError("Connection stalled", error_type="connection_stalled")
+        return StepExecutionResult(response="done", artifacts={}, status_code="confirmed")
+
+    runtime = BlackboardWorkflowRuntime(
+        issue_dir=issue_dir,
+        playbook=playbook,
+        executor=executor,
+    )
+
+    result = runtime.run(start_step="spec", max_transitions=5)
+
+    assert result.completed is False
+    assert result.final_step == "spec"
+    assert result.final_status_code == "confirmed"
+
+    bb = BlackboardStore(issue_dir).load_or_create("spec", playbook_id="default")
+    assert bb.current_step == "plan"
+    assert [e.event_type for e in bb.events].count("step_reconciled") == 1
+    reconciled_event = next(e for e in bb.events if e.event_type == "step_reconciled")
+    assert reconciled_event.data["to_step"] == "plan"
+    assert reconciled_event.data["validated_evidence"] == ["baton", "output", "checklist"]
+    assert not any(
+        e.event_type == "workflow_paused" and e.data.get("status_code") == "INTERRUPTED"
+        for e in bb.events
+    )
+
+    iteration_data = json.loads((issue_dir / "spec" / "iteration_001" / "iteration.json").read_text())
+    assert iteration_data["status_code"] == "confirmed"
+    assert iteration_data["end_time"]
+
+
+def test_runtime_preserves_interrupted_when_reconciliation_evidence_incomplete(tmp_path: Path) -> None:
+    """Incomplete persisted evidence should not be inferred as a completed handoff."""
+    from cafe.agents.executor import AgentExecutionError
+
+    issue_dir = tmp_path / ".cafe" / "issues" / "demo-reconcile-incomplete"
+    playbook = {
+        "playbook": {"id": "default"},
+        "steps": {
+            "spec": {"skill": "spec_first", "role": "developer", "on": {"await_agent": "plan"}},
+            "plan": {"skill": "plan", "role": "developer", "on": {"await_agent": "_done"}},
+        },
+    }
+
+    def executor(step_name: str, step_def: dict, state: object) -> StepExecutionResult:
+        _write_baton(
+            issue_dir,
+            from_step="spec",
+            to_owner="agent",
+            to_step="plan",
+            intent="await_agent",
+            status_code="confirmed",
+        )
+        _write_iteration_evidence(issue_dir, "spec", checklist="- [ ] unfinished\n")
+        raise AgentExecutionError("Connection stalled", error_type="connection_stalled")
+
+    runtime = BlackboardWorkflowRuntime(
+        issue_dir=issue_dir,
+        playbook=playbook,
+        executor=executor,
+    )
+
+    result = runtime.run(start_step="spec", max_transitions=5)
+
+    assert result.completed is False
+    assert result.final_status_code == "INTERRUPTED:agent_connection_stalled"
+
+    bb = BlackboardStore(issue_dir).load_or_create("spec", playbook_id="default")
+    assert bb.current_step == "spec"
+    failed_event = next(e for e in bb.events if e.event_type == "step_reconciliation_failed")
+    assert "checklist_complete" in failed_event.data["missing_evidence"]
+    assert any(
+        e.event_type == "workflow_paused" and e.data.get("status_code") == "INTERRUPTED"
+        for e in bb.events
+    )
+
+
+def test_runtime_resume_reconciliation_is_idempotent(tmp_path: Path) -> None:
+    """Resume-time reconciliation repairs an interrupted handoff once."""
+    issue_dir = tmp_path / ".cafe" / "issues" / "demo-reconcile-resume"
+    issue_dir.mkdir(parents=True)
+    _write_baton(
+        issue_dir,
+        from_step="spec",
+        to_owner="agent",
+        to_step="plan",
+        intent="await_agent",
+        status_code="confirmed",
+    )
+    _write_iteration_evidence(issue_dir, "spec")
+    (issue_dir / "blackboard.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "current_step": "spec",
+                "playbook_id": "default",
+                "artifacts": {},
+                "events": [
+                    {
+                        "timestamp": "2026-04-26T23:00:00+08:00",
+                        "step": "spec",
+                        "event_type": "step_interrupted",
+                        "message": "{}",
+                        "data": {"step": "spec", "reason": "agent_connection_stalled"},
+                    }
+                ],
+                "decisions": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    playbook = {
+        "playbook": {"id": "default"},
+        "steps": {
+            "spec": {"skill": "spec_first", "role": "developer", "on": {"await_agent": "plan"}},
+            "plan": {"skill": "plan", "role": "developer", "on": {"await_agent": "_done"}},
+        },
+    }
+
+    runtime = BlackboardWorkflowRuntime(
+        issue_dir=issue_dir,
+        playbook=playbook,
+        executor=lambda *_args, **_kwargs: StepExecutionResult(response="confirmed", artifacts={}, status_code="confirmed"),
+    )
+
+    first = runtime._try_resume_reconcile_interrupted_handoff(runtime_label="legacy_until_boundary")
+    second = runtime._try_resume_reconcile_interrupted_handoff(runtime_label="legacy_until_boundary")
+
+    assert first is not None
+    assert second is None
+    bb = BlackboardStore(issue_dir).load_or_create("spec", playbook_id="default")
+    assert bb.current_step == "plan"
+    assert [e.event_type for e in bb.events].count("step_reconciled") == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_workflow_runtime.py
+++ b/tests/unit/test_workflow_runtime.py
@@ -18,6 +18,7 @@ def _write_baton(
     to_step: str,
     intent: str,
     status_code: str = "",
+    source: str = "test",
 ) -> None:
     (issue_dir / "next_step.txt").write_text(
         json.dumps(
@@ -29,7 +30,7 @@ def _write_baton(
                 "intent": intent,
                 "status_code": status_code,
                 "created_at": "2026-04-26T23:00:00+08:00",
-                "source": "test",
+                "source": source,
             }
         ),
         encoding="utf-8",
@@ -1576,6 +1577,74 @@ def test_runtime_resume_reconciliation_is_idempotent(tmp_path: Path) -> None:
     bb = BlackboardStore(issue_dir).load_or_create("spec", playbook_id="default")
     assert bb.current_step == "plan"
     assert [e.event_type for e in bb.events].count("step_reconciled") == 1
+
+
+def test_runtime_reconciles_after_consumed_handoff_start_step(tmp_path: Path) -> None:
+    """Normal workflow resume repairs a consumed downstream baton before running target."""
+    issue_dir = tmp_path / ".cafe" / "issues" / "demo-reconcile-consumed"
+    issue_dir.mkdir(parents=True)
+    _write_baton(
+        issue_dir,
+        from_step="spec",
+        to_owner="agent",
+        to_step="plan",
+        intent="await_agent",
+        status_code="confirmed",
+        source="workflow.consume_handoff",
+    )
+    _write_iteration_evidence(issue_dir, "spec")
+    (issue_dir / "blackboard.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "current_step": "plan",
+                "playbook_id": "default",
+                "artifacts": {},
+                "events": [
+                    {
+                        "timestamp": "2026-04-26T23:00:00+08:00",
+                        "step": "spec",
+                        "event_type": "step_interrupted",
+                        "message": "{}",
+                        "data": {"step": "spec", "reason": "agent_connection_stalled"},
+                    }
+                ],
+                "decisions": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    playbook = {
+        "playbook": {"id": "default"},
+        "steps": {
+            "spec": {"skill": "spec_first", "role": "developer", "on": {"await_agent": "plan"}},
+            "plan": {"skill": "plan", "role": "developer", "on": {"confirmed": "_done"}},
+        },
+    }
+    executed_steps: list[str] = []
+
+    def executor(step_name: str, step_def: dict, state: object) -> StepExecutionResult:
+        executed_steps.append(step_name)
+        return StepExecutionResult(response="confirmed", artifacts={}, status_code="confirmed")
+
+    runtime = BlackboardWorkflowRuntime(
+        issue_dir=issue_dir,
+        playbook=playbook,
+        executor=executor,
+    )
+
+    result = runtime.run(start_step="plan", max_transitions=1)
+
+    assert executed_steps == ["plan"]
+    assert result.final_step == "plan"
+    bb = BlackboardStore(issue_dir).load_or_create("spec", playbook_id="default")
+    assert [e.event_type for e in bb.events].count("step_reconciled") == 1
+    reconciled_event = next(e for e in bb.events if e.event_type == "step_reconciled")
+    assert reconciled_event.data["step"] == "spec"
+    assert reconciled_event.data["to_step"] == "plan"
+    iteration_data = json.loads((issue_dir / "spec" / "iteration_001" / "iteration.json").read_text())
+    assert iteration_data["status_code"] == "confirmed"
+    assert iteration_data["end_time"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #286. When a CAFE agent dies after writing a complete on-disk handoff (`next_step.txt`, iteration `output.md`, completed `checklist.md`) but before the runtime records `step_completed`, the blackboard no longer stays interrupted-only. Post-interrupt and resume-time reconciliation validate persisted artifacts, emit auditable `step_reconciled` events for complete handoffs, and preserve interrupted state with `step_reconciliation_failed` and `missing_evidence` when validation fails. Summary and `cafe show` views align with the reconciled on-disk state.

## Changes

- **`7d0f333`** — `issue286: reconcile completed handoffs after agent errors`
  - Add handoff validation and reconciliation helpers in `src/cafe/core/workflow_runtime.py`
  - Reconcile agent execution failures before returning `INTERRUPTED:*` when baton, output, checklist, and required `questions.xml` are valid
  - Add idempotent resume-time reconciliation at `BlackboardWorkflowRuntime.run()` entry
  - Emit `step_reconciled` / `step_reconciliation_failed`; patch iteration metadata for summary/show consistency
  - Extend `src/cafe/services/summary_service.py` and `src/cafe/ui/commands/workflow.py` show status fallback
  - Unit tests in `tests/unit/test_workflow_runtime.py` and `tests/unit/test_cli_show.py`

- **`a0cb1b6`** — `issue286: reconcile consumed handoff resumes`
  - Add `_should_attempt_resume_reconciliation()` so `run(start_step=<target>)` after a consumed persistent baton (`workflow.consume_handoff`) still repairs the interrupted source step
  - Regression test for `run(start_step="plan")` after consumed handoff (one `step_reconciled`, patched iteration metadata)

## Test Plan

- [ ] `pytest tests/unit/test_workflow_runtime.py tests/unit/test_summary_service.py tests/unit/test_cli_show.py -q` — interrupt-time reconcile, incomplete evidence, resume repair, show status fallback
- [ ] `pytest tests/integration/test_workflow_e2e.py -q` — cross-step workflow regression
- [ ] `pytest -q` — full suite (2151 passed in latest develop iteration)
- [ ] Manual: trigger agent failure after a complete baton and checklist; confirm `cafe summary` / `cafe show <step>` show reconciled completion and `step_reconciled` in blackboard events
- [ ] Manual: leave checklist incomplete or baton invalid; confirm interrupted state with `step_reconciliation_failed.missing_evidence`