### PR TITLE
Phase retirement cleanup: legacy CLI as aliases, docstrings, roadmap/CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,18 @@ cafe audit
 
 This command checks that all builtin skills and playbooks are internally consistent (agent files exist, placeholder conventions are met, hooks are registered and executable, and baton intents are valid). It exits non-zero if any check fails. Run it again after fixing any reported gaps to confirm they are resolved.
 
+## Workflow behavior
+
+Default development flow (spec → plan → develop → review → pr) is driven by **playbook YAML**, **skills**, and the **workflow runtime** (`BlackboardWorkflowRuntime`, `GenericPhase`). Do not add logic to removed per-phase Python classes (`SpecPhase`, `PlanPhase`, etc.).
+
+| Change type | Where it belongs |
+| --- | --- |
+| Step transitions, baton intents, hooks | Playbook YAML under `playbooks/` |
+| Agent instructions, checklists, phase prompts | Skills (`SKILL.md` and related files) |
+| Orchestration, blackboard, execution | Runtime code under `src/cafe/core/` and `src/cafe/phases/` |
+
+Primary CLI entrypoints: `cafe make` and `cafe workflow`. Hidden `cafe spec` / `plan` / `develop` / `review` / `pr` commands are documented aliases for `cafe workflow --start-step <step> --execute`.
+
 ## Coding Style
 
 *   This project follows the [PEP 8](https://www.python.org/dev/peps/pep-0008/) style guide.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -85,6 +85,7 @@ CAFE 長期採 **repo-first** 的 definition model，但不預設最終所有流
 
 完成標準：
 - default 開發流程可完全跑在新架構上
+- **per-phase Python workflow classes（Spec/Plan/Develop/Review/PR Phase）已退役**；workflow 行為以 **playbook YAML + skill + runtime**（`BlackboardWorkflowRuntime` / `GenericPhase`）為唯一來源。隱藏指令 `cafe spec|plan|develop|review|pr` 保留為 `cafe workflow --start-step <step> --execute` 的別名（Option A，見 issue #294）。
 - custom skill / custom playbook 可運作
 - v0.2 的狀態機與 Blackboard 不會把人工介入硬綁成 `interactive_qa` 單一路徑
 - 至少一條非軟體開發流程可用 custom playbook 完成 `writeable + validatable`

--- a/src/cafe/core/phase.py
+++ b/src/cafe/core/phase.py
@@ -942,9 +942,9 @@ class Phase(PhaseStateMixin, PhaseSandboxMixin, PhaseReviewMixin, PhaseChecklist
         Returns:
             Path to status.json in {phase_dir}/status.json
 
-        For workflow steps:
-            - GenericPhase: .cafe/issues/myissue/{step}/iteration_001/iteration.json
-            - Legacy phase classes may still use {phase_dir}/status.json (being retired)
+        For workflow steps, GenericPhase uses
+        ``.cafe/issues/{issue}/{step}/iteration_N/iteration.json``. This path covers
+        legacy ``{phase_dir}/status.json`` layouts still read by some helpers.
         """
         if not hasattr(self, "phase_dir"):
             raise AttributeError("Phase must have 'phase_dir' attribute")

--- a/src/cafe/ui/cli_shared.py
+++ b/src/cafe/ui/cli_shared.py
@@ -1402,10 +1402,17 @@ def _reject_unsupported_phase_options(phase_name: str, unsupported_options: Dict
     raise typer.Exit(1)
 
 
-def _print_legacy_phase_command_notice(*, phase_name: str, preferred_command: str) -> None:
-    """Show migration guidance for legacy phase aliases."""
+def _print_legacy_phase_command_notice(
+    *,
+    phase_name: str,
+    preferred_command: str,
+    workflow_step: str | None = None,
+) -> None:
+    """Show alias guidance for hidden legacy workflow step commands."""
+    step = workflow_step or phase_name.split()[0]
     console.print(
-        f"[yellow]Legacy phase command:[/yellow] [bold]cafe {phase_name}[/bold] is being retired."
+        f"[yellow]Legacy workflow alias:[/yellow] [bold]cafe {phase_name}[/bold] runs the same "
+        f"runtime path as [bold]cafe workflow --start-step {step} --execute[/bold]."
     )
     console.print(
         f"[dim]Preferred entrypoint:[/dim] [bold]{preferred_command}[/bold]"

--- a/src/cafe/ui/commands/phases_legacy.py
+++ b/src/cafe/ui/commands/phases_legacy.py
@@ -1,4 +1,10 @@
-"""Legacy phase command wrappers extracted from cli.py."""
+"""Hidden legacy workflow-step CLI aliases (Option A, issue #294).
+
+Product decision: keep ``cafe spec|plan|develop|review|pr`` as thin documented aliases.
+Each command delegates to ``BlackboardWorkflowRuntime`` + ``GenericPhase`` — the same path as
+``cafe workflow --start-step <step> --execute``. Primary entrypoints are ``cafe make`` and
+``cafe workflow``; these hidden commands exist for scripted backward compatibility only.
+"""
 
 from __future__ import annotations
 
@@ -185,11 +191,11 @@ def spec(
         help="Sync spec to GitHub issue when confirmed (default: auto-detect based on issue_id)",
     ),
 ) -> None:
-    """Legacy wrapper for the specification step.
+    """Hidden alias for the specification workflow step.
 
-    Prefer `cafe make --user-input ...` or
-    `cafe workflow --start-step spec --execute --user-input ...`.
-    Use `cafe edit spec` to open the latest spec artifact.
+    Equivalent to ``cafe workflow --start-step spec --execute`` (same runtime as this command).
+    Prefer ``cafe make --user-input ...`` or the workflow form above for new scripts.
+    Use ``cafe edit spec`` to open the latest spec artifact.
 
     \b
     Examples:
@@ -352,13 +358,14 @@ def plan(
         help="Sync plan to GitHub issue when confirmed (default: auto-detect based on issue_id)",
     ),
 ) -> None:
-    """Legacy wrapper for the planning step.
+    """Hidden alias for the planning workflow step.
 
-    Prefer `cafe make` to continue the workflow.
-    Use `cafe edit plan` to edit the latest plan artifact.
+    Equivalent to ``cafe workflow --start-step plan --execute`` (same runtime as this command).
+    Prefer ``cafe make`` for new scripts. Use ``cafe edit plan`` to edit the latest plan artifact.
 
     \b
     Examples:
+        cafe workflow --start-step plan --execute
         cafe make --user-input "Draft the implementation approach"
         cafe make
         cafe edit plan
@@ -523,12 +530,14 @@ def develop(
         help="Auto mode: continue iterations automatically within the legacy wrapper",
     ),
 ) -> None:
-    """Legacy wrapper for the development step.
+    """Hidden alias for the develop workflow step.
 
-    Prefer `cafe make` to continue the workflow.
+    Equivalent to ``cafe workflow --start-step develop --execute`` (same runtime as this command).
+    Prefer ``cafe make`` for new scripts.
 
     \b
     Examples:
+        cafe workflow --start-step develop --execute
         cafe make
         cafe make --user-input "Please be careful"
         cafe edit develop
@@ -681,12 +690,14 @@ def review(
         help="Force re-execution even if review already completed",
     ),
 ) -> None:
-    """Legacy wrapper for the review step.
+    """Hidden alias for the review workflow step.
 
-    Prefer `cafe make` to continue the workflow.
+    Equivalent to ``cafe workflow --start-step review --execute`` (same runtime as this command).
+    Prefer ``cafe make`` for new scripts.
 
     \b
     Examples:
+        cafe workflow --start-step review --execute
         cafe make
         cafe edit review
     """
@@ -864,12 +875,14 @@ def pr(
         help="Post organized todo list as PR comment (default: auto-detect from config)",
     ),
 ) -> None:
-    """Legacy wrapper for the PR step.
+    """Hidden alias for the PR workflow step.
 
-    Prefer `cafe make` to continue the workflow.
+    Equivalent to ``cafe workflow --start-step pr --execute`` (same runtime as this command).
+    Prefer ``cafe make`` for new scripts.
 
     \b
     Examples:
+        cafe workflow --start-step pr --execute
         cafe make
         cafe edit pr
     """

--- a/src/cafe/utils/pr.py
+++ b/src/cafe/utils/pr.py
@@ -1,4 +1,4 @@
-"""PR title/body parsing helpers extracted from legacy PRPhase."""
+"""PR title/body parsing helpers for workflow PR publish paths."""
 
 
 def parse_pr_title(content: str) -> str:

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,5 +1,5 @@
 # Test artifacts created by tests with incorrect tmp_path usage
-# ReviewPhase tests use tmp_path / "requirements.md" instead of proper issue structure
+# Legacy review tests use tmp_path / "requirements.md" instead of proper issue structure
 # This creates MagicMock/ directory when spec_path.parent.parent.name evaluates to MagicMock
-# TODO: Fix ReviewPhase tests to use proper .cafe/issues/{name}/spec/spec.md structure
+# TODO: Fix review tests to use proper .cafe/issues/{name}/spec/spec.md structure
 MagicMock/

--- a/tests/MIGRATION.md
+++ b/tests/MIGRATION.md
@@ -140,7 +140,9 @@ Baseline (develop iteration 001): `pytest tests/unit tests/integration -q` → 1
 
 **Product decision:** Option A — retain hidden `cafe spec|plan|develop|review|pr` as thin documented aliases equivalent to `cafe workflow --start-step <step> --execute` (via `BlackboardWorkflowRuntime` + `GenericPhase`). Primary entrypoints remain `cafe make` and `cafe workflow`.
 
-Pre-flight `src/` grep targets: `src/cafe/utils/pr.py` (PRPhase docstring), `src/cafe/ui/cli_shared.py` + `src/cafe/core/phase.py` (“being retired” copy).
+Pre-flight `src/` grep (before cleanup): `src/cafe/utils/pr.py`, `src/cafe/ui/cli_shared.py`, `src/cafe/core/phase.py`.
+
+Final verification: `rg 'SpecPhase|PlanPhase|DevelopPhase|ReviewPhase|PRPhase' src/` → **zero** lines; guardrail `tests/unit/test_no_deleted_phase_names_in_src.py`.
 
 ### Re-homed / updated contracts
 
@@ -148,7 +150,8 @@ Pre-flight `src/` grep targets: `src/cafe/utils/pr.py` (PRPhase docstring), `src
 | --- | --- | --- |
 | Legacy CLI notice | Alias wording + workflow start-step equivalence | `cli_shared._print_legacy_phase_command_notice`, `tests/unit/test_cli_spec_output.py` |
 | Module docs | Option A recorded on `phases_legacy.py` | Per-command docstrings cite `cafe workflow --start-step`; notice must not say "being retired" |
-| Contributor docs | Source-of-truth boundary | `CONTRIBUTING.md`, `docs/roadmap.md` |
+| Contributor docs | Source-of-truth boundary | `CONTRIBUTING.md` **Workflow behavior**, `docs/roadmap.md` v0.2 completion criteria |
+| PR parsing utils | `parse_pr_title` / `parse_pr_body` | `src/cafe/utils/pr.py` (generic module docstring) |
 
 ### Removed-by-design
 
@@ -156,3 +159,4 @@ Pre-flight `src/` grep targets: `src/cafe/utils/pr.py` (PRPhase docstring), `src
 | --- | --- |
 | Option B (delete `phases_legacy.py`) | Spec iteration 002 confirmed Option A for scripted backward compatibility |
 | Per-phase Python classes | Already removed in #289–#293; this issue scrubs cosmetic names only |
+| “being retired” legacy CLI copy | Replaced with explicit alias-to-workflow messaging |

--- a/tests/MIGRATION.md
+++ b/tests/MIGRATION.md
@@ -131,3 +131,28 @@ Production PR already runs via `BlackboardWorkflowRuntime` + `GenericPhase` + sk
 | `test_pr_phase_output_todo_only.py` output.md empty guard | Todo contract in `post_pr_todo_list` tests; init is runtime-owned |
 | `test_pr_phase_prepare_content.py` / `test_pr_phase_generate_content.py` | Legacy agent orchestration; production uses workflow executor |
 | `PRPhase.execute()` draft/custom title integration | Legacy `cafe pr` routes to runtime alias; publish uses `sync_pr.sh` + `parse_pr_*` |
+
+## Issue 294 — Phase retirement cleanup
+
+GitHub: issue #294 (closes umbrella #288)
+
+Baseline (develop iteration 001): `pytest tests/unit tests/integration -q` → 1980 passed, 5 skipped, 1 xfailed.
+
+**Product decision:** Option A — retain hidden `cafe spec|plan|develop|review|pr` as thin documented aliases equivalent to `cafe workflow --start-step <step> --execute` (via `BlackboardWorkflowRuntime` + `GenericPhase`). Primary entrypoints remain `cafe make` and `cafe workflow`.
+
+Pre-flight `src/` grep targets: `src/cafe/utils/pr.py` (PRPhase docstring), `src/cafe/ui/cli_shared.py` + `src/cafe/core/phase.py` (“being retired” copy).
+
+### Re-homed / updated contracts
+
+| Area | Behavior | Notes |
+| --- | --- | --- |
+| Legacy CLI notice | Alias wording + workflow start-step equivalence | `cli_shared._print_legacy_phase_command_notice`, `tests/unit/test_cli_spec_output.py` |
+| Module docs | Option A recorded on `phases_legacy.py` | Per-command docstrings cite `cafe workflow --start-step` |
+| Contributor docs | Source-of-truth boundary | `CONTRIBUTING.md`, `docs/roadmap.md` |
+
+### Removed-by-design
+
+| Behavior | Rationale |
+| --- | --- |
+| Option B (delete `phases_legacy.py`) | Spec iteration 002 confirmed Option A for scripted backward compatibility |
+| Per-phase Python classes | Already removed in #289–#293; this issue scrubs cosmetic names only |

--- a/tests/MIGRATION.md
+++ b/tests/MIGRATION.md
@@ -147,7 +147,7 @@ Pre-flight `src/` grep targets: `src/cafe/utils/pr.py` (PRPhase docstring), `src
 | Area | Behavior | Notes |
 | --- | --- | --- |
 | Legacy CLI notice | Alias wording + workflow start-step equivalence | `cli_shared._print_legacy_phase_command_notice`, `tests/unit/test_cli_spec_output.py` |
-| Module docs | Option A recorded on `phases_legacy.py` | Per-command docstrings cite `cafe workflow --start-step` |
+| Module docs | Option A recorded on `phases_legacy.py` | Per-command docstrings cite `cafe workflow --start-step`; notice must not say "being retired" |
 | Contributor docs | Source-of-truth boundary | `CONTRIBUTING.md`, `docs/roadmap.md` |
 
 ### Removed-by-design

--- a/tests/unit/test_cli_auto_mode.py
+++ b/tests/unit/test_cli_auto_mode.py
@@ -147,7 +147,7 @@ class TestAutoModeErrorHandling:
         from cafe.core.types import CriticalPhaseError
         with patch('cafe.ui.cli._execute_single_step_alias') as mock_execute_alias:
             mock_execute_alias.side_effect = CriticalPhaseError(
-                message="Something critical", error_type="rate_limit", phase_name="SpecPhase"
+                message="Something critical", error_type="rate_limit", phase_name="spec"
             )
             from typer.testing import CliRunner
             runner = CliRunner()

--- a/tests/unit/test_cli_spec_auto.py
+++ b/tests/unit/test_cli_spec_auto.py
@@ -72,7 +72,7 @@ class TestSpecAutoMode:
                  patch("cafe.ui.cli.ConfigManager") as mock_config_cls, \
                  patch("cafe.ui.cli.AgentManager") as mock_agent_cls, \
                  patch("cafe.ui.cli.PermissionHandler") as mock_perm_cls, \
-                 patch("cafe.ui.cli.SpecPhase") as mock_phase_cls:
+                 patch("cafe.ui.cli._execute_single_step_alias") as mock_phase_cls:
                 
                 # Setup mocks
                 mock_git = MagicMock()
@@ -148,7 +148,7 @@ class TestSpecAutoMode:
              patch("cafe.ui.cli.ConfigManager") as mock_config_cls, \
              patch("cafe.ui.cli.AgentManager") as mock_agent_cls, \
              patch("cafe.ui.cli.PermissionHandler") as mock_perm_cls, \
-             patch("cafe.ui.cli.SpecPhase") as mock_phase_cls, \
+             patch("cafe.ui.cli._execute_single_step_alias") as mock_phase_cls, \
              patch("sys.stdin.isatty", return_value=True):
             
             # Setup mocks
@@ -212,7 +212,7 @@ class TestSpecAutoMode:
              patch("cafe.ui.cli.ConfigManager") as mock_config_cls, \
              patch("cafe.ui.cli.AgentManager") as mock_agent_cls, \
              patch("cafe.ui.cli.PermissionHandler") as mock_perm_cls, \
-             patch("cafe.ui.cli.SpecPhase") as mock_phase_cls, \
+             patch("cafe.ui.cli._execute_single_step_alias") as mock_phase_cls, \
              patch("sys.stdin.isatty", return_value=True):
             
             # Setup mocks
@@ -275,7 +275,7 @@ class TestSpecAutoMode:
              patch("cafe.ui.cli.ConfigManager") as mock_config_cls, \
              patch("cafe.ui.cli.AgentManager") as mock_agent_cls, \
              patch("cafe.ui.cli.PermissionHandler") as mock_perm_cls, \
-             patch("cafe.ui.cli.SpecPhase") as mock_phase_cls:
+             patch("cafe.ui.cli._execute_single_step_alias") as mock_phase_cls:
             
             # Setup mocks
             mock_git = MagicMock()

--- a/tests/unit/test_cli_spec_output.py
+++ b/tests/unit/test_cli_spec_output.py
@@ -239,6 +239,59 @@ class TestSpecCommandLegacyNotice:
         result = runner.invoke(app, ["spec", "--interactive", "--user-input", "test"])
 
         assert result.exit_code == 0
-        assert "Legacy phase command:" in result.stdout
-        assert "cafe spec" in result.stdout
+        output = result.stdout.replace("\n", "")
+        assert "Legacy workflow alias:" in output
+        assert "cafe spec" in output
+        assert "cafe workflow" in output
+        assert "--start-step spec" in output
         assert "cafe make --user-input" in result.stdout
+        assert "being retired" not in result.stdout
+
+    @pytest.mark.parametrize(
+        "command,step,preferred_fragment,invoke_args",
+        [
+            ("plan", "plan", "cafe make", ["plan", "--no-interactive", "--template", "default"]),
+            ("develop", "develop", "cafe make", ["develop", "--no-interactive"]),
+        ],
+    )
+    def test_hidden_step_commands_share_alias_notice(
+        self,
+        runner,
+        mock_git_ops,
+        mock_execute_alias,
+        mock_agent_manager,
+        mock_permission_handler,
+        setup_test_env,
+        command,
+        step,
+        preferred_fragment,
+        invoke_args,
+    ):
+        def _fake_latest_versioned_file(phase_name: str, issue_name: str) -> Path:
+            return Path(f".cafe/issues/{issue_name}/{phase_name}/iteration_001/output.md")
+
+        mock_execute_alias.return_value = {
+            "iterations": 1,
+            "status_code": "confirmed",
+            "next_step": "review",
+        }
+
+        with patch(
+            "cafe.ui.commands.phases_legacy._get_latest_versioned_file",
+            side_effect=_fake_latest_versioned_file,
+        ), patch("cafe.ui.cli.is_branch_initialized", return_value=True), patch(
+            "cafe.ui.cli.select_template", return_value="default"
+        ), patch("cafe.templates.manager.TemplateManager"), patch(
+            "cafe.ui.cli._run_iterative_alias_step",
+            return_value={"iterations": 1, "status_code": "confirmed"},
+        ):
+            result = runner.invoke(app, invoke_args)
+
+        assert result.exit_code == 0
+        output = result.stdout.replace("\n", "")
+        assert "Legacy workflow alias:" in output
+        assert f"cafe {command}" in output
+        assert "cafe workflow" in output
+        assert f"--start-step {step}" in output
+        assert preferred_fragment in result.stdout
+        assert "being retired" not in result.stdout

--- a/tests/unit/test_no_deleted_phase_names_in_src.py
+++ b/tests/unit/test_no_deleted_phase_names_in_src.py
@@ -1,0 +1,23 @@
+"""Guardrail: deleted per-phase Python class names must not reappear in src/."""
+
+from pathlib import Path
+
+DELETED_PHASE_NAMES = (
+    "SpecPhase",
+    "PlanPhase",
+    "DevelopPhase",
+    "ReviewPhase",
+    "PRPhase",
+)
+
+
+def test_src_has_no_deleted_phase_class_names() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    src_root = repo_root / "src"
+    hits: list[str] = []
+    for path in src_root.rglob("*.py"):
+        text = path.read_text(encoding="utf-8")
+        for name in DELETED_PHASE_NAMES:
+            if name in text:
+                hits.append(f"{path.relative_to(repo_root)}: {name}")
+    assert hits == [], "Remove deleted phase class names from production source:\n" + "\n".join(hits)


### PR DESCRIPTION
## Summary\n\nPart of umbrella #288 (final cleanup). After #289-#293 retired all five per-phase Python classes, this PR closes the remaining loose ends.\n\n## Changes\n\n- **Option A**: Keep hidden `cafe spec/plan/develop/review/pr` commands as documented thin aliases for `cafe workflow --start-step <step>`\n- Update `phases_legacy.py` docstrings and notice text to say "alias" not "being retired"\n- Scrub remaining `*Phase` class name references from `src/cafe/core/phase.py`, `src/cafe/utils/pr.py` docstrings\n- Remove stale `SpecPhase` patches from test files\n- Update `docs/roadmap.md` with retirement confirmation and source-of-truth boundary\n- Update `CONTRIBUTING.md` with workflow source-of-truth statement\n- Close `tests/MIGRATION.md` entries (all sub-issues complete)\n- Closes #288 (umbrella)\n\n## Test Plan\n\n- `pytest tests/unit tests/integration` → 1983 passed\n- `rg 'SpecPhase|PlanPhase|DevelopPhase|ReviewPhase|PRPhase' src` → no hits in production code\n- Legacy CLI aliases still work: `cafe spec --help`, `cafe plan --help`, etc.