### PR TITLE
Add Manage crew settings menu and legacy agents migration

### DIFF
--- a/src/cafe/ui/menu.py
+++ b/src/cafe/ui/menu.py
@@ -209,8 +209,22 @@ class InteractiveMenu:
             {"name": "Agent CLI & model setup", "value": "setup"},
             {"name": "View config", "value": "config"},
             {"name": "Edit config", "value": "config_edit"},
+            {"name": "Manage crew", "value": "crew_manage"},
             {"name": "Manage agents", "value": "agent_edit"},
             {"name": "Manage templates", "value": "template_edit"},
+            {"name": "Back", "value": "back"},
+        ]
+
+    def _build_crew_menu_choices(self) -> List[Dict[str, Any]]:
+        """Build the list of choices for the crew management submenu.
+
+        Returns:
+            List of InquirerPy choice dicts with "name" and "value" keys
+        """
+        return [
+            {"name": "List crew", "value": "crew_list"},
+            {"name": "Set primary CLI", "value": "crew_set_primary"},
+            {"name": "Set fallback CLI", "value": "crew_set_fallback"},
             {"name": "Back", "value": "back"},
         ]
 
@@ -306,10 +320,31 @@ class InteractiveMenu:
                 _run_command(["config"])
             elif selection == "config_edit":
                 _run_command(["config", "edit"])
+            elif selection == "crew_manage":
+                self._show_crew_menu()
             elif selection == "agent_edit":
                 _run_command(["agent", "edit"])
             elif selection == "template_edit":
                 _run_command(["template", "edit"])
+
+    def _show_crew_menu(self) -> None:
+        """Display the crew management submenu and handle the user's selection.
+
+        This menu loops until the user selects "Back".
+        """
+        while True:
+            choices = self._build_crew_menu_choices()
+            selection = prompt_list("CAFE  Manage crew", choices)
+
+            if selection == "back":
+                return
+
+            if selection == "crew_list":
+                _run_command(["crew", "list"])
+            elif selection == "crew_set_primary":
+                _run_command(["crew", "set-primary"])
+            elif selection == "crew_set_fallback":
+                _run_command(["crew", "set-fallback"])
 
     def _get_available_agents(self) -> List[Dict[str, str]]:
         """Get all configured agents.

--- a/src/cafe/utils/config.py
+++ b/src/cafe/utils/config.py
@@ -8,6 +8,7 @@ import json
 import time
 
 from cafe.core.types import AgentCLI
+from cafe.utils.crew import CrewManager
 
 
 class ConfigError(Exception):
@@ -176,6 +177,7 @@ class ConfigManager:
             )
 
         try:
+            CrewManager(cafe_dir=self.config_dir).migrate_legacy_agents_from_config()
             with open(self.config_file, "r") as f:
                 self._config = yaml.safe_load(f)
             if issue_config:

--- a/src/cafe/utils/crew.py
+++ b/src/cafe/utils/crew.py
@@ -1,5 +1,6 @@
 """Crew configuration management for CAFE."""
 
+import copy
 from pathlib import Path
 from typing import Any, Dict, List
 
@@ -167,3 +168,57 @@ class CrewManager:
         self.cafe_dir.mkdir(parents=True, exist_ok=True)
         with open(self.crew_file, "w") as f:
             yaml.dump(agents, f, default_flow_style=False, allow_unicode=True, sort_keys=False)
+
+    def _load_crew_file_only(self) -> Dict[str, Any]:
+        """Load crew.yaml only (no config.yaml agents fallback)."""
+        if not self.crew_file.exists():
+            return {}
+        try:
+            data = yaml.safe_load(self.crew_file.read_text())
+            return data if isinstance(data, dict) else {}
+        except yaml.YAMLError:
+            return {}
+
+    def migrate_legacy_agents_from_config(self) -> bool:
+        """Move legacy ``agents:`` from config.yaml into crew.yaml, then remove it.
+
+        Existing crew.yaml role entries are never overwritten. Returns True when
+        the config file had a non-empty ``agents`` block that was processed.
+        """
+        if not self.config_file.exists():
+            return False
+
+        try:
+            config_data = yaml.safe_load(self.config_file.read_text())
+        except yaml.YAMLError:
+            return False
+
+        if not isinstance(config_data, dict):
+            return False
+
+        legacy_agents = config_data.get("agents")
+        if not isinstance(legacy_agents, dict) or not legacy_agents:
+            return False
+
+        crew_data = self._load_crew_file_only()
+        merged_any = False
+        for role, role_config in legacy_agents.items():
+            if role in crew_data:
+                continue
+            if isinstance(role_config, dict):
+                crew_data[role] = copy.copy(role_config)
+                merged_any = True
+
+        if merged_any:
+            self.save(crew_data)
+
+        del config_data["agents"]
+        with open(self.config_file, "w") as f:
+            yaml.dump(
+                config_data,
+                f,
+                default_flow_style=False,
+                allow_unicode=True,
+                sort_keys=False,
+            )
+        return True

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -163,21 +163,21 @@ class TestConfigCommand:
         old_cwd = os.getcwd()
         try:
             os.chdir(tmp_path)
-            # Save custom config with dict structure for agents
             custom_config = {
+                "python_bin": "python3",
                 "agents": {
                     "pm": {"name": "Roger"}
-                }
+                },
             }
             config_manager = ConfigManager()
             config_manager.save_config(custom_config)
 
-            result = runner.invoke(app, ["config", "get", "agents.pm.name"])
+            result = runner.invoke(app, ["config", "get", "python_bin"])
         finally:
             os.chdir(old_cwd)
 
         assert result.exit_code == 0
-        assert "Roger" in result.stdout
+        assert "python3" in result.stdout
 
     def test_config_get_nonexistent_key(self, tmp_path: Path) -> None:
         """測試取得不存在設定值"""

--- a/tests/unit/test_cli_setup.py
+++ b/tests/unit/test_cli_setup.py
@@ -210,7 +210,9 @@ class TestSetupInteractiveFlow:
     def test_interactive_preserves_existing_agents_key(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Interactive setup does not remove an existing agents: key from config.yaml."""
