### PR TITLE
issue298: Git health check and active_issue workflow recovery fallback

### DIFF
--- a/src/cafe/core/active_issue.py
+++ b/src/cafe/core/active_issue.py
@@ -1,0 +1,49 @@
+"""Runtime marker for active issue fallback when Git branch detection is unhealthy."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+MARKER_FILENAME = "active_issue"
+
+
+def marker_path(cafe_dir: Path) -> Path:
+    """Return the path to the active issue marker file."""
+    return cafe_dir / MARKER_FILENAME
+
+
+def read_marker(cafe_dir: Path) -> Optional[str]:
+    """Read the active issue name from the marker file, or None if missing/empty."""
+    path = marker_path(cafe_dir)
+    if not path.is_file():
+        return None
+    text = path.read_text(encoding="utf-8").strip()
+    return text or None
+
+
+def write_marker(cafe_dir: Path, issue_name: str) -> None:
+    """Write the active issue marker for the given issue name."""
+    cafe_dir.mkdir(parents=True, exist_ok=True)
+    marker_path(cafe_dir).write_text(f"{issue_name.strip()}\n", encoding="utf-8")
+
+
+def clear_marker(cafe_dir: Path) -> None:
+    """Remove the active issue marker file if it exists."""
+    path = marker_path(cafe_dir)
+    if path.is_file():
+        path.unlink()
+
+
+def clear_marker_if_matches(cafe_dir: Path, issue_name: str) -> bool:
+    """Clear the marker only when it matches the given issue name."""
+    current = read_marker(cafe_dir)
+    if current != issue_name.strip():
+        return False
+    clear_marker(cafe_dir)
+    return True
+
+
+def issue_exists(cafe_dir: Path, issue_name: str) -> bool:
+    """Return True when a prepared issue directory exists."""
+    return (cafe_dir / "issues" / issue_name.strip()).is_dir()

--- a/src/cafe/core/git.py
+++ b/src/cafe/core/git.py
@@ -1,8 +1,18 @@
 """Git operations for CAFE."""
 
 import subprocess
+from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Optional
+
+
+@dataclass(frozen=True)
+class BranchHealth:
+    """Result of checking whether the current Git branch context is safe for issue detection."""
+
+    is_healthy: bool
+    branch_name: Optional[str] = None
+    reason: Optional[str] = None  # detached_head | in_progress | git_error
 
 
 class GitError(Exception):
@@ -62,6 +72,42 @@ class GitOperations:
         """
         current_branch = self.get_current_branch()
         return bool(current_branch)
+
+    def _git_dir_path(self) -> Path:
+        """Resolve the repository .git directory (handles worktrees)."""
+        git_dir = Path(self.run_git("rev-parse", "--git-dir"))
+        if not git_dir.is_absolute():
+            git_dir = (self.repo_path / git_dir).resolve()
+        return git_dir
+
+    def has_in_progress_operation(self) -> bool:
+        """Return True when rebase, merge, cherry-pick, revert, or bisect is in progress."""
+        git_dir = self._git_dir_path()
+        markers = (
+            "rebase-merge",
+            "rebase-apply",
+            "MERGE_HEAD",
+            "CHERRY_PICK_HEAD",
+            "REVERT_HEAD",
+            "BISECT_LOG",
+        )
+        return any((git_dir / name).exists() for name in markers)
+
+    def get_branch_health(self) -> BranchHealth:
+        """Check whether branch-based issue detection is safe to use."""
+        try:
+            branch = self.get_current_branch()
+        except GitError:
+            return BranchHealth(is_healthy=False, reason="git_error")
+        if not branch:
+            return BranchHealth(is_healthy=False, reason="detached_head")
+        if self.has_in_progress_operation():
+            return BranchHealth(
+                is_healthy=False,
+                branch_name=branch,
+                reason="in_progress",
+            )
+        return BranchHealth(is_healthy=True, branch_name=branch)
 
     def create_branch(self, branch_name: str) -> None:
         """Create and checkout a new branch.

--- a/src/cafe/core/issue_resolution.py
+++ b/src/cafe/core/issue_resolution.py
@@ -1,0 +1,83 @@
+"""Resolve the active issue from Git branch health or runtime fallback marker."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from cafe.core import active_issue
+from cafe.core.git import GitOperations
+
+
+@dataclass(frozen=True)
+class ResolvedActiveIssue:
+    """Result of resolving which issue to run."""
+
+    issue_name: str
+    cafe_dir: Path
+    source: str  # explicit | branch | fallback
+
+
+class ActiveIssueResolutionError(Exception):
+    """Could not determine which issue to use."""
+
+    def __init__(self, message: str, guidance: str) -> None:
+        super().__init__(message)
+        self.message = message
+        self.guidance = guidance
+
+
+_RECOVERY_GUIDANCE = (
+    "Run `cafe prepare <issue>` on a healthy branch, or fix Git state "
+    "(finish rebase/merge, checkout a feature branch), then run `cafe make` again."
+)
+
+
+def resolve_active_issue(
+    *,
+    cafe_dir: Path,
+    git_ops: GitOperations,
+    explicit_issue: Optional[str] = None,
+) -> ResolvedActiveIssue:
+    """Resolve the active issue for workflow startup.
+
+    Explicit ``--issue`` bypasses branch and fallback logic. Healthy Git branch
+    with a prepared issue wins and synchronizes the marker. Unhealthy Git uses
+    the marker only when it references an existing prepared issue.
+    """
+    if explicit_issue:
+        name = explicit_issue.strip()
+        if not name:
+            raise ActiveIssueResolutionError(
+                "Issue name cannot be empty.",
+                _RECOVERY_GUIDANCE,
+            )
+        return ResolvedActiveIssue(name, cafe_dir, "explicit")
+
+    health = git_ops.get_branch_health()
+    if health.is_healthy:
+        branch = health.branch_name
+        assert branch is not None
+        if active_issue.issue_exists(cafe_dir, branch):
+            active_issue.write_marker(cafe_dir, branch)
+            return ResolvedActiveIssue(branch, cafe_dir, "branch")
+        raise ActiveIssueResolutionError(
+            f"No prepared issue found for branch '{branch}'.",
+            f"Run `cafe prepare {branch}` or switch to a prepared feature branch.",
+        )
+
+    marker = active_issue.read_marker(cafe_dir)
+    if marker and active_issue.issue_exists(cafe_dir, marker):
+        return ResolvedActiveIssue(marker, cafe_dir, "fallback")
+
+    if marker and not active_issue.issue_exists(cafe_dir, marker):
+        raise ActiveIssueResolutionError(
+            f"Active issue marker points to missing issue '{marker}'.",
+            _RECOVERY_GUIDANCE,
+        )
+
+    raise ActiveIssueResolutionError(
+        "Cannot determine active issue: Git branch detection is unavailable.",
+        _RECOVERY_GUIDANCE,
+    )

