### PR TITLE
issue317: align workflow, worktree, and skill install tests

### DIFF
--- a/tests/MIGRATION.md
+++ b/tests/MIGRATION.md
@@ -160,3 +160,44 @@ Final verification: `rg 'SpecPhase|PlanPhase|DevelopPhase|ReviewPhase|PRPhase' s
 | Option B (delete `phases_legacy.py`) | Adopted in issue #315 after Option A served its transition period |
 | Per-phase Python classes | Already removed in #289–#293; this issue scrubs cosmetic names only |
 | “being retired” legacy CLI copy | Replaced with explicit alias-to-workflow messaging |
+
+## Issue 317 — Workflow/worktree/skill test audit
+
+GitHub: issue #317
+
+Baseline (issue317 develop): `uv run --with pytest pytest tests/unit tests/integration -q` → 2017 passed, 1 skipped, 1 xfailed (before changes); **2022 passed**, 1 skipped, 1 xfailed (after issue317 additions).
+
+### Inventory (keep / update / delete / add)
+
+| File / area | Disposition | Notes |
+| --- | --- | --- |
+| `tests/unit/test_skill_loader.py` | **keep** | project > global > builtin precedence; project `install_skill` body |
+| `tests/unit/test_generic_phase.py` | **keep** | project-local native skill install paths |
+| `tests/unit/test_generic_workflow_step.py` | **keep** | workflow-common + phase skill install per step |
+| `tests/unit/test_workflow_runtime.py` | **keep** | structured baton default; `test_runtime_rejects_legacy_text_baton_in_core_path`; agent-step legacy normalize (`test_runtime_normalizes_legacy_baton_written_by_pr_agent`) as explicit boundary |
+| `tests/unit/test_workflow_models.py` | **keep** | `allow_legacy_text` legacy step-name fallback; invalid JSON still rejects |
+| `tests/unit/test_phases_legacy_retired.py` | **update** | guardrail for retired `cafe spec|plan|…`; add `cafe workflow --start-step spec` dry-run |
+| `tests/unit/test_issue_yaml_config.py` | **update** | docstrings only (remove SpecPhase/PlanPhase mirror wording) |
+| `tests/integration/test_workflow_e2e.py` | **keep** | happy path, pause/resume, baton handoff |
+| `tests/integration/test_*_clarification_runtime.py` | **keep** | per-step user pause contracts |
+| `tests/unit/test_git_worktree.py` | **keep** | git worktree plumbing only |
+| `tests/unit/test_cli_prepare.py`, `test_prepare_non_github.py` | **keep** | prepare/close worktree options |
+| `tests/unit/test_parallel_skill_install.py` | **add** | parallel workflow installs isolated per project root; no home-dir writes |
+| `tests/integration/test_worktree_workflow_parallel.py` | **add** | worktree cwd workflow pause→resume; two worktrees / two issues isolated |
+
+### Added coverage
+
+| Behavior | New location |
+| --- | --- |
+| Parallel CAFE workflows install skills without cross-writing | `tests/unit/test_parallel_skill_install.py` |
+| `install_skill` does not populate user home native skills dir | `tests/unit/test_parallel_skill_install.py` |
+| Workflow in git worktree: spec user pause then advance toward plan | `tests/integration/test_worktree_workflow_parallel.py` |
+| Parallel worktrees: separate blackboard/baton/artifacts per issue | `tests/integration/test_worktree_workflow_parallel.py` |
+| `cafe workflow --start-step spec` supported; `cafe spec` unknown | `tests/unit/test_phases_legacy_retired.py` |
+
+### Removed-by-design (issue317)
+
+| Behavior | Rationale |
+| --- | --- |
+| Duplicate legacy-text baton tests outside runtime/models boundaries | No additional deletes this pass; runtime agent-step normalize kept as single integration boundary alongside `test_workflow_models.allow_legacy_text` |
+| Tests asserting global home as default install target | None found; new contract tests lock project-local install |

--- a/tests/integration/test_worktree_workflow_parallel.py
+++ b/tests/integration/test_worktree_workflow_parallel.py
@@ -89,7 +89,7 @@ def _write_agent_baton(
 def test_worktree_workflow_spec_pause_resume_reaches_plan(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Workflow driven from a linked worktree keeps artifacts under that worktree."""
+    """Workflow in a worktree pauses at user, resumes on spec, and reaches plan."""
     git = _init_repo_with_cafe(tmp_path, monkeypatch)
     main_repo = Path.cwd()
     worktree_path = tmp_path / "repo" / "worktrees" / "feature-wt"
@@ -103,9 +103,12 @@ def test_worktree_workflow_spec_pause_resume_reaches_plan(
         nonlocal spec_calls
         artifact_key = str(step_def.get("output_artifact", step_name))
         rel_path = f"{step_name}/iteration_001/output.md"
+        artifact_path = issue_dir / rel_path
+        artifact_path.parent.mkdir(parents=True, exist_ok=True)
         if step_name == "spec":
             spec_calls += 1
             if spec_calls == 1:
+                artifact_path.write_text("# Spec draft\n", encoding="utf-8")
                 _write_agent_baton(
                     issue_dir,
                     from_step="spec",
@@ -115,10 +118,11 @@ def test_worktree_workflow_spec_pause_resume_reaches_plan(
                 )
                 return StepExecutionResult(
                     response="confirm_output",
-                    artifacts={artifact_key: rel_path},
+                    artifacts={artifact_key: str(artifact_path)},
                     status_code="confirm_output",
                     auto_continue=False,
                 )
+            artifact_path.write_text("# Spec confirmed\n", encoding="utf-8")
             _write_agent_baton(
                 issue_dir,
                 from_step="spec",
@@ -127,16 +131,12 @@ def test_worktree_workflow_spec_pause_resume_reaches_plan(
                 intent="await_agent",
             )
         elif step_name == "plan":
-            _write_agent_baton(
-                issue_dir,
-                from_step="plan",
-                to_owner="user",
-                to_step="user",
-                intent="confirm_output",
-            )
+            artifact_path.write_text("# Plan\n", encoding="utf-8")
+        else:
+            artifact_path.write_text(f"# {step_name}\n", encoding="utf-8")
         return StepExecutionResult(
             response="confirmed",
-            artifacts={artifact_key: rel_path},
+            artifacts={artifact_key: str(artifact_path)},
             status_code="confirmed",
         )
 
@@ -144,20 +144,46 @@ def test_worktree_workflow_spec_pause_resume_reaches_plan(
     issue_dir = worktree_path / ".cafe" / "issues" / issue_name
     issue_dir.mkdir(parents=True)
 
-    result = _run_until_settled(
+    runner = BlackboardWorkflowRuntime(
         issue_dir=issue_dir,
         playbook=playbook,
         executor=executor,
-        start_step="spec",
     )
+    paused = runner.run(start_step="spec", max_transitions=10)
 
-    assert result is not None
+    assert paused.completed is False
     blackboard = BlackboardStore(issue_dir).load_or_create("spec")
-    assert blackboard.current_step in {"plan", "user"}
+    assert blackboard.current_step == "user"
+    assert spec_calls == 1
+    pause_events = [e for e in blackboard.events if e.event_type == "workflow_paused"]
+    assert pause_events
+
+    with pytest.raises(RuntimeError, match="max transition limit"):
+        BlackboardWorkflowRuntime(
+            issue_dir=issue_dir,
+            playbook=playbook,
+            executor=executor,
+        ).run(start_step="spec", max_transitions=2)
+
+    assert spec_calls == 2
+    blackboard = BlackboardStore(issue_dir).load_or_create("spec")
+    plan_started = [
+        e
+        for e in blackboard.events
+        if e.event_type == "step_started" and e.data.get("step") == "plan"
+    ]
+    plan_completed = [
+        e
+        for e in blackboard.events
+        if e.event_type == "step_completed" and e.data.get("step") == "plan"
+    ]
+    assert plan_started
+    assert plan_completed
+    plan_artifact = issue_dir / "plan" / "iteration_001" / "output.md"
+    assert plan_artifact.exists()
+    assert plan_artifact.read_text(encoding="utf-8") == "# Plan\n"
     assert str(issue_dir).startswith(str(worktree_path.resolve()))
     assert not (main_repo / ".cafe" / "issues" / issue_name).exists()
-    plan_artifact = issue_dir / "plan" / "iteration_001" / "output.md"
-    assert plan_artifact.exists() or blackboard.current_step == "user"
 
 
 def test_parallel_worktrees_keep_issue_state_isolated(

--- a/tests/integration/test_worktree_workflow_parallel.py
+++ b/tests/integration/test_worktree_workflow_parallel.py
@@ -1,0 +1,234 @@
+"""Integration tests for CAFE workflows inside git worktrees and parallel issue isolation."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from cafe.core.blackboard import BlackboardStore, HandoffIntent, HandoffOwner
+from cafe.core.git import GitOperations
+from cafe.core.workflow_models import StepExecutionResult
+from cafe.core.workflow_runtime import BlackboardWorkflowRuntime
+from cafe.playbooks.loader import PlaybookLoader
+from tests.conftest import create_minimal_config
+
+
+def _init_repo_with_cafe(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> GitOperations:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.setenv("GIT_CEILING_DIRECTORIES", str(tmp_path))
+    monkeypatch.chdir(repo)
+    for var in ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE"):
+        monkeypatch.delenv(var, raising=False)
+    git = GitOperations(str(repo))
+    git.run_git("init", "-b", "main")
+    git.run_git("config", "user.email", "test@example.com")
+    git.run_git("config", "user.name", "Test User")
+    create_minimal_config(repo)
+    (repo / "README.md").write_text("root\n", encoding="utf-8")
+    git.run_git("add", ".")
+    git.commit("Initial commit")
+    return git
+
+
+def _run_until_settled(
+    *,
+    issue_dir: Path,
+    playbook: dict,
+    executor,
+    start_step: str = "spec",
+    max_transitions: int = 20,
+):
+    last_result = None
+    pending_start: str | None = start_step
+    for _ in range(8):
+        runner = BlackboardWorkflowRuntime(
+            issue_dir=issue_dir,
+            playbook=playbook,
+            executor=executor,
+        )
+        last_result = runner.run(start_step=pending_start, max_transitions=max_transitions)
+        latest = BlackboardStore(issue_dir).load_or_create(
+            str(playbook.get("entry_point") or next(iter(playbook["steps"].keys()))),
+            playbook_id=str(playbook["playbook"]["id"]),
+        )
+        if last_result.completed:
+            return last_result
+        if latest.current_step in {"user", "done"}:
+            return last_result
+        pending_start = latest.current_step
+    return last_result
+
+
+def _write_agent_baton(
+    issue_dir: Path,
+    *,
+    from_step: str,
+    to_owner: str,
+    to_step: str,
+    intent: str,
+) -> None:
+    payload = {
+        "version": 1,
+        "from_step": from_step,
+        "to_owner": to_owner,
+        "to_step": to_step,
+        "intent": intent,
+        "status_code": "",
+        "created_at": "2026-05-25T12:00:00+08:00",
+        "source": from_step,
+    }
+    (issue_dir / "next_step.txt").write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+
+def test_worktree_workflow_spec_pause_resume_reaches_plan(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Workflow driven from a linked worktree keeps artifacts under that worktree."""
+    git = _init_repo_with_cafe(tmp_path, monkeypatch)
+    main_repo = Path.cwd()
+    worktree_path = tmp_path / "repo" / "worktrees" / "feature-wt"
+    git.create_worktree(str(worktree_path), "feature-wt", "main")
+
+    playbook = PlaybookLoader().load("default")
+    issue_name = "issue-wt-flow"
+    spec_calls = 0
+
+    def executor(step_name: str, step_def: dict, state) -> StepExecutionResult:
+        nonlocal spec_calls
+        artifact_key = str(step_def.get("output_artifact", step_name))
+        rel_path = f"{step_name}/iteration_001/output.md"
+        if step_name == "spec":
+            spec_calls += 1
+            if spec_calls == 1:
+                _write_agent_baton(
+                    issue_dir,
+                    from_step="spec",
+                    to_owner="user",
+                    to_step="user",
+                    intent="confirm_output",
+                )
+                return StepExecutionResult(
+                    response="confirm_output",
+                    artifacts={artifact_key: rel_path},
+                    status_code="confirm_output",
+                    auto_continue=False,
+                )
+            _write_agent_baton(
+                issue_dir,
+                from_step="spec",
+                to_owner="agent",
+                to_step="plan",
+                intent="await_agent",
+            )
+        elif step_name == "plan":
+            _write_agent_baton(
+                issue_dir,
+                from_step="plan",
+                to_owner="user",
+                to_step="user",
+                intent="confirm_output",
+            )
+        return StepExecutionResult(
+            response="confirmed",
+            artifacts={artifact_key: rel_path},
+            status_code="confirmed",
+        )
+
+    monkeypatch.chdir(worktree_path)
+    issue_dir = worktree_path / ".cafe" / "issues" / issue_name
+    issue_dir.mkdir(parents=True)
+
+    result = _run_until_settled(
+        issue_dir=issue_dir,
+        playbook=playbook,
+        executor=executor,
+        start_step="spec",
+    )
+
+    assert result is not None
+    blackboard = BlackboardStore(issue_dir).load_or_create("spec")
+    assert blackboard.current_step in {"plan", "user"}
+    assert str(issue_dir).startswith(str(worktree_path.resolve()))
+    assert not (main_repo / ".cafe" / "issues" / issue_name).exists()
+    plan_artifact = issue_dir / "plan" / "iteration_001" / "output.md"
+    assert plan_artifact.exists() or blackboard.current_step == "user"
+
+
+def test_parallel_worktrees_keep_issue_state_isolated(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two worktrees running different issues do not share blackboard or baton files."""
+    git = _init_repo_with_cafe(tmp_path, monkeypatch)
+    wt_a = tmp_path / "repo" / "worktrees" / "wt-a"
+    wt_b = tmp_path / "repo" / "worktrees" / "wt-b"
+    git.create_worktree(str(wt_a), "wt-a", "main")
+    git.create_worktree(str(wt_b), "wt-b", "main")
+
+    playbook = {
+        "playbook": {"id": "default"},
+        "steps": {
+            "spec": {
+                "skill": "spec_first",
+                "role": "pm",
+                "output_artifact": "spec",
+                "valid_intents": ["await_agent", "confirm_output"],
+                "on": {"await_agent": "plan", "confirm_output": "spec"},
+            },
+        },
+    }
+
+    def make_executor(issue_dir: Path, marker: str):
+        def executor(step_name: str, step_def: dict, state) -> StepExecutionResult:
+            _write_agent_baton(
+                issue_dir,
+                from_step="spec",
+                to_owner="user",
+                to_step="user",
+                intent="confirm_output",
+            )
+            artifact = issue_dir / "spec" / "iteration_001" / "output.md"
+            artifact.parent.mkdir(parents=True, exist_ok=True)
+            artifact.write_text(f"# {marker}\n", encoding="utf-8")
+            return StepExecutionResult(
+                response="confirmed",
+                artifacts={"spec": str(artifact)},
+                status_code="confirmed",
+            )
+
+        return executor
+
+    issue_a = wt_a / ".cafe" / "issues" / "issue-a"
+    issue_b = wt_b / ".cafe" / "issues" / "issue-b"
+    issue_a.mkdir(parents=True)
+    issue_b.mkdir(parents=True)
+
+    runtime_a = BlackboardWorkflowRuntime(
+        issue_dir=issue_a,
+        playbook=playbook,
+        executor=make_executor(issue_a, "alpha"),
+    )
+    runtime_b = BlackboardWorkflowRuntime(
+        issue_dir=issue_b,
+        playbook=playbook,
+        executor=make_executor(issue_b, "beta"),
+    )
+
+    runtime_a.run(start_step="spec", max_transitions=3)
+    runtime_b.run(start_step="spec", max_transitions=3)
+
+    baton_a = json.loads((issue_a / "next_step.txt").read_text(encoding="utf-8"))
+    baton_b = json.loads((issue_b / "next_step.txt").read_text(encoding="utf-8"))
+    assert baton_a["from_step"] == "spec"
+    assert baton_b["from_step"] == "spec"
+    assert (issue_a / "spec" / "iteration_001" / "output.md").read_text(encoding="utf-8") == "# alpha\n"
+    assert (issue_b / "spec" / "iteration_001" / "output.md").read_text(encoding="utf-8") == "# beta\n"
+    assert (issue_a / "blackboard.json").resolve() != (issue_b / "blackboard.json").resolve()
+    bb_a = json.loads((issue_a / "blackboard.json").read_text(encoding="utf-8"))
+    bb_b = json.loads((issue_b / "blackboard.json").read_text(encoding="utf-8"))
+    assert bb_a != bb_b

--- a/tests/unit/test_issue_yaml_config.py
+++ b/tests/unit/test_issue_yaml_config.py
@@ -16,7 +16,7 @@ def _read_issue_config(config_file: Path) -> dict:
 
 
 def _load_spec_sync_github(issue_dir: Path, cli_value: bool | None = None) -> bool:
-    """Mirror legacy spec-phase sync_github resolution without SpecPhase."""
+    """Resolve spec.sync_github the same way the workflow runtime does (issue.yaml)."""
     config_data = _read_issue_config(issue_dir / "issue.yaml")
     spec_config = config_data.get("spec", {}) if config_data else {}
     config_value = bool(spec_config["sync_github"]) if "sync_github" in spec_config else None
@@ -35,7 +35,7 @@ def _save_spec_issue_config(
     rigor: SpecRigor,
     sync_github: bool,
 ) -> None:
-    """Mirror legacy spec-phase save while preserving unrelated keys."""
+    """Persist spec.sync_github in issue.yaml while preserving unrelated keys."""
     config_file = issue_dir / "issue.yaml"
     existing = _read_issue_config(config_file)
     config_data = {**existing}
@@ -126,7 +126,7 @@ class TestSaveSpecSyncGithub:
 
 
 def _load_plan_sync_github(issue_dir: Path, cli_value: bool | None = None) -> bool:
-    """Mirror legacy plan-phase sync_github resolution without PlanPhase."""
+    """Resolve plan.sync_github the same way the workflow runtime does (issue.yaml)."""
     config_data = _read_issue_config(issue_dir / "issue.yaml")
     plan_config = config_data.get("plan", {}) if config_data else {}
     spec_config = config_data.get("spec", {}) if config_data else {}

--- a/tests/unit/test_parallel_skill_install.py
+++ b/tests/unit/test_parallel_skill_install.py
@@ -1,0 +1,97 @@
+"""Contract tests for parallel CAFE workflows installing skills in isolated project roots."""
+
+from pathlib import Path
+
+from cafe.core.types import AgentCLI
+from cafe.skills.loader import SkillLoader
+from cafe.skills.native_bridge import NativeSkillBridge
+
+
+def _write_plan_skill(root: Path, body: str) -> None:
+    skill_dir = root / "plan"
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: plan\ndescription: test plan\n---\n\n{body}\n",
+        encoding="utf-8",
+    )
+
+
+def _bridge_for_project(
+    tmp_path: Path,
+    *,
+    project_root: Path,
+    global_root: Path,
+    home_dir: Path,
+) -> NativeSkillBridge:
+    builtin = tmp_path / "builtin" / "skills"
+    _write_plan_skill(builtin, "builtin plan")
+    loader = SkillLoader(
+        project_root=project_root,
+        global_root=global_root,
+        builtin_root=tmp_path / "builtin",
+    )
+    loader.discover()
+    return NativeSkillBridge(loader, project_root=project_root, home_dir=home_dir)
+
+
+def test_parallel_workflow_skill_installs_use_isolated_project_roots(tmp_path: Path) -> None:
+    """Two project roots can install the same skill without cross-writing."""
+    global_root = tmp_path / "global" / "skills"
+    home_dir = tmp_path / "home"
+    project_a = tmp_path / "worktree-a"
+    project_b = tmp_path / "worktree-b"
+    for project in (project_a, project_b):
+        (project / ".cafe").mkdir(parents=True)
+    _write_plan_skill(project_a / ".cafe" / "skills", "Project A plan")
+    _write_plan_skill(project_b / ".cafe" / "skills", "Project B plan")
+
+    bridge_a = _bridge_for_project(
+        tmp_path, project_root=project_a, global_root=global_root, home_dir=home_dir
+    )
+    bridge_b = _bridge_for_project(
+        tmp_path, project_root=project_b, global_root=global_root, home_dir=home_dir
+    )
+
+    bridge_a.install_skill("plan", AgentCLI.CODEX)
+    bridge_b.install_skill("plan", AgentCLI.CODEX)
+
+    installed_a = project_a / ".codex" / "skills" / "cafe-plan" / "SKILL.md"
+    installed_b = project_b / ".codex" / "skills" / "cafe-plan" / "SKILL.md"
+    assert "Project A plan" in installed_a.read_text(encoding="utf-8")
+    assert "Project B plan" in installed_b.read_text(encoding="utf-8")
+
+    installed_a.write_text("mutated in A\n", encoding="utf-8")
+    assert "mutated in A" not in installed_b.read_text(encoding="utf-8")
+    assert "Project B plan" in installed_b.read_text(encoding="utf-8")
+
+
+def test_parallel_workflow_installs_do_not_write_global_home_skills(tmp_path: Path) -> None:
+    """install_skill targets project-local CLI dirs, not the user home skills tree."""
+    global_root = tmp_path / "global" / "skills"
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    project_root = tmp_path / "project"
+    (project_root / ".cafe" / "skills").mkdir(parents=True)
+    _write_plan_skill(global_root, "global plan")
+    _write_plan_skill(project_root / ".cafe" / "skills", "project plan")
+
+    global_home_skill = home_dir / ".codex" / "skills" / "cafe-plan" / "SKILL.md"
+    if global_home_skill.parent.exists():
+        marker = global_home_skill.read_text(encoding="utf-8")
+    else:
+        marker = "absent"
+
+    bridge = _bridge_for_project(
+        tmp_path, project_root=project_root, global_root=global_root, home_dir=home_dir
+    )
+    bridge.install_skill("plan", AgentCLI.CODEX)
+
+    project_installed = project_root / ".codex" / "skills" / "cafe-plan" / "SKILL.md"
+    assert project_installed.exists()
+    assert "project plan" in project_installed.read_text(encoding="utf-8")
+
+    global_dir = bridge.get_global_native_skills_dir(AgentCLI.CODEX)
+    global_installed = global_dir / "cafe-plan"
+    assert not global_installed.exists()
+    if global_home_skill.exists():
+        assert global_home_skill.read_text(encoding="utf-8") == marker

--- a/tests/unit/test_phases_legacy_retired.py
+++ b/tests/unit/test_phases_legacy_retired.py
@@ -1,11 +1,13 @@
 """Guardrails ensuring phases_legacy hidden CLI aliases stay removed (issue #315)."""
 
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 from typer.testing import CliRunner
 
 from cafe.ui.cli import app
+from tests.conftest import create_minimal_config
 
 runner = CliRunner()
 
@@ -24,3 +26,28 @@ def test_legacy_phase_commands_are_unknown(legacy_command: str) -> None:
     result = runner.invoke(app, [legacy_command])
     assert result.exit_code != 0
     assert "No such command" in result.output
+
+
+def test_workflow_start_step_spec_is_supported(tmp_path: Path, monkeypatch) -> None:
+    """Replacement entry: cafe workflow --start-step spec (not the retired cafe spec alias)."""
+    monkeypatch.chdir(tmp_path)
+    create_minimal_config(tmp_path)
+    issue_dir = tmp_path / ".cafe" / "issues" / "issue-legacy-guard"
+    issue_dir.mkdir(parents=True)
+
+    with patch("cafe.ui.cli.GitOperations") as mock_git_cls:
+        git = MagicMock()
+        git.get_current_branch.return_value = "issue-legacy-guard"
+        mock_git_cls.return_value = git
+
+        result = runner.invoke(
+            app,
+            ["workflow", "--playbook", "default", "--dry-run", "--start-step", "spec"],
+        )
+
+    assert result.exit_code == 0
+    assert "playbook=default step=spec" in result.stdout
+
+    legacy = runner.invoke(app, ["spec"])
+    assert legacy.exit_code != 0
+    assert "No such command" in legacy.output


### PR DESCRIPTION
## Summary

Addresses [issue #317](https://github.com/luyotw/cafe/issues/317): audit and align tests for v0.2 workflow, git worktree, project-local skill install, legacy CLI guardrails, and structured baton handoff—without changing product behavior. Adds contract tests for parallel skill installs, worktree workflow pause/resume through plan, and parallel worktree isolation; documents keep/update/add inventory in `tests/MIGRATION.md`.

## Changes

- Add **Issue 317** section to `tests/MIGRATION.md` with pytest baseline (2017 → 2022 passed), file inventory, added coverage matrix, and removed-by-design notes.
- Add `tests/unit/test_parallel_skill_install.py` — isolated per-project-root native skill installs; no writes to user home skills dir.
- Add `tests/integration/test_worktree_workflow_parallel.py` — worktree cwd workflow (spec pause → resume → plan); two worktrees with separate blackboard/baton/artifacts.
- Extend `tests/unit/test_phases_legacy_retired.py` — `cafe workflow --start-step spec` dry-run succeeds; retired `cafe spec` remains unknown.
- Update `tests/unit/test_issue_yaml_config.py` docstrings to describe workflow `sync_github` resolution (no behavior change).

**Commits (develop..issue317):**

- `6bca801` issue317: add test audit inventory to MIGRATION.md
- `6691660` issue317: cover isolated skill install across parallel workflows
- `6e9395b` issue317: add worktree workflow integration coverage
- `cf82323` issue317: tighten legacy CLI guardrail and sync_github docstrings
- `96fd3a1` issue317: strengthen worktree pause-resume-plan integration test

## Test Plan

- [x] `uv run --with pytest pytest tests/unit tests/integration -q` → 2022 passed, 1 skipped, 1 xfailed
- [x] `uv run --with pytest pytest tests/unit/test_parallel_skill_install.py tests/integration/test_worktree_workflow_parallel.py tests/unit/test_phases_legacy_retired.py -q`
- [x] Confirm `CONTRIBUTING.md` / CI use the same pytest scope (`tests/unit` + `tests/integration`)