### PR TITLE
Enforce test-invariants policy in plan/develop/review workflow (#321)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,10 @@ You can contribute to this project in several ways:
 
 6.  Open a Pull Request to the `main` branch of the original repository. In the PR description, please detail your changes, their purpose, and any relevant Issue numbers.
 
+## Testing policy (workflow)
+
+Plan, develop, and review skills enforce a **test invariants** policy: tests should protect business rules and user-journey outcomes, not fragile UI structure. See `src/cafe/data/skills/plan/references/test_invariants_policy.md` for what to test, what to avoid, and examples.
+
 ## Pre-release Verification
 
 Before cutting a release or merging large changes to builtin skills, playbooks, or agents, run the builtin tooling audit:

--- a/src/cafe/data/skills/develop/SKILL.md
+++ b/src/cafe/data/skills/develop/SKILL.md
@@ -16,6 +16,8 @@ Read your agent file: {agent_file}
 ## Instructions
 - 依計畫逐項完成
 - 先補測試再改程式
+- 新增或修改的測試必須對應計畫 **Test List** 項目（範圍變更時先更新計畫）
+- 斷言以 invariant 為主：避免綁定 UI copy、CSS class、DOM 結構、內部 state shape；允許 a11y role/label、`data-testid`、以及規格明訂的文案（見 `plan/references/test_invariants_policy.md`）
 - 每輪完成後更新 checklist
 - 維持既有 commit 風格與程式碼註解語言
 - 優先重用現有模式與工具

--- a/src/cafe/data/skills/develop/references/execution_steps_correction.md
+++ b/src/cafe/data/skills/develop/references/execution_steps_correction.md
@@ -9,6 +9,8 @@
 [ ] Confirm: Maximized code reuse by looking for existing patterns and utilities
 [ ] Confirm: Commit messages strictly match existing format, language, and structure
 [ ] Confirm: All issues are fixed
+[ ] Read the plan **Test List** in {plan_file_path}; new or changed tests still map to listed items and follow `src/cafe/data/skills/plan/references/test_invariants_policy.md`
+[ ] Confirm: Corrected tests do not reintroduce brittle bindings (UI copy, CSS classes, DOM structure, internal state shape) unless the spec explicitly allows them
 [ ] Confirm: All tests pass and are not fragile
 [ ] Update blackboard and next-step baton to hand off to the next workflow target
 

--- a/src/cafe/data/skills/develop/references/execution_steps_normal.md
+++ b/src/cafe/data/skills/develop/references/execution_steps_normal.md
@@ -9,6 +9,10 @@
 [ ] Confirm: Maximized code reuse by looking for existing patterns and utilities
 [ ] Confirm: Commit messages strictly match existing format, language, and structure
 [ ] Confirm: All tasks in {plan_file_path} are marked [x]
+[ ] Read the plan **Test List** (`## Test List` in {plan_file_path}); every new or changed test maps to a listed item (update the plan first if scope changed)
+[ ] Confirm: New/changed tests assert **invariants** (business rules, journey outcomes)—not UI copy, CSS classes, DOM structure, or internal state shape unless the spec explicitly requires it
+[ ] Confirm: Unit tests target extractable pure business logic in shared library modules when applicable; integration tests are named by **user journey** and **invariant outcome**, not by UI component
+[ ] Read `src/cafe/data/skills/plan/references/test_invariants_policy.md` before adding user-visible UI assertions (allowed: a11y roles/labels, test ids, spec-mandated copy)
 [ ] Confirm: All tests pass and are not fragile
 [ ] Confirm: All commits are made
 [ ] Confirm: No pending work remains

--- a/src/cafe/data/skills/plan/SKILL.md
+++ b/src/cafe/data/skills/plan/SKILL.md
@@ -23,6 +23,8 @@ bash scripts/sync_github.sh --help
 ## Instructions
 - 依規格拆解實作步驟，先列測試，再列實作
 - 嚴格遵守 TDD，避免直接寫程式碼
+- 產出計畫前必須完成 **`## Test List`**（`Unit tests (N)` 與 `Integration tests (M)`，每項有標籤並對應 invariant 或 user journey；N 或 M 為 0 時簡述原因）
+- 撰寫 Test List 與斷言規則時請閱讀 `references/test_invariants_policy.md`（integration 以 journey/invariant 描述，不以 UI component 列項）
 - 延續既有計畫格式與使用者需求
 - User 確認暫停、交給 `develop` 前是否執行 GitHub sync、以及 baton 順序：請依 shared skill「workflow-common」的 **Confirming spec and plan with the user**、**Where policies live**，並搭配 `github_sync` skill 的腳本說明；本 skill 不重複敘述。
 - 計畫草稿需 user 確認時：把 next-step baton 寫入 `user`，不要直接交給 `develop`（其餘細節以 workflow-common 為準）。

--- a/src/cafe/data/skills/plan/assets/templates/bug.md
+++ b/src/cafe/data/skills/plan/assets/templates/bug.md
@@ -14,6 +14,16 @@
 
 ---
 
+## Test List
+
+### Unit tests (N)
+1. **Label** — Invariant: … — Scope: pure business logic / shared library module
+
+### Integration tests (M)
+1. **Label** — Journey: … — Invariant outcome: … — Boundary: system-level behavior (not per-component)
+
+_(If N or M is 0, one sentence explains why.)_
+
 ## Task Breakdown
 
 > **Instructions for Developer:** Update this checklist as you progress. Replace placeholders with actual implementation steps once you identify the root cause.

--- a/src/cafe/data/skills/plan/assets/templates/default.md
+++ b/src/cafe/data/skills/plan/assets/templates/default.md
@@ -59,6 +59,16 @@
     }
     ```
 
+## Test List
+
+### Unit tests (N)
+1. **Label** — Invariant: … — Scope: pure business logic / shared library module
+
+### Integration tests (M)
+1. **Label** — Journey: … — Invariant outcome: … — Boundary: system-level behavior (not per-component)
+
+_(If N or M is 0, one sentence explains why.)_
+
 ### 📋 Development Task Breakdown
 
 #### Task 1: Create service layer foundation

--- a/src/cafe/data/skills/plan/assets/templates/simple.md
+++ b/src/cafe/data/skills/plan/assets/templates/simple.md
@@ -3,6 +3,16 @@
 ## Goal
 Add a "forgot password" link to the login page
 
+## Test List
+
+### Unit tests (N)
+1. **Label** — Invariant: … — Scope: pure business logic / shared library module
+
+### Integration tests (M)
+1. **Label** — Journey: … — Invariant outcome: … — Boundary: system-level behavior (not per-component)
+
+_(If N or M is 0, one sentence explains why.)_
+
 ## Tasks
 - [ ] Task 1: Add `forgot_password()` view in `views/auth_views.py`
 - [ ] Task 2: Add "Forgot password?" link to `templates/auth/login.html`

--- a/src/cafe/data/skills/plan/references/execution_steps_iteration_1.md
+++ b/src/cafe/data/skills/plan/references/execution_steps_iteration_1.md
@@ -4,6 +4,10 @@
 [ ] Read the development guide in {plan_file_path}
 [ ] Read the requirements document {spec_file_path}
 [ ] Plan implementation steps (planning, not implementation)
+[ ] Complete **`## Test List`** in the plan output (`Unit tests (N)` and `Integration tests (M)` with labels mapping to invariants or user journeys; if N or M is 0, explain why)
+[ ] Read `src/cafe/data/skills/plan/references/test_invariants_policy.md` when writing Test List items and assertion guidance
+[ ] Confirm: Integration test entries describe **user journeys** and **invariant outcomes**, not UI components
+[ ] Confirm: Test List items avoid brittle bindings (UI copy, CSS classes, DOM structure, internal state shape) unless the spec explicitly requires them
 [ ] Append plan after "## Development Guide" section
 [ ] Keep "## Development Guide" section unchanged
 [ ] Confirm: Only wrote plans and steps, NO actual code

