### PR TITLE
Send `continue` on same-CLI same-session workflow resume (#299)

### DIFF
--- a/src/cafe/core/hooks/native.py
+++ b/src/cafe/core/hooks/native.py
@@ -269,21 +269,6 @@ class UserInputCollector(NoOpHook):
         if step_name == "pr" and previous_status in {"ready_for_review", "confirm_output"}:
             return HookResult()
 
-        # Non-interactive mode: cannot call InquirerPy prompts.
-        # Return empty result — the workflow stops at the user step and the
-        # caller provides input via --user-input on resume.
-        if not getattr(phase, "interactive", False):
-            return HookResult()
-
-        prompt_role = {"pm": "pm", "reviewer": "reviewer"}.get(role, "developer")
-        previous_output_file = self._get_previous_output_file(phase, step_name)
-        # Steps that declare confirm_output use delta view on READY_FOR_REVIEW (less noisy).
-        if not (
-            step_on_declares(step_def, "confirm_output")
-            and previous_status == "ready_for_review"
-        ):
-            self._display_previous_output(phase, step_name, previous_output_file)
-
         current_iter_dir = phase._get_iteration_dir(phase.iteration)
         current_user_input_file = current_iter_dir / "user_input.md"
         if current_user_input_file.exists():
@@ -300,6 +285,21 @@ class UserInputCollector(NoOpHook):
                         }
                     ],
                 )
+
+        # Non-interactive mode: cannot call InquirerPy prompts.
+        # Return empty result — the workflow stops at the user step and the
+        # caller provides input via --user-input on resume.
+        if not getattr(phase, "interactive", False):
+            return HookResult()
+
+        prompt_role = {"pm": "pm", "reviewer": "reviewer"}.get(role, "developer")
+        previous_output_file = self._get_previous_output_file(phase, step_name)
+        # Steps that declare confirm_output use delta view on READY_FOR_REVIEW (less noisy).
+        if not (
+            step_on_declares(step_def, "confirm_output")
+            and previous_status == "ready_for_review"
+        ):
+            self._display_previous_output(phase, step_name, previous_output_file)
 
         if previous_status in {"confirm_output", "ready_for_review"}:
             delta_displayed = self._display_previous_iteration_delta(phase, previous_output_file)

