### PR TITLE
Add playbook commands.prepare metadata for cafe prepare (#331)

### DIFF
--- a/src/cafe/core/playbook.py
+++ b/src/cafe/core/playbook.py
@@ -12,10 +12,14 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 from cafe.core.status_codes import PLAYBOOK_INTENT_KEYS, PhaseStatusCode
 from cafe.skills.exceptions import SkillDiscoveryError
 from cafe.skills.loader import SkillLoader
+from cafe.templates.manager import TemplateManager
 
 
 DONE_TARGET = "_done"
 SCRIPT_HOOK_STAGES = {"before_execute", "after_execute"}
+
+RigorLevel = Literal["low", "medium", "high"]
+InputMethodDefault = Literal["manual", "github"]
 
 
 class PlaybookMeta(BaseModel):
@@ -126,6 +130,138 @@ class StepConfig(BaseModel):
         return normalized
 
 
+class PrepareSetupModeEntry(BaseModel):
+    """One setup mode offered during interactive prepare."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = True
+    label: str
+
+
+class PrepareSetupModes(BaseModel):
+    """Quick setup vs custom configuration choices."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    quick: PrepareSetupModeEntry = Field(
+        default_factory=lambda: PrepareSetupModeEntry(
+            label="Quick setup (use recommended defaults)"
+        )
+    )
+    custom: PrepareSetupModeEntry = Field(
+        default_factory=lambda: PrepareSetupModeEntry(label="Custom configuration")
+    )
+
+
+class PrepareQuickSetupSpec(BaseModel):
+    """Spec defaults applied when the user picks quick setup."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    rigor: RigorLevel = "medium"
+    template: str = "auto"
+
+
+class PrepareQuickSetupPlan(BaseModel):
+    """Plan defaults applied when the user picks quick setup."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    template: str = "auto"
+
+
+class PrepareSyncGithubDefaults(BaseModel):
+    """GitHub sync defaults derived from input method during quick setup."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    when_issue_id_present: bool = True
+    when_manual_input: bool = False
+
+
+class PrepareQuickSetupPr(BaseModel):
+    """PR defaults applied when the user picks quick setup."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    auto_create_on_github_repo: bool = True
+    post_todo_list_when_auto_create: bool = True
+
+
+class PrepareQuickSetup(BaseModel):
+    """Recommended defaults for interactive quick setup."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    spec: PrepareQuickSetupSpec = Field(default_factory=PrepareQuickSetupSpec)
+    plan: PrepareQuickSetupPlan = Field(default_factory=PrepareQuickSetupPlan)
+    sync_github: PrepareSyncGithubDefaults = Field(default_factory=PrepareSyncGithubDefaults)
+    pr: PrepareQuickSetupPr = Field(default_factory=PrepareQuickSetupPr)
+
+
+class PrepareNonInteractiveDefaults(BaseModel):
+    """Defaults used when prepare runs with --no-interactive."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    rigor: RigorLevel = "medium"
+    spec_template: str = "auto"
+    plan_template: str = "default"
+
+
+class PrepareInputMethod(BaseModel):
+    """Input-method prompt behavior for prepare."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    prompt_on_github_repo: bool = True
+    non_github_default: InputMethodDefault = "manual"
+
+
+class PrepareConstraints(BaseModel):
+    """Allowed values for prepare configuration fields."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    rigor: List[RigorLevel] = Field(default_factory=lambda: ["low", "medium", "high"])
+
+
+class PrepareConfig(BaseModel):
+    """Declarative ``cafe prepare`` prompt and default metadata."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    prompt_for_spec_plan_config: bool = True
+    setup_modes: PrepareSetupModes = Field(default_factory=PrepareSetupModes)
+    quick_setup: PrepareQuickSetup = Field(default_factory=PrepareQuickSetup)
+    non_interactive_defaults: PrepareNonInteractiveDefaults = Field(
+        default_factory=PrepareNonInteractiveDefaults
+    )
+    input_method: PrepareInputMethod = Field(default_factory=PrepareInputMethod)
+    constraints: PrepareConstraints = Field(default_factory=PrepareConstraints)
+
+
+class CommandsConfig(BaseModel):
+    """Command-level metadata blocks owned by a playbook."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    prepare: Optional[PrepareConfig] = None
+
+
+def default_prepare_config() -> PrepareConfig:
+    """Return backward-compatible prepare defaults matching the built-in default playbook."""
+    return PrepareConfig()
+
+
+def resolve_prepare_config(model: PlaybookDefinition) -> PrepareConfig:
+    """Resolve effective prepare metadata, applying defaults when omitted."""
+    if model.commands and model.commands.prepare is not None:
+        return model.commands.prepare
+    return default_prepare_config()
+
+
 class PlaybookDefinition(BaseModel):
     """Top-level playbook definition."""
 