+        """Interactive setup migrates legacy agents into crew.yaml without losing assignments."""
+        import yaml
+
         cafe_dir = tmp_path / ".cafe"
         cafe_dir.mkdir()
         original = {
@@ -228,6 +230,6 @@ class TestSetupInteractiveFlow:
 
         assert result.exit_code == 0
         cfg = _read_config(cafe_dir)
-        # agents key should be preserved (not written to, but not deleted either)
-        assert "agents" in cfg
-        assert cfg["agents"]["pm"]["cli"] == "claude"
+        assert "agents" not in cfg
+        crew = yaml.safe_load((cafe_dir / "crew.yaml").read_text())
+        assert crew["pm"]["cli"] == "claude"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 import yaml
 
 from cafe.utils.config import ConfigManager, ConfigError
+from cafe.utils.crew import CrewManager
 from cafe.core.types import AgentCLI
 
 
@@ -81,6 +82,27 @@ class TestLoadConfig:
 
         with pytest.raises(ConfigError, match="Failed to load config"):
             manager.load_config()
+
+    def test_load_config_migrates_legacy_agents_to_crew_yaml(self, tmp_path: Path) -> None:
+        """載入含 legacy agents 的 config 時會遷移至 crew.yaml 並清除 config agents。"""
+        config_dir = tmp_path / ".cafe"
+        config_dir.mkdir()
+        config_file = config_dir / "config.yaml"
+        config_file.write_text(
+            "python_bin: python3\n"
+            "agents:\n"
+            "  pm:\n    name: Roger\n    cli: copilot\n"
+        )
+
+        manager = ConfigManager(config_dir=str(config_dir))
+        loaded = manager.load_config()
+
+        assert "agents" not in loaded
+        assert loaded["python_bin"] == "python3"
+        crew_data = yaml.safe_load((config_dir / "crew.yaml").read_text())
+        assert crew_data["pm"]["name"] == "Roger"
+        config_on_disk = yaml.safe_load(config_file.read_text())
+        assert "agents" not in config_on_disk
 
 
 class TestDefaultConfig:
@@ -283,13 +305,17 @@ class TestResetConfig:
     def test_reset_persists_to_file(self, config_with_file) -> None:
         """測試重置會持久化到檔案"""
         config_with_file.set("agents.pm.cli", "claude")
+        crew_file = config_with_file.config_dir / "crew.yaml"
+        if crew_file.exists():
+            crew_file.unlink()
         config_with_file.reset()
 
         # Load with new manager
         manager2 = ConfigManager(config_dir=str(config_with_file.config_dir))
-        config = manager2.load_config()
+        manager2.load_config()
+        crew = CrewManager(cafe_dir=config_with_file.config_dir).load()
 
-        assert config["agents"]["pm"]["cli"] == "gemini"  # Default from get_default_config()
+        assert crew["pm"]["cli"] == "gemini"  # Default from get_default_config()
 
 
 class TestAliasResolution:
@@ -396,13 +422,12 @@ class TestConfigUnicodeHandling:
         # Save config
         config_manager.save_config(unicode_config)
 
-        # Load config back
-        loaded_config = config_manager.load_config()
+        config_manager.load_config()
+        crew = CrewManager(cafe_dir=config_dir).load()
 
-        # Verify Unicode characters are preserved (not escaped)
-        assert loaded_config["agents"]["developer"]["name"] == "黃建"
-        assert loaded_config["agents"]["pm"]["name"] == "方竹"
-        assert loaded_config["agents"]["reviewer"]["name"] == "安那"
+        assert crew["developer"]["name"] == "黃建"
+        assert crew["pm"]["name"] == "方竹"
+        assert crew["reviewer"]["name"] == "安那"
 
     def test_config_file_contains_readable_unicode(self, tmp_path: Path) -> None:
         """Test that saved config file contains readable Unicode (not escape sequences)."""
@@ -441,18 +466,18 @@ class TestConfigUnicodeHandling:
             "python_bin": "python3",
         }
 