--- a/src/cafe/core/phase.py
+++ b/src/cafe/core/phase.py
@@ -156,12 +156,10 @@ class Phase(PhaseStateMixin, PhaseSandboxMixin, PhaseReviewMixin, PhaseChecklist
         iteration_dir = self._get_iteration_dir(self.iteration)
         iteration_dir.mkdir(parents=True, exist_ok=True)
 
-        # Save user_input to dedicated markdown file
-        # Don't overwrite existing non-empty user_input.md (e.g., from PR phase)
+        # Persist the exact user_input sent to the agent for this iteration.
         user_input_file = iteration_dir / "user_input.md"
-        if not user_input_file.exists() or user_input_file.stat().st_size == 0:
-            with open(user_input_file, "w", encoding="utf-8") as f:
-                f.write(user_input)
+        with open(user_input_file, "w", encoding="utf-8") as f:
+            f.write(user_input)
 
         # Create initial context data (user_input is stored in user_input.md,
         # no longer duplicated into context.json)

--- a/src/cafe/core/resume_user_input.py
+++ b/src/cafe/core/resume_user_input.py
@@ -1,0 +1,67 @@
+"""Resume user-input resolution for workflow step iterations."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+CONTINUE_USER_INPUT = "continue"
+
+
+def resolve_resume_user_input(
+    *,
+    candidate: str,
+    prior_cli: Optional[str],
+    prior_session_id: Optional[str],
+    current_cli: Optional[str],
+    current_session_id: Optional[str],
+) -> str:
+    """Return ``continue`` when resuming with the same CLI and session id."""
+    if not prior_cli or not prior_session_id:
+        return candidate
+    if not current_cli or not current_session_id:
+        return candidate
+    if prior_cli == current_cli and prior_session_id == current_session_id:
+        return CONTINUE_USER_INPUT
+    return candidate
+
+
+def is_resume_iteration(
+    *,
+    iteration: int,
+    previous_iteration_data: Optional[Dict[str, Any]],
+    current_iteration_data: Optional[Dict[str, Any]],
+) -> bool:
+    """True when this step iteration continues a prior agent run in the same step."""
+    if iteration > 1:
+        return True
+    if current_iteration_data and current_iteration_data.get("cli"):
+        if not current_iteration_data.get("end_time"):
+            return True
+    return False
+
+
+def load_prior_run_context(
+    *,
+    iteration: int,
+    previous_iteration_data: Optional[Dict[str, Any]],
+    current_iteration_data: Optional[Dict[str, Any]],
+) -> Optional[Dict[str, Any]]:
+    """Load iteration metadata from the prior run being resumed."""
+    if iteration > 1:
+        return previous_iteration_data
+    if current_iteration_data and current_iteration_data.get("cli"):
+        if not current_iteration_data.get("end_time"):
+            return current_iteration_data
+    return None
+
+
+def prior_cli_and_session(
+    prior_context: Optional[Dict[str, Any]],
+) -> tuple[Optional[str], Optional[str]]:
+    if not prior_context:
+        return None, None
+    cli = prior_context.get("cli")
+    session_id = prior_context.get("session_id")
+    prior_cli = cli if isinstance(cli, str) else None
+    prior_session = session_id if isinstance(session_id, str) else None
+    return prior_cli, prior_session

--- a/src/cafe/phases/generic_phase.py
+++ b/src/cafe/phases/generic_phase.py
@@ -229,6 +229,10 @@ class GenericPhase:
                 published=False,
             )
 
+        transform_runtime_context = hook_kwargs.get("transform_runtime_context")
+        if callable(transform_runtime_context):
+            runtime_context = transform_runtime_context(runtime_context)
+
         response = ""
         status_code: Optional[PhaseStatusCode] = None
         goto_target: Optional[str] = None

--- a/src/cafe/phases/generic_workflow_step.py
+++ b/src/cafe/phases/generic_workflow_step.py
@@ -25,6 +25,12 @@ from cafe.core.status_codes import (
 )
 from cafe.core.workflow_models import StepExecutionResult
 from cafe.phases.generic_phase import GenericPhase
+from cafe.core.resume_user_input import (
+    is_resume_iteration,
+    load_prior_run_context,
+    prior_cli_and_session,
+    resolve_resume_user_input,
+)
 from cafe.utils.checklist_generator import (
     generate_develop_checklist,
     generate_plan_checklist,
@@ -157,6 +163,7 @@ class GenericWorkflowStepExecutor(Phase):
         skill_name = self._resolve_skill_name(step_def, self.iteration)
         valid_intents = self._resolve_valid_intents(step_def)
         agent_name = self._resolve_agent_name(step_def)
+        self._step_agent_name = agent_name
         self._apply_step_agent_model(step_name=step_name, step_def=step_def, agent_name=agent_name)
         agent_cli = self.agent_manager.get_agent(agent_name).config.cli
         shared_skill_invocations = self.generic_phase.prepare_skills(
@@ -351,11 +358,45 @@ class GenericWorkflowStepExecutor(Phase):
         is not replayed on subsequent iterations or handoff cycles.
         """
         if step_name in self.step_user_inputs:
-            value = self.step_user_inputs.pop(step_name)
-            return value
-        if step_name == "plan" and self.iteration == 1:
-            return ""
-        return "workflow execute"
+            candidate = self.step_user_inputs.pop(step_name)
+        elif step_name == "plan" and self.iteration == 1:
+            candidate = ""
+        else:
+            candidate = "workflow execute"
+
+        agent_name = getattr(self, "_step_agent_name", None)
+        if not agent_name or not hasattr(self, "agent_manager"):
+            return candidate
+
+        previous_data = self._load_previous_iteration_data()
+        current_data = self._load_current_iteration_data()
+        if not is_resume_iteration(
+            iteration=self.iteration,
+            previous_iteration_data=previous_data,
+            current_iteration_data=current_data,
+        ):
+            return candidate
+
+        prior_context = load_prior_run_context(
+            iteration=self.iteration,
+            previous_iteration_data=previous_data,
+            current_iteration_data=current_data,
+        )
+        prior_cli, prior_session_id = prior_cli_and_session(prior_context)
+
+        config = self.agent_manager.get_agent(agent_name).config
+        current_cli = config.cli.value if hasattr(config.cli, "value") else str(config.cli)
+        current_session_id = (
+            config.session_id if isinstance(config.session_id, str) else None
+        )
+
+        return resolve_resume_user_input(
+            candidate=candidate,
+            prior_cli=prior_cli,
+            prior_session_id=prior_session_id,
+            current_cli=current_cli,
+            current_session_id=current_session_id,
+        )
 
     def _detect_written_output_files(self) -> List[Path]:
         if self._current_output_file and self._current_output_file.exists():

--- a/src/cafe/phases/generic_workflow_step.py
+++ b/src/cafe/phases/generic_workflow_step.py
@@ -119,6 +119,7 @@ class GenericWorkflowStepExecutor(Phase):
         self.phase_dir = issue_dir
         self.iteration = 0
         self._current_output_file: Optional[Path] = None
+        self._resolved_iteration_user_input: Optional[str] = None
         self._config_allowed_directories: List[str] = list(config_allowed_directories or [])
         self._extra_allowed_directories: List[str] = list(extra_allowed_directories or [])
 
@@ -142,6 +143,7 @@ class GenericWorkflowStepExecutor(Phase):
         self.phase_dir.mkdir(parents=True, exist_ok=True)
 
         self.iteration = self._get_next_iteration_number(step_name, self.phase_dir)
+        self._resolved_iteration_user_input = None
         iteration_dir = self._get_iteration_dir(self.iteration)
         iteration_dir.mkdir(parents=True, exist_ok=True)
 
@@ -206,7 +208,7 @@ class GenericWorkflowStepExecutor(Phase):
 
         def run_agent(prompt: str) -> str:
             last_prompt[:] = [prompt]
-            resolved_user_input = self._resolve_iteration_user_input(step_name)
+            resolved_user_input = self._get_resolved_iteration_user_input(step_name)
             if extra_prompt:
                 resolved_user_input = (
                     f"{extra_prompt}\n\n{resolved_user_input}" if resolved_user_input else extra_prompt
@@ -242,6 +244,12 @@ class GenericWorkflowStepExecutor(Phase):
                 "questions_xml_file": questions_xml_file,
                 "publish_request_file": publish_request_file if step_name == "pr" else None,
                 "blackboard_state": blackboard_state,
+                "transform_runtime_context": (
+                    lambda runtime_context: self._apply_resume_to_runtime_context(
+                        runtime_context,
+                        step_name,
+                    )
+                ),
             },
         )
 
