### PR TITLE
Add declarative PrepareField schema and fields_ref loader

### DIFF
--- a/docs/prepare_fields.md
+++ b/docs/prepare_fields.md
@@ -1,0 +1,128 @@
+# Declarative Prepare Fields
+
+This document describes the declarative prepare field contract introduced for playbook and skill assets. It is validation-only in the current release: `cafe prepare` interactive rendering still uses legacy `commands.prepare` metadata.
+
+## PrepareField schema
+
+Each prepare question is declared as one field object:
+
+| Property | Required | Description |
+| --- | --- | --- |
+| `id` | yes | Stable identifier (for example `input_method`, `quick_rigor`) |
+| `type` | yes | `enum`, `boolean`, `template`, `text`, or `setup_mode` |
+| `label` | yes | User-facing label |
+| `write` | yes* | Issue config target (`spec.rigor`, `plan.template`, `pr.auto_create`, …) |
+| `help` | no | Optional help text |
+| `default` | no | Default value when applicable |
+| `choices` | yes for `enum` / `setup_mode` | `{ value, label, description? }` entries |
+| `show_when` | no | Simple visibility conditions |
+| `group` | no | Logical grouping (`input`, `setup`, `quick_defaults`, `custom`) |
+
+Allowed `write` targets:
+
+- `spec.rigor`, `spec.template`, `spec.sync_github`, `spec.input_method`, `spec.issue_id`
+- `plan.template`, `plan.sync_github`
+- `pr.auto_create`, `pr.post_todo_list`
+
+`setup_mode` fields describe the setup-mode chooser and must not declare `write`.
+
+Optional document metadata:
+
+```yaml
+meta:
+  prompt_for_spec_plan_config: true
+fields:
+  - id: setup_mode
+    type: setup_mode
+    ...
+```
+
+## Declaring fields on a playbook
+
+Inline fields:
+
+```yaml
+commands:
+  prepare:
+    fields:
+      - id: rigor
+        type: enum
+        label: Rigor
+        write: spec.rigor
+        ...
+```
+
+External static asset via `fields_ref`:
+
+```yaml
+commands:
+  prepare:
+    fields_ref: skill://spec/assets/prepare/default_prepare_fields.yaml
+```
+
+`fields` and `fields_ref` are mutually exclusive.
+
+When a playbook keeps legacy `commands.prepare` blocks **and** declares `fields` / `fields_ref`, `cafe playbook validate` checks semantic parity between the legacy metadata and the declarative fields.
+
+## `fields_ref` sources
+
+### Skill asset URI (preferred)
+
+```
+skill://<skill-name>/assets/<relative-path>
+```
+
+Example:
+
+```
+skill://spec/assets/prepare/default_prepare_fields.yaml
+```
+
+Resolution uses `SkillLoader.get_skill_dir()` and only allows files under that skill's `assets/` directory.
+
+### Playbook-relative path
+
+```
+assets/local_prepare_fields.yaml
+```
+
+Resolved relative to the playbook YAML file directory. The ref must not contain `://`.
+
+## Security rules
+
+Common rules for both formats:
+
+- Load with `yaml.safe_load` / `json.load` only
+- No script execution, no imports
+- Allowed extensions: `.yaml`, `.yml`, `.json`
+- Relative paths only; `..` is rejected
+- Resolved path must stay inside the allowed sandbox directory
+- Target must exist and be a regular file
+
+Skill URI additional rules:
+
+- URI must match `skill://<skill>/assets/<path>`
+- Unknown skills are rejected
+- Path segments must not include `scripts`
+- References like `skill://spec/references/...` or `skill://spec/scripts/...` are rejected
+
+Playbook-relative additional rules:
+
+- Ref must not contain `://`
+- Resolved path must stay under the playbook directory
+
+## Canonical example
+
+The built-in default playbook references:
+
+`src/cafe/data/skills/spec/assets/prepare/default_prepare_fields.yaml`
+
+That asset fully describes the current default prepare flow, including setup mode selection, quick/custom branches, GitHub-only prompts, and sync/PR defaults. Legacy `commands.prepare` remains on `src/cafe/data/playbooks/default.yaml` for runtime behavior and parity validation.
+
+## Validation entry points
+
+- `cafe playbook validate <name>`
+- `load_playbook_file()` / `PlaybookLoader.load_model()`
+- `PrepareProfile.resolved_prepare_fields()` (read-only contract access; does not drive UI)
+
+Omitting both `fields` and `fields_ref` preserves backward-compatible behavior.

--- a/src/cafe/core/playbook.py
+++ b/src/cafe/core/playbook.py
@@ -10,6 +10,12 @@ import yaml
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from cafe.core.status_codes import PLAYBOOK_INTENT_KEYS, PhaseStatusCode
+from cafe.core.prepare_fields import (
+    PrepareField,
+    assert_prepare_semantics_match,
+    resolve_prepare_fields,
+    validate_field_semantics,
+)
 from cafe.skills.exceptions import SkillDiscoveryError
 from cafe.skills.loader import SkillLoader
 from cafe.templates.manager import TemplateManager
@@ -240,6 +246,14 @@ class PrepareConfig(BaseModel):
     )
     input_method: PrepareInputMethod = Field(default_factory=PrepareInputMethod)
     constraints: PrepareConstraints = Field(default_factory=PrepareConstraints)
+    fields: Optional[List[PrepareField]] = None
+    fields_ref: Optional[str] = None
+
+    @model_validator(mode="after")
+    def _validate_fields_source(self) -> "PrepareConfig":
+        if self.fields and self.fields_ref:
+            raise ValueError("commands.prepare.fields and commands.prepare.fields_ref are mutually exclusive")
+        return self
 
 
 class CommandsConfig(BaseModel):
@@ -370,15 +384,20 @@ def validate_playbook(
                 f"Step '{step_name}': assignee_type={step.assignee_type} (reserved for v0.3)"
             )
 
-    _validate_prepare_metadata(model)
+    _validate_prepare_metadata(model, skill_loader=skill_loader, playbook_path=path)
 
     if warnings and strict:
         raise ValueError("\n".join(warnings))
     return warnings
 
 
-def _validate_prepare_metadata(model: PlaybookDefinition) -> None:
-    """Validate prepare metadata templates and rigor constraints."""
+def _validate_prepare_metadata(
+    model: PlaybookDefinition,
+    *,
+    skill_loader: SkillLoader,
+    playbook_path: Path,
+) -> None:
+    """Validate prepare metadata templates, rigor constraints, and declarative fields."""
     prepare = resolve_prepare_config(model)
     spec_manager = TemplateManager(template_type="spec")
     plan_manager = TemplateManager(template_type="plan")
