### PR TITLE
Drive cafe prepare from playbook metadata (#332)

### DIFF
--- a/src/cafe/core/prepare_profile.py
+++ b/src/cafe/core/prepare_profile.py
@@ -1,0 +1,101 @@
+"""Playbook-driven decision layer for ``cafe prepare``."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+from cafe.core.playbook import PlaybookDefinition, PrepareConfig, resolve_prepare_config
+
+
+class PrepareRigorError(ValueError):
+    """Raised when rigor is outside playbook ``constraints.rigor``."""
+
+
+@dataclass(frozen=True)
+class PrepareIssueConfig:
+    """Resolved spec/plan/pr blocks for ``issue.yaml``."""
+
+    spec: Dict[str, Any]
+    plan: Dict[str, Any]
+    pr: Dict[str, Any]
+
+
+@dataclass(frozen=True)
+class NonInteractiveDefaults:
+    """Defaults applied when optional prepare flags are omitted."""
+
+    rigor: str
+    spec_template: str
+    plan_template: str
+
+
+@dataclass(frozen=True)
+class PrepareProfile:
+    """Effective prepare behavior from playbook metadata and repo context."""
+
+    prepare: PrepareConfig
+    is_github_repo: bool
+
+    @classmethod
+    def from_playbook(cls, model: PlaybookDefinition, is_github_repo: bool) -> PrepareProfile:
+        return cls(prepare=resolve_prepare_config(model), is_github_repo=is_github_repo)
+
+    def should_prompt_spec_plan_config(self, base_should_prompt: bool) -> bool:
+        return base_should_prompt and self.prepare.prompt_for_spec_plan_config
+
+    def enabled_setup_mode_labels(self) -> list[str]:
+        labels: list[str] = []
+        if self.prepare.setup_modes.quick.enabled:
+            labels.append(self.prepare.setup_modes.quick.label)
+        if self.prepare.setup_modes.custom.enabled:
+            labels.append(self.prepare.setup_modes.custom.label)
+        return labels
+
+    def is_quick_setup_choice(self, choice: str) -> bool:
+        return choice == self.prepare.setup_modes.quick.label
+
+    def quick_setup_issue_config(self, issue_id: Optional[int]) -> PrepareIssueConfig:
+        quick = self.prepare.quick_setup
+        spec: Dict[str, Any] = {
+            "rigor": quick.spec.rigor,
+            "template": quick.spec.template,
+        }
+        plan: Dict[str, Any] = {"template": quick.plan.template}
+        pr: Dict[str, Any] = {}
+
+        sync = quick.sync_github
+        has_issue_id = issue_id is not None
+        spec["sync_github"] = sync.when_issue_id_present if has_issue_id else sync.when_manual_input
+        plan["sync_github"] = sync.when_issue_id_present if has_issue_id else sync.when_manual_input
+
+        if self.is_github_repo and quick.pr.auto_create_on_github_repo:
+            pr["auto_create"] = True
+            if quick.pr.post_todo_list_when_auto_create:
+                pr["post_todo_list"] = True
+        else:
+            pr["auto_create"] = False
+
+        return PrepareIssueConfig(spec=spec, plan=plan, pr=pr)
+
+    def non_interactive_defaults(self) -> NonInteractiveDefaults:
+        defaults = self.prepare.non_interactive_defaults
+        return NonInteractiveDefaults(
+            rigor=defaults.rigor,
+            spec_template=defaults.spec_template,
+            plan_template=defaults.plan_template,
+        )
+
+    def validate_rigor(self, rigor: str) -> None:
+        allowed = set(self.prepare.constraints.rigor)
+        if rigor not in allowed:
+            allowed_display = ", ".join(f"'{level}'" for level in self.prepare.constraints.rigor)
+            raise PrepareRigorError(
+                f"--rigor must be one of: {allowed_display}"
+            )
+
+    def should_prompt_input_method(self) -> bool:
+        return self.is_github_repo and self.prepare.input_method.prompt_on_github_repo
+
+    def default_input_method(self) -> str:
+        return self.prepare.input_method.non_github_default

--- a/src/cafe/core/prepare_profile.py
+++ b/src/cafe/core/prepare_profile.py
@@ -94,6 +94,9 @@ class PrepareProfile:
                 f"--rigor must be one of: {allowed_display}"
             )
 
+    def allowed_rigor_values(self) -> list[str]:
+        return list(self.prepare.constraints.rigor)
+
     def should_prompt_input_method(self) -> bool:
         return self.is_github_repo and self.prepare.input_method.prompt_on_github_repo
 

--- a/src/cafe/ui/commands/lifecycle.py
+++ b/src/cafe/ui/commands/lifecycle.py
@@ -204,6 +204,23 @@ def prepare(
                 console.print(f"[red]Error: {e}[/red]")
                 raise typer.Exit(1)
 
+        from cafe.core.prepare_profile import PrepareProfile, PrepareRigorError
+        from cafe.playbooks.loader import PlaybookLoader
+        from cafe.ui.cli_shared import _resolve_selected_playbook
+        from cafe.utils.git_utils import is_github_repo
+
+        playbook_name = _resolve_selected_playbook(None)
+        try:
+            loaded_playbook = PlaybookLoader().load_model(playbook_name)
+        except (FileNotFoundError, ValueError) as exc:
+            console.print(f"[red]Error: Failed to load playbook '{playbook_name}': {exc}[/red]")
+            console.print(
+                "[yellow]Check .cafe/config.yaml playbook setting or add the playbook file.[/yellow]"
+            )
+            raise typer.Exit(1)
+
+        profile = PrepareProfile.from_playbook(loaded_playbook.model, is_github_repo())
+
         # 2. Determine interactive mode and config prompt behavior
         # should_prompt_for_config: Should we show config prompts?
         #   - True if user didn't provide issue_name as argument AND interactive flag is True
@@ -240,18 +257,21 @@ def prepare(
                 console.print("[red]Error: --issue-id is required when using --input-method=github[/red]")
                 raise typer.Exit(1)
 
-            # 4.4. Validate rigor if provided
-            if rigor and rigor not in ["low", "medium", "high"]:
-                console.print("[red]Error: --rigor must be 'low', 'medium', or 'high'[/red]")
-                raise typer.Exit(1)
-
-            # 4.5. Set default values for optional parameters
+            # 4.4. Apply playbook non-interactive defaults
+            defaults = profile.non_interactive_defaults()
             if rigor is None:
-                rigor = "medium"
+                rigor = defaults.rigor
             if plan_template is None:
-                plan_template = "default"
+                plan_template = defaults.plan_template
             if spec_template is None:
-                spec_template = "auto"
+                spec_template = defaults.spec_template
+
+            # 4.5. Validate rigor against playbook constraints
+            try:
+                profile.validate_rigor(rigor)
+            except PrepareRigorError as exc:
+                console.print(f"[red]Error: {exc}[/red]")
+                raise typer.Exit(1)
 
         # 5. Initialize Git operations
         try:
@@ -349,7 +369,7 @@ def prepare(
         plan_config = {}
         pr_config = {}
 
-        if should_prompt_for_config:
+        if profile.should_prompt_spec_plan_config(should_prompt_for_config):
             console.print()
             console.print("[bold cyan]📝 Pre-configure spec and plan phases[/bold cyan]")
             console.print(
@@ -361,56 +381,32 @@ def prepare(
             display = Display()
             github_ops = GitHubOps()
 
-            # Step 1: Prompt for input method and issue ID (only for GitHub repos)
-            from cafe.utils.git_utils import is_github_repo
-
-            if is_github_repo():
+            # Step 1: Input method and issue ID (playbook-driven)
+            if profile.should_prompt_input_method():
                 input_method, issue_id = prompt_for_input_method(display, github_ops)
                 spec_config["input_method"] = input_method
                 if issue_id is not None:
                     spec_config["issue_id"] = str(issue_id)
             else:
-                # Non-GitHub repo: use manual input only
-                spec_config["input_method"] = "manual"
+                spec_config["input_method"] = profile.default_input_method()
                 issue_id = None
 
             # Step 2: Prompt for setup mode (after input method selection)
             console.print()
-            setup_mode_choices = [
-                "Quick setup (use recommended defaults)",
-                "Custom configuration",
-            ]
+            setup_mode_choices = profile.enabled_setup_mode_labels()
             setup_mode_choice = prompt_list(
                 message="Choose setup mode:",
                 choices=setup_mode_choices,
                 default=setup_mode_choices[0],
             )
-            
-            use_quick_setup = setup_mode_choice.startswith("Quick setup")
-            
+
+            use_quick_setup = profile.is_quick_setup_choice(setup_mode_choice)
+
             if use_quick_setup:
-                # Quick setup: Apply default values without prompting
-                # Default values
-                spec_config["rigor"] = "medium"
-                spec_config["template"] = "auto"
-                plan_config["template"] = "auto"
-                
-                # Sync settings based on input method
-                if issue_id is not None:
-                    spec_config["sync_github"] = True  # GitHub Issue -> sync
-                    plan_config["sync_github"] = True
-                else:
-                    spec_config["sync_github"] = False  # Manual input -> no sync
-                    plan_config["sync_github"] = False
-                
-                # Auto create PR depends on whether it's a GitHub repo
-                if is_github_repo():
-                    pr_config["auto_create"] = True
-                    # In Quick setup, auto_create is always True for GitHub repos,
-                    # so always enable post_todo_list as well
-                    pr_config["post_todo_list"] = True
-                else:
-                    pr_config["auto_create"] = False
+                quick_config = profile.quick_setup_issue_config(issue_id)
+                spec_config.update(quick_config.spec)
+                plan_config.update(quick_config.plan)
+                pr_config.update(quick_config.pr)
 
                 # Display default values summary
                 console.print()
@@ -419,7 +415,7 @@ def prepare(
                 console.print(f"  • Spec template: {spec_config['template']}")
                 console.print(f"  • Plan template: {plan_config['template']}")
                 console.print(f"  • Input method: {spec_config['input_method']}")
-                if is_github_repo():
+                if profile.is_github_repo:
                     console.print(f"  • Sync to GitHub: {spec_config.get('sync_github', False)}")
                     console.print(f"  • Auto create PR: {pr_config.get('auto_create', False)}")
                     console.print(f"  • Post PR todo list: {pr_config.get('post_todo_list', False)}")

--- a/src/cafe/ui/commands/lifecycle.py
+++ b/src/cafe/ui/commands/lifecycle.py
@@ -441,7 +441,12 @@ def prepare(
                     console.print()
 
                 # Prompt for rigor level
-                rigor = prompt_for_rigor(display)
+                rigor = prompt_for_rigor(display, allowed=profile.allowed_rigor_values())
+                try:
+                    profile.validate_rigor(rigor)
+                except PrepareRigorError as exc:
+                    console.print(f"[red]Error: {exc}[/red]")
+                    raise typer.Exit(1)
                 spec_config["rigor"] = rigor
 
                 # Prompt for spec template

--- a/src/cafe/ui/phase_prompts.py
+++ b/src/cafe/ui/phase_prompts.py
@@ -67,25 +67,33 @@ def prompt_for_input_method(display: Display, github_ops: GitHubOps) -> tuple[st
                 print()
 
 
-def prompt_for_rigor(display: Display) -> str:
+def prompt_for_rigor(display: Display, allowed: Optional[List[str]] = None) -> str:
     """Ask for specification rigor level
 
     Args:
         display: Display instance (not currently used, but kept for future extension)
+        allowed: Optional allowed rigor values from the selected playbook
 
     Returns:
         Rigor level string: 'low' | 'medium' | 'high'
     """
-    choices = [
-        "Low - Fast development mode\n   • Ask only critical information\n   • Allow ambiguity, let developers decide\n   • Suitable for: rapid prototypes, MVP, internal tools",
-        "Medium - Balanced mode [Default]\n   • Ask important details and key scenarios\n   • Balance speed and precision\n   • Suitable for: general feature development",
-        "High - Precise specification mode\n   • Ask all details and edge cases\n   • Ensure requirements are testable, no ambiguity\n   • Suitable for: core features, API design, external products",
-    ]
+    choice_by_value = {
+        "low": "Low - Fast development mode\n   • Ask only critical information\n   • Allow ambiguity, let developers decide\n   • Suitable for: rapid prototypes, MVP, internal tools",
+        "medium": "Medium - Balanced mode [Default]\n   • Ask important details and key scenarios\n   • Balance speed and precision\n   • Suitable for: general feature development",
+        "high": "High - Precise specification mode\n   • Ask all details and edge cases\n   • Ensure requirements are testable, no ambiguity\n   • Suitable for: core features, API design, external products",
+    }
+    allowed_values = allowed or ["low", "medium", "high"]
+    choices = [choice_by_value[value] for value in allowed_values if value in choice_by_value]
+    default_choice = (
+        choice_by_value["medium"]
+        if "medium" in allowed_values
+        else choices[0]
+    )
 
     choice = prompt_list(
         message="Please select specification rigor level:",
         choices=choices,
-        default=choices[1],  # Default to Medium
+        default=default_choice,
     )
 
     # Parse the choice to get rigor level

--- a/tests/integration/test_prepare_playbook_driven.py
+++ b/tests/integration/test_prepare_playbook_driven.py
@@ -211,6 +211,58 @@ commands:
         )
         assert bad_result.exit_code == 1
 
+    @patch("cafe.ui.phase_prompts.prompt_confirm")
+    @patch("cafe.ui.cli.prompt_confirm")
+    @patch("cafe.ui.template_selector.prompt_list")
+    @patch("cafe.ui.phase_prompts.prompt_list")
+    @patch("cafe.ui.cli.prompt_list")
+    @patch("cafe.ui.cli.prompt_text")
+    def test_custom_configuration_rigor_choices_follow_playbook_constraints(
+        self,
+        mock_prompt_text,
+        mock_cli_list,
+        mock_phase_list,
+        mock_template_list,
+        mock_cli_confirm,
+        mock_phase_confirm,
+        temp_repo_dir,
+        mock_git_ops,
+    ):
+        prepare_block = """
+commands:
+  prepare:
+    quick_setup:
+      spec:
+        rigor: high
+    non_interactive_defaults:
+      rigor: high
+    constraints:
+      rigor: [high]
+"""
+        _write_custom_playbook(temp_repo_dir, "strict-custom", prepare_block)
+        _write_config_with_playbook(temp_repo_dir, "strict-custom")
+
+        mock_prompt_text.return_value = "strict-custom"
+        mock_cli_confirm.return_value = False
+        mock_phase_confirm.return_value = False
+        mock_cli_list.return_value = "Custom configuration"
+        mock_phase_list.side_effect = [
+            "1. Manual input",
+            "High - Precise specification mode\n   • Ask all details and edge cases\n   • Ensure requirements are testable, no ambiguity\n   • Suitable for: core features, API design, external products",
+        ]
+        mock_template_list.return_value = "auto"
+
+        result = runner.invoke(app, ["prepare"])
+
+        assert result.exit_code == 0
+        rigor_prompt = mock_phase_list.call_args_list[1]
+        assert rigor_prompt.kwargs["choices"] == [
+            "High - Precise specification mode\n   • Ask all details and edge cases\n   • Ensure requirements are testable, no ambiguity\n   • Suitable for: core features, API design, external products"
+        ]
+        config_file = temp_repo_dir / ".cafe" / "issues" / "strict-custom" / "issue.yaml"
+        config_data = yaml.safe_load(config_file.read_text(encoding="utf-8"))
+        assert config_data["spec"]["rigor"] == "high"
+
     def test_invalid_playbook_exits_with_actionable_error(
         self, temp_repo_dir, mock_git_ops
     ):

--- a/tests/integration/test_prepare_playbook_driven.py
+++ b/tests/integration/test_prepare_playbook_driven.py
@@ -1,0 +1,223 @@
+"""Integration tests for playbook-driven cafe prepare behavior."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from cafe.ui.cli import app
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def temp_repo_dir(tmp_path):
+    from tests.conftest import create_minimal_config
+
+    create_minimal_config(tmp_path)
+    return tmp_path
+
+
+@pytest.fixture(autouse=True)
+def change_test_dir(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+
+@pytest.fixture
+def mock_git_ops():
+    with patch("cafe.ui.cli.GitOperations") as MockGitOperations, patch(
+        "cafe.utils.git_utils.is_github_repo"
+    ) as mock_is_github_repo, patch(
+        "cafe.ui.phase_prompts.is_github_repo"
+    ) as mock_is_github_repo_phase:
+        mock_git = MagicMock()
+        MockGitOperations.return_value = mock_git
+        mock_git.get_current_branch.return_value = "main"
+        mock_git.has_uncommitted_changes.return_value = False
+        mock_git.branch_exists.return_value = False
+        mock_git.worktree_exists.return_value = False
+        mock_is_github_repo.return_value = True
+        mock_is_github_repo_phase.return_value = True
+        yield mock_git
+
+
+def _write_config_with_playbook(base_dir: Path, playbook_id: str) -> None:
+    config_path = base_dir / ".cafe" / "config.yaml"
+    data = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    data["playbook"] = playbook_id
+    config_path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+
+
+def _write_custom_playbook(base_dir: Path, name: str, prepare_block: str) -> None:
+    playbooks_dir = base_dir / ".cafe" / "playbooks"
+    playbooks_dir.mkdir(parents=True, exist_ok=True)
+    content = f"""
+playbook:
+  id: {name}
+steps:
+  spec:
+    type: skill
+    skill: spec
+    role: pm
+    "on":
+      await_agent: plan
+  plan:
+    type: skill
+    skill: plan
+    role: developer
+    "on":
+      await_agent: _done
+{prepare_block}
+"""
+    (playbooks_dir / f"{name}.yaml").write_text(content, encoding="utf-8")
+
+
+class TestPreparePlaybookDriven:
+    """Test List integration #1–#4."""
+
+    @patch("cafe.ui.phase_prompts.prompt_text")
+    @patch("cafe.ui.phase_prompts.GitHubOps")
+    @patch("cafe.ui.cli.GitHubOps")
+    @patch("cafe.ui.cli.prompt_confirm")
+    @patch("cafe.ui.template_selector.prompt_list")
+    @patch("cafe.ui.phase_prompts.prompt_list")
+    @patch("cafe.ui.cli.prompt_list")
+    @patch("cafe.ui.cli.prompt_text")
+    def test_default_playbook_quick_setup_writes_expected_issue_yaml(
+        self,
+        mock_prompt_text_cli,
+        mock_cli_list,
+        mock_phase_list,
+        mock_template_list,
+        mock_prompt_confirm,
+        MockGitHubOps_cli,
+        MockGitHubOps_phase,
+        mock_prompt_text_phase,
+        temp_repo_dir,
+        mock_git_ops,
+    ):
+        """Integration #1 — default playbook interactive quick setup parity."""
+        mock_github_ops = MagicMock()
+        MockGitHubOps_cli.return_value = mock_github_ops
+        MockGitHubOps_phase.return_value = mock_github_ops
+        mock_github_ops.extract_issue_number.return_value = "123"
+
+        mock_prompt_text_cli.return_value = "parity-quick"
+        mock_prompt_text_phase.return_value = "123"
+        mock_prompt_confirm.return_value = False
+        mock_phase_list.return_value = "2. Fetch from GitHub Issue"
+        mock_cli_list.return_value = "Quick setup (use recommended defaults)"
+
+        result = runner.invoke(app, ["prepare"])
+
+        assert result.exit_code == 0
+        config_file = temp_repo_dir / ".cafe" / "issues" / "parity-quick" / "issue.yaml"
+        config_data = yaml.safe_load(config_file.read_text(encoding="utf-8"))
+        assert config_data["spec"]["rigor"] == "medium"
+        assert config_data["spec"]["template"] == "auto"
+        assert config_data["plan"]["template"] == "auto"
+        assert config_data["spec"]["sync_github"] is True
+        assert config_data["pr"]["auto_create"] is True
+
+    def test_default_playbook_non_interactive_manual_input(
+        self, temp_repo_dir, mock_git_ops
+    ):
+        """Integration #2 — default playbook non-interactive parity."""
+        result = runner.invoke(
+            app,
+            ["prepare", "parity-ni", "--no-interactive", "--input-method=manual"],
+        )
+
+        assert result.exit_code == 0
+        config_file = temp_repo_dir / ".cafe" / "issues" / "parity-ni" / "issue.yaml"
+        config_data = yaml.safe_load(config_file.read_text(encoding="utf-8"))
+        assert config_data["spec"]["input_method"] == "manual"
+        assert config_data["spec"]["rigor"] == "medium"
+        assert config_data["spec"]["template"] == "auto"
+        assert config_data["plan"]["template"] == "default"
+
+    @patch("cafe.ui.cli.prompt_confirm")
+    @patch("cafe.ui.cli.prompt_text")
+    def test_hotfix_playbook_skips_spec_plan_config(
+        self, mock_prompt_text, mock_prompt_confirm, temp_repo_dir, mock_git_ops
+    ):
+        """Integration #3 — hotfix playbook skips spec/plan pre-configuration."""
+        _write_config_with_playbook(temp_repo_dir, "hotfix")
+        mock_prompt_text.return_value = "hotfix-issue"
+        mock_prompt_confirm.return_value = False
+
+        result = runner.invoke(app, ["prepare"])
+
+        assert result.exit_code == 0
+        assert "Pre-configure spec and plan phases" not in result.stdout
+        config_file = temp_repo_dir / ".cafe" / "issues" / "hotfix-issue" / "issue.yaml"
+        config_data = yaml.safe_load(config_file.read_text(encoding="utf-8"))
+        assert "spec" not in config_data
+        assert "plan" not in config_data
+        assert "pr" not in config_data
+
+    @patch("cafe.ui.cli.prompt_confirm")
+    @patch("cafe.ui.template_selector.prompt_list")
+    @patch("cafe.ui.phase_prompts.prompt_list")
+    @patch("cafe.ui.cli.prompt_list")
+    @patch("cafe.ui.cli.prompt_text")
+    def test_custom_playbook_quick_setup_and_rigor_constraint(
+        self,
+        mock_prompt_text,
+        mock_cli_list,
+        mock_phase_list,
+        mock_template_list,
+        mock_prompt_confirm,
+        temp_repo_dir,
+        mock_git_ops,
+    ):
+        """Integration #4 — custom playbook overrides quick-setup and enforces rigor."""
+        prepare_block = """
+commands:
+  prepare:
+    quick_setup:
+      spec:
+        rigor: high
+    non_interactive_defaults:
+      rigor: high
+    constraints:
+      rigor: [high]
+"""
+        _write_custom_playbook(temp_repo_dir, "strict", prepare_block)
+        _write_config_with_playbook(temp_repo_dir, "strict")
+
+        mock_prompt_text.return_value = "strict-quick"
+        mock_prompt_confirm.return_value = False
+        mock_phase_list.return_value = "1. Manual input"
+        mock_cli_list.return_value = "Quick setup (use recommended defaults)"
+
+        quick_result = runner.invoke(app, ["prepare"])
+        assert quick_result.exit_code == 0
+        config_file = temp_repo_dir / ".cafe" / "issues" / "strict-quick" / "issue.yaml"
+        config_data = yaml.safe_load(config_file.read_text(encoding="utf-8"))
+        assert config_data["spec"]["rigor"] == "high"
+
+        bad_result = runner.invoke(
+            app,
+            [
+                "prepare",
+                "strict-bad",
+                "--no-interactive",
+                "--input-method=manual",
+                "--rigor=low",
+            ],
+        )
+        assert bad_result.exit_code == 1
+
+    def test_invalid_playbook_exits_with_actionable_error(
+        self, temp_repo_dir, mock_git_ops
+    ):
+        """DoD — unloadable playbook fails gracefully."""
+        _write_config_with_playbook(temp_repo_dir, "does-not-exist")
+
+        result = runner.invoke(app, ["prepare", "bad-playbook"])
+
+        assert result.exit_code == 1
+        assert "Failed to load playbook" in result.stdout

--- a/tests/unit/test_prepare_profile.py
+++ b/tests/unit/test_prepare_profile.py
@@ -170,6 +170,7 @@ commands:
 """
         profile = _profile_from_yaml(tmp_path, prepare_yaml, is_github_repo=False)
         profile.validate_rigor("high")
+        assert profile.allowed_rigor_values() == ["high"]
 
 
 class TestPrepareProfileSetupModes:

--- a/tests/unit/test_prepare_profile.py
+++ b/tests/unit/test_prepare_profile.py
@@ -1,0 +1,223 @@
+"""Unit tests for playbook-driven prepare profile."""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from cafe.core.playbook import PlaybookDefinition, default_prepare_config, resolve_prepare_config
+from cafe.core.prepare_profile import PrepareProfile, PrepareRigorError
+from cafe.playbooks.loader import PlaybookLoader
+from cafe.skills.loader import SkillLoader
+
+
+def _write_skill(root: Path, name: str) -> None:
+    skill_dir = root / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: desc-{name}\n---\n\n# {name}\n",
+        encoding="utf-8",
+    )
+
+
+def _minimal_playbook_yaml(*, prepare_block: str = "") -> str:
+    return f"""
+playbook: {{id: test}}
+steps:
+  spec:
+    role: pm
+    skill: spec_first
+    "on":
+      await_agent: _done
+{prepare_block}
+"""
+
+
+def _loader(tmp_path: Path) -> PlaybookLoader:
+    builtin_root = tmp_path / "builtin"
+    _write_skill(builtin_root / "skills", "spec_first")
+    return PlaybookLoader(
+        project_root=tmp_path / "project",
+        global_root=tmp_path / "global",
+        builtin_root=builtin_root,
+    )
+
+
+def _profile_from_yaml(tmp_path: Path, prepare_yaml: str, *, is_github_repo: bool) -> PrepareProfile:
+    loader = _loader(tmp_path)
+    playbook_dir = loader._roots()[0]
+    playbook_dir.mkdir(parents=True, exist_ok=True)
+    (playbook_dir / "test.yaml").write_text(
+        _minimal_playbook_yaml(prepare_block=prepare_yaml),
+        encoding="utf-8",
+    )
+    model = loader.load_model("test").model
+    return PrepareProfile.from_playbook(model, is_github_repo)
+
+
+class TestPrepareProfilePromptGating:
+    """Test List unit #1 — profile gates spec/plan prompts."""
+
+    def test_disables_spec_plan_prompts_when_playbook_metadata_false(
+        self, tmp_path: Path
+    ) -> None:
+        profile = _profile_from_yaml(
+            tmp_path,
+            "commands:\n  prepare:\n    prompt_for_spec_plan_config: false\n",
+            is_github_repo=True,
+        )
+        assert profile.should_prompt_spec_plan_config(True) is False
+
+    def test_respects_base_flag_when_metadata_allows(self) -> None:
+        profile = PrepareProfile.from_playbook(
+            PlaybookDefinition.model_validate(
+                yaml.safe_load(_minimal_playbook_yaml())
+            ),
+            is_github_repo=True,
+        )
+        assert profile.should_prompt_spec_plan_config(True) is True
+        assert profile.should_prompt_spec_plan_config(False) is False
+
+
+class TestPrepareProfileQuickSetup:
+    """Test List unit #2 and #3 — quick setup defaults."""
+
+    def test_quick_setup_with_issue_id_enables_sync(self) -> None:
+        profile = PrepareProfile.from_playbook(
+            PlaybookDefinition.model_validate(yaml.safe_load(_minimal_playbook_yaml())),
+            is_github_repo=True,
+        )
+        result = profile.quick_setup_issue_config(issue_id=42)
+        assert result.spec["rigor"] == "medium"
+        assert result.spec["template"] == "auto"
+        assert result.plan["template"] == "auto"
+        assert result.spec["sync_github"] is True
+        assert result.plan["sync_github"] is True
+
+    def test_quick_setup_without_issue_id_disables_sync(self) -> None:
+        profile = PrepareProfile.from_playbook(
+            PlaybookDefinition.model_validate(yaml.safe_load(_minimal_playbook_yaml())),
+            is_github_repo=True,
+        )
+        result = profile.quick_setup_issue_config(issue_id=None)
+        assert result.spec["sync_github"] is False
+        assert result.plan["sync_github"] is False
+
+    def test_github_repo_sets_pr_defaults_from_metadata(self) -> None:
+        profile = PrepareProfile.from_playbook(
+            PlaybookDefinition.model_validate(yaml.safe_load(_minimal_playbook_yaml())),
+            is_github_repo=True,
+        )
+        result = profile.quick_setup_issue_config(issue_id=None)
+        assert result.pr["auto_create"] is True
+        assert result.pr["post_todo_list"] is True
+
+    def test_non_github_repo_skips_pr_auto_create(self) -> None:
+        profile = PrepareProfile.from_playbook(
+            PlaybookDefinition.model_validate(yaml.safe_load(_minimal_playbook_yaml())),
+            is_github_repo=False,
+        )
+        result = profile.quick_setup_issue_config(issue_id=None)
+        assert result.pr["auto_create"] is False
+        assert "post_todo_list" not in result.pr
+
+
+class TestPrepareProfileNonInteractive:
+    """Test List unit #4 and #5 — non-interactive defaults and rigor validation."""
+
+    def test_non_interactive_defaults_from_metadata(self, tmp_path: Path) -> None:
+        prepare_yaml = """
+commands:
+  prepare:
+    non_interactive_defaults:
+      rigor: high
+      spec_template: detailed
+      plan_template: bug
+"""
+        profile = _profile_from_yaml(tmp_path, prepare_yaml, is_github_repo=False)
+        defaults = profile.non_interactive_defaults()
+        assert defaults.rigor == "high"
+        assert defaults.spec_template == "detailed"
+        assert defaults.plan_template == "bug"
+
+    def test_validate_rigor_rejects_disallowed_value(self, tmp_path: Path) -> None:
+        prepare_yaml = """
+commands:
+  prepare:
+    quick_setup:
+      spec:
+        rigor: high
+    non_interactive_defaults:
+      rigor: high
+    constraints:
+      rigor: [high]
+"""
+        profile = _profile_from_yaml(tmp_path, prepare_yaml, is_github_repo=False)
+        with pytest.raises(PrepareRigorError):
+            profile.validate_rigor("low")
+
+    def test_validate_rigor_accepts_allowed_value(self, tmp_path: Path) -> None:
+        prepare_yaml = """
+commands:
+  prepare:
+    quick_setup:
+      spec:
+        rigor: high
+    non_interactive_defaults:
+      rigor: high
+    constraints:
+      rigor: [high]
+"""
+        profile = _profile_from_yaml(tmp_path, prepare_yaml, is_github_repo=False)
+        profile.validate_rigor("high")
+
+
+class TestPrepareProfileSetupModes:
+    """Test List unit #6 — setup mode labels."""
+
+    def test_only_enabled_modes_listed(self, tmp_path: Path) -> None:
+        prepare_yaml = """
+commands:
+  prepare:
+    setup_modes:
+      quick:
+        enabled: false
+        label: "Quick"
+      custom:
+        enabled: true
+        label: "Custom only"
+"""
+        profile = _profile_from_yaml(tmp_path, prepare_yaml, is_github_repo=False)
+        assert profile.enabled_setup_mode_labels() == ["Custom only"]
+
+
+class TestPrepareProfileFallback:
+    """Test List unit #7 — missing prepare metadata fallback."""
+
+    def test_playbook_without_prepare_matches_default_config(self) -> None:
+        model = PlaybookDefinition.model_validate(yaml.safe_load(_minimal_playbook_yaml()))
+        profile = PrepareProfile.from_playbook(model, is_github_repo=True)
+        assert profile.prepare.model_dump() == default_prepare_config().model_dump()
+
+
+class TestPrepareProfileInputMethod:
+    """Test List unit #8 — input method prompt gating."""
+
+    def test_non_github_uses_default_without_prompt(self) -> None:
+        profile = PrepareProfile.from_playbook(
+            PlaybookDefinition.model_validate(yaml.safe_load(_minimal_playbook_yaml())),
+            is_github_repo=False,
+        )
+        assert profile.should_prompt_input_method() is False
+        assert profile.default_input_method() == "manual"
+
+    def test_github_skips_prompt_when_metadata_disables(self, tmp_path: Path) -> None:
+        prepare_yaml = """
+commands:
+  prepare:
+    input_method:
+      prompt_on_github_repo: false
+      non_github_default: manual
+"""
+        profile = _profile_from_yaml(tmp_path, prepare_yaml, is_github_repo=True)
+        assert profile.should_prompt_input_method() is False


### PR DESCRIPTION
## Summary

Implements [issue #332](https://github.com/luyotw/cafe/issues/332): wire `cafe prepare` to the selected playbook's `commands.prepare` metadata (delivered in #331) so interactive prompts, quick-setup defaults, and non-interactive validation come from playbook YAML instead of hardcoded CLI logic.

A new `PrepareProfile` decision layer resolves effective prepare behavior from `resolve_prepare_config()` plus repo context (`is_github_repo`). The default playbook retains today-compatible behavior; custom playbooks (e.g. hotfix) can disable spec/plan pre-config or override defaults without editing Python.

Review approved with one non-blocking note: interactive custom-configuration rigor prompts remain hardcoded (out of scope per spec DoD).

## Changes

### Core

- Add `src/cafe/core/prepare_profile.py` — `PrepareProfile`, `PrepareIssueConfig`, `PrepareRigorError`; methods for prompt gating, setup modes, quick-setup `issue.yaml` blocks, non-interactive defaults, and rigor constraint validation.

### CLI

- Update `src/cafe/ui/commands/lifecycle.py` — load playbook via `PlaybookLoader` + `_resolve_selected_playbook` after init sync; fail gracefully on missing/invalid playbook; drive interactive and non-interactive prepare paths from profile methods.

### Tests

- Add `tests/unit/test_prepare_profile.py` — 13 unit tests covering plan Test List items #1–8.
- Add `tests/integration/test_prepare_playbook_driven.py` — 5 integration tests (default parity, hotfix skip-config, custom rigor constraints, invalid playbook).

### Commits (issue332 branch, ahead of `develop`)

| Commit | Subject |
| --- | --- |
| `0d27d20` | Add prepare profile module with unit tests |
| `9760cd9` | Drive cafe prepare from playbook metadata |

Closes #332.

## Test Plan

- [x] `pytest tests/unit/test_prepare_profile.py` — profile prompt gating, quick-setup defaults, non-interactive defaults, rigor validation, fallback.
- [x] `pytest tests/integration/test_prepare_playbook_driven.py` — default quick-setup parity, non-interactive parity, hotfix skip-config, custom playbook rigor constraint, invalid playbook error.
- [x] `pytest tests/unit/test_cli_prepare.py tests/unit/test_prepare_auto_sync.py tests/integration/test_prepare_non_github.py` — no regressions (74 prepare-related tests).
- [x] Full pre-commit suite — 2078 passed at develop time.
- [ ] Manual: `cafe prepare` with default playbook — confirm interactive quick setup and `--no-interactive` behave as before.
- [ ] Manual: set `playbook: hotfix` in `.cafe/config.yaml` and run interactive `cafe prepare` — confirm spec/plan pre-config section is skipped.