@@ -260,7 +268,7 @@ class GenericWorkflowStepExecutor(Phase):
             and status_code is not None
             and self._should_validate_checklist(status_code)
         ):
-            resolved_user_input = self._resolve_iteration_user_input(step_name)
+            resolved_user_input = self._get_resolved_iteration_user_input(step_name)
             response, validated_status, validation_passed = self._validate_and_retry_checklist_completion(
                 agent_name=agent_name,
                 prompt=last_prompt[0] if last_prompt else "",
@@ -351,19 +359,23 @@ class GenericWorkflowStepExecutor(Phase):
             events=events,
         )
 
-    def _resolve_iteration_user_input(self, step_name: str) -> str:
-        """Resolve user_input sent to agent for this step iteration.
-
-        Consumes the entry from ``step_user_inputs`` after first use so it
-        is not replayed on subsequent iterations or handoff cycles.
-        """
+    def _load_iteration_user_input_candidate(self, step_name: str) -> str:
+        """Load raw user input before resume-token optimization."""
         if step_name in self.step_user_inputs:
-            candidate = self.step_user_inputs.pop(step_name)
-        elif step_name == "plan" and self.iteration == 1:
-            candidate = ""
-        else:
-            candidate = "workflow execute"
+            return self.step_user_inputs.pop(step_name)
 
