### PR TITLE
Add Manage allowed directories settings menu

### DIFF
--- a/src/cafe/ui/menu.py
+++ b/src/cafe/ui/menu.py
@@ -367,6 +367,10 @@ class InteractiveMenu:
 
         This menu loops until the user selects "Back".
         """
+        if not Path(".cafe/config.yaml").exists():
+            console.print("[yellow]Project not initialized. Run 'cafe init' first.[/yellow]")
+            return
+
         config_manager = ConfigManager()
         while True:
             choices = self._build_allowed_directories_menu_choices()

--- a/src/cafe/ui/menu.py
+++ b/src/cafe/ui/menu.py
@@ -210,6 +210,7 @@ class InteractiveMenu:
             {"name": "View config", "value": "config"},
             {"name": "Edit config", "value": "config_edit"},
             {"name": "Manage crew", "value": "crew_manage"},
+            {"name": "Manage allowed directories", "value": "allowed_dirs_manage"},
             {"name": "Manage agents", "value": "agent_edit"},
             {"name": "Manage templates", "value": "template_edit"},
             {"name": "Back", "value": "back"},
@@ -225,6 +226,19 @@ class InteractiveMenu:
             {"name": "List crew", "value": "crew_list"},
             {"name": "Set primary CLI", "value": "crew_set_primary"},
             {"name": "Set fallback CLI", "value": "crew_set_fallback"},
+            {"name": "Back", "value": "back"},
+        ]
+
+    def _build_allowed_directories_menu_choices(self) -> List[Dict[str, Any]]:
+        """Build the list of choices for the allowed directories submenu.
+
+        Returns:
+            List of InquirerPy choice dicts with "name" and "value" keys
+        """
+        return [
+            {"name": "List", "value": "allowed_dirs_list"},
+            {"name": "Add", "value": "allowed_dirs_add"},
+            {"name": "Remove", "value": "allowed_dirs_remove"},
             {"name": "Back", "value": "back"},
         ]
 
@@ -322,6 +336,8 @@ class InteractiveMenu:
                 _run_command(["config", "edit"])
             elif selection == "crew_manage":
                 self._show_crew_menu()
+            elif selection == "allowed_dirs_manage":
+                self._show_allowed_directories_menu()
             elif selection == "agent_edit":
                 _run_command(["agent", "edit"])
             elif selection == "template_edit":
@@ -345,6 +361,70 @@ class InteractiveMenu:
                 _run_command(["crew", "set-primary"])
             elif selection == "crew_set_fallback":
                 _run_command(["crew", "set-fallback"])
+
+    def _show_allowed_directories_menu(self) -> None:
+        """Display the allowed directories submenu and handle the user's selection.
+
+        This menu loops until the user selects "Back".
+        """
+        config_manager = ConfigManager()
+        while True:
+            choices = self._build_allowed_directories_menu_choices()
+            selection = prompt_list("CAFE  Manage allowed directories", choices)
+
+            if selection == "back":
+                return
+
+            if selection == "allowed_dirs_list":
+                self._handle_allowed_directories_list(config_manager)
+            elif selection == "allowed_dirs_add":
+                self._handle_allowed_directories_add(config_manager)
+            elif selection == "allowed_dirs_remove":
+                self._handle_allowed_directories_remove(config_manager)
+
+    def _handle_allowed_directories_list(self, config_manager: ConfigManager) -> None:
+        """Print current allowed directories."""
+        entries = config_manager.list_allowed_directories()
+        if not entries:
+            console.print("[yellow]No allowed directories configured.[/yellow]")
+            return
+        for entry in entries:
+            console.print(entry)
+
+    def _handle_allowed_directories_add(self, config_manager: ConfigManager) -> None:
+        """Prompt for a directory path and append it to allowed_directories."""
+        path = prompt_text("Directory path:")
+        if not path.strip():
+            return
+
+        check_path = Path(path.strip()).expanduser()
+        try:
+            check_path = check_path.resolve()
+        except (OSError, RuntimeError):
+            pass
+        if not check_path.is_dir():
+            console.print("[yellow]Warning: directory does not exist on disk; saving anyway.[/yellow]")
+
+        if config_manager.add_allowed_directory(path):
+            console.print("[green]Allowed directory added.[/green]")
+        else:
+            console.print("[yellow]Directory already in allowed list.[/yellow]")
+
+    def _handle_allowed_directories_remove(self, config_manager: ConfigManager) -> None:
+        """Prompt for an existing directory entry and remove it."""
+        entries = config_manager.list_allowed_directories()
+        if not entries:
+            console.print("[yellow]No allowed directories to remove.[/yellow]")
+            return
+
+        choices = [{"name": entry, "value": entry} for entry in entries]
+        choices.append({"name": "Back", "value": "back"})
+        selection = prompt_list("Select directory to remove:", choices)
+        if selection == "back":
+            return
+
+        config_manager.remove_allowed_directory(selection)
+        console.print("[green]Allowed directory removed.[/green]")
 
     def _get_available_agents(self) -> List[Dict[str, str]]:
         """Get all configured agents.