--- a/src/cafe/data/skills/plan/references/test_invariants_policy.md
+++ b/src/cafe/data/skills/plan/references/test_invariants_policy.md
@@ -1,0 +1,73 @@
+# Test Invariants Policy
+
+Workflow agents should write tests that protect **stable invariants** (business rules and user-journey outcomes), not fragile implementation details.
+
+## What to test
+
+- **Business invariants** — rules that must remain true across refactors.
+- **User-journey outcomes** — what the user can do and what they observe as results, without binding to incidental presentation.
+- **Contract-level behavior** of public interfaces (inputs → outputs / side effects) when those contracts are intentional and stable.
+- **Pure business logic** in shared library modules — cover with **unit tests** using representative inputs, boundaries, and error cases.
+
+## What not to test (unless explicitly required)
+
+| Avoid binding to | Exception |
+| --- | --- |
+| Exact **UI copy** | Copy listed as an explicit product requirement in the spec (legal/contractual wording, mandated labels) |
+| **CSS class names** and styling | — |
+| **DOM structure** (nesting, order, wrappers) | — |
+| **Internal state shape** | Only when state shape is itself a stable external contract |
+
+## Allowed integration-test UI assertions
+
+When verifying user-visible outcomes, prefer stable contracts over presentation details:
+
+- Accessibility **roles** and **labels** (for example, `button`, `alert`).
+- **Test identifiers** designed for testing (`data-testid`, not CSS classes).
+- **Exact copy** only when the spec for this change explicitly requires that wording.
+
+Integration tests must **not** use “no UI assertions at all” as a blanket rule; use stable contracts instead of brittle structure.
+
+## Unit vs integration
+
+| Layer | Organize by | Assert on |
+| --- | --- | --- |
+| **Unit** | Pure function / shared module | Invariants over inputs and boundaries |
+| **Integration** | **User journey** + **invariant outcome** | System behavior across boundaries, not per-component internals |
+
+## Good vs Bad (place order journey)
+
+**Invariant:** Order total is computed correctly and a valid order is created.
+
+### Good (invariant-focused)
+
+- **Unit — Total calculation invariant:** Given items and discounts, total equals expected value (empty cart, max discount, rounding).
+- **Integration — Place order succeeds:** Given a valid cart, when the user places an order, an order exists and success is visible via a stable contract (alert role, test id, or non-copy outcome signal)—not via CSS classes or DOM nesting.
+
+### Bad (implementation-detail focused)
+
+- Asserting exact copy like `Order placed successfully!` when that string is not a spec-mandated product requirement.
+- Asserting CSS classes such as `.btn-primary` or `.success-banner`.
+- Asserting DOM position such as “success message is the 2nd child of the header wrapper”.
+- Asserting `state.checkout.step === "CONFIRMATION"` when that schema is not a public contract.
+
+## Plan Test List (required in plan output)
+
+Every plan must include:
+
+```markdown
+## Test List
+
+### Unit tests (N)
+1. **Label** — Invariant: … — Scope: …
+
+### Integration tests (M)
+1. **Label** — Journey: … — Invariant outcome: … — Boundary: …
+```
+
+When **N** or **M** is zero, add one sentence explaining why.
+
+## Develop and review
+
+- **Develop:** Every new or changed test must map to a plan Test List item; follow this policy for assertions.
+- **Review:** Reject added/changed tests that violate the “what not to test” rules; accept allowed stable UI contracts. Existing unrelated tests do not require wholesale rewrites.