@@ -134,6 +270,7 @@ class PlaybookDefinition(BaseModel):
     playbook: PlaybookMeta
     roles: Dict[str, PlaybookRole] = Field(default_factory=dict)
     steps: Dict[str, StepConfig]
+    commands: Optional[CommandsConfig] = None
     entry_point: Optional[str] = None
 
     @model_validator(mode="after")
@@ -233,9 +370,64 @@ def validate_playbook(
                 f"Step '{step_name}': assignee_type={step.assignee_type} (reserved for v0.3)"
             )
 
+    _validate_prepare_metadata(model)
+
     if warnings and strict:
         raise ValueError("\n".join(warnings))
     return warnings
+
+
+def _validate_prepare_metadata(model: PlaybookDefinition) -> None:
+    """Validate prepare metadata templates and rigor constraints."""
+    prepare = resolve_prepare_config(model)
+    spec_manager = TemplateManager(template_type="spec")
+    plan_manager = TemplateManager(template_type="plan")
+
+    _validate_prepare_template(
+        spec_manager,
+        prepare.quick_setup.spec.template,
+        "commands.prepare.quick_setup.spec.template",
+    )
+    _validate_prepare_template(
+        plan_manager,
+        prepare.quick_setup.plan.template,
+        "commands.prepare.quick_setup.plan.template",
+    )
+    _validate_prepare_template(
+        spec_manager,
+        prepare.non_interactive_defaults.spec_template,
+        "commands.prepare.non_interactive_defaults.spec_template",
+    )
+    _validate_prepare_template(
+        plan_manager,
+        prepare.non_interactive_defaults.plan_template,
+        "commands.prepare.non_interactive_defaults.plan_template",
+    )
+
+    allowed_rigor = set(prepare.constraints.rigor)
+    if prepare.quick_setup.spec.rigor not in allowed_rigor:
+        raise ValueError(
+            "commands.prepare.quick_setup.spec.rigor "
+            f"{prepare.quick_setup.spec.rigor!r} is not listed in "
+            f"commands.prepare.constraints.rigor"
+        )
+    if prepare.non_interactive_defaults.rigor not in allowed_rigor:
+        raise ValueError(
+            "commands.prepare.non_interactive_defaults.rigor "
+            f"{prepare.non_interactive_defaults.rigor!r} is not listed in "
+            f"commands.prepare.constraints.rigor"
+        )
+
+
+def _validate_prepare_template(
+    manager: TemplateManager,
+    template_name: str,
+    field_path: str,
+) -> None:
+    if template_name == "auto":
+        return
+    if not manager.template_exists(template_name):
+        raise ValueError(f"Unknown template {template_name!r} for {field_path}")
 
 
 def _report_structural_issue(

--- a/src/cafe/data/playbooks/default.yaml
+++ b/src/cafe/data/playbooks/default.yaml
@@ -16,6 +16,38 @@ roles:
     default_agent: "Richard"
     default_cli: "gemini"
 
+commands:
+  prepare:
+    prompt_for_spec_plan_config: true
+    setup_modes:
+      quick:
+        enabled: true
+        label: "Quick setup (use recommended defaults)"
+      custom:
+        enabled: true
+        label: "Custom configuration"
+    quick_setup:
+      spec:
+        rigor: medium
+        template: auto
+      plan:
+        template: auto
+      sync_github:
+        when_issue_id_present: true
+        when_manual_input: false
+      pr:
+        auto_create_on_github_repo: true
+        post_todo_list_when_auto_create: true
+    non_interactive_defaults:
+      rigor: medium
+      spec_template: auto
+      plan_template: default
+    input_method:
+      prompt_on_github_repo: true
+      non_github_default: manual
+    constraints:
+      rigor: [low, medium, high]
+
 steps:
   spec:
     type: skill

--- a/src/cafe/data/playbooks/hotfix.yaml
+++ b/src/cafe/data/playbooks/hotfix.yaml
@@ -12,6 +12,38 @@ roles:
     default_agent: "Richard"
     default_cli: "gemini"
 
+commands:
+  prepare:
+    prompt_for_spec_plan_config: false
+    setup_modes:
+      quick:
+        enabled: true
+        label: "Quick setup (use recommended defaults)"
+      custom:
+        enabled: true
+        label: "Custom configuration"
+    quick_setup:
+      spec:
+        rigor: medium
+        template: auto
+      plan:
+        template: auto
+      sync_github:
+        when_issue_id_present: true
+        when_manual_input: false
+      pr:
+        auto_create_on_github_repo: true
+        post_todo_list_when_auto_create: true
+    non_interactive_defaults:
+      rigor: medium
+      spec_template: auto
+      plan_template: default
+    input_method:
+      prompt_on_github_repo: true
+      non_github_default: manual
+    constraints:
+      rigor: [low, medium, high]
+
 steps:
   develop:
     type: skill

--- a/src/cafe/data/playbooks/simple.yaml
+++ b/src/cafe/data/playbooks/simple.yaml
@@ -12,6 +12,38 @@ roles:
     default_agent: "David"
     default_cli: "claude"
 
+commands:
+  prepare:
+    prompt_for_spec_plan_config: true
+    setup_modes:
+      quick:
+        enabled: true
+        label: "Quick setup (use recommended defaults)"
+      custom:
+        enabled: true
+        label: "Custom configuration"
+    quick_setup:
+      spec:
+        rigor: medium
+        template: auto
+      plan:
+        template: auto
+      sync_github:
+        when_issue_id_present: true
+        when_manual_input: false
+      pr:
+        auto_create_on_github_repo: true
+        post_todo_list_when_auto_create: true
+    non_interactive_defaults:
+      rigor: medium
+      spec_template: auto
+      plan_template: default
+    input_method:
+      prompt_on_github_repo: true
+      non_github_default: manual
+    constraints:
+      rigor: [low, medium, high]
+
 steps:
   spec:
     type: skill

--- a/src/cafe/data/playbooks/tdd.yaml
+++ b/src/cafe/data/playbooks/tdd.yaml
@@ -16,6 +16,38 @@ roles:
     default_agent: "Richard"
     default_cli: "gemini"
 
+commands:
+  prepare:
+    prompt_for_spec_plan_config: true
+    setup_modes:
+      quick:
+        enabled: true
+        label: "Quick setup (use recommended defaults)"
+      custom:
+        enabled: true
+        label: "Custom configuration"
+    quick_setup:
+      spec:
+        rigor: medium
+        template: auto
+      plan:
+        template: auto
+      sync_github:
+        when_issue_id_present: true
+        when_manual_input: false
+      pr:
+        auto_create_on_github_repo: true
+        post_todo_list_when_auto_create: true
+    non_interactive_defaults:
+      rigor: medium
+      spec_template: auto
+      plan_template: default
+    input_method:
+      prompt_on_github_repo: true
+      non_github_default: manual
+    constraints:
+      rigor: [low, medium, high]
+
 steps:
   spec:
     type: skill

--- a/tests/unit/test_cli_playbook_validate.py
+++ b/tests/unit/test_cli_playbook_validate.py
@@ -1,0 +1,42 @@
+"""CLI tests for cafe playbook validate with prepare metadata."""
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from cafe.ui.cli import app
+
+
+runner = CliRunner()
+
+
+def test_playbook_validate_succeeds_for_builtin_prepare_playbooks() -> None:
+    for name in ("default", "simple", "tdd", "hotfix"):
+        result = runner.invoke(app, ["playbook", "validate", name])
+        assert result.exit_code == 0, result.stdout
+        assert "Valid" in result.stdout
+        assert name in result.stdout
+
+
+def test_playbook_validate_accepts_project_override_without_prepare(tmp_path: Path, monkeypatch) -> None:
+    project_root = tmp_path / "project"
+    cafe_dir = project_root / ".cafe" / "playbooks"
+    cafe_dir.mkdir(parents=True)
+    (cafe_dir / "custom.yaml").write_text(
+        """
+playbook: {id: custom}
+steps:
+  spec:
+    role: pm
+    skill: spec
+    on:
+      await_agent: _done
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(project_root)
+
+    result = runner.invoke(app, ["playbook", "validate", "custom"])
+
+    assert result.exit_code == 0, result.stdout
+    assert "Valid custom" in result.stdout

--- a/tests/unit/test_playbook_prepare_metadata.py
+++ b/tests/unit/test_playbook_prepare_metadata.py
@@ -72,7 +72,7 @@ steps:
   spec:
     role: pm
     skill: spec_first
-    on:
+    "on":
       await_agent: _done
 {prepare_block}
 """
@@ -140,13 +140,16 @@ def test_invalid_boolean_shape_rejected() -> None:
             prepare_block="""
 commands:
   prepare:
-    prompt_for_spec_plan_config: yes
+    prompt_for_spec_plan_config:
+      enabled: true
 """
         )
     )
 
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError) as exc_info:
         PlaybookDefinition.model_validate(data)