--- a/src/cafe/core/workflow_runtime.py
+++ b/src/cafe/core/workflow_runtime.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import re
 from typing import Any, Dict, Optional
 
+from cafe.core.active_issue import clear_marker_if_matches
 from cafe.core.blackboard import BlackboardStore, HandoffContract, HandoffIntent, HandoffOwner
 from cafe.core.questions_schema import validate_questions_xml
 from cafe.core.status_codes import (
@@ -588,6 +589,8 @@ class BlackboardWorkflowRuntime:
                 status_code=status_code,
                 source=contract_source,
             )
+        cafe_dir = self.issue_dir.parent.parent
+        clear_marker_if_matches(cafe_dir, self.issue_dir.name)
         return PlaybookRunResult(
             final_step=current_step,
             final_status_code=status_code,

--- a/src/cafe/ui/commands/lifecycle.py
+++ b/src/cafe/ui/commands/lifecycle.py
@@ -919,8 +919,6 @@ def close() -> None:
                 )
                 # Continue with worktree removal even if sync fails
 
-            clear_marker_if_matches(worktree_abs / ".cafe", issue_name)
-
             # Step 5: Remove worktree
             try:
                 console.print(f"[dim]Removing worktree: {worktree_path}[/dim]")
@@ -935,6 +933,8 @@ def close() -> None:
                 console.print(f"  3. cafe rm {issue_name}")
                 console.print()
                 raise typer.Exit(1)
+
+            clear_marker_if_matches(worktree_abs / ".cafe", issue_name)
 
             # Step 6: Delete feature branch
             try:

--- a/src/cafe/ui/commands/lifecycle.py
+++ b/src/cafe/ui/commands/lifecycle.py
@@ -10,6 +10,8 @@ from typing import Any, List, Optional
 import typer
 import yaml
 
+from cafe.core.active_issue import clear_marker_if_matches, write_marker
+
 VALID_PHASES = ["spec", "plan", "develop", "review", "pr"]
 
 console: Any = None
@@ -653,6 +655,11 @@ def prepare(
         console.print(f"[green]✓ Issue config saved to {relative_config_path}[/green]")
         console.print()
 
+        if use_worktree:
+            write_marker(worktree_cafe_dir, issue_name)
+        else:
+            write_marker(cafe_dir, issue_name)
+
         # 12. Display success message
         console.print()
         console.print(f"[green]✓ Successfully prepared issue: {issue_name}[/green]")
@@ -912,6 +919,8 @@ def close() -> None:
                 )
                 # Continue with worktree removal even if sync fails
 