--- a/src/cafe/data/skills/review/references/execution_steps.md
+++ b/src/cafe/data/skills/review/references/execution_steps.md
@@ -48,6 +48,14 @@
 [ ] Review test quality and edge cases
 [ ] Check the tests are not fragile or flaky
 
+## Test Invariants Review
+[ ] Plan includes a **Test List** with **Unit tests (N)** and **Integration tests (M)**; each item has a label mapped to an invariant or user journey; if N or M is zero, the plan states why
+[ ] New/changed tests align with the plan Test List and protect invariants or journey outcomes—not implementation details
+[ ] New/changed tests do **not** couple to disallowed UI copy, CSS classes, DOM structure, or internal state shape (unless spec/DoD explicitly allows exact copy as a product requirement)
+[ ] Integration tests map to plan journeys/invariants, not per-component or internal UI structure
+[ ] Extractable pure business logic in shared library modules has unit-level coverage when applicable
+[ ] Allowed UI contracts are respected: accessibility roles/labels, test ids (`data-testid`), and exact copy only when mandated in the spec
+
 ## Final Steps
 [ ] Confirm: No code was modified
 [ ] Write review findings to {review_file_path} in todo list format (same format as PR phase)

--- a/tests/fixtures/checklists/develop_correction.md
+++ b/tests/fixtures/checklists/develop_correction.md
@@ -9,6 +9,8 @@
 [ ] Confirm: Maximized code reuse by looking for existing patterns and utilities
 [ ] Confirm: Commit messages strictly match existing format, language, and structure
 [ ] Confirm: All issues are fixed