-        # First save
         config_manager.save_config(original_config)
-        loaded_once = config_manager.load_config()
+        config_manager.load_config()
+        crew_once = CrewManager(cafe_dir=config_dir).load()
 
-        # Second save (with loaded config)
-        config_manager.save_config(loaded_once)
-        loaded_twice = config_manager.load_config()
+        config_manager.save_config({"python_bin": "python3"})
+        config_manager.load_config()
+        crew_twice = CrewManager(cafe_dir=config_dir).load()
 
-        # All Unicode should be preserved
         for agent_type in ["developer", "pm", "reviewer"]:
-            assert original_config["agents"][agent_type]["name"] == loaded_once["agents"][agent_type]["name"]
-            assert original_config["agents"][agent_type]["name"] == loaded_twice["agents"][agent_type]["name"]
+            expected = original_config["agents"][agent_type]["name"]
+            assert crew_once[agent_type]["name"] == expected
+            assert crew_twice[agent_type]["name"] == expected
 
 
 class TestGetAllowedDirectories:

--- a/tests/unit/test_crew_manager.py
+++ b/tests/unit/test_crew_manager.py
@@ -82,6 +82,63 @@ class TestCrewManagerLoad:
         assert data["pm"]["name"] == "CrewPM"
 
 
+class TestCrewManagerMigrateLegacyAgents:
+    """Test one-shot migration from config.yaml agents: to crew.yaml."""
+
+    def test_legacy_only_creates_crew_and_removes_agents(self, tmp_path: Path) -> None:
+        cafe_dir = tmp_path / ".cafe"
+        cafe_dir.mkdir()
+        config_yaml = cafe_dir / "config.yaml"
+        config_yaml.write_text(
+            "auto:\n  max_review_iterations: 3\n"
+            "agents:\n"
+            "  pm:\n    name: Roger\n    cli: copilot\n"
+            "  developer:\n    name: David\n    cli: copilot\n"
+        )
+        manager = CrewManager(cafe_dir=cafe_dir)
+        assert manager.migrate_legacy_agents_from_config() is True
+
+        crew_data = yaml.safe_load((cafe_dir / "crew.yaml").read_text())
+        assert crew_data["pm"]["name"] == "Roger"
+        assert crew_data["developer"]["name"] == "David"
+
+        config_data = yaml.safe_load(config_yaml.read_text())
+        assert "agents" not in config_data
+        assert config_data["auto"]["max_review_iterations"] == 3
+
+    def test_legacy_plus_existing_crew_preserves_crew_and_merges_missing(
+        self, tmp_path: Path
+    ) -> None:
+        cafe_dir = tmp_path / ".cafe"
+        cafe_dir.mkdir()
+        (cafe_dir / "crew.yaml").write_text("pm:\n  name: CrewPM\n  cli: claude\n")
+        config_yaml = cafe_dir / "config.yaml"
+        config_yaml.write_text(
+            "agents:\n"
+            "  pm:\n    name: ConfigPM\n    cli: copilot\n"
+            "  developer:\n    name: David\n    cli: copilot\n"
+        )
+        manager = CrewManager(cafe_dir=cafe_dir)
+        assert manager.migrate_legacy_agents_from_config() is True
+
+        crew_data = yaml.safe_load((cafe_dir / "crew.yaml").read_text())
+        assert crew_data["pm"]["name"] == "CrewPM"
+        assert crew_data["developer"]["name"] == "David"
+
+        config_data = yaml.safe_load(config_yaml.read_text())
+        assert "agents" not in config_data
+
+    def test_no_legacy_is_noop(self, tmp_path: Path) -> None:
+        cafe_dir = tmp_path / ".cafe"
+        cafe_dir.mkdir()
+        config_yaml = cafe_dir / "config.yaml"
+        config_yaml.write_text("auto:\n  max_review_iterations: 5\n")
+        manager = CrewManager(cafe_dir=cafe_dir)
+        assert manager.migrate_legacy_agents_from_config() is False
+        assert not (cafe_dir / "crew.yaml").exists()
+        assert yaml.safe_load(config_yaml.read_text()) == {"auto": {"max_review_iterations": 5}}
+
+
 class TestCrewManagerSave:
     """Test CrewManager.save()."""
 