+        iteration_dir = self._get_iteration_dir(self.iteration)
+        user_input_file = iteration_dir / "user_input.md"
+        if user_input_file.exists():
+            content = user_input_file.read_text(encoding="utf-8")
+            if content.strip():
+                return content
+
+        if step_name == "plan" and self.iteration == 1:
+            return ""
+        return "workflow execute"
+
+    def _apply_resume_user_input_to_candidate(self, step_name: str, candidate: str) -> str:
         agent_name = getattr(self, "_step_agent_name", None)
         if not agent_name or not hasattr(self, "agent_manager"):
             return candidate
@@ -397,6 +409,41 @@ class GenericWorkflowStepExecutor(Phase):
             current_cli=current_cli,
             current_session_id=current_session_id,
         )
+
+    def _resolve_iteration_user_input(self, step_name: str) -> str:
+        """Resolve user_input sent to agent for this step iteration."""
+        candidate = self._load_iteration_user_input_candidate(step_name)
+        return self._apply_resume_user_input_to_candidate(step_name, candidate)
+
+    def _get_resolved_iteration_user_input(self, step_name: str) -> str:
+        cached = self._resolved_iteration_user_input
+        if cached is not None:
+            return cached
+        resolved = self._resolve_iteration_user_input(step_name)
+        self._resolved_iteration_user_input = resolved
+        return resolved
+
+    def _apply_resume_to_runtime_context(
+        self,
+        runtime_context: Dict[str, str],
+        step_name: str,
+    ) -> Dict[str, str]:
+        """Apply resume user-input rules to prompt runtime context."""
+        updated = dict(runtime_context)
+        if step_name in self.step_user_inputs:
+            candidate = self.step_user_inputs.pop(step_name)
+        elif updated.get("user_input"):
+            candidate = updated["user_input"]
+        else:
+            candidate = self._load_iteration_user_input_candidate(step_name)
+
+        resolved = self._apply_resume_user_input_to_candidate(step_name, candidate)
+        self._resolved_iteration_user_input = resolved
+        if resolved:
+            updated["user_input"] = resolved
+        else:
+            updated.pop("user_input", None)
+        return updated
 
     def _detect_written_output_files(self) -> List[Path]:
         if self._current_output_file and self._current_output_file.exists():