+[ ] Read the plan **Test List** in .cafe/issues/test/plan/iteration_001/output.md; new or changed tests still map to listed items and follow `src/cafe/data/skills/plan/references/test_invariants_policy.md`
+[ ] Confirm: Corrected tests do not reintroduce brittle bindings (UI copy, CSS classes, DOM structure, internal state shape) unless the spec explicitly allows them
 [ ] Confirm: All tests pass and are not fragile
 [ ] Update blackboard and next-step baton to hand off to the next workflow target
 

--- a/tests/fixtures/checklists/develop_normal.md
+++ b/tests/fixtures/checklists/develop_normal.md
@@ -9,6 +9,10 @@
 [ ] Confirm: Maximized code reuse by looking for existing patterns and utilities
 [ ] Confirm: Commit messages strictly match existing format, language, and structure
 [ ] Confirm: All tasks in .cafe/issues/test/plan/iteration_001/output.md are marked [x]
+[ ] Read the plan **Test List** (`## Test List` in .cafe/issues/test/plan/iteration_001/output.md); every new or changed test maps to a listed item (update the plan first if scope changed)
+[ ] Confirm: New/changed tests assert **invariants** (business rules, journey outcomes)—not UI copy, CSS classes, DOM structure, or internal state shape unless the spec explicitly requires it
+[ ] Confirm: Unit tests target extractable pure business logic in shared library modules when applicable; integration tests are named by **user journey** and **invariant outcome**, not by UI component
+[ ] Read `src/cafe/data/skills/plan/references/test_invariants_policy.md` before adding user-visible UI assertions (allowed: a11y roles/labels, test ids, spec-mandated copy)
 [ ] Confirm: All tests pass and are not fragile
 [ ] Confirm: All commits are made
 [ ] Confirm: No pending work remains

--- a/tests/fixtures/checklists/plan_iter1.md
+++ b/tests/fixtures/checklists/plan_iter1.md
@@ -4,6 +4,10 @@
 [ ] Read the development guide in .cafe/issues/test/plan/iteration_001/output.md
 [ ] Read the requirements document .cafe/issues/test/spec/iteration_001/output.md
 [ ] Plan implementation steps (planning, not implementation)
+[ ] Complete **`## Test List`** in the plan output (`Unit tests (N)` and `Integration tests (M)` with labels mapping to invariants or user journeys; if N or M is 0, explain why)
+[ ] Read `src/cafe/data/skills/plan/references/test_invariants_policy.md` when writing Test List items and assertion guidance
+[ ] Confirm: Integration test entries describe **user journeys** and **invariant outcomes**, not UI components
+[ ] Confirm: Test List items avoid brittle bindings (UI copy, CSS classes, DOM structure, internal state shape) unless the spec explicitly requires them
 [ ] Append plan after "## Development Guide" section
 [ ] Keep "## Development Guide" section unchanged
 [ ] Confirm: Only wrote plans and steps, NO actual code

--- a/tests/fixtures/checklists/review.md
+++ b/tests/fixtures/checklists/review.md
@@ -48,6 +48,14 @@
 [ ] Review test quality and edge cases
 [ ] Check the tests are not fragile or flaky
 
+## Test Invariants Review
+[ ] Plan includes a **Test List** with **Unit tests (N)** and **Integration tests (M)**; each item has a label mapped to an invariant or user journey; if N or M is zero, the plan states why
+[ ] New/changed tests align with the plan Test List and protect invariants or journey outcomes—not implementation details
+[ ] New/changed tests do **not** couple to disallowed UI copy, CSS classes, DOM structure, or internal state shape (unless spec/DoD explicitly allows exact copy as a product requirement)
+[ ] Integration tests map to plan journeys/invariants, not per-component or internal UI structure
+[ ] Extractable pure business logic in shared library modules has unit-level coverage when applicable
+[ ] Allowed UI contracts are respected: accessibility roles/labels, test ids (`data-testid`), and exact copy only when mandated in the spec
+
 ## Final Steps
 [ ] Confirm: No code was modified
 [ ] Write review findings to .cafe/issues/test/review/iteration_001/output.md in todo list format (same format as PR phase)