@@ -417,6 +436,24 @@ def _validate_prepare_metadata(model: PlaybookDefinition) -> None:
             f"{prepare.non_interactive_defaults.rigor!r} is not listed in "
             f"commands.prepare.constraints.rigor"
         )
+
+    parsed_fields = resolve_prepare_fields(
+        prepare,
+        playbook_path=playbook_path,
+        skill_loader=skill_loader,
+    )
+    if parsed_fields is None:
+        return
+
+    validate_field_semantics(
+        parsed_fields.fields,
+        prepare,
+        spec_manager=spec_manager,
+        plan_manager=plan_manager,
+    )
+
+    if model.commands is not None and model.commands.prepare is not None:
+        assert_prepare_semantics_match(model.commands.prepare, parsed_fields)
 
 
 def _validate_prepare_template(

--- a/src/cafe/core/playbook.py
+++ b/src/cafe/core/playbook.py
@@ -264,6 +264,9 @@ class CommandsConfig(BaseModel):
     prepare: Optional[PrepareConfig] = None
 
 
+_PREPARE_FIELDS_ONLY_KEYS = frozenset({"fields", "fields_ref"})
+
+
 def default_prepare_config() -> PrepareConfig:
     """Return backward-compatible prepare defaults matching the built-in default playbook."""
     return PrepareConfig()
@@ -445,14 +448,18 @@ def _validate_prepare_metadata(
     if parsed_fields is None:
         return
 
+    has_explicit_legacy_prepare_metadata = bool(
+        prepare.model_fields_set - _PREPARE_FIELDS_ONLY_KEYS
+    )
     validate_field_semantics(
         parsed_fields.fields,
         prepare,
         spec_manager=spec_manager,
         plan_manager=plan_manager,
+        enforce_legacy_setup_modes=has_explicit_legacy_prepare_metadata,
     )
 
-    if model.commands is not None and model.commands.prepare is not None:
+    if has_explicit_legacy_prepare_metadata:
         assert_prepare_semantics_match(model.commands.prepare, parsed_fields)
 
 

--- a/src/cafe/core/prepare_fields.py
+++ b/src/cafe/core/prepare_fields.py
@@ -1,0 +1,488 @@
+"""Declarative prepare field schema, loading, and semantic validation."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Dict, List, Literal, Optional
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from cafe.skills.exceptions import SkillDiscoveryError
+from cafe.skills.loader import SkillLoader
+from cafe.templates.manager import TemplateManager
+
+ALLOWED_WRITE_TARGETS = frozenset(
+    {
+        "spec.rigor",
+        "spec.template",
+        "spec.sync_github",
+        "spec.input_method",
+        "spec.issue_id",
+        "plan.template",
+        "plan.sync_github",
+        "pr.auto_create",
+        "pr.post_todo_list",
+    }
+)
+
+ALLOWED_FIELD_TYPES = frozenset({"enum", "boolean", "template", "text", "setup_mode"})
+ALLOWED_SHOW_WHEN_KEYS = frozenset({"github_repo", "issue_id_present", "setup_mode"})
+ALLOWED_SETUP_MODES = frozenset({"quick", "custom"})
+ALLOWED_STATIC_SUFFIXES = frozenset({".yaml", ".yml", ".json"})
+
+SKILL_FIELDS_REF_PATTERN = re.compile(r"^skill://([^/]+)/assets/(.+)$")
+
+
+class FieldsRefKind(str, Enum):
+    SKILL_ASSET = "skill_asset"
+    PLAYBOOK_RELATIVE = "playbook_relative"
+
+
+class PrepareFieldChoice(BaseModel):
+    """One enum/setup_mode choice."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    value: str
+    label: str
+    description: Optional[str] = None
+
+
+class ShowWhen(BaseModel):
+    """Simple visibility conditions for one prepare field."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    github_repo: Optional[bool] = None
+    issue_id_present: Optional[bool] = None
+    setup_mode: Optional[Literal["quick", "custom"]] = None
+
+    @model_validator(mode="after")
+    def _validate_known_keys_only(self) -> "ShowWhen":
+        return self
+
+
+class PrepareField(BaseModel):
+    """One declarative prepare question."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    type: Literal["enum", "boolean", "template", "text", "setup_mode"]
+    label: str
+    write: Optional[str] = None
+    help: Optional[str] = None
+    default: Optional[Any] = None
+    choices: List[PrepareFieldChoice] = Field(default_factory=list)
+    show_when: Optional[ShowWhen] = None
+    group: Optional[str] = None
+
+    @field_validator("id")
+    @classmethod
+    def _validate_id(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("field id must not be empty")
+        return value
+
+    @field_validator("write")
+    @classmethod
+    def _validate_write(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return value
+        if value not in ALLOWED_WRITE_TARGETS:
+            raise ValueError(
+                f"unknown write target {value!r}; "
+                f"must be one of {sorted(ALLOWED_WRITE_TARGETS)}"
+            )
+        return value
+
+    @model_validator(mode="after")
+    def _validate_type_constraints(self) -> "PrepareField":
+        if self.type in {"enum", "setup_mode"} and not self.choices:
+            raise ValueError(f"field {self.id!r} requires choices for type {self.type!r}")
+        if self.type == "setup_mode" and self.write is not None:
+            raise ValueError(f"setup_mode field {self.id!r} must not declare write target")
+        if self.type != "setup_mode" and self.write is None:
+            raise ValueError(f"field {self.id!r} requires write target")
+        return self
+
+
+class PrepareFieldsMeta(BaseModel):
+    """Optional document-level prepare metadata mirrored from legacy blocks."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    prompt_for_spec_plan_config: Optional[bool] = None
+
+
+class PrepareFieldsDocument(BaseModel):
+    """Top-level document loaded from inline fields or fields_ref assets."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    meta: Optional[PrepareFieldsMeta] = None
+    fields: List[PrepareField]
+
+
+@dataclass(frozen=True)
+class ParsedPrepareFields:
+    """Parsed prepare field document."""
+
+    fields: List[PrepareField]
+    meta: Optional[PrepareFieldsMeta] = None
+
+
+def parse_prepare_fields_document(raw: Any) -> ParsedPrepareFields:
+    """Parse a fields document or bare list into typed prepare fields."""
+    if isinstance(raw, list):
+        return ParsedPrepareFields(fields=[PrepareField.model_validate(item) for item in raw])
+    if isinstance(raw, dict):
+        document = PrepareFieldsDocument.model_validate(raw)
+        return ParsedPrepareFields(fields=document.fields, meta=document.meta)
+    raise ValueError("prepare fields document must be a list or mapping with 'fields'")
+
+
+def parse_prepare_fields(raw: Any) -> List[PrepareField]:
+    """Parse a fields document or bare list into typed prepare fields."""
+    return parse_prepare_fields_document(raw).fields
+
+
+def parse_fields_ref(ref: str) -> FieldsRefKind:
+    """Classify a fields_ref string."""
+    token = str(ref or "").strip()
+    if not token:
+        raise ValueError("commands.prepare.fields_ref must not be empty")
+    if "://" in token:
+        if token.startswith("skill://"):
+            return FieldsRefKind.SKILL_ASSET
+        raise ValueError(f"unsupported fields_ref scheme in {token!r}")
+    return FieldsRefKind.PLAYBOOK_RELATIVE
+
+
+def _validate_relative_path(path: str, *, field_name: str) -> Path:
+    candidate = Path(path)
+    if candidate.is_absolute():
+        raise ValueError(f"{field_name} must be a relative path")
+    if ".." in candidate.parts:
+        raise ValueError(f"{field_name} must not contain '..'")
+    if any(part == "scripts" for part in candidate.parts):
+        raise ValueError(f"{field_name} must not reference scripts/")
+    suffix = candidate.suffix.lower()
+    if suffix not in ALLOWED_STATIC_SUFFIXES:
+        raise ValueError(
+            f"{field_name} must use one of {sorted(ALLOWED_STATIC_SUFFIXES)}"
+        )
+    return candidate
+
+
+def _assert_contained(resolved: Path, sandbox: Path, *, field_name: str) -> Path:
+    sandbox_resolved = sandbox.resolve()
+    target = resolved.resolve()
+    if not target.is_relative_to(sandbox_resolved):
+        raise ValueError(f"{field_name} resolves outside allowed directory")
+    if not target.is_file():
+        raise FileNotFoundError(f"{field_name} not found: {target}")
+    return target
+
+
+def resolve_fields_ref_path(
+    *,
+    ref: str,
+    playbook_path: Path,
+    skill_loader: SkillLoader,
+) -> Path:
+    """Resolve fields_ref to a concrete static asset path."""
+    kind = parse_fields_ref(ref)
+    if kind is FieldsRefKind.SKILL_ASSET:
+        match = SKILL_FIELDS_REF_PATTERN.match(ref.strip())
+        if match is None:
+            raise ValueError(f"invalid skill fields_ref {ref!r}")
+        skill_name, asset_path = match.groups()
+        relative = _validate_relative_path(asset_path, field_name="commands.prepare.fields_ref")
+        try:
+            skill_dir = skill_loader.get_skill_dir(skill_name)
+        except (SkillDiscoveryError, FileNotFoundError) as exc:
+            raise ValueError(
+                f"commands.prepare.fields_ref references unknown skill {skill_name!r}"
+            ) from exc
+        assets_dir = (skill_dir / "assets").resolve()
+        target = (assets_dir / relative).resolve()
+        return _assert_contained(target, assets_dir, field_name="commands.prepare.fields_ref")
+
+    relative = _validate_relative_path(ref.strip(), field_name="commands.prepare.fields_ref")
+    playbook_dir = playbook_path.parent.resolve()
+    target = (playbook_dir / relative).resolve()
+    return _assert_contained(target, playbook_dir, field_name="commands.prepare.fields_ref")
+
+
+def _load_static_document(path: Path) -> Any:
+    text = path.read_text(encoding="utf-8")
+    suffix = path.suffix.lower()
+    if suffix == ".json":
+        return json.loads(text)
+    return yaml.safe_load(text)
+
+
+def load_fields_ref(
+    *,
+    ref: str,
+    playbook_path: Path,
+    skill_loader: SkillLoader,
+) -> ParsedPrepareFields:
+    """Load prepare fields from a static playbook or skill asset reference."""
+    asset_path = resolve_fields_ref_path(
+        ref=ref,
+        playbook_path=playbook_path,
+        skill_loader=skill_loader,
+    )
+    raw = _load_static_document(asset_path)
+    if raw is None:
+        raise ValueError(f"commands.prepare.fields_ref asset is empty: {asset_path}")
+    return parse_prepare_fields_document(raw)
+
+
+def resolve_prepare_fields(
+    prepare: Any,
+    *,
+    playbook_path: Path,
+    skill_loader: SkillLoader,
+) -> Optional[ParsedPrepareFields]:
+    """Return effective prepare fields declared on one playbook, if any."""
+    if prepare.fields_ref:
+        return load_fields_ref(
+            ref=prepare.fields_ref,
+            playbook_path=playbook_path,
+            skill_loader=skill_loader,
+        )
+    if prepare.fields:
+        return ParsedPrepareFields(fields=list(prepare.fields))
+    return None
+
+
+def validate_show_when(show_when: Optional[ShowWhen], *, field_id: str) -> None:
+    """Reject unknown show_when keys (handled by pydantic) and invalid setup_mode."""
+    if show_when is None:
+        return
+    if show_when.setup_mode is not None and show_when.setup_mode not in ALLOWED_SETUP_MODES:
+        raise ValueError(
+            f"field {field_id!r} has invalid show_when.setup_mode {show_when.setup_mode!r}"
+        )
+
+
+def validate_field_semantics(
+    fields: List[PrepareField],
+    prepare: Any,
+    *,
+    spec_manager: TemplateManager,
+    plan_manager: TemplateManager,
+) -> None:
+    """Apply semantic validation to loaded prepare fields."""
+    allowed_rigor = set(prepare.constraints.rigor)
+    seen_ids: set[str] = set()
+
+    for field in fields:
+        if field.id in seen_ids:
+            raise ValueError(f"duplicate prepare field id {field.id!r}")
+        seen_ids.add(field.id)
+        validate_show_when(field.show_when, field_id=field.id)
+
+        if field.type == "template" and field.default is not None:
+            manager = spec_manager if field.write and field.write.startswith("spec.") else plan_manager
+            _validate_template_default(manager, str(field.default), field)
+
+        if field.write == "spec.rigor":
+            _validate_rigor_value(field.default, allowed_rigor, field.id)
+            for choice in field.choices:
+                if choice.value not in allowed_rigor:
+                    raise ValueError(
+                        f"field {field.id!r} choice {choice.value!r} is not listed in "
+                        "commands.prepare.constraints.rigor"
+                    )
+
+        if field.type == "setup_mode":
+            legacy = prepare.setup_modes
+            expected = [
+                (legacy.quick.label, legacy.quick.enabled),
+                (legacy.custom.label, legacy.custom.enabled),
+            ]
+            actual = [(choice.label, True) for choice in field.choices]
+            enabled_labels = [label for label, enabled in expected if enabled]
+            actual_labels = [label for label, _ in actual]
+            if actual_labels != enabled_labels:
+                raise ValueError(
+                    f"setup_mode field {field.id!r} choices do not match commands.prepare.setup_modes"
+                )
+
+
+def _validate_template_default(
+    manager: TemplateManager,
+    template_name: str,
+    field: PrepareField,
+) -> None:
+    if template_name == "auto":
+        return
+    if not manager.template_exists(template_name):
+        raise ValueError(
+            f"field {field.id!r} references unknown template {template_name!r}"
+        )
+
+
+def _validate_rigor_value(
+    value: Any,
+    allowed: set[str],
+    field_id: str,
+) -> None:
+    if value is None:
+        return
+    if value not in allowed:
+        raise ValueError(
+            f"field {field_id!r} default {value!r} is not listed in "
+            "commands.prepare.constraints.rigor"
+        )
+
+
+def _show_when_tuple(show_when: Optional[ShowWhen]) -> tuple[tuple[str, Any], ...]:
+    if show_when is None:
+        return ()
+    items: List[tuple[str, Any]] = []
+    if show_when.github_repo is not None:
+        items.append(("github_repo", show_when.github_repo))
+    if show_when.issue_id_present is not None:
+        items.append(("issue_id_present", show_when.issue_id_present))
+    if show_when.setup_mode is not None:
+        items.append(("setup_mode", show_when.setup_mode))
+    return tuple(sorted(items, key=lambda item: item[0]))
+
+
+def _legacy_field_defaults(prepare: Any) -> Dict[tuple[Optional[str], tuple[tuple[str, Any], ...]], Any]:
+    quick = prepare.quick_setup
+    defaults: Dict[tuple[Optional[str], tuple[tuple[str, Any], ...]], Any] = {
+        ("spec.rigor", (("setup_mode", "quick"),)): quick.spec.rigor,
+        ("spec.template", (("setup_mode", "quick"),)): quick.spec.template,
+        ("plan.template", (("setup_mode", "quick"),)): quick.plan.template,
+        (
+            "spec.sync_github",
+            (("issue_id_present", True), ("setup_mode", "quick")),
+        ): quick.sync_github.when_issue_id_present,
+        (
+            "spec.sync_github",
+            (("issue_id_present", False), ("setup_mode", "quick")),
+        ): quick.sync_github.when_manual_input,
+        (
+            "plan.sync_github",
+            (("issue_id_present", True), ("setup_mode", "quick")),
+        ): quick.sync_github.when_issue_id_present,
+        (
+            "plan.sync_github",
+            (("issue_id_present", False), ("setup_mode", "quick")),
+        ): quick.sync_github.when_manual_input,
+        (
+            "pr.auto_create",
+            (("github_repo", True), ("setup_mode", "quick")),
+        ): quick.pr.auto_create_on_github_repo,
+        (
+            "pr.post_todo_list",
+            (("github_repo", True), ("setup_mode", "quick")),
+        ): quick.pr.post_todo_list_when_auto_create,
+        ("spec.sync_github", (("issue_id_present", True), ("setup_mode", "custom"))): True,
+        ("plan.sync_github", (("issue_id_present", True), ("setup_mode", "custom"))): True,
+        (
+            "pr.post_todo_list",
+            (("github_repo", True), ("setup_mode", "custom")),
+        ): True,
+    }
+    return defaults
+
+
+def _fields_default_map(fields: List[PrepareField]) -> Dict[tuple[Optional[str], tuple[tuple[str, Any], ...]], Any]:
+    mapping: Dict[tuple[Optional[str], tuple[tuple[str, Any], ...]], Any] = {}
+    for field in fields:
+        if field.type == "setup_mode" or field.write is None:
+            continue
+        mapping[(field.write, _show_when_tuple(field.show_when))] = field.default
+    return mapping
+
+
+def build_legacy_semantics(prepare: Any) -> Dict[str, Any]:
+    """Build canonical prepare semantics from legacy commands.prepare metadata."""
+    enabled_modes = []
+    for name in ("quick", "custom"):
+        entry = getattr(prepare.setup_modes, name)
+        if entry.enabled:
+            enabled_modes.append({"name": name, "label": entry.label})
+    return {
+        "prompt_for_spec_plan_config": prepare.prompt_for_spec_plan_config,
+        "setup_modes": enabled_modes,
+        "non_interactive_defaults": prepare.non_interactive_defaults.model_dump(),
+        "input_method": prepare.input_method.model_dump(),
+        "constraints": prepare.constraints.model_dump(),
+        "defaults": _legacy_field_defaults(prepare),
+    }
+
+
+def build_fields_semantics(
+    parsed: ParsedPrepareFields,
+    *,
+    prepare: Any,
+) -> Dict[str, Any]:
+    """Build canonical prepare semantics from declarative fields."""
+    setup_field = next((field for field in parsed.fields if field.type == "setup_mode"), None)
+    enabled_modes = []
+    legacy_modes = [prepare.setup_modes.quick, prepare.setup_modes.custom]
+    if setup_field is not None:
+        for index, choice in enumerate(setup_field.choices):
+            mode_name = "quick" if index == 0 else "custom"
+            enabled = legacy_modes[index].enabled if index < len(legacy_modes) else True
+            if enabled:
+                enabled_modes.append({"name": mode_name, "label": choice.label})
+    else:
+        for name in ("quick", "custom"):
+            entry = getattr(prepare.setup_modes, name)
+            if entry.enabled:
+                enabled_modes.append({"name": name, "label": entry.label})
+
+    prompt_for_spec_plan_config = prepare.prompt_for_spec_plan_config
+    if parsed.meta is not None and parsed.meta.prompt_for_spec_plan_config is not None:
+        prompt_for_spec_plan_config = parsed.meta.prompt_for_spec_plan_config
+
+    return {
+        "prompt_for_spec_plan_config": prompt_for_spec_plan_config,
+        "setup_modes": enabled_modes,
+        "non_interactive_defaults": prepare.non_interactive_defaults.model_dump(),
+        "input_method": prepare.input_method.model_dump(),
+        "constraints": prepare.constraints.model_dump(),
+        "defaults": _fields_default_map(parsed.fields),
+    }
+
+
+def assert_prepare_semantics_match(
+    legacy: Any,
+    parsed: ParsedPrepareFields,
+) -> None:
+    """Ensure declarative fields describe the same prepare semantics as legacy metadata."""
+    legacy_semantics = build_legacy_semantics(legacy)
+    fields_semantics = build_fields_semantics(parsed, prepare=legacy)
+
+    for key in (
+        "prompt_for_spec_plan_config",
+        "setup_modes",
+        "non_interactive_defaults",
+        "input_method",
+        "constraints",
+    ):
+        if legacy_semantics[key] != fields_semantics[key]:
+            raise ValueError(
+                f"commands.prepare.fields disagree with legacy metadata for {key!r}"
+            )
+
+    for key, expected in legacy_semantics["defaults"].items():
+        actual = fields_semantics["defaults"].get(key)
+        if actual != expected:
+            raise ValueError(
+                f"commands.prepare.fields default for {key!r} disagrees with legacy commands.prepare"
+            )

--- a/src/cafe/core/prepare_fields.py
+++ b/src/cafe/core/prepare_fields.py
@@ -280,6 +280,7 @@ def validate_field_semantics(
     *,
     spec_manager: TemplateManager,
     plan_manager: TemplateManager,
+    enforce_legacy_setup_modes: bool = True,
 ) -> None:
     """Apply semantic validation to loaded prepare fields."""
     allowed_rigor = set(prepare.constraints.rigor)
@@ -304,7 +305,7 @@ def validate_field_semantics(
                         "commands.prepare.constraints.rigor"
                     )
 
-        if field.type == "setup_mode":
+        if field.type == "setup_mode" and enforce_legacy_setup_modes:
             legacy = prepare.setup_modes
             expected = [
                 (legacy.quick.label, legacy.quick.enabled),

--- a/src/cafe/core/prepare_profile.py
+++ b/src/cafe/core/prepare_profile.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Dict, Optional
 
 from cafe.core.playbook import PlaybookDefinition, PrepareConfig, resolve_prepare_config
+from cafe.core.prepare_fields import ParsedPrepareFields, resolve_prepare_fields
+from cafe.skills.loader import SkillLoader
 
 
 class PrepareRigorError(ValueError):
@@ -102,3 +105,16 @@ class PrepareProfile:
 
     def default_input_method(self) -> str:
         return self.prepare.input_method.non_github_default
+
+    def resolved_prepare_fields(
+        self,
+        *,
+        playbook_path: Path,
+        skill_loader: SkillLoader,
+    ) -> Optional[ParsedPrepareFields]:
+        """Return declarative prepare fields for this playbook, if declared."""
+        return resolve_prepare_fields(
+            self.prepare,
+            playbook_path=playbook_path,
+            skill_loader=skill_loader,
+        )

--- a/src/cafe/data/playbooks/default.yaml
+++ b/src/cafe/data/playbooks/default.yaml
@@ -47,6 +47,7 @@ commands:
       non_github_default: manual
     constraints:
       rigor: [low, medium, high]
+    fields_ref: skill://spec/assets/prepare/default_prepare_fields.yaml
 
 steps:
   spec:

--- a/src/cafe/data/skills/spec/assets/prepare/default_prepare_fields.yaml
+++ b/src/cafe/data/skills/spec/assets/prepare/default_prepare_fields.yaml
@@ -1,0 +1,190 @@
+meta:
+  prompt_for_spec_plan_config: true
+
+fields:
+  - id: input_method
+    type: enum
+    label: "Input method"
+    help: "Choose how issue requirements are provided."
+    write: spec.input_method
+    show_when:
+      github_repo: true
+    choices:
+      - value: manual
+        label: "Manual input"
+      - value: github
+        label: "GitHub issue"
+
+  - id: setup_mode
+    type: setup_mode
+    label: "Choose setup mode"
+    group: setup
+    choices:
+      - value: quick
+        label: "Quick setup (use recommended defaults)"
+      - value: custom
+        label: "Custom configuration"
+
+  - id: quick_rigor
+    type: enum
+    label: "Rigor level"
+    write: spec.rigor
+    default: medium
+    group: quick_defaults
+    show_when:
+      setup_mode: quick
+    choices:
+      - value: low
+        label: "Low"
+      - value: medium
+        label: "Medium"
+      - value: high
+        label: "High"
+
+  - id: quick_spec_template
+    type: template
+    label: "Spec template"
+    write: spec.template
+    default: auto
+    group: quick_defaults
+    show_when:
+      setup_mode: quick
+
+  - id: quick_plan_template
+    type: template
+    label: "Plan template"
+    write: plan.template
+    default: auto
+    group: quick_defaults
+    show_when:
+      setup_mode: quick
+
+  - id: quick_sync_spec_with_issue
+    type: boolean
+    label: "Sync spec to GitHub when issue id is present"
+    write: spec.sync_github
+    default: true
+    group: quick_defaults
+    show_when:
+      setup_mode: quick
+      issue_id_present: true
+
+  - id: quick_sync_spec_manual
+    type: boolean
+    label: "Sync spec to GitHub for manual input"
+    write: spec.sync_github
+    default: false
+    group: quick_defaults
+    show_when:
+      setup_mode: quick
+      issue_id_present: false
+
+  - id: quick_sync_plan_with_issue
+    type: boolean
+    label: "Sync plan to GitHub when issue id is present"
+    write: plan.sync_github
+    default: true
+    group: quick_defaults
+    show_when:
+      setup_mode: quick
+      issue_id_present: true
+
+  - id: quick_sync_plan_manual
+    type: boolean
+    label: "Sync plan to GitHub for manual input"
+    write: plan.sync_github
+    default: false
+    group: quick_defaults
+    show_when:
+      setup_mode: quick
+      issue_id_present: false
+
+  - id: quick_pr_auto_create
+    type: boolean
+    label: "Auto create pull request"
+    write: pr.auto_create
+    default: true
+    group: quick_defaults
+    show_when:
+      setup_mode: quick
+      github_repo: true
+
+  - id: quick_pr_post_todo_list
+    type: boolean
+    label: "Post PR todo list"
+    write: pr.post_todo_list
+    default: true
+    group: quick_defaults
+    show_when:
+      setup_mode: quick
+      github_repo: true
+
+  - id: custom_sync_spec
+    type: boolean
+    label: "Sync spec to GitHub issue when confirmed?"
+    write: spec.sync_github
+    default: true
+    group: custom
+    show_when:
+      setup_mode: custom
+      issue_id_present: true
+
+  - id: custom_sync_plan
+    type: boolean
+    label: "Sync plan to GitHub issue when confirmed?"
+    write: plan.sync_github
+    default: true
+    group: custom
+    show_when:
+      setup_mode: custom
+      issue_id_present: true
+
+  - id: custom_rigor
+    type: enum
+    label: "Rigor level"
+    write: spec.rigor
+    group: custom
+    show_when:
+      setup_mode: custom
+    choices:
+      - value: low
+        label: "Low"
+      - value: medium
+        label: "Medium"
+      - value: high
+        label: "High"
+
+  - id: custom_spec_template
+    type: template
+    label: "Spec template"
+    write: spec.template
+    group: custom
+    show_when:
+      setup_mode: custom
+
+  - id: custom_plan_template
+    type: template
+    label: "Plan template"
+    write: plan.template
+    group: custom
+    show_when:
+      setup_mode: custom
+
+  - id: custom_pr_auto_create
+    type: boolean
+    label: "Auto create pull request"
+    write: pr.auto_create
+    group: custom
+    show_when:
+      setup_mode: custom
+      github_repo: true
+
+  - id: custom_pr_post_todo_list
+    type: boolean
+    label: "Post organized PR comments as todo list to PR?"
+    write: pr.post_todo_list
+    default: true
+    group: custom
+    show_when:
+      setup_mode: custom
+      github_repo: true

--- a/tests/unit/test_playbook_prepare_metadata.py
+++ b/tests/unit/test_playbook_prepare_metadata.py
@@ -65,9 +65,9 @@ def _write_playbook(root: Path, name: str, content: str) -> None:
     (root / f"{name}.yaml").write_text(content, encoding="utf-8")
 
 
-def _minimal_playbook_yaml(*, prepare_block: str = "") -> str:
+def _minimal_playbook_yaml(*, prepare_block: str = "", playbook_id: str = "test") -> str:
     return f"""
-playbook: {{id: test}}
+playbook: {{id: {playbook_id}}}
 steps:
   spec:
     role: pm
@@ -245,23 +245,33 @@ steps:
 
 
 def _expected_standard_prepare() -> dict:
-    return default_prepare_config().model_dump()
+    return _legacy_prepare_dump(default_prepare_config())
+
+
+def _legacy_prepare_dump(prepare) -> dict:
+    data = prepare.model_dump()
+    data.pop("fields", None)
+    data.pop("fields_ref", None)
+    return data
 
 
 def test_builtin_default_playbook_prepare_parity() -> None:
     loader = PlaybookLoader()
     resolved = resolve_prepare_config(loader.load_model("default").model)
 
-    assert resolved.model_dump() == _expected_standard_prepare()
+    assert _legacy_prepare_dump(resolved) == _expected_standard_prepare()
+    assert resolved.fields_ref == "skill://spec/assets/prepare/default_prepare_fields.yaml"
 
 
 def test_builtin_simple_and_tdd_match_default_prepare() -> None:
     loader = PlaybookLoader()
-    default_prepare = resolve_prepare_config(loader.load_model("default").model).model_dump()
+    default_prepare = _legacy_prepare_dump(
+        resolve_prepare_config(loader.load_model("default").model)
+    )
 
     for name in ("simple", "tdd"):
         resolved = resolve_prepare_config(loader.load_model(name).model)
-        assert resolved.model_dump() == default_prepare
+        assert _legacy_prepare_dump(resolved) == default_prepare
 
 
 def test_builtin_hotfix_disables_spec_plan_prompts() -> None:
@@ -279,3 +289,127 @@ def test_builtin_non_prepare_playbooks_still_load_without_prepare_section() -> N
     for name in ("research", "editorial", "incident"):
         model = loader.load_model(name).model
         assert model.commands is None or model.commands.prepare is None
+
+
+def test_prepare_fields_and_fields_ref_are_mutually_exclusive() -> None:
+    data = yaml.safe_load(
+        _minimal_playbook_yaml(
+            prepare_block="""
+commands:
+  prepare:
+    fields_ref: assets/fields.yaml
+    fields:
+      - id: rigor
+        type: enum
+        label: Rigor
+        write: spec.rigor
+        choices:
+          - value: low
+            label: Low
+"""
+        )
+    )
+    with pytest.raises(ValidationError):
+        PlaybookDefinition.model_validate(data)
+
+
+def test_invalid_prepare_field_write_target_fails_validate(tmp_path: Path) -> None:
+    loader = _loader(tmp_path)
+    playbook_dir = loader._roots()[0]
+    playbook_dir.mkdir(parents=True, exist_ok=True)
+    asset = playbook_dir / "bad_fields.yaml"
+    asset.write_text(
+        yaml.safe_dump(
+            {
+                "fields": [
+                    {
+                        "id": "bad",
+                        "type": "boolean",
+                        "label": "Bad",
+                        "write": "spec.unknown",
+                        "default": True,
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    _write_playbook(
+        playbook_dir,
+        "bad",
+        _minimal_playbook_yaml(
+            playbook_id="bad",
+            prepare_block=f"""
+commands:
+  prepare:
+    fields_ref: {asset.name}
+""",
+        ),
+    )
+
+    with pytest.raises((ValueError, ValidationError), match="unknown write target"):
+        loader.load_model("bad")
+
+
+def test_prepare_fields_semantic_mismatch_fails_validate(tmp_path: Path) -> None:
+    loader = _loader(tmp_path)
+    playbook_dir = loader._roots()[0]
+    playbook_dir.mkdir(parents=True, exist_ok=True)
+    asset = playbook_dir / "mismatch_fields.yaml"
+    asset.write_text(
+        yaml.safe_dump(
+            {
+                "fields": [
+                    {
+                        "id": "setup_mode",
+                        "type": "setup_mode",
+                        "label": "Setup",
+                        "choices": [
+                            {"value": "quick", "label": "Quick setup (use recommended defaults)"},
+                            {"value": "custom", "label": "Custom configuration"},
+                        ],
+                    },
+                    {
+                        "id": "quick_rigor",
+                        "type": "enum",
+                        "label": "Rigor",
+                        "write": "spec.rigor",
+                        "default": "high",
+                        "show_when": {"setup_mode": "quick"},
+                        "choices": [
+                            {"value": "low", "label": "Low"},
+                            {"value": "medium", "label": "Medium"},
+                            {"value": "high", "label": "High"},
+                        ],
+                    },
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    _write_playbook(
+        playbook_dir,
+        "mismatch",
+        _minimal_playbook_yaml(
+            playbook_id="mismatch",
+            prepare_block=f"""
+commands:
+  prepare:
+    quick_setup:
+      spec:
+        rigor: medium
+    fields_ref: {asset.name}
+""",
+        ),
+    )
+
+    with pytest.raises(ValueError, match="disagrees with legacy"):
+        loader.load_model("mismatch")
+
+
+def test_default_playbook_fields_ref_passes_semantic_validation() -> None:
+    loader = PlaybookLoader()
+    loaded = loader.load_model("default")
+    assert loaded.model.commands is not None
+    assert loaded.model.commands.prepare is not None
+    assert loaded.model.commands.prepare.fields_ref is not None

--- a/tests/unit/test_playbook_prepare_metadata.py
+++ b/tests/unit/test_playbook_prepare_metadata.py
@@ -407,6 +407,61 @@ commands:
         loader.load_model("mismatch")
 
 
+def test_prepare_fields_without_legacy_metadata_skips_parity_validate(tmp_path: Path) -> None:
+    loader = _loader(tmp_path)
+    playbook_dir = loader._roots()[0]
+    playbook_dir.mkdir(parents=True, exist_ok=True)
+    asset = playbook_dir / "declarative_only_fields.yaml"
+    asset.write_text(
+        yaml.safe_dump(
+            {
+                "fields": [
+                    {
+                        "id": "setup_mode",
+                        "type": "setup_mode",
+                        "label": "Setup",
+                        "choices": [
+                            {"value": "quick", "label": "Fast path"},
+                        ],
+                    },
+                    {
+                        "id": "quick_rigor",
+                        "type": "enum",
+                        "label": "Rigor",
+                        "write": "spec.rigor",
+                        "default": "high",
+                        "show_when": {"setup_mode": "quick"},
+                        "choices": [
+                            {"value": "low", "label": "Low"},
+                            {"value": "medium", "label": "Medium"},
+                            {"value": "high", "label": "High"},
+                        ],
+                    },
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    _write_playbook(
+        playbook_dir,
+        "declarative-only",
+        _minimal_playbook_yaml(
+            playbook_id="declarative-only",
+            prepare_block=f"""
+commands:
+  prepare:
+    fields_ref: {asset.name}
+""",
+        ),
+    )
+
+    loaded = loader.load_model("declarative-only")
+
+    assert loaded.model.commands is not None
+    assert loaded.model.commands.prepare is not None
+    assert loaded.model.commands.prepare.fields_ref == asset.name
+
+
 def test_default_playbook_fields_ref_passes_semantic_validation() -> None:
     loader = PlaybookLoader()
     loaded = loader.load_model("default")

--- a/tests/unit/test_prepare_fields_loader.py
+++ b/tests/unit/test_prepare_fields_loader.py
@@ -1,0 +1,194 @@
+"""Tests for prepare field schema and fields_ref loading."""
+
+from pathlib import Path
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from cafe.core.prepare_fields import (
+    FieldsRefKind,
+    load_fields_ref,
+    parse_fields_ref,
+    parse_prepare_fields,
+    parse_prepare_fields_document,
+    resolve_fields_ref_path,
+)
+from cafe.skills.loader import SkillLoader
+
+
+MINIMAL_FIELD = {
+    "id": "rigor",
+    "type": "enum",
+    "label": "Rigor",
+    "write": "spec.rigor",
+    "default": "medium",
+    "choices": [
+        {"value": "low", "label": "Low"},
+        {"value": "medium", "label": "Medium"},
+        {"value": "high", "label": "High"},
+    ],
+}
+
+
+def test_prepare_field_schema_parses_valid_definition() -> None:
+    fields = parse_prepare_fields([MINIMAL_FIELD])
+    assert fields[0].id == "rigor"
+    assert fields[0].write == "spec.rigor"
+
+
+def test_prepare_field_schema_rejects_unknown_write_target() -> None:
+    invalid = dict(MINIMAL_FIELD, write="spec.unknown")
+    with pytest.raises(ValidationError):
+        parse_prepare_fields([invalid])
+
+
+def test_prepare_field_schema_rejects_enum_without_choices() -> None:
+    invalid = {key: value for key, value in MINIMAL_FIELD.items() if key != "choices"}
+    with pytest.raises(ValidationError):
+        parse_prepare_fields([invalid])
+
+
+def test_prepare_field_schema_rejects_invalid_type() -> None:
+    invalid = dict(MINIMAL_FIELD, type="checkbox")
+    with pytest.raises(ValidationError):
+        parse_prepare_fields([invalid])
+
+
+def _write_skill(root: Path, name: str) -> None:
+    skill_dir = root / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: desc-{name}\n---\n\n# {name}\n",
+        encoding="utf-8",
+    )
+
+
+def _loader(tmp_path: Path) -> SkillLoader:
+    builtin_root = tmp_path / "builtin"
+    _write_skill(builtin_root / "skills", "spec")
+    return SkillLoader(
+        project_root=tmp_path / "project",
+        global_root=tmp_path / "global",
+        builtin_root=builtin_root,
+    )
+
+
+def test_fields_ref_playbook_relative_loads_yaml(tmp_path: Path) -> None:
+    playbook_dir = tmp_path / "playbooks"
+    playbook_dir.mkdir(parents=True)
+    asset = playbook_dir / "fields.yaml"
+    asset.write_text(yaml.safe_dump({"fields": [MINIMAL_FIELD]}), encoding="utf-8")
+    playbook_path = playbook_dir / "test.yaml"
+    playbook_path.write_text("playbook: {id: test}\n", encoding="utf-8")
+
+    parsed = load_fields_ref(
+        ref="fields.yaml",
+        playbook_path=playbook_path,
+        skill_loader=_loader(tmp_path),
+    )
+    assert parsed.fields[0].id == "rigor"
+
+
+def test_fields_ref_skill_uri_loads_asset(tmp_path: Path) -> None:
+    loader = _loader(tmp_path)
+    asset_dir = loader.get_skill_dir("spec") / "assets" / "prepare"
+    asset_dir.mkdir(parents=True)
+    asset = asset_dir / "fields.yaml"
+    asset.write_text(yaml.safe_dump({"fields": [MINIMAL_FIELD]}), encoding="utf-8")
+
+    parsed = load_fields_ref(
+        ref="skill://spec/assets/prepare/fields.yaml",
+        playbook_path=tmp_path / "playbooks" / "test.yaml",
+        skill_loader=loader,
+    )
+    assert parsed.fields[0].default == "medium"
+
+
+def test_fields_ref_playbook_relative_rejects_unsafe_paths(tmp_path: Path) -> None:
+    playbook_path = tmp_path / "playbooks" / "test.yaml"
+    playbook_path.parent.mkdir(parents=True)
+    playbook_path.write_text("playbook: {id: test}\n", encoding="utf-8")
+    loader = _loader(tmp_path)
+
+    for ref in ("../secrets.yaml", "/etc/passwd.yaml", "fields.py", "scripts/hook.yaml"):
+        with pytest.raises(ValueError):
+            resolve_fields_ref_path(ref=ref, playbook_path=playbook_path, skill_loader=loader)
+
+
+def test_fields_ref_skill_uri_rejects_unsafe_refs(tmp_path: Path) -> None:
+    loader = _loader(tmp_path)
+    playbook_path = tmp_path / "playbooks" / "test.yaml"
+    playbook_path.parent.mkdir(parents=True)
+    playbook_path.write_text("playbook: {id: test}\n", encoding="utf-8")
+
+    unsafe_refs = [
+        "skill://missing/assets/fields.yaml",
+        "skill://spec/references/policy.md",
+        "skill://spec/assets/../scripts/run.sh",
+        "skill://spec/assets/prepare/fields.py",
+        "http://example.com/fields.yaml",
+    ]
+    for ref in unsafe_refs:
+        with pytest.raises((ValueError, FileNotFoundError)):
+            resolve_fields_ref_path(ref=ref, playbook_path=playbook_path, skill_loader=loader)
+
+
+def test_fields_ref_rejects_missing_asset(tmp_path: Path) -> None:
+    playbook_path = tmp_path / "playbooks" / "test.yaml"
+    playbook_path.parent.mkdir(parents=True)
+    playbook_path.write_text("playbook: {id: test}\n", encoding="utf-8")
+    loader = _loader(tmp_path)
+
+    with pytest.raises(FileNotFoundError):
+        load_fields_ref(
+            ref="missing.yaml",
+            playbook_path=playbook_path,
+            skill_loader=loader,
+        )
+
+
+def test_parse_fields_ref_classifies_sources() -> None:
+    assert parse_fields_ref("assets/fields.yaml") is FieldsRefKind.PLAYBOOK_RELATIVE
+    assert parse_fields_ref("skill://spec/assets/prepare/fields.yaml") is FieldsRefKind.SKILL_ASSET
+
+
+def test_skill_loader_precedence_for_fields_ref(tmp_path: Path) -> None:
+    project_root = tmp_path / "project"
+    builtin_root = tmp_path / "builtin"
+    _write_skill(builtin_root / "skills", "spec")
+    _write_skill(project_root / ".cafe" / "skills", "spec")
+
+    builtin_asset = builtin_root / "skills" / "spec" / "assets" / "prepare" / "fields.yaml"
+    builtin_asset.parent.mkdir(parents=True)
+    builtin_asset.write_text(
+        yaml.safe_dump({"fields": [dict(MINIMAL_FIELD, default="low")]}),
+        encoding="utf-8",
+    )
+
+    project_asset = project_root / ".cafe" / "skills" / "spec" / "assets" / "prepare" / "fields.yaml"
+    project_asset.parent.mkdir(parents=True)
+    project_asset.write_text(
+        yaml.safe_dump({"fields": [dict(MINIMAL_FIELD, default="high")]}),
+        encoding="utf-8",
+    )
+
+    loader = SkillLoader(
+        project_root=project_root,
+        global_root=tmp_path / "global",
+        builtin_root=builtin_root,
+    )
+    parsed = load_fields_ref(
+        ref="skill://spec/assets/prepare/fields.yaml",
+        playbook_path=project_root / ".cafe" / "playbooks" / "test.yaml",
+        skill_loader=loader,
+    )
+    assert parsed.fields[0].default == "high"
+
+
+def test_prepare_fields_document_parses_meta() -> None:
+    parsed = parse_prepare_fields_document(
+        {"meta": {"prompt_for_spec_plan_config": False}, "fields": [MINIMAL_FIELD]}
+    )
+    assert parsed.meta is not None
+    assert parsed.meta.prompt_for_spec_plan_config is False

--- a/tests/unit/test_prepare_profile.py
+++ b/tests/unit/test_prepare_profile.py
@@ -222,3 +222,30 @@ commands:
 """
         profile = _profile_from_yaml(tmp_path, prepare_yaml, is_github_repo=True)
         assert profile.should_prompt_input_method() is False
+
+
+class TestPrepareProfileResolvedFields:
+    """Test List unit #14 — resolved prepare field contract."""
+
+    def test_returns_none_when_fields_not_declared(self) -> None:
+        loader = PlaybookLoader()
+        loaded = loader.load_model("simple")
+        profile = PrepareProfile.from_playbook(loaded.model, is_github_repo=True)
+        assert (
+            profile.resolved_prepare_fields(
+                playbook_path=loaded.path,
+                skill_loader=SkillLoader(),
+            )
+            is None
+        )
+
+    def test_returns_fields_for_default_playbook(self) -> None:
+        loader = PlaybookLoader()
+        loaded = loader.load_model("default")
+        profile = PrepareProfile.from_playbook(loaded.model, is_github_repo=True)
+        parsed = profile.resolved_prepare_fields(
+            playbook_path=loaded.path,
+            skill_loader=SkillLoader(),
+        )
+        assert parsed is not None
+        assert any(field.id == "setup_mode" for field in parsed.fields)


### PR DESCRIPTION
## Summary

Implements GitHub issue #335: a declarative prepare field contract for playbooks and skill assets, with validation at `cafe playbook validate` time. Supports inline `fields` or `fields_ref` pointing to playbook-relative static files or `skill://<skill>/assets/<path>` URIs. Legacy `commands.prepare` behavior and `cafe prepare` interactive rendering are unchanged.

## Changes

- **`src/cafe/core/prepare_fields.py`**: `PrepareField` pydantic models, secure dual-source `fields_ref` loader, field semantic validation, and legacy ↔ fields parity check
- **`src/cafe/core/playbook.py`**: optional `commands.prepare.fields` / `fields_ref` (mutually exclusive); validation wired through `_validate_prepare_metadata`
- **`src/cafe/core/prepare_profile.py`**: read-only `resolved_prepare_fields()` API (no lifecycle changes)
- **`src/cafe/data/skills/spec/assets/prepare/default_prepare_fields.yaml`**: full declarative mapping of default prepare prompts (setup mode, conditional fields, sync/PR defaults)
- **`src/cafe/data/playbooks/default.yaml`**: `fields_ref: skill://spec/assets/prepare/default_prepare_fields.yaml` alongside existing legacy `commands.prepare`
- **`docs/prepare_fields.md`**: schema, dual ref formats, and security rules

### Commits

| SHA | Message |
| --- | --- |
| `a471433` | Add PrepareField schema and secure fields_ref loader |
| `c1bd340` | Wire PrepareField validation into playbook validate |
| `5bfc510` | Add default prepare fields asset and prepare_profile resolver |
| `c249f3b` | Document prepare fields schema and dual fields_ref sources |

## Test Plan

- [x] `pytest tests/unit/test_prepare_fields_loader.py` — schema parse, playbook-relative + skill URI load, unsafe ref rejection, SkillLoader precedence
- [x] `pytest tests/unit/test_playbook_prepare_metadata.py` — backward compat, parity pass/fail, builtin default `fields_ref`, invalid field validate
- [x] `pytest tests/unit/test_prepare_profile.py` — `resolved_prepare_fields()` contract; existing prepare profile behavior unchanged
- [x] `pytest tests/unit/test_cli_playbook_validate.py` — builtin playbooks (default/simple/tdd/hotfix) validate
- [x] `pytest tests/integration/test_prepare_playbook_driven.py` — `cafe prepare --no-interactive` issue.yaml output unchanged
- [x] Manual: `cafe playbook validate default` succeeds with skill `fields_ref` and legacy parity