--- a/tests/unit/test_menu.py
+++ b/tests/unit/test_menu.py
@@ -403,12 +403,16 @@ class TestInteractiveMenuSettingsSubmenu:
         choices = menu._build_settings_menu_choices()
 
         values = [c["value"] for c in choices]
+        names = [c["name"] for c in choices]
         assert "setup" in values
         assert "config" in values
         assert "config_edit" in values
+        assert "crew_manage" in values
         assert "agent_edit" in values
         assert "template_edit" in values
         assert "back" in values
+        assert "Manage crew" in names
+        assert "Manage agents" in names
 
     def test_settings_back_from_main_menu_returns_to_main(self):
         """測試從主選單進入設定後，Back 回到主選單"""
@@ -516,6 +520,217 @@ class TestInteractiveMenuSettingsSubmenu:
 
         called_cmds = [call[0][0] for call in mock_run.call_args_list]
         assert any("config" in cmd for cmd in called_cmds)
+
+    def test_settings_dispatches_agent_edit_command(self):
+        """測試選擇 Manage agents 時執行 cafe agent edit"""
+        detector = MagicMock(spec=MenuStateDetector)
+        detector.detect_state.return_value = MenuState.NO_ACTIVE_ISSUE
+        detector.get_current_issue_name.return_value = None
+
+        menu = InteractiveMenu(state_detector=detector)
+
+        with (
+            patch("cafe.ui.menu.prompt_list") as mock_prompt,
+            patch("cafe.ui.menu.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = MagicMock(returncode=0)
+            mock_prompt.side_effect = ["settings", "agent_edit", "back", "exit"]
+            menu.run()
+
+        called_cmds = [call[0][0] for call in mock_run.call_args_list]
+        assert any("agent" in cmd and "edit" in cmd for cmd in called_cmds)
+
+    def test_settings_manage_crew_enters_crew_submenu(self):
+        """測試從 Settings 選擇 Manage crew 會進入 crew 子選單"""
+        detector = MagicMock(spec=MenuStateDetector)
+        detector.detect_state.return_value = MenuState.NO_ACTIVE_ISSUE
+        detector.get_current_issue_name.return_value = None
+
+        menu = InteractiveMenu(state_detector=detector)
+        prompt_calls = []
+        settings_visits = 0
+        main_visits = 0
+
+        def prompt_side_effect(msg, choices, **kwargs):
+            values = [c["value"] for c in choices]
+            if "crew_list" in values:
+                prompt_calls.append("crew")
+                return "back"
+            if "crew_manage" in values:
+                nonlocal settings_visits
+                settings_visits += 1
+                if settings_visits == 1:
+                    prompt_calls.append("settings_to_crew")
+                    return "crew_manage"
+                return "back"
+            if "prepare" in values:
+                nonlocal main_visits
+                main_visits += 1
+                prompt_calls.append("main")
+                return "settings" if main_visits == 1 else "exit"
+            return "exit"
+
+        with patch("cafe.ui.menu.prompt_list", side_effect=prompt_side_effect):
+            menu.run()
+
+        assert "settings_to_crew" in prompt_calls
+        assert "crew" in prompt_calls
+
+
+class TestInteractiveMenuCrewSubmenu:
+    """Tests for crew management submenu."""
+
+    def test_crew_menu_shows_all_options(self):
+        """測試 crew 子選單顯示所有選項"""
+        detector = MagicMock(spec=MenuStateDetector)
+        menu = InteractiveMenu(state_detector=detector)
+        choices = menu._build_crew_menu_choices()
+
+        values = [c["value"] for c in choices]
+        assert "crew_list" in values
+        assert "crew_set_primary" in values
+        assert "crew_set_fallback" in values
+        assert "back" in values
+
+    def test_crew_menu_dispatches_list_command(self):
+        """測試選擇 List crew 時執行 cafe crew list"""
+        detector = MagicMock(spec=MenuStateDetector)
+        detector.detect_state.return_value = MenuState.NO_ACTIVE_ISSUE
+        detector.get_current_issue_name.return_value = None
+
+        menu = InteractiveMenu(state_detector=detector)
+
+        with (
+            patch("cafe.ui.menu.prompt_list") as mock_prompt,
+            patch("cafe.ui.menu.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = MagicMock(returncode=0)
+            mock_prompt.side_effect = ["settings", "crew_manage", "crew_list", "back", "back", "exit"]
+            menu.run()
+
+        called_cmds = [call[0][0] for call in mock_run.call_args_list]
+        assert any("crew" in cmd and "list" in cmd for cmd in called_cmds)
+
+    def test_crew_menu_dispatches_set_primary_command(self):
+        """測試選擇 Set primary CLI 時執行 cafe crew set-primary"""
+        detector = MagicMock(spec=MenuStateDetector)
+        detector.detect_state.return_value = MenuState.NO_ACTIVE_ISSUE
+        detector.get_current_issue_name.return_value = None
+
+        menu = InteractiveMenu(state_detector=detector)
+
+        with (
+            patch("cafe.ui.menu.prompt_list") as mock_prompt,
+            patch("cafe.ui.menu.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = MagicMock(returncode=0)
+            mock_prompt.side_effect = [
+                "settings",
+                "crew_manage",
+                "crew_set_primary",
+                "back",
+                "back",
+                "exit",
+            ]
+            menu.run()
+
+        called_cmds = [call[0][0] for call in mock_run.call_args_list]
+        assert any("crew" in cmd and "set-primary" in cmd for cmd in called_cmds)
+
+    def test_crew_menu_dispatches_set_fallback_command(self):
+        """測試選擇 Set fallback CLI 時執行 cafe crew set-fallback"""
+        detector = MagicMock(spec=MenuStateDetector)
+        detector.detect_state.return_value = MenuState.NO_ACTIVE_ISSUE
+        detector.get_current_issue_name.return_value = None
+
+        menu = InteractiveMenu(state_detector=detector)
+
+        with (
+            patch("cafe.ui.menu.prompt_list") as mock_prompt,
+            patch("cafe.ui.menu.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = MagicMock(returncode=0)
+            mock_prompt.side_effect = [
+                "settings",
+                "crew_manage",
+                "crew_set_fallback",
+                "back",
+                "back",
+                "exit",
+            ]
+            menu.run()
+
+        called_cmds = [call[0][0] for call in mock_run.call_args_list]
+        assert any("crew" in cmd and "set-fallback" in cmd for cmd in called_cmds)
+
+    def test_crew_menu_back_returns_to_settings(self):
+        """測試 crew 子選單 Back 回到 Settings"""
+        detector = MagicMock(spec=MenuStateDetector)
+        detector.detect_state.return_value = MenuState.NO_ACTIVE_ISSUE
+        detector.get_current_issue_name.return_value = None
+
+        menu = InteractiveMenu(state_detector=detector)
+        prompt_calls = []
+        settings_visits = 0
+        main_visits = 0
+
+        def prompt_side_effect(msg, choices, **kwargs):
+            values = [c["value"] for c in choices]
+            if "crew_list" in values:
+                prompt_calls.append("crew")
+                return "back"
+            if "crew_manage" in values:
+                nonlocal settings_visits
+                settings_visits += 1
+                prompt_calls.append("settings")
+                return "crew_manage" if settings_visits == 1 else "back"
+            if "prepare" in values:
+                nonlocal main_visits
+                main_visits += 1
+                return "settings" if main_visits == 1 else "exit"
+            return "exit"
+
+        with patch("cafe.ui.menu.prompt_list", side_effect=prompt_side_effect):
+            menu.run()
+
+        assert prompt_calls.count("settings") >= 2
+
+    def test_crew_menu_back_from_issue_menu_returns_to_issue(self):
+        """測試從 issue 選單進入 Settings → Manage crew → Back 回到 issue 選單"""
+        detector = MagicMock(spec=MenuStateDetector)
+        detector.detect_state.return_value = MenuState.ACTIVE_ISSUE
+        detector.get_current_issue_name.return_value = "my-issue"
+
+        menu = InteractiveMenu(state_detector=detector)
+        prompt_calls = []
+        settings_visits = 0
+        issue_visits = 0
+
+        def prompt_side_effect(msg, choices, **kwargs):
+            values = [c["value"] for c in choices]
+            if "make" in values:
+                nonlocal issue_visits
+                issue_visits += 1
+                prompt_calls.append("issue")
+                if issue_visits == 1:
+                    return "settings"
+                return "exit"
+            if "crew_list" in values:
+                prompt_calls.append("crew")
+                return "back"
+            if "crew_manage" in values:
+                nonlocal settings_visits
+                settings_visits += 1
+                prompt_calls.append("settings")
+                return "crew_manage" if settings_visits == 1 else "back"
+            return "exit"
+
+        with patch("cafe.ui.menu.prompt_list", side_effect=prompt_side_effect):
+            menu.run()
+
+        assert "issue" in prompt_calls
+        assert "crew" in prompt_calls
+        assert prompt_calls.count("issue") >= 2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements [issue #308](https://github.com/luyotw/cafe/issues/308) (spec: `.cafe/issues/issue308/spec/iteration_002/output.md`). The interactive Settings menu now separates **crew CLI assignment** from **agent persona editing**, and legacy `agents:` data in `config.yaml` is migrated once into `crew.yaml` on config load without overwriting existing crew entries.

## Changes

- **Settings menu**: Added `Manage crew` alongside `Manage agents`; persona flow still dispatches `cafe agent edit`.
- **Crew submenu**: Nested menu for `cafe crew list`, `set-primary`, and `set-fallback`, with Back returning to Settings (`src/cafe/ui/menu.py`).
- **Legacy migration**: `CrewManager.migrate_legacy_agents_from_config()` merges missing roles into `crew.yaml`, removes `agents:` from `config.yaml`; invoked from `ConfigManager.load_config()`.
- **Tests**: Migration cases (legacy-only, legacy+existing crew, no-legacy, load integration); menu choice building, dispatch, and crew submenu navigation; CLI/setup tests updated for post-migration config shape.
- **Commits**:
  - `281b651` issue308: migrate legacy agents from config.yaml to crew.yaml
  - `718dc72` issue308: add Manage crew submenu in interactive settings

## Test Plan

- [x] `pytest tests/unit/test_menu.py tests/unit/test_crew_manager.py tests/unit/test_config.py`
- [x] Full suite: `pytest` (2052 passed, 5 skipped, 1 xfailed)
- [ ] Manual: run `cafe` → Settings → confirm **Manage crew** and **Manage agents** both appear
- [ ] Manual: **Manage crew** → List crew / Set primary / Set fallback / Back
- [ ] Manual: project with legacy `agents:` in `config.yaml` → load config → verify `crew.yaml` populated and `agents:` removed