--- a/tests/fixtures/checklists/review_pr_todo.md
+++ b/tests/fixtures/checklists/review_pr_todo.md
@@ -48,6 +48,14 @@
 [ ] Review test quality and edge cases
 [ ] Check the tests are not fragile or flaky
 
+## Test Invariants Review
+[ ] Plan includes a **Test List** with **Unit tests (N)** and **Integration tests (M)**; each item has a label mapped to an invariant or user journey; if N or M is zero, the plan states why
+[ ] New/changed tests align with the plan Test List and protect invariants or journey outcomes—not implementation details
+[ ] New/changed tests do **not** couple to disallowed UI copy, CSS classes, DOM structure, or internal state shape (unless spec/DoD explicitly allows exact copy as a product requirement)
+[ ] Integration tests map to plan journeys/invariants, not per-component or internal UI structure
+[ ] Extractable pure business logic in shared library modules has unit-level coverage when applicable
+[ ] Allowed UI contracts are respected: accessibility roles/labels, test ids (`data-testid`), and exact copy only when mandated in the spec
+
 ## Final Steps
 [ ] Confirm: No code was modified
 [ ] Write review findings to .cafe/issues/test/review/iteration_001/output.md in todo list format (same format as PR phase)

--- a/tests/unit/test_develop_checklist_test_policy.py
+++ b/tests/unit/test_develop_checklist_test_policy.py
@@ -1,0 +1,32 @@
+"""Tests that develop execution steps reference test invariants policy."""
+
+from cafe.skills.bridge import load_skill_reference
+
+TEST_LIST_KEYWORDS = ("Test List", "test list", "test_invariants_policy")
+BRITTLE_KEYWORDS = (
+    "UI copy",
+    "CSS",
+    "DOM",
+    "internal state",
+    "brittle",
+    "invariant",
+)
+
+
+def _assert_develop_steps_include_test_policy(reference_name: str) -> None:
+    content = load_skill_reference("develop", reference_name)
+    lower = content.lower()
+    assert any(kw.lower() in lower for kw in TEST_LIST_KEYWORDS), (
+        f"develop/{reference_name} must mention plan Test List"
+    )
+    assert sum(1 for kw in BRITTLE_KEYWORDS if kw.lower() in lower) >= 2, (
+        f"develop/{reference_name} must warn about brittle test bindings"
+    )
+
+
+def test_develop_normal_execution_steps_reference_test_policy() -> None:
+    _assert_develop_steps_include_test_policy("execution_steps_normal.md")
+
+
+def test_develop_correction_execution_steps_reference_test_policy() -> None:
+    _assert_develop_steps_include_test_policy("execution_steps_correction.md")

--- a/tests/unit/test_plan_checklist_test_policy.py
+++ b/tests/unit/test_plan_checklist_test_policy.py
@@ -1,0 +1,17 @@
+"""Tests that plan execution steps reference test invariants policy."""
+
+from cafe.skills.bridge import load_skill_reference
+
+TEST_LIST_KEYWORDS = ("Test List", "test list", "test_invariants_policy")
+INVARIANT_KEYWORDS = ("invariant", "journey", "UI copy", "CSS", "DOM")
+
+
+def test_plan_iteration_1_execution_steps_reference_test_policy() -> None:
+    content = load_skill_reference("plan", "execution_steps_iteration_1.md")
+    lower = content.lower()
+    assert any(kw.lower() in lower for kw in TEST_LIST_KEYWORDS), (
+        "plan/execution_steps_iteration_1.md must require Test List"
+    )
+    assert sum(1 for kw in INVARIANT_KEYWORDS if kw.lower() in lower) >= 3, (
+        "plan/execution_steps_iteration_1.md must describe invariant-focused test planning"
+    )

--- a/tests/unit/test_plan_templates_test_list.py
+++ b/tests/unit/test_plan_templates_test_list.py
@@ -1,0 +1,18 @@
+"""Tests that builtin plan templates include a required Test List section."""
+
+from pathlib import Path
+
+import pytest
+
+TEMPLATES_DIR = Path("src/cafe/data/skills/plan/assets/templates")
+BUILTIN_TEMPLATES = ("default.md", "simple.md", "bug.md")
+
+
+@pytest.mark.parametrize("template_name", BUILTIN_TEMPLATES)
+def test_builtin_plan_template_includes_test_list_section(template_name: str) -> None:
+    path = TEMPLATES_DIR / template_name
+    assert path.is_file(), f"{path} must exist"
+    content = path.read_text(encoding="utf-8")
+    assert "## Test List" in content
+    assert "Unit tests" in content
+    assert "Integration tests" in content