+
+    assert "prompt_for_spec_plan_config" in str(exc_info.value)
 
 
 def test_unknown_nested_prepare_key_forbidden() -> None:
@@ -194,7 +197,7 @@ steps:
   spec:
     role: pm
     skill: spec_first
-    on:
+    "on":
       await_agent: _done
 commands:
   prepare:
@@ -230,7 +233,7 @@ steps:
   spec:
     role: pm
     skill: spec_first
-    on:
+    "on":
       await_agent: _done
 """,
     )

--- a/tests/unit/test_playbook_prepare_metadata.py
+++ b/tests/unit/test_playbook_prepare_metadata.py
@@ -1,0 +1,278 @@
+"""Tests for playbook commands.prepare metadata schema and validation."""
+
+from pathlib import Path
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from cafe.core.playbook import (
+    PlaybookDefinition,
+    default_prepare_config,
+    load_playbook_file,
+    resolve_prepare_config,
+)
+from cafe.playbooks.loader import PlaybookLoader
+from cafe.skills.loader import SkillLoader
+
+
+STANDARD_PREPARE_YAML = """
+commands:
+  prepare:
+    prompt_for_spec_plan_config: true
+    setup_modes:
+      quick:
+        enabled: true
+        label: "Quick setup (use recommended defaults)"
+      custom:
+        enabled: true
+        label: "Custom configuration"
+    quick_setup:
+      spec:
+        rigor: medium
+        template: auto
+      plan:
+        template: auto
+      sync_github:
+        when_issue_id_present: true
+        when_manual_input: false
+      pr:
+        auto_create_on_github_repo: true
+        post_todo_list_when_auto_create: true
+    non_interactive_defaults:
+      rigor: medium
+      spec_template: auto
+      plan_template: default
+    input_method:
+      prompt_on_github_repo: true
+      non_github_default: manual
+    constraints:
+      rigor: [low, medium, high]
+"""
+
+
+def _write_skill(root: Path, name: str) -> None:
+    skill_dir = root / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: desc-{name}\n---\n\n# {name}\n",
+        encoding="utf-8",
+    )
+
+
+def _write_playbook(root: Path, name: str, content: str) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / f"{name}.yaml").write_text(content, encoding="utf-8")
+
+
+def _minimal_playbook_yaml(*, prepare_block: str = "") -> str:
+    return f"""
+playbook: {{id: test}}
+steps:
+  spec:
+    role: pm
+    skill: spec_first
+    on:
+      await_agent: _done
+{prepare_block}
+"""
+
+
+def _loader(tmp_path: Path) -> PlaybookLoader:
+    builtin_root = tmp_path / "builtin"
+    _write_skill(builtin_root / "skills", "spec_first")
+    return PlaybookLoader(
+        project_root=tmp_path / "project",
+        global_root=tmp_path / "global",
+        builtin_root=builtin_root,
+    )
+
+
+def test_prepare_schema_parses_valid_block(tmp_path: Path) -> None:
+    loader = _loader(tmp_path)
+    _write_playbook(
+        loader._roots()[0],
+        "test",
+        _minimal_playbook_yaml(prepare_block=STANDARD_PREPARE_YAML),
+    )
+
+    result = loader.load_model("test")
+
+    assert result.model.commands is not None
+    assert result.model.commands.prepare is not None
+    assert result.model.commands.prepare.prompt_for_spec_plan_config is True
+    assert result.model.commands.prepare.quick_setup.spec.rigor == "medium"
+
+
+def test_omitted_prepare_section_resolves_defaults(tmp_path: Path) -> None:
+    loader = _loader(tmp_path)
+    _write_playbook(loader._roots()[0], "test", _minimal_playbook_yaml())
+
+    result = loader.load_model("test")
+    resolved = resolve_prepare_config(result.model)
+    expected = default_prepare_config()
+
+    assert resolved.model_dump() == expected.model_dump()
+
+
+def test_invalid_rigor_rejected_with_field_path() -> None:
+    data = yaml.safe_load(
+        _minimal_playbook_yaml(
+            prepare_block="""
+commands:
+  prepare:
+    quick_setup:
+      spec:
+        rigor: extreme
+"""
+        )
+    )
+
+    with pytest.raises(ValidationError) as exc_info:
+        PlaybookDefinition.model_validate(data)
+
+    assert "rigor" in str(exc_info.value)
+
+
+def test_invalid_boolean_shape_rejected() -> None:
+    data = yaml.safe_load(
+        _minimal_playbook_yaml(
+            prepare_block="""
+commands:
+  prepare:
+    prompt_for_spec_plan_config: yes
+"""
+        )
+    )
+
+    with pytest.raises(ValidationError):
+        PlaybookDefinition.model_validate(data)
+
+
+def test_unknown_nested_prepare_key_forbidden() -> None:
+    data = yaml.safe_load(
+        _minimal_playbook_yaml(
+            prepare_block="""
+commands:
+  prepare:
+    typo_field: true
+"""
+        )
+    )
+
+    with pytest.raises(ValidationError) as exc_info:
+        PlaybookDefinition.model_validate(data)
+
+    assert "typo_field" in str(exc_info.value)
+
+
+def test_unknown_template_rejected_at_load_time(tmp_path: Path) -> None:
+    loader = _loader(tmp_path)
+    _write_playbook(
+        loader._roots()[0],
+        "test",
+        _minimal_playbook_yaml(
+            prepare_block="""
+commands:
+  prepare:
+    quick_setup:
+      plan:
+        template: not-a-real-template
+"""
+        ),
+    )
+
+    with pytest.raises(ValueError, match="commands.prepare.quick_setup.plan.template"):
+        loader.load_model("test")
+
+
+def test_invalid_prepare_fails_via_load_playbook_file_and_loader(tmp_path: Path) -> None:
+    loader = _loader(tmp_path)
+    content = """
+playbook: {id: bad}
+steps:
+  spec:
+    role: pm
+    skill: spec_first
+    on:
+      await_agent: _done
+commands:
+  prepare:
+    non_interactive_defaults:
+      plan_template: missing-template-name
+"""
+    path = loader._roots()[0] / "bad.yaml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+    skill_loader = SkillLoader(
+        project_root=tmp_path / "project",
+        global_root=tmp_path / "global",
+        builtin_root=tmp_path / "builtin",
+    )
+
+    with pytest.raises(ValueError, match="non_interactive_defaults.plan_template"):
+        load_playbook_file(path, source="builtin", skill_loader=skill_loader)
+
+    _write_playbook(loader._roots()[0], "bad", content)
+    with pytest.raises(ValueError, match="non_interactive_defaults.plan_template"):
+        loader.load_model("bad")
+
+
+def test_legacy_playbook_without_prepare_section_loads(tmp_path: Path) -> None:
+    loader = _loader(tmp_path)
+    _write_playbook(
+        loader._roots()[0],
+        "legacy",
+        """
+playbook: {id: legacy}
+steps:
+  spec:
+    role: pm
+    skill: spec_first
+    on:
+      await_agent: _done
+""",
+    )
+
+    result = loader.load_model("legacy")
+
+    assert result.model.commands is None
+    assert resolve_prepare_config(result.model) == default_prepare_config()
+
+
+def _expected_standard_prepare() -> dict:
+    return default_prepare_config().model_dump()
+
+
+def test_builtin_default_playbook_prepare_parity() -> None:
+    loader = PlaybookLoader()
+    resolved = resolve_prepare_config(loader.load_model("default").model)
+
+    assert resolved.model_dump() == _expected_standard_prepare()
+
+
+def test_builtin_simple_and_tdd_match_default_prepare() -> None:
+    loader = PlaybookLoader()
+    default_prepare = resolve_prepare_config(loader.load_model("default").model).model_dump()
+
+    for name in ("simple", "tdd"):
+        resolved = resolve_prepare_config(loader.load_model(name).model)
+        assert resolved.model_dump() == default_prepare
+
+
+def test_builtin_hotfix_disables_spec_plan_prompts() -> None:
+    loader = PlaybookLoader()
+    resolved = resolve_prepare_config(loader.load_model("hotfix").model)
+
+    assert resolved.prompt_for_spec_plan_config is False
+    assert resolved.quick_setup.pr.auto_create_on_github_repo is True
+    assert resolved.quick_setup.pr.post_todo_list_when_auto_create is True
+
+
+def test_builtin_non_prepare_playbooks_still_load_without_prepare_section() -> None:
+    loader = PlaybookLoader()
+
+    for name in ("research", "editorial", "incident"):
+        model = loader.load_model(name).model
+        assert model.commands is None or model.commands.prepare is None


### PR DESCRIPTION
## Summary

Implements [issue #331](https://github.com/luyotw/cafe/issues/331): a declarative `commands.prepare` block on playbooks that describes `cafe prepare` prompt and default behavior without changing the CLI runtime yet.

Built-in playbooks (`default`, `simple`, `tdd`, `hotfix`) now declare prepare metadata matching today's hard-coded behavior. The schema validates at playbook load time and via `cafe playbook validate`. Playbooks without the section still load with backward-compatible defaults. Review approved after develop iteration 002 (boolean validation test fix).

## Changes

### Schema and validation

- Extend `src/cafe/core/playbook.py` with nested `PrepareConfig` models under `commands.prepare` (setup modes, quick-setup defaults, non-interactive defaults, input method, constraints).
- Add `default_prepare_config()` and `resolve_prepare_config()` for shared default resolution when metadata is omitted.
- Validate template names via `TemplateManager` and cross-check rigor values against declared constraints.

### Built-in playbooks

- Add `commands.prepare` to `default.yaml`, `simple.yaml`, and `tdd.yaml` (standard prepare defaults).
- Add `commands.prepare` to `hotfix.yaml` with `prompt_for_spec_plan_config: false`.
- Leave `research`, `editorial`, and `incident` unchanged.

### Tests

- `tests/unit/test_playbook_prepare_metadata.py` — schema parsing, default resolution, invalid metadata, built-in parity (12 scenarios).
- `tests/unit/test_cli_playbook_validate.py` — CLI validate for built-in and legacy project override playbooks (2 scenarios).

### Commits (issue331 branch, ahead of `develop`)

| Commit | Subject |
| --- | --- |
| `0b3869f` | Add commands.prepare schema and validation to playbook loader |
| `72464d1` | Add unit tests for playbook prepare metadata |
| `fa7c584` | Declare prepare metadata on builtin playbooks |
| `a727bf0` | Add CLI validate tests for prepare-enabled playbooks |
| `ebfe961` | Fix prepare metadata bool validation test to target schema field |

Closes #331.

## Test Plan

- [x] `pytest tests/unit/test_playbook_prepare_metadata.py tests/unit/test_cli_playbook_validate.py tests/unit/test_playbook_loader.py tests/unit/test_cli_prepare.py` — 78 passed (prepare behavior unchanged).
- [x] `cafe playbook validate default` / `simple` / `tdd` / `hotfix` — all valid.
- [x] Playbooks without `commands.prepare` load successfully with resolved defaults.
- [x] Invalid prepare metadata (unknown template, invalid rigor, malformed bool) fails at load and validate with field-level errors.
- [ ] Follow-up issue: wire `cafe prepare` to consume `resolve_prepare_config()` (out of scope here).