--- a/src/cafe/utils/config.py
+++ b/src/cafe/utils/config.py
@@ -291,6 +291,52 @@ class ConfigManager:
             return []
         return value
 
+    def list_allowed_directories(self) -> List[str]:
+        """Return the current allowed_directories list."""
+        return self.get_allowed_directories()
+
+    def add_allowed_directory(self, path: str) -> bool:
+        """Append a normalized path to allowed_directories if not already present."""
+        normalized = self._normalize_allowed_directory_path(path)
+        current = self.get_allowed_directories()
+        existing = {self._normalize_allowed_directory_path(entry) for entry in current}
+        if normalized in existing:
+            return False
+        self.set("allowed_directories", [*current, normalized])
+        return True
+
+    def remove_allowed_directory(self, path: str) -> bool:
+        """Remove the first allowed_directories entry matching the normalized path."""
+        normalized = self._normalize_allowed_directory_path(path)
+        current = self.get_allowed_directories()
+        updated: List[str] = []
+        removed = False
+        for entry in current:
+            if not removed and self._normalize_allowed_directory_path(entry) == normalized:
+                removed = True
+                continue
+            updated.append(entry)
+        if not removed:
+            return False
+        self.set("allowed_directories", updated)
+        return True
+
+    def _normalize_allowed_directory_path(self, path: str) -> str:
+        """Normalize a user-provided directory path for storage and comparison."""
+        expanded = Path(path.strip()).expanduser()
+        try:
+            resolved = expanded.resolve()
+        except (OSError, RuntimeError):
+            resolved = expanded
+
+        cwd = Path.cwd()
+        try:
+            if resolved.is_relative_to(cwd):
+                return resolved.relative_to(cwd).as_posix()
+        except ValueError:
+            pass
+        return resolved.as_posix()
+
     def set(self, key: str, value: Any) -> None:
         """Set configuration value.
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -518,6 +518,109 @@ class TestGetAllowedDirectories:
         assert manager2.get_allowed_directories() == []
 
 
+class TestAllowedDirectoryMutations:
+    """Test ConfigManager list/add/remove allowed_directories helpers."""
+
+    def test_list_allowed_directories_returns_empty_when_missing(self, tmp_path: Path) -> None:
+        """config.yaml 未含 allowed_directories 時 list 應回傳空 list。"""
+        config_dir = tmp_path / ".cafe"
+        config_dir.mkdir()
+        (config_dir / "config.yaml").write_text("agents: {}\n")
+        manager = ConfigManager(config_dir=str(config_dir))
+        manager.load_config()
+        assert manager.list_allowed_directories() == []
+
+    def test_add_allowed_directory_appends_and_persists(self, tmp_path: Path, monkeypatch) -> None:
+        """add_allowed_directory 應追加新路徑並寫入 config.yaml。"""
+        monkeypatch.chdir(tmp_path)
+        config_dir = tmp_path / ".cafe"
+        config_dir.mkdir()
+        (config_dir / "config.yaml").write_text("agents: {}\n")
+        (tmp_path / "docs").mkdir()
+
+        manager = ConfigManager(config_dir=str(config_dir))
+        manager.load_config()
+        assert manager.add_allowed_directory("docs") is True
+        assert manager.get_allowed_directories() == ["docs"]
+
+        reloaded = ConfigManager(config_dir=str(config_dir))
+        reloaded.load_config()
+        assert reloaded.get_allowed_directories() == ["docs"]
+
+    def test_add_allowed_directory_dedupes_duplicate(self, tmp_path: Path, monkeypatch) -> None:
+        """重複加入相同路徑時應回傳 False 且不產生第二筆。"""
+        monkeypatch.chdir(tmp_path)
+        config_dir = tmp_path / ".cafe"
+        config_dir.mkdir()
+        (config_dir / "config.yaml").write_text("agents: {}\nallowed_directories:\n  - src\n")
+        (tmp_path / "src").mkdir()
+
+        manager = ConfigManager(config_dir=str(config_dir))
+        manager.load_config()
+        assert manager.add_allowed_directory("src") is False
+        assert manager.get_allowed_directories() == ["src"]
+
+    def test_add_allowed_directory_dedupes_equivalent_paths(self, tmp_path: Path, monkeypatch) -> None:
+        """正規化後等價的路徑不應重複加入。"""
+        monkeypatch.chdir(tmp_path)
+        config_dir = tmp_path / ".cafe"
+        config_dir.mkdir()
+        (config_dir / "config.yaml").write_text("agents: {}\n")
+        (tmp_path / "src").mkdir()
+
+        manager = ConfigManager(config_dir=str(config_dir))
+        manager.load_config()
+        assert manager.add_allowed_directory("./src") is True
+        assert manager.add_allowed_directory("src") is False
+        assert manager.get_allowed_directories() == ["src"]
+
+    def test_add_allowed_directory_preserves_other_config_keys(self, tmp_path: Path, monkeypatch) -> None:
+        """新增 allowed directory 時應保留其他 config 鍵與順序。"""
+        monkeypatch.chdir(tmp_path)
+        config_dir = tmp_path / ".cafe"
+        config_dir.mkdir()
+        original = "agents: {}\nallowed_directories:\n  - src\nextra: kept\n"
+        (config_dir / "config.yaml").write_text(original)
+        (tmp_path / "tests").mkdir()
+
+        manager = ConfigManager(config_dir=str(config_dir))
+        manager.load_config()
+        assert manager.add_allowed_directory("tests") is True
+
+        saved = (config_dir / "config.yaml").read_text()
+        assert saved.index("agents:") < saved.index("allowed_directories:")
+        assert "extra: kept" in saved
+        assert manager.get_allowed_directories() == ["src", "tests"]
+
+    def test_remove_allowed_directory_removes_existing(self, tmp_path: Path) -> None:
+        """remove_allowed_directory 應移除既有項目並持久化。"""
+        config_dir = tmp_path / ".cafe"
+        config_dir.mkdir()
+        (config_dir / "config.yaml").write_text(
+            "agents: {}\nallowed_directories:\n  - src\n  - tests\n"
+        )
+
+        manager = ConfigManager(config_dir=str(config_dir))
+        manager.load_config()
+        assert manager.remove_allowed_directory("src") is True
+        assert manager.get_allowed_directories() == ["tests"]
+
+        reloaded = ConfigManager(config_dir=str(config_dir))
+        reloaded.load_config()
+        assert reloaded.get_allowed_directories() == ["tests"]
+
+    def test_remove_allowed_directory_noop_when_missing(self, tmp_path: Path) -> None:
+        """移除不存在的路徑時應回傳 False 且 list 不變。"""
+        config_dir = tmp_path / ".cafe"
+        config_dir.mkdir()
+        (config_dir / "config.yaml").write_text("agents: {}\nallowed_directories:\n  - src\n")
+
+        manager = ConfigManager(config_dir=str(config_dir))
+        manager.load_config()
+        assert manager.remove_allowed_directory("nope") is False
+        assert manager.get_allowed_directories() == ["src"]
+
+
 class TestValidateDirectoriesExist:
     """Test validate_directories_exist()."""
 

--- a/tests/unit/test_menu.py
+++ b/tests/unit/test_menu.py
@@ -893,6 +893,43 @@ class TestInteractiveMenuAllowedDirectoriesSubmenu:
         mock_prompt.assert_not_called()
         assert mock_print.call_count == 1
 
+    def test_allowed_directories_menu_without_config_shows_message(self, tmp_path, monkeypatch):
+        """測試未初始化專案時進入 allowed directories 子選單會顯示提示且不拋例外"""
+        monkeypatch.chdir(tmp_path)
+        menu = InteractiveMenu()
+
+        with (
+            patch("cafe.ui.menu.ConfigManager") as mock_config_cls,
+            patch("cafe.ui.menu.console.print") as mock_print,
+        ):
+            menu._show_allowed_directories_menu()
+
+        mock_config_cls.assert_not_called()
+        assert mock_print.call_count == 1
+
+    def test_allowed_directories_menu_without_config_returns_to_settings(self, tmp_path, monkeypatch):
+        """測試未初始化專案時 Settings → Manage allowed directories 可安全返回"""
+        monkeypatch.chdir(tmp_path)
+        detector = MagicMock(spec=MenuStateDetector)
+        detector.detect_state.return_value = MenuState.NOT_INITIALIZED
+        detector.get_current_issue_name.return_value = None
+
+        menu = InteractiveMenu(state_detector=detector)
+
+        with (
+            patch("cafe.ui.menu.prompt_list") as mock_prompt,
+            patch("cafe.ui.menu.console.print") as mock_print,
+        ):
+            mock_prompt.side_effect = ["settings", "allowed_dirs_manage", "back", "exit"]
+            menu.run()
+
+        for call in mock_prompt.call_args_list:
+            values = [c["value"] for c in call[0][1]]
+            assert "allowed_dirs_list" not in values
+
+        printed = [str(call.args[0]) for call in mock_print.call_args_list]
+        assert any("init" in text.lower() for text in printed)
+
     def test_allowed_directories_remove_deletes_selected_entry(self):
         """測試 Remove 會移除使用者選擇的 entry"""
         detector = MagicMock(spec=MenuStateDetector)

--- a/tests/unit/test_menu.py
+++ b/tests/unit/test_menu.py
@@ -408,10 +408,12 @@ class TestInteractiveMenuSettingsSubmenu:
         assert "config" in values
         assert "config_edit" in values
         assert "crew_manage" in values
+        assert "allowed_dirs_manage" in values
         assert "agent_edit" in values
         assert "template_edit" in values
         assert "back" in values
         assert "Manage crew" in names
+        assert "Manage allowed directories" in names
         assert "Manage agents" in names
 
     def test_settings_back_from_main_menu_returns_to_main(self):
@@ -576,6 +578,41 @@ class TestInteractiveMenuSettingsSubmenu:
         assert "settings_to_crew" in prompt_calls
         assert "crew" in prompt_calls
 
+    def test_settings_manage_allowed_directories_enters_submenu(self):
+        """測試從 Settings 選擇 Manage allowed directories 會進入子選單"""
+        detector = MagicMock(spec=MenuStateDetector)
+        detector.detect_state.return_value = MenuState.NO_ACTIVE_ISSUE
+        detector.get_current_issue_name.return_value = None
+
+        menu = InteractiveMenu(state_detector=detector)
+        prompt_calls = []
+        settings_visits = 0
+        main_visits = 0
+
+        def prompt_side_effect(msg, choices, **kwargs):
+            nonlocal settings_visits, main_visits
+            values = [c["value"] for c in choices]
+            if "allowed_dirs_list" in values:
+                prompt_calls.append("allowed_dirs")
+                return "back"
+            if "allowed_dirs_manage" in values:
+                settings_visits += 1
+                if settings_visits == 1:
+                    prompt_calls.append("settings_to_allowed_dirs")
+                    return "allowed_dirs_manage"
+                return "back"
+            if "prepare" in values:
+                main_visits += 1
+                prompt_calls.append("main")
+                return "settings" if main_visits == 1 else "exit"
+            return "exit"
+
+        with patch("cafe.ui.menu.prompt_list", side_effect=prompt_side_effect):
+            menu.run()
+
+        assert "settings_to_allowed_dirs" in prompt_calls
+        assert "allowed_dirs" in prompt_calls
+
 
 class TestInteractiveMenuCrewSubmenu:
     """Tests for crew management submenu."""
@@ -731,6 +768,145 @@ class TestInteractiveMenuCrewSubmenu:
         assert "issue" in prompt_calls
         assert "crew" in prompt_calls
         assert prompt_calls.count("issue") >= 2
+
+
+class TestInteractiveMenuAllowedDirectoriesSubmenu:
+    """Tests for allowed directories management submenu."""
+
+    def test_allowed_directories_menu_shows_all_options(self):
+        """測試 allowed directories 子選單顯示所有選項"""
+        detector = MagicMock(spec=MenuStateDetector)
+        menu = InteractiveMenu(state_detector=detector)
+        choices = menu._build_allowed_directories_menu_choices()
+
+        values = [c["value"] for c in choices]
+        assert "allowed_dirs_list" in values
+        assert "allowed_dirs_add" in values
+        assert "allowed_dirs_remove" in values
+        assert "back" in values
+
+    def test_allowed_directories_menu_back_returns_to_settings(self):
+        """測試 allowed directories 子選單 Back 回到 Settings"""
+        detector = MagicMock(spec=MenuStateDetector)
+        detector.detect_state.return_value = MenuState.NO_ACTIVE_ISSUE
+        detector.get_current_issue_name.return_value = None
+
+        menu = InteractiveMenu(state_detector=detector)
+        prompt_calls = []
+        settings_visits = 0
+        main_visits = 0
+
+        def prompt_side_effect(msg, choices, **kwargs):
+            nonlocal settings_visits, main_visits
+            values = [c["value"] for c in choices]
+            if "allowed_dirs_list" in values:
+                prompt_calls.append("allowed_dirs")
+                return "back"
+            if "allowed_dirs_manage" in values:
+                settings_visits += 1
+                prompt_calls.append("settings")
+                return "allowed_dirs_manage" if settings_visits == 1 else "back"
+            if "prepare" in values:
+                main_visits += 1
+                return "settings" if main_visits == 1 else "exit"
+            return "exit"
+
+        with patch("cafe.ui.menu.prompt_list", side_effect=prompt_side_effect):
+            menu.run()
+
+        assert prompt_calls.count("settings") >= 2
+
+    def test_allowed_directories_list_prints_entries(self):
+        """測試 List 會列出目前 allowed directories"""
+        detector = MagicMock(spec=MenuStateDetector)
+        menu = InteractiveMenu(state_detector=detector)
+        mock_config = MagicMock()
+        mock_config.list_allowed_directories.return_value = ["src", "tests"]
+
+        with patch("cafe.ui.menu.console.print") as mock_print:
+            menu._handle_allowed_directories_list(mock_config)
+
+        mock_config.list_allowed_directories.assert_called_once()
+        printed = [call.args[0] for call in mock_print.call_args_list]
+        assert "src" in printed
+        assert "tests" in printed
+
+    def test_allowed_directories_list_empty_prints_message(self):
+        """測試 List 在空 list 時顯示訊息"""
+        detector = MagicMock(spec=MenuStateDetector)
+        menu = InteractiveMenu(state_detector=detector)
+        mock_config = MagicMock()
+        mock_config.list_allowed_directories.return_value = []
+
+        with patch("cafe.ui.menu.console.print") as mock_print:
+            menu._handle_allowed_directories_list(mock_config)
+
+        assert mock_print.call_count == 1
+
+    def test_allowed_directories_add_warns_and_saves_missing_directory(self, tmp_path, monkeypatch):
+        """測試 Add 對不存在目錄顯示警告但仍呼叫 add_allowed_directory"""
+        monkeypatch.chdir(tmp_path)
+        detector = MagicMock(spec=MenuStateDetector)
+        menu = InteractiveMenu(state_detector=detector)
+        mock_config = MagicMock()
+        mock_config.add_allowed_directory.return_value = True
+
+        with (
+            patch("cafe.ui.menu.prompt_text", return_value="missing-dir"),
+            patch("cafe.ui.menu.console.print") as mock_print,
+        ):
+            menu._handle_allowed_directories_add(mock_config)
+
+        mock_config.add_allowed_directory.assert_called_once_with("missing-dir")
+        printed = [str(call.args[0]) for call in mock_print.call_args_list]
+        assert any("Warning" in text for text in printed)
+
+    def test_allowed_directories_add_duplicate_does_not_add_twice(self, tmp_path, monkeypatch):
+        """測試 Add 重複路徑時 add_allowed_directory 回傳 False"""
+        monkeypatch.chdir(tmp_path)
+        detector = MagicMock(spec=MenuStateDetector)
+        menu = InteractiveMenu(state_detector=detector)
+        mock_config = MagicMock()
+        mock_config.add_allowed_directory.return_value = False
+
+        with (
+            patch("cafe.ui.menu.prompt_text", return_value="src"),
+            patch("cafe.ui.menu.console.print"),
+        ):
+            menu._handle_allowed_directories_add(mock_config)
+
+        mock_config.add_allowed_directory.assert_called_once_with("src")
+
+    def test_allowed_directories_remove_empty_prints_message(self):
+        """測試 Remove 在空 list 時顯示訊息且不呼叫 prompt_list 選 entry"""
+        detector = MagicMock(spec=MenuStateDetector)
+        menu = InteractiveMenu(state_detector=detector)
+        mock_config = MagicMock()
+        mock_config.list_allowed_directories.return_value = []
+
+        with (
+            patch("cafe.ui.menu.prompt_list") as mock_prompt,
+            patch("cafe.ui.menu.console.print") as mock_print,
+        ):
+            menu._handle_allowed_directories_remove(mock_config)
+
+        mock_prompt.assert_not_called()
+        assert mock_print.call_count == 1
+
+    def test_allowed_directories_remove_deletes_selected_entry(self):
+        """測試 Remove 會移除使用者選擇的 entry"""
+        detector = MagicMock(spec=MenuStateDetector)
+        menu = InteractiveMenu(state_detector=detector)
+        mock_config = MagicMock()
+        mock_config.list_allowed_directories.return_value = ["src", "tests"]
+
+        with (
+            patch("cafe.ui.menu.prompt_list", return_value="src"),
+            patch("cafe.ui.menu.console.print"),
+        ):
+            menu._handle_allowed_directories_remove(mock_config)
+
+        mock_config.remove_allowed_directory.assert_called_once_with("src")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements [issue #309](https://github.com/luyotw/cafe/issues/309) (spec: `.cafe/issues/issue309/spec/iteration_002/output.md`). The interactive Settings menu now includes **Manage allowed directories**, a submenu to list, add, and remove entries in `.cafe/config.yaml` `allowed_directories` without manual YAML editing. All persistence goes through new `ConfigManager` helpers; workflow and CLI `--add-dir` behavior are unchanged.

## Changes

- **ConfigManager** (`src/cafe/utils/config.py`): Added `list_allowed_directories()`, `add_allowed_directory()`, `remove_allowed_directory()`, and path normalization (strip, expanduser, resolve, prefer relative paths under cwd). Dedupes on normalized form; remove is a no-op when the entry is missing.
- **Settings menu** (`src/cafe/ui/menu.py`): Added **Manage allowed directories** entry and nested submenu (List / Add / Remove / Back). Add warns on non-existent paths but still saves; remove shows a message when the list is empty.
- **Review fix**: Guard uninitialized projects — if `.cafe/config.yaml` is missing, show a recoverable init message instead of raising `ConfigError`.
- **Tests**: `TestAllowedDirectoryMutations` (7 cases); `TestInteractiveMenuAllowedDirectoriesSubmenu` (10 cases including missing-config navigation).
- **Commits**:
  - `e35829d` issue309: add ConfigManager allowed directory helpers
  - `f4a7ec0` issue309: add allowed directories settings submenu and handlers
  - `0b17e8a` issue309: add allowed directories menu tests
  - `1d6292d` issue309: handle missing config in allowed directories menu

## Test Plan

- [x] `pytest tests/unit/test_config.py::TestAllowedDirectoryMutations tests/unit/test_menu.py::TestInteractiveMenuAllowedDirectoriesSubmenu -q`
- [x] Full suite: `pytest` (2070 passed, 5 skipped, 1 xfailed)
- [ ] Manual: run `cafe` → Settings → **Manage allowed directories** → List / Add / Remove / Back
- [ ] Manual: add a duplicate path and confirm only one entry remains
- [ ] Manual: add a non-existent path and confirm warning without blocking save
- [ ] Manual: on an uninitialized project, confirm Settings → Manage allowed directories shows init message and returns safely