--- a/tests/unit/test_test_invariants_policy.py
+++ b/tests/unit/test_test_invariants_policy.py
@@ -1,0 +1,20 @@
+"""Tests for test invariants policy reference document."""
+
+from pathlib import Path
+
+POLICY_PATH = Path(
+    "src/cafe/data/skills/plan/references/test_invariants_policy.md"
+)
+
+
+def test_test_invariants_policy_file_exists() -> None:
+    assert POLICY_PATH.is_file(), f"{POLICY_PATH} must exist"
+
+
+def test_test_invariants_policy_contains_good_bad_examples_and_invariant_language() -> None:
+    content = POLICY_PATH.read_text(encoding="utf-8")
+    assert "Good" in content
+    assert "Bad" in content
+    lower = content.lower()
+    assert "invariant" in lower
+    assert "journey" in lower or "user journey" in lower


### PR DESCRIPTION
## Summary

Implements issue #321: a project-wide **test invariants** policy so workflow agents write tests for behavioral invariants and user-journey outcomes—not brittle UI copy, CSS classes, DOM structure, or internal state shape.

Changes span plan, develop, and review skills/templates/checklists, plus a canonical policy reference document and unit tests that lock in the structure. Review approved after develop iteration 002 (plan execution-step Test List gates and commit-style fixes).

## Changes

### Policy and documentation

- Add `src/cafe/data/skills/plan/references/test_invariants_policy.md` — what to test vs what not to test, allowed/blocked assertions, unit vs integration boundaries.
- Link policy from `CONTRIBUTING.md`.

### Plan phase

- Require `## Test List` (Unit tests N + Integration tests M, labeled, with zero-count rationale) in builtin plan templates (`default`, `simple`, `bug`).
- Update `plan/SKILL.md` to require Test List completion and point to the policy reference.
- Extend `plan/references/execution_steps_iteration_1.md` with Test List and invariant-focused planning gates.
- Regenerate golden `tests/fixtures/checklists/plan_iter1.md`; add `tests/unit/test_plan_checklist_test_policy.py`.

### Develop phase

- Update `develop/SKILL.md` and `execution_steps_normal.md` / `execution_steps_correction.md` so tests map to the plan Test List and avoid brittle bindings.
- Add `tests/unit/test_develop_checklist_test_policy.py`.

### Review phase

- Add **Test Invariants Review** subsection to `review/references/execution_steps.md`.
- Regenerate golden `tests/fixtures/checklists/review.md`.

### Tests (this change)

- `tests/unit/test_test_invariants_policy.py` — policy doc exists and includes good/bad markers.
- `tests/unit/test_plan_templates_test_list.py` — builtin templates include Test List sections.

### Commits (issue321 branch, ahead of `develop`)

| Commit | Subject |
| --- | --- |
| `5313eb9` | Add test invariants policy reference for workflow agents |
| `769099a` | Require Test List section in plan templates and plan skill |
| `dfe3039` | Enforce test invariants in develop skill checklists |
| `72f4a51` | Add test invariants gates to review checklist |
| `18efbad` | Add Test List gates to plan execution checklist |

Closes #321.

## Test Plan

- [x] `pytest` — full suite (2033 passed at develop iteration 002; re-run before merge if needed).
- [x] `cafe audit` — skill/template references valid.
- [x] `tests/unit/test_test_invariants_policy.py` — policy reference present and substantive.
- [x] `tests/unit/test_plan_templates_test_list.py` — builtin plan templates include `## Test List`.
- [x] `tests/unit/test_develop_checklist_test_policy.py` — develop execution steps reference Test List / brittle-test rules.
- [x] `tests/unit/test_plan_checklist_test_policy.py` — plan execution steps reference Test List / policy.
- [x] `tests/unit/test_skill_checklist_composer.py` — review (and plan) golden checklists match composed output.
- [ ] Manual: run a sample `cafe make` issue through plan → develop → review and confirm agents see Test List / test-invariants gates in composed checklists.