+            clear_marker_if_matches(worktree_abs / ".cafe", issue_name)
+
             # Step 5: Remove worktree
             try:
                 console.print(f"[dim]Removing worktree: {worktree_path}[/dim]")
@@ -1038,6 +1047,8 @@ def close() -> None:
         except Exception as e:
             console.print(f"[yellow]⚠️  Failed to archive issue data: {e}[/yellow]")
             console.print(f"[yellow]   Issue data remains at: .cafe/issues/{issue_name}/[/yellow]")
+
+        clear_marker_if_matches(Path(".cafe"), issue_name)
 
         # 7. Display success message
         console.print()

--- a/src/cafe/ui/commands/workflow.py
+++ b/src/cafe/ui/commands/workflow.py
@@ -12,6 +12,7 @@ import typer
 from rich.console import Console
 
 from cafe.core.blackboard import BlackboardStore, HandoffIntent, HandoffOwner
+from cafe.core.issue_resolution import ActiveIssueResolutionError, resolve_active_issue
 from cafe.core.types import CriticalPhaseError
 from cafe.core.workflow_models import StepExecutionResult, StepInterrupted
 from cafe.core.workflow_runtime import BlackboardWorkflowRuntime
@@ -559,8 +560,19 @@ def workflow(
             return count + 1
 
         git = _get_GitOperations()()
-        issue_name = issue or git.get_current_branch()
-        issue_dir = Path(".cafe/issues") / issue_name
+        cafe_dir = Path(".cafe")
+        try:
+            resolved = resolve_active_issue(
+                cafe_dir=cafe_dir,
+                git_ops=git,
+                explicit_issue=issue,
+            )
+        except ActiveIssueResolutionError as exc:
+            console.print(f"[red]Error: {exc.message}[/red]")
+            console.print(f"[dim]{exc.guidance}[/dim]")
+            raise typer.Exit(1)
+        issue_name = resolved.issue_name
+        issue_dir = cafe_dir / "issues" / issue_name
         selected_playbook = _resolve_selected_playbook(playbook)
         config_manager = _get_ConfigManager()(".cafe")
         try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,8 +3,11 @@
 import sys
 import shutil
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
+
 import pytest
+
+from cafe.core.git import BranchHealth
 
 
 def _ensure_src_on_path() -> None:
@@ -36,6 +39,37 @@ def create_minimal_config(base_dir: Path) -> None:
 
     # 複製檔案內容
     config_file.write_text(fixture_file.read_text())
+
+
+@pytest.fixture(autouse=True)
+def _wire_git_branch_health_for_mock_git(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Configure MagicMock GitOperations for active issue resolution in workflow tests."""
+    from cafe.ui.commands import workflow as workflow_mod
+
+    original_resolve = workflow_mod.resolve_active_issue
+
+    def _resolve_with_mock_health(
+        *,
+        cafe_dir: Path,
+        git_ops: object,
+        explicit_issue: str | None = None,
+    ):
+        if explicit_issue is None and isinstance(git_ops, MagicMock):
+            if not isinstance(git_ops.get_branch_health.return_value, BranchHealth):
+                branch = git_ops.get_current_branch()
+                if isinstance(branch, str) and branch:
+                    git_ops.get_branch_health.return_value = BranchHealth(
+                        is_healthy=True,
+                        branch_name=branch,
+                    )
+                    (cafe_dir / "issues" / branch).mkdir(parents=True, exist_ok=True)
+        return original_resolve(
+            cafe_dir=cafe_dir,
+            git_ops=git_ops,
+            explicit_issue=explicit_issue,
+        )
+
+    monkeypatch.setattr(workflow_mod, "resolve_active_issue", _resolve_with_mock_health)
 
 
 @pytest.fixture(autouse=True, scope="function")

--- a/tests/unit/test_active_issue.py
+++ b/tests/unit/test_active_issue.py
@@ -1,0 +1,58 @@
+"""Tests for active issue runtime marker helpers."""
+
+from pathlib import Path
+
+import pytest
+
+from cafe.core import active_issue
+
+
+@pytest.fixture
+def cafe_dir(tmp_path: Path) -> Path:
+    root = tmp_path / ".cafe"
+    root.mkdir()
+    return root
+
+
+class TestActiveIssueMarker:
+    def test_write_and_read_marker(self, cafe_dir: Path) -> None:
+        active_issue.write_marker(cafe_dir, "issue-298")
+        assert active_issue.read_marker(cafe_dir) == "issue-298"
+
+    def test_read_missing_marker_returns_none(self, cafe_dir: Path) -> None:
+        assert active_issue.read_marker(cafe_dir) is None
+
+    def test_read_empty_marker_returns_none(self, cafe_dir: Path) -> None:
+        active_issue.marker_path(cafe_dir).write_text("\n", encoding="utf-8")
+        assert active_issue.read_marker(cafe_dir) is None
+
+    def test_read_trims_whitespace(self, cafe_dir: Path) -> None:
+        active_issue.marker_path(cafe_dir).write_text("  issue-a  \n", encoding="utf-8")
+        assert active_issue.read_marker(cafe_dir) == "issue-a"
+
+    def test_clear_marker_removes_file(self, cafe_dir: Path) -> None:
+        active_issue.write_marker(cafe_dir, "issue-a")
+        active_issue.clear_marker(cafe_dir)
+        assert not active_issue.marker_path(cafe_dir).exists()
+
+    def test_clear_if_matches_only_when_equal(self, cafe_dir: Path) -> None:
+        active_issue.write_marker(cafe_dir, "issue-a")
+        assert active_issue.clear_marker_if_matches(cafe_dir, "issue-a") is True
+        assert active_issue.read_marker(cafe_dir) is None
+
+    def test_clear_if_matches_skips_other_issue(self, cafe_dir: Path) -> None:
+        active_issue.write_marker(cafe_dir, "issue-a")
+        assert active_issue.clear_marker_if_matches(cafe_dir, "issue-b") is False
+        assert active_issue.read_marker(cafe_dir) == "issue-a"
+
+    def test_issue_exists_checks_prepared_directory(self, cafe_dir: Path) -> None:
+        (cafe_dir / "issues" / "prepared").mkdir(parents=True)
+        assert active_issue.issue_exists(cafe_dir, "prepared") is True
+        assert active_issue.issue_exists(cafe_dir, "missing") is False
+
+
+class TestActiveIssueGitignore:
+    def test_cafe_directory_is_gitignored(self) -> None:
+        repo_root = Path(__file__).resolve().parents[2]
+        gitignore = (repo_root / ".gitignore").read_text(encoding="utf-8")
+        assert ".cafe" in gitignore

--- a/tests/unit/test_cli_close.py
+++ b/tests/unit/test_cli_close.py
@@ -379,6 +379,28 @@ class TestCloseCommandWorktree:
         assert "git branch -D test-worktree-issue" in result.stdout
         assert "cafe rm test-worktree-issue" in result.stdout
 
+    def test_close_worktree_remove_failure_preserves_active_issue_marker(
+        self, temp_repo_dir, mock_git_ops, mock_github_ops_no_pr, issue_with_worktree_config
+    ):
+        """Worktree marker must remain when remove_worktree fails."""
+        (temp_repo_dir / ".git").mkdir()
+        worktree_path = temp_repo_dir / "worktrees" / "test-worktree-issue"
+        worktree_cafe = worktree_path / ".cafe"
+        worktree_cafe.mkdir(parents=True)
+        marker = worktree_cafe / "active_issue"
+        marker.write_text("test-worktree-issue\n", encoding="utf-8")
+        worktree_issue = worktree_cafe / "issues" / "test-worktree-issue"
+        worktree_issue.mkdir(parents=True)
+
+        mock_git_ops.get_current_branch.return_value = "test-worktree-issue"
+        mock_git_ops.remove_worktree.side_effect = GitError("failed to remove worktree")
+
+        result = runner.invoke(app, ["close"])
+
+        assert result.exit_code == 1
+        assert marker.exists()
+        assert marker.read_text(encoding="utf-8").strip() == "test-worktree-issue"
+
     def test_close_clears_matching_active_issue_marker(
         self, temp_repo_dir, mock_git_ops, mock_github_ops_no_pr, issue_with_config
     ):

--- a/tests/unit/test_cli_close.py
+++ b/tests/unit/test_cli_close.py
@@ -379,6 +379,38 @@ class TestCloseCommandWorktree:
         assert "git branch -D test-worktree-issue" in result.stdout
         assert "cafe rm test-worktree-issue" in result.stdout
 
+    def test_close_clears_matching_active_issue_marker(
+        self, temp_repo_dir, mock_git_ops, mock_github_ops_no_pr, issue_with_config
+    ):
+        marker = temp_repo_dir / ".cafe" / "active_issue"
+        marker.write_text("test-issue\n", encoding="utf-8")
+
+        result = runner.invoke(app, ["close"])
+
+        assert result.exit_code == 0
+        assert not marker.exists()
+
+    def test_close_blocked_by_open_pr_preserves_active_issue_marker(
+        self, temp_repo_dir, mock_git_ops, issue_with_config
+    ):
+        marker = temp_repo_dir / ".cafe" / "active_issue"
+        marker.write_text("test-issue\n", encoding="utf-8")
+
+        with patch("cafe.ui.cli.GitHubOps") as MockGitHubOps:
+            mock_gh = MagicMock()
+            MockGitHubOps.return_value = mock_gh
+            mock_gh.get_pr_for_branch.return_value = {
+                "number": 1,
+                "state": "OPEN",
+                "isDraft": False,
+                "title": "Open PR",
+                "url": "https://example.com/pr/1",
+            }
+            result = runner.invoke(app, ["close"])
+
+        assert result.exit_code == 1
+        assert marker.read_text(encoding="utf-8").strip() == "test-issue"
+
     def test_close_without_worktree_normal_flow(
         self, temp_repo_dir, mock_git_ops, mock_github_ops_no_pr
     ):

--- a/tests/unit/test_cli_prepare.py
+++ b/tests/unit/test_cli_prepare.py
@@ -86,6 +86,9 @@ class TestPrepareCommand:
         mock_git_ops.branch_exists.assert_called_once_with("test-issue")
         mock_git_ops.create_branch.assert_called_once_with("test-issue")
 
+        marker = (temp_repo_dir / ".cafe" / "active_issue").read_text(encoding="utf-8").strip()
+        assert marker == "test-issue"
+
     @patch("cafe.ui.phase_prompts.prompt_confirm")
     @patch("cafe.ui.cli.prompt_confirm")
     @patch("cafe.ui.template_selector.prompt_list")
@@ -589,6 +592,21 @@ class TestPrepareCommandWorktree:
             config_data = yaml.safe_load(f)
             # Non-interactive mode should not have pr config
             assert "pr" not in config_data
+
+    def test_prepare_worktree_overwrites_copied_active_issue_marker(self, temp_repo_dir, mock_git_ops):
+        """Worktree prepare overwrites a copied stale active_issue marker."""
+        worktree_path = temp_repo_dir / ".cafe" / "worktrees" / "new-issue"
+        worktree_cafe = worktree_path / ".cafe"
+        worktree_cafe.mkdir(parents=True)
+        (worktree_cafe / "active_issue").write_text("old-issue\n", encoding="utf-8")
+
+        result = runner.invoke(
+            app,
+            ["prepare", "new-issue", "--worktree", str(worktree_path)],
+        )
+
+        assert result.exit_code == 0
+        assert (worktree_cafe / "active_issue").read_text(encoding="utf-8").strip() == "new-issue"
 
     def test_prepare_worktree_creates_issue_yaml_in_repo_root(self, temp_repo_dir, mock_git_ops):
         """測試 worktree 模式下，在 repo root 也創建 issue.yaml 供 cafe ls 讀取"""

--- a/tests/unit/test_cli_workflow_command.py
+++ b/tests/unit/test_cli_workflow_command.py
@@ -2,12 +2,14 @@
 
 import json
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
+import pytest
 from typer.testing import CliRunner
 
 from cafe.agents.executor import AgentExecutionError
 from cafe.core.blackboard import BlackboardStore, HandoffIntent, HandoffOwner
+from cafe.core.git import BranchHealth
 from cafe.core.workflow_models import StepExecutionResult
 from cafe.ui.cli import app, _execute_single_step_alias, _find_external_resume_step, _handle_user_phase
 from cafe.ui.cli_shared import _build_workflow_step_executor
@@ -2048,3 +2050,76 @@ steps:
         result = runner.invoke(app, ["workflow", "--execute"])
         assert result.exit_code == 0
         assert executed_steps == ["develop", "pr"]
+
+
+def test_workflow_execute_syncs_active_issue_on_healthy_branch(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    cafe_dir = tmp_path / ".cafe"
+    issue_dir = cafe_dir / "issues" / "issue-sync"
+    issue_dir.mkdir(parents=True)
+    (cafe_dir / "active_issue").write_text("stale\n", encoding="utf-8")
+
+    with (
+        patch("cafe.ui.cli.GitOperations") as mock_git_cls,
+        patch("cafe.ui.cli._build_workflow_step_executor") as mock_builder,
+    ):
+        git = MagicMock()
+        git.get_current_branch.return_value = "issue-sync"
+        mock_git_cls.return_value = git
+        executor = MagicMock()
+        executor.execute_step.return_value = _result(
+            status_code="confirmed",
+            step_name="spec",
+            step_def={"output_artifact": "spec"},
+        )
+        mock_builder.return_value = executor
+
+        result = runner.invoke(app, ["workflow", "--playbook", "default", "--execute", "--single-step"])
+
+    assert result.exit_code == 0
+    assert (cafe_dir / "active_issue").read_text(encoding="utf-8").strip() == "issue-sync"
+
+
+def test_workflow_execute_recovers_from_unhealthy_git_via_marker(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    cafe_dir = tmp_path / ".cafe"
+    issue_dir = cafe_dir / "issues" / "saved-issue"
+    issue_dir.mkdir(parents=True)
+    (cafe_dir / "active_issue").write_text("saved-issue\n", encoding="utf-8")
+
+    with (
+        patch("cafe.ui.cli.GitOperations") as mock_git_cls,
+        patch("cafe.ui.cli._build_workflow_step_executor") as mock_builder,
+    ):
+        git = MagicMock()
+        git.get_branch_health.return_value = BranchHealth(is_healthy=False, reason="detached_head")
+        mock_git_cls.return_value = git
+        executor = MagicMock()
+        executor.execute_step.return_value = _result(
+            status_code="confirmed",
+            step_name="spec",
+            step_def={"output_artifact": "spec"},
+        )
+        mock_builder.return_value = executor
+
+        result = runner.invoke(app, ["workflow", "--playbook", "default", "--execute", "--single-step"])
+
+    assert result.exit_code == 0
+    assert (cafe_dir / "active_issue").read_text(encoding="utf-8").strip() == "saved-issue"
+
+
+def test_workflow_execute_invalid_marker_exits_with_guidance(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    cafe_dir = tmp_path / ".cafe"
+    (cafe_dir / "issues").mkdir(parents=True)
+    (cafe_dir / "active_issue").write_text("missing-issue\n", encoding="utf-8")
+
+    with patch("cafe.ui.cli.GitOperations") as mock_git_cls:
+        git = MagicMock()
+        git.get_branch_health.return_value = BranchHealth(is_healthy=False, reason="git_error")
+        mock_git_cls.return_value = git
+
+        result = runner.invoke(app, ["workflow", "--playbook", "default", "--execute"])
+
+    assert result.exit_code == 1
+    assert "missing-issue" in result.stdout

--- a/tests/unit/test_git_branch_health.py
+++ b/tests/unit/test_git_branch_health.py
@@ -1,0 +1,44 @@
+"""Tests for Git branch health detection."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from cafe.core.git import GitOperations
+
+
+class TestBranchHealth:
+    def test_healthy_branch(self, tmp_path: Path) -> None:
+        git = GitOperations(str(tmp_path))
+        with patch.object(git, "get_current_branch", return_value="feature"), patch.object(
+            git, "has_in_progress_operation", return_value=False
+        ):
+            health = git.get_branch_health()
+        assert health.is_healthy is True
+        assert health.branch_name == "feature"
+
+    def test_detached_head_unhealthy(self, tmp_path: Path) -> None:
+        git = GitOperations(str(tmp_path))
+        with patch.object(git, "get_current_branch", return_value=""):
+            health = git.get_branch_health()
+        assert health.is_healthy is False
+        assert health.reason == "detached_head"
+
+    def test_in_progress_unhealthy(self, tmp_path: Path) -> None:
+        git = GitOperations(str(tmp_path))
+        with patch.object(git, "get_current_branch", return_value="feature"), patch.object(
+            git, "has_in_progress_operation", return_value=True
+        ):
+            health = git.get_branch_health()
+        assert health.is_healthy is False
+        assert health.reason == "in_progress"
+        assert health.branch_name == "feature"
+
+    def test_has_in_progress_operation_detects_merge_head(self, tmp_path: Path) -> None:
+        git_dir = tmp_path / ".git"
+        git_dir.mkdir()
+        (git_dir / "MERGE_HEAD").write_text("abc", encoding="utf-8")
+        git = GitOperations(str(tmp_path))
+        with patch.object(git, "_git_dir_path", return_value=git_dir):
+            assert git.has_in_progress_operation() is True

--- a/tests/unit/test_issue_resolution.py
+++ b/tests/unit/test_issue_resolution.py
@@ -1,0 +1,136 @@
+"""Tests for active issue resolution with Git health and fallback marker."""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from cafe.core.git import BranchHealth, GitError
+from cafe.core.issue_resolution import ActiveIssueResolutionError, resolve_active_issue
+from cafe.core import active_issue
+
+
+@pytest.fixture
+def cafe_dir(tmp_path: Path) -> Path:
+    root = tmp_path / ".cafe"
+    (root / "issues").mkdir(parents=True)
+    return root
+
+
+def _prepared(cafe_dir: Path, name: str) -> None:
+    (cafe_dir / "issues" / name).mkdir(parents=True)
+
+
+class TestResolveActiveIssueHealthy:
+    def test_healthy_branch_with_prepared_issue_syncs_marker(self, cafe_dir: Path) -> None:
+        _prepared(cafe_dir, "feature-a")
+        git = MagicMock()
+        git.get_branch_health.return_value = BranchHealth(is_healthy=True, branch_name="feature-a")
+
+        resolved = resolve_active_issue(cafe_dir=cafe_dir, git_ops=git)
+
+        assert resolved.issue_name == "feature-a"
+        assert resolved.source == "branch"
+        assert active_issue.read_marker(cafe_dir) == "feature-a"
+
+    def test_healthy_branch_disagrees_with_marker_corrects_marker(self, cafe_dir: Path) -> None:
+        _prepared(cafe_dir, "feature-b")
+        active_issue.write_marker(cafe_dir, "stale-issue")
+        git = MagicMock()
+        git.get_branch_health.return_value = BranchHealth(is_healthy=True, branch_name="feature-b")
+
+        resolved = resolve_active_issue(cafe_dir=cafe_dir, git_ops=git)
+
+        assert resolved.issue_name == "feature-b"
+        assert active_issue.read_marker(cafe_dir) == "feature-b"
+
+    def test_healthy_branch_without_prepared_issue_errors(self, cafe_dir: Path) -> None:
+        git = MagicMock()
+        git.get_branch_health.return_value = BranchHealth(is_healthy=True, branch_name="orphan")
+
+        with pytest.raises(ActiveIssueResolutionError) as exc:
+            resolve_active_issue(cafe_dir=cafe_dir, git_ops=git)
+
+        assert "orphan" in exc.value.message
+
+
+class TestResolveActiveIssueUnhealthy:
+    def test_detached_head_uses_valid_marker(self, cafe_dir: Path) -> None:
+        _prepared(cafe_dir, "saved-issue")
+        active_issue.write_marker(cafe_dir, "saved-issue")
+        git = MagicMock()
+        git.get_branch_health.return_value = BranchHealth(
+            is_healthy=False,
+            reason="detached_head",
+        )
+
+        resolved = resolve_active_issue(cafe_dir=cafe_dir, git_ops=git)
+
+        assert resolved.issue_name == "saved-issue"
+        assert resolved.source == "fallback"
+        assert active_issue.read_marker(cafe_dir) == "saved-issue"
+
+    def test_mid_rebase_uses_valid_marker_without_overwrite(self, cafe_dir: Path) -> None:
+        _prepared(cafe_dir, "saved-issue")
+        active_issue.write_marker(cafe_dir, "saved-issue")
+        git = MagicMock()
+        git.get_branch_health.return_value = BranchHealth(
+            is_healthy=False,
+            branch_name="feature-x",
+            reason="in_progress",
+        )
+
+        resolved = resolve_active_issue(cafe_dir=cafe_dir, git_ops=git)
+
+        assert resolved.issue_name == "saved-issue"
+        assert active_issue.read_marker(cafe_dir) == "saved-issue"
+
+    def test_git_error_uses_valid_marker(self, cafe_dir: Path) -> None:
+        _prepared(cafe_dir, "saved-issue")
+        active_issue.write_marker(cafe_dir, "saved-issue")
+        git = MagicMock()
+        git.get_branch_health.return_value = BranchHealth(is_healthy=False, reason="git_error")
+
+        resolved = resolve_active_issue(cafe_dir=cafe_dir, git_ops=git)
+        assert resolved.issue_name == "saved-issue"
+
+    def test_unhealthy_missing_marker_errors(self, cafe_dir: Path) -> None:
+        git = MagicMock()
+        git.get_branch_health.return_value = BranchHealth(is_healthy=False, reason="git_error")
+
+        with pytest.raises(ActiveIssueResolutionError):
+            resolve_active_issue(cafe_dir=cafe_dir, git_ops=git)
+
+    def test_unhealthy_empty_marker_errors(self, cafe_dir: Path) -> None:
+        active_issue.marker_path(cafe_dir).write_text("\n", encoding="utf-8")
+        git = MagicMock()
+        git.get_branch_health.return_value = BranchHealth(is_healthy=False, reason="detached_head")
+
+        with pytest.raises(ActiveIssueResolutionError):
+            resolve_active_issue(cafe_dir=cafe_dir, git_ops=git)
+
+    def test_unhealthy_stale_marker_errors(self, cafe_dir: Path) -> None:
+        active_issue.write_marker(cafe_dir, "gone-issue")
+        git = MagicMock()
+        git.get_branch_health.return_value = BranchHealth(is_healthy=False, reason="detached_head")
+
+        with pytest.raises(ActiveIssueResolutionError) as exc:
+            resolve_active_issue(cafe_dir=cafe_dir, git_ops=git)
+
+        assert "gone-issue" in exc.value.message
+
+
+class TestResolveExplicitIssue:
+    def test_explicit_issue_bypasses_git(self, cafe_dir: Path) -> None:
+        git = MagicMock()
+        git.get_branch_health.side_effect = GitError("should not be called")
+
+        resolved = resolve_active_issue(
+            cafe_dir=cafe_dir,
+            git_ops=git,
+            explicit_issue="manual-issue",
+        )
+
+        assert resolved.issue_name == "manual-issue"
+        assert resolved.source == "explicit"
+        git.get_branch_health.assert_not_called()

--- a/tests/unit/test_workflow_runtime.py
+++ b/tests/unit/test_workflow_runtime.py
@@ -887,6 +887,67 @@ def test_runtime_records_done_handoff_for_non_pr_terminal_transition(tmp_path: P
     assert blackboard.events[-1].event_type == "workflow_completed"
 
 
+def test_emit_complete_clears_matching_active_issue_marker(tmp_path: Path) -> None:
+    cafe_dir = tmp_path / ".cafe"
+    issue_dir = cafe_dir / "issues" / "done-issue"
+    issue_dir.mkdir(parents=True)
+    (cafe_dir / "active_issue").write_text("done-issue\n", encoding="utf-8")
+    playbook = {
+        "playbook": {"id": "default"},
+        "steps": {
+            "review": {
+                "skill": "spec_first",
+                "role": "reviewer",
+                "valid_intents": ["confirmed"],
+                "on": {"await_agent": "done"},
+            },
+        },
+    }
+
+    def executor(step_name: str, step_def: dict, state: object):
+        return ("confirmed", {})
+
+    runtime = BlackboardWorkflowRuntime(
+        issue_dir=issue_dir,
+        playbook=playbook,
+        executor=executor,
+    )
+    result = runtime.run(start_step="review")
+
+    assert result.completed is True
+    assert not (cafe_dir / "active_issue").exists()
+
+
+def test_emit_complete_does_not_clear_non_matching_active_issue_marker(tmp_path: Path) -> None:
+    cafe_dir = tmp_path / ".cafe"
+    issue_dir = cafe_dir / "issues" / "done-issue"
+    issue_dir.mkdir(parents=True)
+    (cafe_dir / "active_issue").write_text("other-issue\n", encoding="utf-8")
+    playbook = {
+        "playbook": {"id": "default"},
+        "steps": {
+            "review": {
+                "skill": "spec_first",
+                "role": "reviewer",
+                "valid_intents": ["confirmed"],
+                "on": {"await_agent": "done"},
+            },
+        },
+    }
+
+    def executor(step_name: str, step_def: dict, state: object):
+        return ("confirmed", {})
+
+    runtime = BlackboardWorkflowRuntime(
+        issue_dir=issue_dir,
+        playbook=playbook,
+        executor=executor,
+    )
+    runtime.run(start_step="review")
+
+    assert (cafe_dir / "active_issue").read_text(encoding="utf-8").strip() == "other-issue"
+
+
 def test_runtime_pauses_for_non_pr_transition_to_user(tmp_path: Path) -> None:
     issue_dir = tmp_path / ".cafe" / "issues" / "user-transition"
     playbook = {


### PR DESCRIPTION
## Summary

Implements GitHub issue #298 to make CAFE suspend/resume more reliable when branch-based issue detection is temporarily unsafe. Branch detection remains primary; `.cafe/active_issue` is a gitignored runtime marker used only when Git is unhealthy (detached HEAD, in-progress rebase/merge, etc.). The marker is written on `cafe prepare`, synchronized on healthy `cafe make`, cleared on successful close and workflow completion, and overwritten in worktree prepare so copied runtime state does not leak across issues.

Closes #298

## Changes

### Core
- Add `src/cafe/core/active_issue.py` for marker read/write/clear and prepared-issue validation
- Add `src/cafe/core/issue_resolution.py` for branch-first resolution with explicit `--issue` bypass
- Extend `src/cafe/core/git.py` with `BranchHealth`, `get_branch_health()`, and in-progress operation detection

### Lifecycle wiring
- `cafe prepare` writes `.cafe/active_issue` after successful setup (worktree `.cafe` overwrites copied markers)
- `cafe workflow` / `cafe make` resolves the active issue before building `issue_dir`
- `cafe close` clears matching markers (worktree marker only after successful `remove_worktree`)
- `BlackboardWorkflowRuntime._emit_complete` clears a matching marker on workflow completion

### Tests
- Unit tests for marker helper, resolution, git health, prepare, workflow recovery, close, and runtime completion
- Global test conftest wiring for MagicMock git health in existing workflow tests

### Commits
- `issue298: add active issue runtime marker helper`
- `issue298: add git branch health and active issue resolution`
- `issue298: wire active issue marker into prepare, workflow, and close`
- `issue298: clear worktree active_issue marker only after remove succeeds`

## Test Plan

- [x] `uv run pytest tests/unit/test_active_issue.py tests/unit/test_issue_resolution.py tests/unit/test_git_branch_health.py`
- [x] `uv run pytest tests/unit/test_cli_prepare.py tests/unit/test_cli_workflow_command.py tests/unit/test_cli_close.py tests/unit/test_workflow_runtime.py`
- [x] `uv run pytest` (2015 passed)