### PR TITLE
Playbook-driven no_changes_needed routing

### DIFF
--- a/src/cafe/data/playbooks/default.yaml
+++ b/src/cafe/data/playbooks/default.yaml
@@ -90,7 +90,7 @@ steps:
       manual_handoff: pr
       need_clarification: develop
       need_permission: develop
-      no_changes_needed: develop
+      no_changes_needed: review
 
   review:
     type: skill

--- a/src/cafe/phases/generic_workflow_step.py
+++ b/src/cafe/phases/generic_workflow_step.py
@@ -770,7 +770,7 @@ class GenericWorkflowStepExecutor(Phase):
 
         if status_code == PhaseStatusCode.NO_CHANGES_NEEDED:
             if self.interactive:
-                # 互動模式：一律暫停，讓 UserInputCollector 顯示 agree/disagree/chat 提示
+                # Interactive: always pause so UserInputCollector can show agree/disagree/chat.
                 store.update_handoff_contract(
                     blackboard_state,
                     from_step=step_name,
@@ -781,7 +781,7 @@ class GenericWorkflowStepExecutor(Phase):
                     source="workflow.status_transition_adapter",
                 )
             else:
-                # 非互動模式：依 playbook on.no_changes_needed 路由
+                # Non-interactive: follow playbook on.no_changes_needed routing.
                 target = step_def.get("on", {}).get("no_changes_needed")
                 if target and target != "user" and target in self.playbook.get("steps", {}):
                     store.update_handoff_contract(
@@ -794,7 +794,7 @@ class GenericWorkflowStepExecutor(Phase):
                         source="workflow.status_transition_adapter",
                     )
                 else:
-                    # 映射缺失或指向 user：向後相容，暫停
+                    # Missing mapping or user target: backward-compatible pause.
                     store.update_handoff_contract(
                         blackboard_state,
                         from_step=step_name,

--- a/src/cafe/phases/generic_workflow_step.py
+++ b/src/cafe/phases/generic_workflow_step.py
@@ -767,12 +767,50 @@ class GenericWorkflowStepExecutor(Phase):
             return
 
         store = BlackboardStore(self.issue_dir)
+
+        if status_code == PhaseStatusCode.NO_CHANGES_NEEDED:
+            if self.interactive:
+                # 互動模式：一律暫停，讓 UserInputCollector 顯示 agree/disagree/chat 提示
+                store.update_handoff_contract(
+                    blackboard_state,
+                    from_step=step_name,
+                    to_owner=HandoffOwner.USER,
+                    to_step="user",
+                    intent=HandoffIntent.NO_CHANGES_NEEDED,
+                    status_code=status_code.value,
+                    source="workflow.status_transition_adapter",
+                )
+            else:
+                # 非互動模式：依 playbook on.no_changes_needed 路由
+                target = step_def.get("on", {}).get("no_changes_needed")
+                if target and target != "user" and target in self.playbook.get("steps", {}):
+                    store.update_handoff_contract(
+                        blackboard_state,
+                        from_step=step_name,
+                        to_owner=HandoffOwner.AGENT,
+                        to_step=target,
+                        intent=HandoffIntent.AWAIT_AGENT,
+                        status_code=status_code.value,
+                        source="workflow.status_transition_adapter",
+                    )
+                else:
+                    # 映射缺失或指向 user：向後相容，暫停
+                    store.update_handoff_contract(
+                        blackboard_state,
+                        from_step=step_name,
+                        to_owner=HandoffOwner.USER,
+                        to_step="user",
+                        intent=HandoffIntent.NO_CHANGES_NEEDED,
+                        status_code=status_code.value,
+                        source="workflow.status_transition_adapter",
+                    )
+            return
+
         if not auto_continue and status_code.value in {
             PhaseStatusCode.READY_FOR_REVIEW.value,
             PhaseStatusCode.CONFIRM_OUTPUT.value,
             PhaseStatusCode.NEED_CLARIFICATION.value,
             PhaseStatusCode.NEED_PERMISSION.value,
-            PhaseStatusCode.NO_CHANGES_NEEDED.value,
         }:
             raw_intent = self._resolve_handoff_intent(step_def, status_code) or "manual_handoff"
             store.update_handoff_contract(

--- a/tests/unit/test_cli_workflow_command.py
+++ b/tests/unit/test_cli_workflow_command.py
@@ -91,7 +91,7 @@ def test_single_step_alias_updates_workflow_pointer_to_requested_step(tmp_path: 
 
     assert result["status_code"] == "no_changes_needed"
     blackboard_data = json.loads((issue_dir / "blackboard.json").read_text(encoding="utf-8"))
-    assert blackboard_data["current_step"] == "develop"
+    assert blackboard_data["current_step"] == "review"
 
 
 def test_workflow_command_runs_dry_mode(tmp_path: Path, monkeypatch) -> None:

--- a/tests/unit/test_generic_workflow_step.py
+++ b/tests/unit/test_generic_workflow_step.py
@@ -2042,3 +2042,172 @@ def test_update_iteration_history_preserves_model_and_stats_on_second_call(
     assert context["prompt"] == "test prompt"
     assert context["status_code"] == "ready_for_review"
     assert context["pr_number"] == "159"
+
+
+# ---------------------------------------------------------------------------
+# Tests for no_changes_needed playbook-driven routing (Issue #301)
+# ---------------------------------------------------------------------------
+
+def _develop_step_playbook_with_no_changes_target(no_changes_target: str | None) -> dict:
+    """Build a minimal develop-step playbook with configurable no_changes_needed routing."""
+    on_map: dict = {"await_agent": "review", "manual_handoff": "pr"}
+    if no_changes_target is not None:
+        on_map["no_changes_needed"] = no_changes_target
+    return {
+        "playbook": {"id": "default"},
+        "roles": {"developer": {"default_agent": "David"}},
+        "steps": {
+            "develop": {
+                "skill": "develop",
+                "role": "developer",
+                "output_artifact": "code",
+                "allowed_tools": ["Read"],
+                "valid_intents": ["no_changes_needed", "confirmed"],
+                "on": on_map,
+            },
+            "review": {
+                "skill": "review",
+                "role": "developer",
+                "output_artifact": "review_feedback",
+                "allowed_tools": ["Read"],
+                "on": {"await_agent": "_done"},
+            },
+            "pr": {
+                "skill": "pr",
+                "role": "developer",
+                "output_artifact": "pr_result",
+                "allowed_tools": ["Read"],
+                "on": {"await_agent": "_done"},
+            },
+        },
+    }
+
+
+def _write_develop_prereq_artifacts(issue_dir: Path) -> None:
+    for phase in ("spec", "plan"):
+        phase_dir = issue_dir / phase / "iteration_001"
+        phase_dir.mkdir(parents=True, exist_ok=True)
+        (phase_dir / "output.md").write_text(f"# {phase.title()}\n", encoding="utf-8")
+        (phase_dir / "iteration.json").write_text('{"iteration": 1}', encoding="utf-8")
+
+
+def test_no_changes_needed_non_interactive_auto_routes_to_playbook_target(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """非互動模式且 playbook 映射為 agent step 時，直接寫 AGENT handoff 自動繼續。"""
+    monkeypatch.chdir(tmp_path)
+    issue_dir = tmp_path / ".cafe" / "issues" / "issue-ncn-noninteractive-auto"
+    _write_develop_prereq_artifacts(issue_dir)
+    playbook = _develop_step_playbook_with_no_changes_target("review")
+    store = BlackboardStore(issue_dir)
+    state = store.load_or_create("develop")
+
+    executor = GenericWorkflowStepExecutor(
+        issue_dir=issue_dir,
+        issue_name="issue-ncn-noninteractive-auto",
+        playbook=playbook,
+        generic_phase=_build_loader(tmp_path),
+        agent_manager=FakeAgentManager("no_changes_needed"),
+        git_ops=FakeGitOperations(),
+        role_agent_map={"developer": "David"},
+        interactive=False,
+    )
+
+    result = executor.execute_step("develop", playbook["steps"]["develop"], state)
+
+    assert result.status_code == "no_changes_needed"
+    reloaded = BlackboardStore(issue_dir).load_or_create("develop")
+    assert reloaded.handoff_contract is not None
+    assert reloaded.handoff_contract.to_owner == HandoffOwner.AGENT
+    assert reloaded.handoff_contract.to_step == "review"
+    assert reloaded.handoff_contract.intent == HandoffIntent.AWAIT_AGENT
+
+
+def test_no_changes_needed_non_interactive_pauses_when_playbook_target_is_user(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """非互動模式且 playbook 映射為 user 時，寫 USER handoff 暫停。"""
+    monkeypatch.chdir(tmp_path)
+    issue_dir = tmp_path / ".cafe" / "issues" / "issue-ncn-noninteractive-user"
+    _write_develop_prereq_artifacts(issue_dir)
+    playbook = _develop_step_playbook_with_no_changes_target("user")
+    state = BlackboardStore(issue_dir).load_or_create("develop")
+
+    executor = GenericWorkflowStepExecutor(
+        issue_dir=issue_dir,
+        issue_name="issue-ncn-noninteractive-user",
+        playbook=playbook,
+        generic_phase=_build_loader(tmp_path),
+        agent_manager=FakeAgentManager("no_changes_needed"),
+        git_ops=FakeGitOperations(),
+        role_agent_map={"developer": "David"},
+        interactive=False,
+    )
+
+    result = executor.execute_step("develop", playbook["steps"]["develop"], state)
+
+    assert result.status_code == "no_changes_needed"
+    reloaded = BlackboardStore(issue_dir).load_or_create("develop")
+    assert reloaded.handoff_contract is not None
+    assert reloaded.handoff_contract.to_owner == HandoffOwner.USER
+    assert reloaded.handoff_contract.to_step == "user"
+
+
+def test_no_changes_needed_non_interactive_pauses_when_mapping_absent(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """非互動模式且 playbook 無 no_changes_needed 映射時，保持向後相容並暫停。"""
+    monkeypatch.chdir(tmp_path)
+    issue_dir = tmp_path / ".cafe" / "issues" / "issue-ncn-noninteractive-absent"
+    _write_develop_prereq_artifacts(issue_dir)
+    playbook = _develop_step_playbook_with_no_changes_target(None)
+    state = BlackboardStore(issue_dir).load_or_create("develop")
+
+    executor = GenericWorkflowStepExecutor(
+        issue_dir=issue_dir,
+        issue_name="issue-ncn-noninteractive-absent",
+        playbook=playbook,
+        generic_phase=_build_loader(tmp_path),
+        agent_manager=FakeAgentManager("no_changes_needed"),
+        git_ops=FakeGitOperations(),
+        role_agent_map={"developer": "David"},
+        interactive=False,
+    )
+
+    result = executor.execute_step("develop", playbook["steps"]["develop"], state)
+
+    assert result.status_code == "no_changes_needed"
+    reloaded = BlackboardStore(issue_dir).load_or_create("develop")
+    assert reloaded.handoff_contract is not None
+    assert reloaded.handoff_contract.to_owner == HandoffOwner.USER
+    assert reloaded.handoff_contract.to_step == "user"
+
+
+def test_no_changes_needed_interactive_always_pauses_regardless_of_playbook(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """互動模式時，無論 playbook 映射為何，一律暫停等待使用者的 agree/disagree 決策。"""
+    monkeypatch.chdir(tmp_path)
+    issue_dir = tmp_path / ".cafe" / "issues" / "issue-ncn-interactive-pause"
+    _write_develop_prereq_artifacts(issue_dir)
+    playbook = _develop_step_playbook_with_no_changes_target("review")
+    state = BlackboardStore(issue_dir).load_or_create("develop")
+
+    executor = GenericWorkflowStepExecutor(
+        issue_dir=issue_dir,
+        issue_name="issue-ncn-interactive-pause",
+        playbook=playbook,
+        generic_phase=_build_loader(tmp_path),
+        agent_manager=FakeAgentManager("no_changes_needed"),
+        git_ops=FakeGitOperations(),
+        role_agent_map={"developer": "David"},
+        interactive=True,
+    )
+
+    result = executor.execute_step("develop", playbook["steps"]["develop"], state)
+
+    assert result.status_code == "no_changes_needed"
+    reloaded = BlackboardStore(issue_dir).load_or_create("develop")
+    assert reloaded.handoff_contract is not None
+    assert reloaded.handoff_contract.to_owner == HandoffOwner.USER
+    assert reloaded.handoff_contract.to_step == "user"

--- a/tests/unit/test_no_changes_needed_handler.py
+++ b/tests/unit/test_no_changes_needed_handler.py
@@ -188,3 +188,39 @@ def test_user_input_collector_chat_then_confirm(
 
     mock_chat.assert_called_once_with("developer", "demo")
     assert result.override_status_code == PhaseStatusCode.MANUAL_HANDOFF
+
+
+def test_user_input_collector_non_interactive_pauses_when_no_user_input_file_present(
+    tmp_path: Path,
+) -> None:
+    """非互動模式且 playbook 路由到 user（或缺少映射）時，hook 作為第二道防線繼續暫停。
+
+    此測試記錄了 UserInputCollector 的「second-line guard」角色：
+    當 _write_status_transition_handoff 已決定暫停（to_owner=USER），
+    workflow 重回 develop 時，hook 在 prepare_input 仍確保 user_input.md
+    為空時不會繼續執行，避免無輸入的空跑。
+    """
+    issue_dir = tmp_path / ".cafe" / "issues" / "demo"
+    phase_dir = issue_dir / "develop"
+    prev_iter = phase_dir / "iteration_001"
+    prev_iter.mkdir(parents=True, exist_ok=True)
+    (prev_iter / "output.md").write_text("reasoning", encoding="utf-8")
+
+    # 目前 iteration 沒有 user_input.md（模擬 playbook 指向 user 後重回 develop 的場景）
+    current_iter = phase_dir / "iteration_002"
+    current_iter.mkdir(parents=True, exist_ok=True)
+
+    _record_no_changes_event(issue_dir)
+
+    phase = _FakeDevelopStep(issue_dir, iteration=2, interactive=False)
+    collector = UserInputCollector()
+    result = collector.run(
+        stage="prepare_input",
+        phase=phase,
+        step_name="develop",
+        step_def={"role": "developer", "name": "develop"},
+        agent_name="David",
+    )
+
+    assert result.continue_pipeline is False
+    assert any(e.get("type") == "no_changes_missing_user_input" for e in result.events)

--- a/tests/unit/test_skill_sync_github_script.py
+++ b/tests/unit/test_skill_sync_github_script.py
@@ -83,3 +83,12 @@ def test_default_playbook_migrates_plan_sync_to_script_hook() -> None:
     assert script_hook["args"]["phase"] == "plan"
     assert script_hook["args"]["output"] == "{output_file}"
     assert script_hook["when_intents"] == ["confirmed"]
+
+
+def test_default_playbook_no_changes_needed_routes_to_review() -> None:
+    project_root = Path(__file__).resolve().parents[2]
+    playbook_path = project_root / "src/cafe/data/playbooks/default.yaml"
+    data = yaml.safe_load(playbook_path.read_text(encoding="utf-8"))
+
+    develop_on = data["steps"]["develop"]["on"]
+    assert develop_on["no_changes_needed"] == "review"


### PR DESCRIPTION
## Summary

Implements issue #301 by moving `no_changes_needed` routing into the playbook so non-interactive runs auto-continue to `review`, interactive runs still pause, and custom playbooks can force a user pause.

## Changes

- `e2a8b44` Default playbook: route `develop.no_changes_needed` to `review` to make the non-interactive default auto-continue.
- `189f802` Runtime: route `no_changes_needed` via playbook in non-interactive mode, pause in interactive mode.
- `26c58ad` Add second-line guard test for non-interactive `no_changes_needed` hook behavior.
- `2ead8a9` Use English comments for the `no_changes_needed` routing branch.
- Kept `src/cafe/ui/commands/phases_legacy.py` untouched, per the issue scope.

The implementation matches the original requirements: default playbook auto-continues, interactive mode still pauses, and custom playbooks can route `no_changes_needed` to `user` for a deliberate pause.

## Test Plan

- `pytest tests/unit/test_generic_workflow_step.py -k no_changes_needed tests/unit/test_no_changes_needed_handler.py tests/unit/test_skill_sync_github_script.py::test_default_playbook_no_changes_needed_routes_to_review tests/unit/test_cli_workflow_command.py -k no_changes_needed`
- Full suite already verified during develop: `1989 passed, 5 skipped, 1 xfailed`.