--- a/tests/unit/test_generic_workflow_step.py
+++ b/tests/unit/test_generic_workflow_step.py
@@ -2306,6 +2306,39 @@ def test_resolve_iteration_user_input_different_session_returns_full_candidate(t
     assert executor._resolve_iteration_user_input("spec") == candidate
 
 
+def test_resolve_iteration_user_input_loads_prewritten_user_input_file(tmp_path: Path) -> None:
+    issue_dir = tmp_path / ".cafe" / "issues" / "issue-resume-input"
+    spec_dir = issue_dir / "spec"
+    current_iter = spec_dir / "iteration_002"
+    current_iter.mkdir(parents=True)
+    (current_iter / "user_input.md").write_text("Answer from workflow --user-input", encoding="utf-8")
+    prev_iter = spec_dir / "iteration_001"
+    prev_iter.mkdir(parents=True)
+    (prev_iter / "iteration.json").write_text(
+        json.dumps(
+            {
+                "cli": "codex",
+                "session_id": "old-session",
+                "end_time": "2026-05-23T00:00:00+08:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    manager = FakeAgentManager("confirmed")
+    manager.agent.config.session_id = "new-session"
+
+    executor = _minimal_spec_executor(tmp_path, agent_manager=manager)
+    executor.phase_dir = spec_dir
+    executor.iteration = 2
+    executor._step_agent_name = "Roger"
+
+    assert (
+        executor._resolve_iteration_user_input("spec")
+        == "Answer from workflow --user-input"
+    )
+
+
 def test_resolve_iteration_user_input_interrupted_iteration_reuse(tmp_path: Path) -> None:
     issue_dir = tmp_path / ".cafe" / "issues" / "issue-resume-input"
     spec_dir = issue_dir / "spec"
@@ -2322,3 +2355,97 @@ def test_resolve_iteration_user_input_interrupted_iteration_reuse(tmp_path: Path
     executor._step_agent_name = "Roger"
 
     assert executor._resolve_iteration_user_input("spec") == "continue"
+
+
+def test_apply_resume_to_runtime_context_replaces_full_input_with_continue(tmp_path: Path) -> None:
+    issue_dir = tmp_path / ".cafe" / "issues" / "issue-resume-input"
+    spec_dir = issue_dir / "spec"
+    prev_iter = spec_dir / "iteration_001"
+    prev_iter.mkdir(parents=True)
+    (prev_iter / "iteration.json").write_text(
+        json.dumps(
+            {
+                "cli": "codex",
+                "session_id": "session-1",
+                "end_time": "2026-05-23T00:00:00+08:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    executor = _minimal_spec_executor(tmp_path, agent_manager=FakeAgentManager("confirmed"))
+    executor.phase_dir = spec_dir
+    executor.iteration = 2
+    executor._step_agent_name = "Roger"
+
+    updated = executor._apply_resume_to_runtime_context(
+        {"user_input": "Long clarification that should not be replayed"},
+        "spec",
+    )
+
+    assert updated["user_input"] == "continue"
+    assert executor._get_resolved_iteration_user_input("spec") == "continue"
+
+
+def test_execute_step_same_session_resume_uses_continue_in_prompt_and_user_input_md(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    issue_dir = tmp_path / ".cafe" / "issues" / "issue-resume-exec"
+    spec_dir = issue_dir / "spec"
+    prev_iter = spec_dir / "iteration_001"
+    prev_iter.mkdir(parents=True)
+    (prev_iter / "iteration.json").write_text(
+        json.dumps(
+            {
+                "cli": "codex",
+                "session_id": "session-1",
+                "end_time": "2026-05-23T00:00:00+08:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (spec_dir / "iteration_002").mkdir(parents=True)
+    (spec_dir / "iteration_002" / "user_input.md").write_text(
+        "Long clarification that should not appear in prompt",
+        encoding="utf-8",
+    )
+
+    playbook = {
+        "playbook": {"id": "default"},
+        "roles": {"pm": {"default_agent": "Roger"}},
+        "steps": {
+            "spec": {
+                "skill": {"1": "spec_first", "default": "spec_first"},
+                "role": "pm",
+                "output_artifact": "spec",
+                "allowed_tools": ["Read"],
+                "valid_intents": ["confirmed"],
+                "on": {"await_agent": "_done"},
+            }
+        },
+    }
+    manager = FakeAgentManager("confirmed")
+    manager.agent.config.session_id = "session-1"
+
+    executor = GenericWorkflowStepExecutor(
+        issue_dir=issue_dir,
+        issue_name="issue-resume-exec",
+        playbook=playbook,
+        generic_phase=_build_loader(tmp_path),
+        agent_manager=manager,
+        git_ops=FakeGitOperations(),
+        role_agent_map={"pm": "Roger"},
+    )
+
+    state = BlackboardStore(issue_dir).load_or_create("spec")
+    executor.execute_step("spec", playbook["steps"]["spec"], state)
+
+    assert manager.prompts
+    prompt = manager.prompts[0]
+    assert "Long clarification that should not appear in prompt" not in prompt
+    assert "Current user input for this iteration:" in prompt
+    assert "continue" in prompt
+    user_input_file = spec_dir / "iteration_002" / "user_input.md"
+    assert user_input_file.read_text(encoding="utf-8") == "continue"

--- a/tests/unit/test_generic_workflow_step.py
+++ b/tests/unit/test_generic_workflow_step.py
@@ -2211,3 +2211,114 @@ def test_no_changes_needed_interactive_always_pauses_regardless_of_playbook(
     assert reloaded.handoff_contract is not None
     assert reloaded.handoff_contract.to_owner == HandoffOwner.USER
     assert reloaded.handoff_contract.to_step == "user"
+
+
+def _minimal_spec_executor(
+    tmp_path: Path,
+    *,
+    agent_manager: FakeAgentManager,
+) -> GenericWorkflowStepExecutor:
+    issue_dir = tmp_path / ".cafe" / "issues" / "issue-resume-input"
+    playbook = {
+        "playbook": {"id": "default"},
+        "roles": {"pm": {"default_agent": "Roger"}},
+        "steps": {
+            "spec": {
+                "skill": "spec_first",
+                "role": "pm",
+                "output_artifact": "spec",
+                "valid_intents": ["confirmed"],
+            }
+        },
+    }
+    return GenericWorkflowStepExecutor(
+        issue_dir=issue_dir,
+        issue_name="issue-resume-input",
+        playbook=playbook,
+        generic_phase=_build_loader(tmp_path),
+        agent_manager=agent_manager,
+        git_ops=FakeGitOperations(),
+        role_agent_map={"pm": "Roger"},
+    )
+
+
+def test_resolve_iteration_user_input_first_start_unchanged(tmp_path: Path) -> None:
+    executor = _minimal_spec_executor(tmp_path, agent_manager=FakeAgentManager("confirmed"))
+    executor.phase_dir = tmp_path / ".cafe" / "issues" / "issue-resume-input" / "spec"
+    executor.iteration = 1
+    executor._step_agent_name = "Roger"
+    executor.step_user_inputs["spec"] = "Cold-start requirements"
+
+    assert executor._resolve_iteration_user_input("spec") == "Cold-start requirements"
+
+
+def test_resolve_iteration_user_input_same_cli_session_returns_continue(tmp_path: Path) -> None:
+    issue_dir = tmp_path / ".cafe" / "issues" / "issue-resume-input"
+    spec_dir = issue_dir / "spec"
+    prev_iter = spec_dir / "iteration_001"
+    prev_iter.mkdir(parents=True)
+    (prev_iter / "iteration.json").write_text(
+        json.dumps(
+            {
+                "cli": "codex",
+                "session_id": "session-1",
+                "end_time": "2026-05-23T00:00:00+08:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    executor = _minimal_spec_executor(tmp_path, agent_manager=FakeAgentManager("confirmed"))
+    executor.phase_dir = spec_dir
+    executor.iteration = 2
+    executor._step_agent_name = "Roger"
+    executor.step_user_inputs["spec"] = "Please apply the feedback"
+
+    assert executor._resolve_iteration_user_input("spec") == "continue"
+
+
+def test_resolve_iteration_user_input_different_session_returns_full_candidate(tmp_path: Path) -> None:
+    issue_dir = tmp_path / ".cafe" / "issues" / "issue-resume-input"
+    spec_dir = issue_dir / "spec"
+    prev_iter = spec_dir / "iteration_001"
+    prev_iter.mkdir(parents=True)
+    (prev_iter / "iteration.json").write_text(
+        json.dumps(
+            {
+                "cli": "codex",
+                "session_id": "old-session",
+                "end_time": "2026-05-23T00:00:00+08:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    manager = FakeAgentManager("confirmed")
+    manager.agent.config.session_id = "new-session"
+
+    executor = _minimal_spec_executor(tmp_path, agent_manager=manager)
+    executor.phase_dir = spec_dir
+    executor.iteration = 2
+    executor._step_agent_name = "Roger"
+    candidate = "Clarification answer"
+    executor.step_user_inputs["spec"] = candidate
+
+    assert executor._resolve_iteration_user_input("spec") == candidate
+
+
+def test_resolve_iteration_user_input_interrupted_iteration_reuse(tmp_path: Path) -> None:
+    issue_dir = tmp_path / ".cafe" / "issues" / "issue-resume-input"
+    spec_dir = issue_dir / "spec"
+    current_iter = spec_dir / "iteration_001"
+    current_iter.mkdir(parents=True)
+    (current_iter / "iteration.json").write_text(
+        json.dumps({"cli": "codex", "session_id": "session-1"}),
+        encoding="utf-8",
+    )
+
+    executor = _minimal_spec_executor(tmp_path, agent_manager=FakeAgentManager("confirmed"))
+    executor.phase_dir = spec_dir
+    executor.iteration = 1
+    executor._step_agent_name = "Roger"
+
+    assert executor._resolve_iteration_user_input("spec") == "continue"

--- a/tests/unit/test_native_user_input_hook.py
+++ b/tests/unit/test_native_user_input_hook.py
@@ -293,6 +293,35 @@ def test_user_input_collector_falls_back_to_prompt_when_questions_xml_invalid(tm
     mock_prompt.assert_called_once()
 
 
+def test_user_input_collector_noninteractive_reads_existing_user_input_file(tmp_path: Path) -> None:
+    phase_dir = tmp_path / "spec"
+    prev_iter_dir = phase_dir / "iteration_001"
+    current_iter_dir = phase_dir / "iteration_002"
+    prev_iter_dir.mkdir(parents=True, exist_ok=True)
+    current_iter_dir.mkdir(parents=True, exist_ok=True)
+    (prev_iter_dir / "output.md").write_text("# Spec\n", encoding="utf-8")
+    _record_previous_step_status(tmp_path, "spec", "need_clarification")
+    (current_iter_dir / "user_input.md").write_text(
+        "Resume answer from workflow",
+        encoding="utf-8",
+    )
+
+    phase = _FakePhase(phase_dir=phase_dir, iteration=2)
+    phase.interactive = False
+    hook = UserInputCollector()
+
+    result = hook.run(
+        stage="prepare_input",
+        phase=phase,
+        step_name="spec",
+        step_def={"role": "pm"},
+        agent_name="Roger",
+    )
+
+    assert result.context_updates["user_input"] == "Resume answer from workflow"
+    assert result.events[0]["source"] == "user_input_file"
+
+
 def test_user_input_collector_reuses_existing_user_input_file_without_reasking(tmp_path: Path) -> None:
     phase_dir = tmp_path / "spec"
     prev_iter_dir = phase_dir / "iteration_001"
@@ -324,7 +353,7 @@ def test_user_input_collector_reuses_existing_user_input_file_without_reasking(t
     assert result.context_updates["user_input"] == "Q1: Question?\nA1: Confirmed answer"
     assert result.events == [{"type": "user_input_collected", "step": "spec", "source": "user_input_file"}]
     assert phase.step_user_inputs["spec"] == "Q1: Question?\nA1: Confirmed answer"
-    mock_display_output.assert_called_once()
+    mock_display_output.assert_not_called()
     mock_qa.assert_not_called()
 
 

--- a/tests/unit/test_resume_user_input.py
+++ b/tests/unit/test_resume_user_input.py
@@ -1,0 +1,113 @@
+"""Tests for resume user-input resolution."""
+
+from cafe.core.resume_user_input import (
+    CONTINUE_USER_INPUT,
+    is_resume_iteration,
+    load_prior_run_context,
+    prior_cli_and_session,
+    resolve_resume_user_input,
+)
+
+
+def test_resolve_resume_user_input_first_start_returns_candidate() -> None:
+    result = resolve_resume_user_input(
+        candidate="Initial requirements",
+        prior_cli=None,
+        prior_session_id=None,
+        current_cli="codex",
+        current_session_id="session-1",
+    )
+    assert result == "Initial requirements"
+
+
+def test_resolve_resume_user_input_same_cli_and_session_returns_continue() -> None:
+    result = resolve_resume_user_input(
+        candidate="Please revise the spec",
+        prior_cli="codex",
+        prior_session_id="abc",
+        current_cli="codex",
+        current_session_id="abc",
+    )
+    assert result == CONTINUE_USER_INPUT
+
+
+def test_resolve_resume_user_input_different_session_returns_candidate() -> None:
+    candidate = "Clarification: use option B"
+    result = resolve_resume_user_input(
+        candidate=candidate,
+        prior_cli="codex",
+        prior_session_id="abc",
+        current_cli="codex",
+        current_session_id="xyz",
+    )
+    assert result == candidate
+
+
+def test_resolve_resume_user_input_different_cli_returns_candidate() -> None:
+    candidate = "workflow execute"
+    result = resolve_resume_user_input(
+        candidate=candidate,
+        prior_cli="codex",
+        prior_session_id="abc",
+        current_cli="gemini",
+        current_session_id="abc",
+    )
+    assert result == candidate
+
+
+def test_resolve_resume_user_input_missing_prior_session_returns_candidate() -> None:
+    result = resolve_resume_user_input(
+        candidate="workflow execute",
+        prior_cli="codex",
+        prior_session_id=None,
+        current_cli="codex",
+        current_session_id="abc",
+    )
+    assert result == "workflow execute"
+
+
+def test_is_resume_iteration_when_iteration_gt_one() -> None:
+    assert is_resume_iteration(
+        iteration=2,
+        previous_iteration_data={"cli": "codex", "session_id": "a"},
+        current_iteration_data=None,
+    )
+
+
+def test_is_resume_iteration_first_start_is_false() -> None:
+    assert not is_resume_iteration(
+        iteration=1,
+        previous_iteration_data=None,
+        current_iteration_data=None,
+    )
+
+
+def test_is_resume_iteration_interrupted_reuse() -> None:
+    assert is_resume_iteration(
+        iteration=1,
+        previous_iteration_data=None,
+        current_iteration_data={"cli": "codex", "session_id": "a"},
+    )
+
+
+def test_load_prior_run_context_from_previous_iteration() -> None:
+    prev = {"cli": "codex", "session_id": "abc", "end_time": "done"}
+    assert load_prior_run_context(
+        iteration=2,
+        previous_iteration_data=prev,
+        current_iteration_data=None,
+    ) == prev
+
+
+def test_load_prior_run_context_from_current_partial() -> None:
+    current = {"cli": "codex", "session_id": "abc"}
+    assert load_prior_run_context(
+        iteration=1,
+        previous_iteration_data=None,
+        current_iteration_data=current,
+    ) == current
+
+
+def test_prior_cli_and_session_extracts_strings() -> None:
+    assert prior_cli_and_session({"cli": "codex", "session_id": "sid"}) == ("codex", "sid")
+    assert prior_cli_and_session(None) == (None, None)


### PR DESCRIPTION
## Summary

Closes [#299](https://github.com/luyotw/cafe/issues/299). When a workflow step resumes with the same agent CLI and session id as the prior run, CAFE now sends only `continue` as the iteration user input instead of replaying the full text—reducing token usage while keeping blackboard handoff context in the skill prompt. First-start iterations and resumes with a different session id still receive the full candidate input.

## Changes

- **`src/cafe/core/resume_user_input.py`** — New helper: `is_resume_iteration`, `resolve_resume_user_input`, prior-run context loading.
- **`src/cafe/phases/generic_workflow_step.py`** — Resolve resume user input from `step_user_inputs`, prewritten `user_input.md`, and prior `iteration.json`; apply `continue` to prompt runtime context via `transform_runtime_context`.
- **`src/cafe/phases/generic_phase.py`** — Invoke optional `transform_runtime_context` after `prepare_input` and before prompt build.
- **`src/cafe/core/phase.py`** — Always persist the resolved `user_input` sent to the agent in `user_input.md`.
- **`src/cafe/core/hooks/native.py`** — Load prewritten `user_input.md` in non-interactive resume before returning.
- **Tests** — Unit coverage for helper, resolver, prompt content, `user_input.md` artifact, and non-interactive hook behavior.

### Commits

| Commit | Description |
| --- | --- |
| `4fd9559` | Add resume user-input helper with unit tests |
| `4e19058` | Send continue on same-cli same-session resume |
| `e8d3a4c` | Apply continue to prompt context and user_input.md |

## Test Plan

- [x] `pytest tests/unit/test_resume_user_input.py` — helper behavior (first-start, same/different session/cli)
- [x] `pytest tests/unit/test_generic_workflow_step.py` — resolver, runtime context, full `execute_step` prompt and `user_input.md`
- [x] `pytest tests/unit/test_native_user_input_hook.py` — non-interactive prewritten `user_input.md`
- [x] Pre-commit full suite (2040+ passed on develop iteration 2)