### PR TITLE
Add plan architecture sections and review ADR enforcement (#322)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,8 @@ Default development flow (spec → plan → develop → review → pr) is driven
 
 Primary CLI entrypoints: `cafe make` and `cafe workflow`. Legacy `cafe spec` / `plan` / `develop` / `review` / `pr` commands were removed in issue #315; use `cafe workflow --start-step <step> --execute` for explicit single-step runs.
 
+Built-in **plan** templates require three architecture sections in every plan artifact: **Negative space** (what we decline to add), **Layering map** (concrete paths for logic/persistence/UI), and **Dependency ADR** (per new dependency or an explicit "none"). The user sees these at plan confirm; **review** diffs dependency manifests against the ADR and routes undeclared packages back to develop.
+
 ## Coding Style
 
 *   This project follows the [PEP 8](https://www.python.org/dev/peps/pep-0008/) style guide.

--- a/src/cafe/data/skills/plan/SKILL.md
+++ b/src/cafe/data/skills/plan/SKILL.md
@@ -29,6 +29,28 @@ bash scripts/sync_github.sh --help
 - User 確認暫停、交給 `develop` 前是否執行 GitHub sync、以及 baton 順序：請依 shared skill「workflow-common」的 **Confirming spec and plan with the user**、**Where policies live**，並搭配 `github_sync` skill 的腳本說明；本 skill 不重複敘述。
 - 計畫草稿需 user 確認時：把 next-step baton 寫入 `user`，不要直接交給 `develop`（其餘細節以 workflow-common 為準）。
 
+### Required plan sections (must be filled before handoff)
+
+Every plan output must include these **labeled** sections (see built-in templates under `assets/templates/`):
+
+1. **Negative space** — what deps/abstractions we will **not** introduce, each with a one-line reason. If none apply, state explicitly (e.g. "No new dependencies expected.").
+2. **Layering map** — where business logic, persistence, and UI live, with **concrete file or module paths**.
+3. **Dependency ADR** — table or list of runtime/dev deps to add (why, alternatives, requirement served), or explicit "No new dependencies expected."
+
+Empty placeholders are incomplete. The user must see all three sections at plan confirm (`confirm_output`).
+
+### Project principles alignment (graceful degradation)
+
+Before finalizing the plan, if the project has `.cafe/strategic_context.yaml`:
+
+- Read `documents.principles.path`:
+  - If `status: exists`: load that file (do not hardcode `PRINCIPLES.md`). Ground **Negative space** (red lines / out-of-scope) and **Dependency ADR** (capability or requirement ties) using principles.
+  - If `status: missing` or the field is absent: keep the three sections in pure technical form; optional note "Principles document not configured; leave principles cross-refs blank."
+
+### Stale major versions (prompt-level)
+
+When the Dependency ADR proposes a **new major** of a package, note whether that major was released within the last **30 days** (default window). If so, justify the risk in the ADR or pick a stable alternative. Full registry automation is out of scope; checklist/template language is the minimum deliverable.
+
 ## Output
 Write plan to: {output_file}
 

--- a/src/cafe/data/skills/plan/assets/templates/bug.md
+++ b/src/cafe/data/skills/plan/assets/templates/bug.md
@@ -12,6 +12,18 @@
 - [File/component 1]
 - [File/component 2]
 
+## Negative space
+
+> Fill after investigation. List obvious-but-declined additions (extra deps, refactors, new abstractions) with one-line reasons. If N/A: "No scope expansion beyond the bug fix."
+
+## Layering map
+
+> Fill after root-cause analysis. Map business logic, persistence, and UI to concrete paths.
+
+## Dependency ADR
+
+> Fill after investigation. List any new runtime/dev deps with why, alternatives, and requirement served — or **"No new dependencies expected."** Flag new majors released within **30 days** unless justified.
+
 ---
 
 ## Test List

--- a/src/cafe/data/skills/plan/assets/templates/default.md
+++ b/src/cafe/data/skills/plan/assets/templates/default.md
@@ -1,5 +1,37 @@
 ## Implementation Analysis
 
+### Negative space
+
+> What we are **not** introducing, and why. If nothing obvious applies, state explicitly (e.g. "No additional runtime deps; template-only change.").
+
+| Declined | Reason |
+| --- | --- |
+| Client router (e.g. react-router) | Only two static tabs; local state suffices |
+| CSS framework | Plain CSS covers the design |
+| PWA / offline stack | Not requested in the spec |
+
+> If `.cafe/strategic_context.yaml` has `documents.principles.path` with `status: exists`, tie declines to principles red lines / out-of-scope items. Otherwise leave principles cross-refs blank.
+
+### Layering map
+
+> Where business logic, persistence, and UI live — use **concrete file or module paths**.
+
+| Layer | Location |
+| --- | --- |
+| Business logic | `services/auth_service.py` |
+| Persistence / data | `models/user.py`, ORM queries in service layer |
+| UI / HTTP | `views/auth_views.py`, `templates/auth/` |
+
+### Dependency ADR
+
+> Every **runtime and dev** dependency this issue expects to add. If none: write **"No new dependencies expected."**
+
+| Package | Type | Why | Alternatives considered | Requirement served |
+| --- | --- | --- | --- | --- |
+| *(example)* `pyjwt` | runtime | JWT signing for login tokens | Session cookies only | Auth token feature |
+
+> For a **new major** version, note release age. If the major shipped within the last **30 days**, justify the risk here or pick a stable alternative.
+
 * Code style reference examples
     * Service layer pattern: `services/user_service.py`
     * View layer style: `views/user_views.py`

--- a/src/cafe/data/skills/plan/assets/templates/simple.md
+++ b/src/cafe/data/skills/plan/assets/templates/simple.md
@@ -3,6 +3,23 @@
 ## Goal
 Add a "forgot password" link to the login page
 
+## Negative space
+
+- **Not adding:** [dependency or abstraction declined] — [one-line reason]
+- If none apply: "No new runtime deps beyond existing stack."
+
+## Layering map
+
+| Layer | Path |
+| --- | --- |
+| UI | `templates/auth/login.html` |
+| Logic | `views/auth_views.py` |
+
+## Dependency ADR
+
+- **New deps:** None expected (or list package + 1–2 sentences: why / alternative / requirement).
+- **Recent majors:** If proposing a new major released within **30 days**, justify here or choose a stable version.
+
 ## Test List
 
 ### Unit tests (N)

--- a/src/cafe/data/skills/plan/references/execution_steps_iteration_1.md
+++ b/src/cafe/data/skills/plan/references/execution_steps_iteration_1.md
@@ -4,6 +4,9 @@
 [ ] Read the development guide in {plan_file_path}
 [ ] Read the requirements document {spec_file_path}
 [ ] Plan implementation steps (planning, not implementation)
+[ ] Fill required sections **Negative space**, **Layering map**, and **Dependency ADR** (explicit "none" / "no new dependencies" if applicable — empty placeholders are incomplete)
+[ ] If `.cafe/strategic_context.yaml` has `documents.principles.path` with `status: exists`, read that file and ground Negative space and Dependency ADR; otherwise leave principles cross-refs blank
+[ ] For any new major in Dependency ADR, note if released within the last 30 days and justify or pick a stable alternative
 [ ] Complete **`## Test List`** in the plan output (`Unit tests (N)` and `Integration tests (M)` with labels mapping to invariants or user journeys; if N or M is 0, explain why)
 [ ] Read `src/cafe/data/skills/plan/references/test_invariants_policy.md` when writing Test List items and assertion guidance
 [ ] Confirm: Integration test entries describe **user journeys** and **invariant outcomes**, not UI components

--- a/src/cafe/data/skills/plan/references/execution_steps_iteration_n.md
+++ b/src/cafe/data/skills/plan/references/execution_steps_iteration_n.md
@@ -4,6 +4,7 @@
 [ ] Read {prev_plan_file} to review previous plan
 [ ] Review user's feedback (provided below)
 [ ] Integrate feedback and update the plan, DO NOT hint the existence of the previous iterations
+[ ] Keep **Negative space**, **Layering map**, and **Dependency ADR** filled and consistent with the revised plan (explicit "none" if still applicable)
 [ ] Write updated plan to {current_plan_file} (NOT in your response)
 [ ] Keep "## Development Guide" section unchanged
 [ ] Confirm: Only wrote plans and steps, NO actual code

--- a/src/cafe/data/skills/review/references/execution_steps.md
+++ b/src/cafe/data/skills/review/references/execution_steps.md
@@ -40,7 +40,9 @@
 [ ] Check if existing unused code can be removed
 
 ## Anti-Over-Engineering Review
-[ ] Dependency hygiene: every new entry in `package.json` / `pyproject.toml` / equivalent has a justification recorded in the plan and serves a declared requirement; flag any unannounced dependency
+[ ] Dependency ADR vs manifest diff: diff dependency manifests (`package.json`, `pyproject.toml`, `requirements*.txt`, or equivalent) against the approved plan's **Dependency ADR** list; any package present in the manifest diff but **not declared** in the plan is undeclared — route back to `develop` and name the package in review output
+[ ] Dependency hygiene: every new manifest entry has a matching ADR entry and serves a declared requirement; flag unannounced or undeclared dependencies
+[ ] Stale majors: if the plan or manifests introduce a **new major** released within the last **30 days**, verify the ADR justifies the risk or an acceptable stable alternative was chosen; flag unjustified bleeding-edge majors
 [ ] Layering and speculative abstractions: business logic that could be a pure function is not buried inside a UI component; no abstractions added for hypothetical future scenarios; implementation matches the layering map declared in the plan
 [ ] Explicit cross-component contracts: when two components share state via persistence or other indirect channels, the protocol is documented (in code or plan), not coincidental; flag implicit coupling that only works because of current framework behavior
 

--- a/tests/fixtures/checklists/plan_iter1.md
+++ b/tests/fixtures/checklists/plan_iter1.md
@@ -4,6 +4,9 @@
 [ ] Read the development guide in .cafe/issues/test/plan/iteration_001/output.md
 [ ] Read the requirements document .cafe/issues/test/spec/iteration_001/output.md
 [ ] Plan implementation steps (planning, not implementation)
+[ ] Fill required sections **Negative space**, **Layering map**, and **Dependency ADR** (explicit "none" / "no new dependencies" if applicable — empty placeholders are incomplete)
+[ ] If `.cafe/strategic_context.yaml` has `documents.principles.path` with `status: exists`, read that file and ground Negative space and Dependency ADR; otherwise leave principles cross-refs blank
+[ ] For any new major in Dependency ADR, note if released within the last 30 days and justify or pick a stable alternative
 [ ] Complete **`## Test List`** in the plan output (`Unit tests (N)` and `Integration tests (M)` with labels mapping to invariants or user journeys; if N or M is 0, explain why)
 [ ] Read `src/cafe/data/skills/plan/references/test_invariants_policy.md` when writing Test List items and assertion guidance
 [ ] Confirm: Integration test entries describe **user journeys** and **invariant outcomes**, not UI components

--- a/tests/fixtures/checklists/plan_iter2.md
+++ b/tests/fixtures/checklists/plan_iter2.md
@@ -4,6 +4,7 @@
 [ ] Read .cafe/issues/test/plan/iteration_001/output.md to review previous plan
 [ ] Review user's feedback (provided below)
 [ ] Integrate feedback and update the plan, DO NOT hint the existence of the previous iterations
+[ ] Keep **Negative space**, **Layering map**, and **Dependency ADR** filled and consistent with the revised plan (explicit "none" if still applicable)
 [ ] Write updated plan to .cafe/issues/test/plan/iteration_002/output.md (NOT in your response)
 [ ] Keep "## Development Guide" section unchanged
 [ ] Confirm: Only wrote plans and steps, NO actual code

--- a/tests/fixtures/checklists/review.md
+++ b/tests/fixtures/checklists/review.md
@@ -40,7 +40,9 @@
 [ ] Check if existing unused code can be removed
 
 ## Anti-Over-Engineering Review
-[ ] Dependency hygiene: every new entry in `package.json` / `pyproject.toml` / equivalent has a justification recorded in the plan and serves a declared requirement; flag any unannounced dependency
+[ ] Dependency ADR vs manifest diff: diff dependency manifests (`package.json`, `pyproject.toml`, `requirements*.txt`, or equivalent) against the approved plan's **Dependency ADR** list; any package present in the manifest diff but **not declared** in the plan is undeclared — route back to `develop` and name the package in review output
+[ ] Dependency hygiene: every new manifest entry has a matching ADR entry and serves a declared requirement; flag unannounced or undeclared dependencies
+[ ] Stale majors: if the plan or manifests introduce a **new major** released within the last **30 days**, verify the ADR justifies the risk or an acceptable stable alternative was chosen; flag unjustified bleeding-edge majors
 [ ] Layering and speculative abstractions: business logic that could be a pure function is not buried inside a UI component; no abstractions added for hypothetical future scenarios; implementation matches the layering map declared in the plan
 [ ] Explicit cross-component contracts: when two components share state via persistence or other indirect channels, the protocol is documented (in code or plan), not coincidental; flag implicit coupling that only works because of current framework behavior
 

--- a/tests/fixtures/checklists/review_pr_todo.md
+++ b/tests/fixtures/checklists/review_pr_todo.md
@@ -40,7 +40,9 @@
 [ ] Check if existing unused code can be removed
 
 ## Anti-Over-Engineering Review
-[ ] Dependency hygiene: every new entry in `package.json` / `pyproject.toml` / equivalent has a justification recorded in the plan and serves a declared requirement; flag any unannounced dependency
+[ ] Dependency ADR vs manifest diff: diff dependency manifests (`package.json`, `pyproject.toml`, `requirements*.txt`, or equivalent) against the approved plan's **Dependency ADR** list; any package present in the manifest diff but **not declared** in the plan is undeclared — route back to `develop` and name the package in review output
+[ ] Dependency hygiene: every new manifest entry has a matching ADR entry and serves a declared requirement; flag unannounced or undeclared dependencies
+[ ] Stale majors: if the plan or manifests introduce a **new major** released within the last **30 days**, verify the ADR justifies the risk or an acceptable stable alternative was chosen; flag unjustified bleeding-edge majors
 [ ] Layering and speculative abstractions: business logic that could be a pure function is not buried inside a UI component; no abstractions added for hypothetical future scenarios; implementation matches the layering map declared in the plan
 [ ] Explicit cross-component contracts: when two components share state via persistence or other indirect channels, the protocol is documented (in code or plan), not coincidental; flag implicit coupling that only works because of current framework behavior
 

--- a/tests/fixtures/plans/two_tab_negative_space.md
+++ b/tests/fixtures/plans/two_tab_negative_space.md
@@ -1,0 +1,27 @@
+# Implementation Plan
+
+## Goal
+Two-tab settings UI without client-side routing.
+
+## Negative space
+
+- **Client router (e.g. react-router):** Not adding — only two static tabs; local component state is enough.
+- **CSS framework:** Not adding — plain CSS covers the layout.
+- **PWA / offline stack:** Not adding — not requested in the spec.
+
+## Layering map
+
+| Layer | Location |
+| --- | --- |
+| UI | `src/components/SettingsTabs.tsx` |
+| State | `src/hooks/useSettingsTab.ts` |
+| Persistence | `src/lib/settingsStorage.ts` |
+
+## Dependency ADR
+
+No new runtime or dev dependencies expected for this feature.
+
+## Tasks
+
+- [ ] Implement tab UI and local state
+- [ ] Wire persistence layer

--- a/tests/fixtures/plans/with_dependency_adr.md
+++ b/tests/fixtures/plans/with_dependency_adr.md
@@ -1,0 +1,28 @@
+# Implementation Plan
+
+## Goal
+Add CSV export for report downloads.
+
+## Negative space
+
+- **Heavy spreadsheet library:** Not adding — `csv` module is sufficient for flat exports.
+
+## Layering map
+
+| Layer | Location |
+| --- | --- |
+| Business logic | `src/cafe/services/export_service.py` |
+| HTTP / UI | `src/cafe/views/report_views.py` |
+
+## Dependency ADR
+
+| Package | Type | Why | Alternatives | Requirement |
+| --- | --- | --- | --- | --- |
+| `openpyxl` | runtime | Optional XLSX path for power users | Built-in `csv` only | Feature: Excel export toggle |
+
+**`openpyxl`:** Chosen for maintained XLSX write support; `csv` remains the default path. Serves acceptance criterion for Excel download.
+
+## Tasks
+
+- [ ] Add export service and tests
+- [ ] Expose download endpoint

--- a/tests/unit/test_plan_architecture_sections.py
+++ b/tests/unit/test_plan_architecture_sections.py
@@ -1,0 +1,90 @@
+"""Tests for plan template architecture sections and review enforcement (#322)."""
+
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+PLAN_TEMPLATES_DIR = (
+    PROJECT_ROOT / "src" / "cafe" / "data" / "skills" / "plan" / "assets" / "templates"
+)
+PLAN_SKILL = PROJECT_ROOT / "src" / "cafe" / "data" / "skills" / "plan" / "SKILL.md"
+PLAN_EXEC_STEPS = (
+    PROJECT_ROOT
+    / "src"
+    / "cafe"
+    / "data"
+    / "skills"
+    / "plan"
+    / "references"
+    / "execution_steps_iteration_1.md"
+)
+REVIEW_EXEC_STEPS = (
+    PROJECT_ROOT
+    / "src"
+    / "cafe"
+    / "data"
+    / "skills"
+    / "review"
+    / "references"
+    / "execution_steps.md"
+)
+FIXTURES_PLANS = PROJECT_ROOT / "tests" / "fixtures" / "plans"
+
+REQUIRED_HEADINGS = ("Negative space", "Layering map", "Dependency ADR")
+
+
+@pytest.mark.parametrize("template_name", ["default.md", "simple.md", "bug.md"])
+def test_plan_templates_contain_required_architecture_headings(
+    template_name: str,
+) -> None:
+    content = (PLAN_TEMPLATES_DIR / template_name).read_text(encoding="utf-8")
+    for heading in REQUIRED_HEADINGS:
+        assert heading in content, f"{template_name} must include section: {heading}"
+
+
+def test_plan_skill_reads_strategic_context_for_principles() -> None:
+    skill = PLAN_SKILL.read_text(encoding="utf-8")
+    assert "strategic_context.yaml" in skill
+    assert "documents.principles.path" in skill
+    assert "Negative space" in skill
+    assert "Dependency ADR" in skill
+
+
+def test_plan_skill_requires_three_sections_before_handoff() -> None:
+    skill = PLAN_SKILL.read_text(encoding="utf-8")
+    assert "Layering map" in skill
+    assert "confirm" in skill.lower() or "確認" in skill
+
+
+def test_plan_execution_steps_require_architecture_sections() -> None:
+    steps = PLAN_EXEC_STEPS.read_text(encoding="utf-8")
+    assert "Negative space" in steps
+    assert "Layering map" in steps
+    assert "Dependency ADR" in steps
+
+
+def test_review_checklist_manifest_diff_vs_dependency_adr() -> None:
+    steps = REVIEW_EXEC_STEPS.read_text(encoding="utf-8")
+    lowered = steps.lower()
+    assert "dependency adr" in lowered
+    assert "develop" in lowered
+    assert "undeclared" in lowered or "not declared" in lowered or "not in" in lowered
+
+
+def test_review_checklist_flags_recent_majors_within_30_days() -> None:
+    steps = REVIEW_EXEC_STEPS.read_text(encoding="utf-8")
+    assert "30" in steps
+    assert "major" in steps.lower()
+
+
+def test_fixture_two_tab_plan_declines_router_in_negative_space() -> None:
+    sample = (FIXTURES_PLANS / "two_tab_negative_space.md").read_text(encoding="utf-8")
+    assert "Negative space" in sample
+    assert "router" in sample.lower()
+
+
+def test_fixture_plan_with_dependency_includes_adr_paragraph() -> None:
+    sample = (FIXTURES_PLANS / "with_dependency_adr.md").read_text(encoding="utf-8")
+    assert "Dependency ADR" in sample
+    assert "why" in sample.lower() or "alternatives" in sample.lower()

--- a/tests/unit/test_principles_aware_scope_guard.py
+++ b/tests/unit/test_principles_aware_scope_guard.py
@@ -43,6 +43,18 @@ def test_spec_default_template_has_principles_alignment_section() -> None:
     assert "Leave blank" in template or "leave blank" in template
 
 
+def test_plan_skill_reads_strategic_context_for_architecture_sections() -> None:
+    plan_skill = (
+        PROJECT_ROOT / "src" / "cafe" / "data" / "skills" / "plan" / "SKILL.md"
+    ).read_text(encoding="utf-8")
+
+    assert "strategic_context.yaml" in plan_skill
+    assert "documents.principles.path" in plan_skill
+    assert "Negative space" in plan_skill
+    assert "Dependency ADR" in plan_skill
+    assert "30 days" in plan_skill
+
+
 def test_review_checklist_has_anti_over_engineering_section() -> None:
     review_steps = (
         PROJECT_ROOT
@@ -59,3 +71,6 @@ def test_review_checklist_has_anti_over_engineering_section() -> None:
     assert "Dependency hygiene" in review_steps
     assert "Layering and speculative abstractions" in review_steps
     assert "Explicit cross-component contracts" in review_steps
+    assert "Dependency ADR vs manifest diff" in review_steps
+    assert "undeclared" in review_steps.lower()
+    assert "30 days" in review_steps


### PR DESCRIPTION
## Summary

Closes [#322](https://github.com/luyotw/cafe/issues/322) by requiring **Negative space**, **Layering map**, and **Dependency ADR** in all built-in plan templates, surfacing them at plan confirm, and extending review to diff dependency manifests against the plan’s ADR (undeclared deps route back to develop; unjustified very-recent majors flagged). Builds on #323 review hygiene and preserves #321 **Test List** / test-invariants gates after rebase onto `develop`.

## Changes

- **Plan templates** (`default.md`, `simple.md`, `bug.md`): mandatory architecture sections with examples (shorter hints in `simple` / `bug`); **Test List** retained from #321.
- **Plan skill** (`plan/SKILL.md`): requires filling all three sections, principles-aware grounding via `.cafe/strategic_context.yaml` when configured, and 30-day major guidance.
- **Plan execution checklists**: gates for architecture sections at plan confirm.
- **Review execution steps**: manifest diff vs Dependency ADR, undeclared-dep route-back, 30-day major check.
- **CONTRIBUTING.md**: documents the three sections and review ADR behavior for adopters.
- **Tests & fixtures**: `test_plan_architecture_sections.py`, sample plans (`two_tab_negative_space.md`, `with_dependency_adr.md`), checklist fixture updates, principles-aware scope guard extension.

**Commit:** `7674ccb` — Add plan architecture sections and review ADR enforcement (#322)

No new runtime or dev dependencies; no new workflow steps or agent roles.

## Test Plan

- [ ] `python3 -m pytest -q tests/unit/test_plan_architecture_sections.py tests/unit/test_plan_templates_test_list.py tests/unit/test_test_invariants_policy.py tests/unit/test_develop_checklist_test_policy.py tests/unit/test_plan_checklist_test_policy.py tests/unit/test_principles_aware_scope_guard.py`
- [ ] `python3 -m pytest -q tests/unit/` (full unit suite)
- [ ] Confirm built-in plan templates show all three architecture sections plus **Test List** at plan confirm
- [ ] Spot-check review checklist text for manifest diff vs ADR and 30-day major wording