### PR TITLE
Render prepare prompts from PrepareField definitions (#337)

### DIFF
--- a/docs/prepare_fields.md
+++ b/docs/prepare_fields.md
@@ -1,6 +1,6 @@
 # Declarative Prepare Fields
 
-This document describes the declarative prepare field contract introduced for playbook and skill assets. It is validation-only in the current release: `cafe prepare` interactive rendering still uses legacy `commands.prepare` metadata.
+This document describes the declarative prepare field contract for playbook and skill assets. When a playbook declares `fields` or `fields_ref`, interactive `cafe prepare` renders prompts from those definitions. Playbooks without declarative fields keep the legacy `commands.prepare` interactive path.
 
 ## PrepareField schema
 

--- a/src/cafe/ui/commands/lifecycle.py
+++ b/src/cafe/ui/commands/lifecycle.py
@@ -77,6 +77,150 @@ def set_runtime(
     Path = path_cls
 
 
+def _run_legacy_prepare_prompts(
+    profile: Any,
+    *,
+    display: Any,
+    github_ops: Any,
+    issue_name: str,
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], Optional[int]]:
+    """Run legacy interactive prepare prompts when no declarative fields exist."""
+    from cafe.core.prepare_profile import PrepareRigorError
+    from cafe.ui.phase_prompts import prompt_and_save_auto_create
+
+    spec_config: dict[str, Any] = {}
+    plan_config: dict[str, Any] = {}
+    pr_config: dict[str, Any] = {}
+    issue_id: Optional[int] = None
+
+    if profile.should_prompt_input_method():
+        input_method, issue_id = prompt_for_input_method(display, github_ops)
+        spec_config["input_method"] = input_method
+        if issue_id is not None:
+            spec_config["issue_id"] = str(issue_id)
+    else:
+        spec_config["input_method"] = profile.default_input_method()
+
+    console.print()
+    setup_mode_choices = profile.enabled_setup_mode_labels()
+    setup_mode_choice = prompt_list(
+        message="Choose setup mode:",
+        choices=setup_mode_choices,
+        default=setup_mode_choices[0],
+    )
+
+    if profile.is_quick_setup_choice(setup_mode_choice):
+        quick_config = profile.quick_setup_issue_config(issue_id)
+        spec_config.update(quick_config.spec)
+        plan_config.update(quick_config.plan)
+        pr_config.update(quick_config.pr)
+
+        console.print()
+        console.print("[green]✓ Quick setup applied with recommended defaults:[/green]")
+        console.print(f"  • Rigor level: {spec_config['rigor']}")
+        console.print(f"  • Spec template: {spec_config['template']}")
+        console.print(f"  • Plan template: {plan_config['template']}")
+        console.print(f"  • Input method: {spec_config['input_method']}")
+        if profile.is_github_repo:
+            console.print(f"  • Sync to GitHub: {spec_config.get('sync_github', False)}")
+            console.print(f"  • Auto create PR: {pr_config.get('auto_create', False)}")
+            console.print(f"  • Post PR todo list: {pr_config.get('post_todo_list', False)}")
+        console.print()
+        return spec_config, plan_config, pr_config, issue_id
+
+    if issue_id is not None:
+        console.print()
+        spec_config["sync_github"] = prompt_confirm(
+            "Sync spec to GitHub issue when confirmed?",
+            default=True,
+        )
+        console.print()
+        plan_config["sync_github"] = prompt_confirm(
+            "Sync plan to GitHub issue when confirmed?",
+            default=True,
+        )
+        console.print()
+
+    rigor = prompt_for_rigor(display, allowed=profile.allowed_rigor_values())
+    try:
+        profile.validate_rigor(rigor)
+    except PrepareRigorError as exc:
+        console.print(f"[red]Error: {exc}[/red]")
+        raise typer.Exit(1)
+    spec_config["rigor"] = rigor
+
+    spec_template_manager = TemplateManager(template_type="spec")
+    spec_templates_with_source = spec_template_manager.list_templates()
+    spec_templates = [name for name, _ in spec_templates_with_source]
+    if spec_templates:
+        console.print()
+        console.print("[bold cyan]Please select a spec template:[/bold cyan]")
+        spec_template_paths = {
+            name: spec_template_manager.get_template_path(name) for name in spec_templates
+        }
+        selected_spec_template = select_template(
+            spec_templates, spec_template_paths, spec_templates_with_source
+        )
+        if selected_spec_template:
+            spec_config["template"] = selected_spec_template
+
+    plan_template_manager = TemplateManager(template_type="plan")
+    plan_templates_with_source = plan_template_manager.list_templates()
+    plan_templates = [name for name, _ in plan_templates_with_source]
+    if plan_templates:
+        console.print()
+        console.print("[bold cyan]Please select a plan template:[/bold cyan]")
+        plan_template_paths = {
+            name: plan_template_manager.get_template_path(name) for name in plan_templates
+        }
+        selected_plan_template = select_template(
+            plan_templates, plan_template_paths, plan_templates_with_source
+        )
+        if selected_plan_template:
+            plan_config["template"] = selected_plan_template
+    else:
+        console.print()
+        console.print("[yellow]⚠️  No plan templates found. Using default template.[/yellow]")
+        console.print("[dim]    Tip: Use 'cafe template add <source> <name>' to add templates.[/dim]")
+
+    config_file = Path(".cafe") / "issues" / issue_name / "issue.yaml"
+    auto_create_pr_result = prompt_and_save_auto_create(config_file, "pr.auto_create")
+    pr_config["auto_create"] = auto_create_pr_result
+    if auto_create_pr_result:
+        console.print()
+        pr_config["post_todo_list"] = prompt_confirm(
+            "Post organized PR comments as todo list to PR?",
+            default=True,
+        )
+    return spec_config, plan_config, pr_config, issue_id
+
+
+def _run_field_driven_prepare_prompts(
+    profile: Any,
+    parsed: Any,
+    *,
+    display: Any,
+    github_ops: Any,
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], Optional[int]]:
+    """Run interactive prepare prompts from declarative PrepareField definitions."""
+    from cafe.ui.prepare_field_renderer import RendererDeps, run_field_driven_prepare_flow
+
+    deps = RendererDeps(
+        prompt_list=prompt_list,
+        prompt_confirm=prompt_confirm,
+        prompt_text=prompt_text,
+        prompt_for_input_method=prompt_for_input_method,
+        select_template=select_template,
+        spec_template_manager=TemplateManager(template_type="spec"),
+        plan_template_manager=TemplateManager(template_type="plan"),
+        console=console,
+        display=display,
+        github_ops=github_ops,
+    )
+    config, issue_id = run_field_driven_prepare_flow(parsed, profile, deps=deps)
+    return config.spec, config.plan, config.pr, issue_id
+
+
 def prepare(
     issue_name: Optional[str] = typer.Argument(
         None,
@@ -377,135 +521,29 @@ def prepare(
             )
             console.print()
 
-            # Initialize Display for prompts
             display = Display()
             github_ops = GitHubOps()
+            from cafe.skills.loader import SkillLoader
 
-            # Step 1: Input method and issue ID (playbook-driven)
-            if profile.should_prompt_input_method():
-                input_method, issue_id = prompt_for_input_method(display, github_ops)
-                spec_config["input_method"] = input_method
-                if issue_id is not None:
-                    spec_config["issue_id"] = str(issue_id)
-            else:
-                spec_config["input_method"] = profile.default_input_method()
-                issue_id = None
-
-            # Step 2: Prompt for setup mode (after input method selection)
-            console.print()
-            setup_mode_choices = profile.enabled_setup_mode_labels()
-            setup_mode_choice = prompt_list(
-                message="Choose setup mode:",
-                choices=setup_mode_choices,
-                default=setup_mode_choices[0],
+            parsed_fields = profile.resolved_prepare_fields(
+                playbook_path=loaded_playbook.path,
+                skill_loader=SkillLoader(),
             )
-
-            use_quick_setup = profile.is_quick_setup_choice(setup_mode_choice)
-
-            if use_quick_setup:
-                quick_config = profile.quick_setup_issue_config(issue_id)
-                spec_config.update(quick_config.spec)
-                plan_config.update(quick_config.plan)
-                pr_config.update(quick_config.pr)
-
-                # Display default values summary
-                console.print()
-                console.print("[green]✓ Quick setup applied with recommended defaults:[/green]")
-                console.print(f"  • Rigor level: {spec_config['rigor']}")
-                console.print(f"  • Spec template: {spec_config['template']}")
-                console.print(f"  • Plan template: {plan_config['template']}")
-                console.print(f"  • Input method: {spec_config['input_method']}")
-                if profile.is_github_repo:
-                    console.print(f"  • Sync to GitHub: {spec_config.get('sync_github', False)}")
-                    console.print(f"  • Auto create PR: {pr_config.get('auto_create', False)}")
-                    console.print(f"  • Post PR todo list: {pr_config.get('post_todo_list', False)}")
-                console.print()
+            issue_id: Optional[int] = None
+            if parsed_fields is None:
+                spec_config, plan_config, pr_config, issue_id = _run_legacy_prepare_prompts(
+                    profile,
+                    display=display,
+                    github_ops=github_ops,
+                    issue_name=issue_name,
+                )
             else:
-                # Custom configuration: Prompt for remaining settings
-                
-                # Prompt for sync settings (only when issue_id is present)
-                if issue_id is not None:
-                    console.print()
-                    sync_spec = prompt_confirm(
-                        "Sync spec to GitHub issue when confirmed?",
-                        default=True
-                    )
-                    spec_config["sync_github"] = sync_spec
-
-                    console.print()
-                    sync_plan = prompt_confirm(
-                        "Sync plan to GitHub issue when confirmed?",
-                        default=True
-                    )
-                    plan_config["sync_github"] = sync_plan
-                    console.print()
-
-                # Prompt for rigor level
-                rigor = prompt_for_rigor(display, allowed=profile.allowed_rigor_values())
-                try:
-                    profile.validate_rigor(rigor)
-                except PrepareRigorError as exc:
-                    console.print(f"[red]Error: {exc}[/red]")
-                    raise typer.Exit(1)
-                spec_config["rigor"] = rigor
-
-                # Prompt for spec template
-                spec_template_manager = TemplateManager(template_type="spec")
-                spec_templates_with_source = spec_template_manager.list_templates()
-                spec_templates = [name for name, _ in spec_templates_with_source]
-
-                if spec_templates:
-                    console.print()
-                    console.print("[bold cyan]Please select a spec template:[/bold cyan]")
-                    spec_template_paths = {
-                        name: spec_template_manager.get_template_path(name) for name in spec_templates
-                    }
-                    selected_spec_template = select_template(
-                        spec_templates, spec_template_paths, spec_templates_with_source
-                    )
-                    if selected_spec_template:
-                        spec_config["template"] = selected_spec_template
-
-                # Prompt for plan template
-                plan_template_manager = TemplateManager(template_type="plan")
-                plan_templates_with_source = plan_template_manager.list_templates()
-                plan_templates = [name for name, _ in plan_templates_with_source]
-
-                if plan_templates:
-                    console.print()
-                    console.print("[bold cyan]Please select a plan template:[/bold cyan]")
-                    plan_template_paths = {
-                        name: plan_template_manager.get_template_path(name) for name in plan_templates
-                    }
-                    selected_plan_template = select_template(
-                        plan_templates, plan_template_paths, plan_templates_with_source
-                    )
-                    if selected_plan_template:
-                        plan_config["template"] = selected_plan_template
-                else:
-                    console.print()
-                    console.print(
-                        "[yellow]⚠️  No plan templates found. Using default template.[/yellow]"
-                    )
-                    console.print(
-                        "[dim]    Tip: Use 'cafe template add <source> <name>' to add templates.[/dim]"
-                    )
-
-                # Prompt for PR auto-create setting (only for GitHub repos)
-                from cafe.ui.phase_prompts import prompt_and_save_auto_create
-
-                config_file = Path(".cafe") / "issues" / issue_name / "issue.yaml"
-                auto_create_pr_result = prompt_and_save_auto_create(config_file, "pr.auto_create")
-                pr_config["auto_create"] = auto_create_pr_result
-
-                # Prompt for post_todo_list only when auto_create is enabled
-                if auto_create_pr_result:
-                    console.print()
-                    post_todo_list_result = prompt_confirm(
-                        "Post organized PR comments as todo list to PR?",
-                        default=True,
-                    )
-                    pr_config["post_todo_list"] = post_todo_list_result
+                spec_config, plan_config, pr_config, issue_id = _run_field_driven_prepare_prompts(
+                    profile,
+                    parsed_fields,
+                    display=display,
+                    github_ops=github_ops,
+                )
         elif not interactive:
             # Explicit non-interactive mode (--no-interactive): use CLI parameters
             from cafe.utils.git_utils import is_github_repo

--- a/src/cafe/ui/phase_prompts.py
+++ b/src/cafe/ui/phase_prompts.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Optional, Any, Dict, List, Tuple
 import yaml
 
+from cafe.core.prepare_fields import PrepareField
 from cafe.core.types import SpecRigor
 from cafe.ui.display import Display
 from cafe.ui.inquirer_prompts import prompt_list, prompt_text, prompt_confirm
@@ -14,7 +15,12 @@ from cafe.utils.github import GitHubOps, GitHubError
 from cafe.utils.git_utils import is_github_repo
 
 
-def prompt_for_input_method(display: Display, github_ops: GitHubOps) -> tuple[str, Optional[int]]:
+def prompt_for_input_method(
+    display: Display,
+    github_ops: GitHubOps,
+    *,
+    field: Optional[PrepareField] = None,
+) -> tuple[str, Optional[int]]:
     """Ask user to select input method (manual vs GitHub Issue)
 
     Args:
@@ -26,45 +32,63 @@ def prompt_for_input_method(display: Display, github_ops: GitHubOps) -> tuple[st
         - method: "manual" or "github"
         - issue_id: Issue ID (int) if GitHub is selected, None otherwise
     """
-    choices = [
-        "1. Manual input",
-        "2. Fetch from GitHub Issue",
-    ]
+    if field is not None and field.choices:
+        choices = [f"{index + 1}. {choice.label}" for index, choice in enumerate(field.choices)]
+        message = field.label
+        if field.help:
+            message = f"{field.label}\n{field.help}"
+    else:
+        choices = [
+            "1. Manual input",
+            "2. Fetch from GitHub Issue",
+        ]
+        message = "Please select input method:"
 
     choice = prompt_list(
-        message="Please select input method:",
+        message=message,
         choices=choices,
     )
 
-    if choice.startswith("1"):
-        return ("manual", None)
+    selected_value = "manual"
+    if field is not None and field.choices:
+        for index, entry in enumerate(field.choices):
+            if choice.startswith(f"{index + 1}") or choice.endswith(entry.label):
+                selected_value = entry.value
+                break
+    elif choice.startswith("1"):
+        selected_value = "manual"
     else:
-        # GitHub Issue mode
-        print()
-        print("⚠️  Note: Upon completion, spec.md will be posted back to GitHub Issue as a comment")
-        print()
+        selected_value = "github"
 
-        # Ask for Issue ID or URL, with error retry handling
-        while True:
-            issue_input = prompt_text(
-                message="Please enter GitHub Issue ID or URL:",
-                default="",
-            )
+    if selected_value == "manual":
+        return ("manual", None)
 
-            try:
-                # Use GitHubOps to extract issue number
-                issue_id_str = github_ops.extract_issue_number(issue_input)
-                issue_id = int(issue_id_str)
+    # GitHub Issue mode
+    print()
+    print("⚠️  Note: Upon completion, spec.md will be posted back to GitHub Issue as a comment")
+    print()
 
-                print()
-                print(f"✓ Will fetch requirements from GitHub Issue #{issue_id}")
-                print()
+    # Ask for Issue ID or URL, with error retry handling
+    while True:
+        issue_input = prompt_text(
+            message="Please enter GitHub Issue ID or URL:",
+            default="",
+        )
 
-                return ("github", issue_id)
-            except (ValueError, GitHubError) as e:
-                print(f"❌ Invalid Issue ID or URL: {e}")
-                print("Please try again...")
-                print()
+        try:
+            # Use GitHubOps to extract issue number
+            issue_id_str = github_ops.extract_issue_number(issue_input)
+            issue_id = int(issue_id_str)
+
+            print()
+            print(f"✓ Will fetch requirements from GitHub Issue #{issue_id}")
+            print()
+
+            return ("github", issue_id)
+        except (ValueError, GitHubError) as e:
+            print(f"❌ Invalid Issue ID or URL: {e}")
+            print("Please try again...")
+            print()
 
 
 def prompt_for_rigor(display: Display, allowed: Optional[List[str]] = None) -> str:

--- a/src/cafe/ui/prepare_field_renderer.py
+++ b/src/cafe/ui/prepare_field_renderer.py
@@ -1,0 +1,343 @@
+"""Render interactive cafe prepare prompts from PrepareField definitions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, List, Literal, Optional
+
+from cafe.core.prepare_fields import ParsedPrepareFields, PrepareField, PrepareFieldChoice
+from cafe.core.prepare_profile import PrepareIssueConfig, PrepareProfile, PrepareRigorError
+from cafe.templates.manager import TemplateManager
+
+SetupMode = Literal["quick", "custom"]
+
+
+@dataclass
+class PreparePromptContext:
+    """Runtime context for evaluating prepare field visibility and defaults."""
+
+    is_github_repo: bool
+    issue_id: Optional[int]
+    setup_mode: Optional[SetupMode]
+    profile: PrepareProfile
+    pr_auto_create: Optional[bool] = None
+
+
+@dataclass
+class RendererDeps:
+    """Host-provided prompt and template dependencies."""
+
+    prompt_list: Callable[..., str]
+    prompt_confirm: Callable[..., bool]
+    prompt_text: Callable[..., str]
+    prompt_for_input_method: Callable[..., tuple[str, Optional[int]]]
+    select_template: Callable[..., Optional[str]]
+    spec_template_manager: TemplateManager
+    plan_template_manager: TemplateManager
+    console: Any = None
+    display: Any = None
+    github_ops: Any = None
+
+
+def field_is_visible(field: PrepareField, ctx: PreparePromptContext) -> bool:
+    """Return whether one field should be shown for the current context."""
+    show_when = field.show_when
+    if show_when is None:
+        return True
+    if show_when.github_repo is not None and show_when.github_repo != ctx.is_github_repo:
+        return False
+    if show_when.issue_id_present is not None:
+        has_issue = ctx.issue_id is not None
+        if show_when.issue_id_present != has_issue:
+            return False
+    if show_when.setup_mode is not None:
+        if ctx.setup_mode is None or show_when.setup_mode != ctx.setup_mode:
+            return False
+    if (
+        field.write == "pr.post_todo_list"
+        and ctx.setup_mode == "custom"
+        and ctx.pr_auto_create is not True
+    ):
+        return False
+    return True
+
+
+def visible_fields(parsed: ParsedPrepareFields, ctx: PreparePromptContext) -> List[PrepareField]:
+    """Return visible fields in declaration order."""
+    return [field for field in parsed.fields if field_is_visible(field, ctx)]
+
+
+def format_enum_choice(choice: PrepareFieldChoice) -> str:
+    """Format one enum choice for prompt_list display."""
+    if choice.description:
+        return f"{choice.label}\n   {choice.description}"
+    return choice.label
+
+
+def parse_enum_selection(selection: str, choices: List[PrepareFieldChoice]) -> str:
+    """Map a prompt_list selection back to the enum value."""
+    for choice in choices:
+        formatted = format_enum_choice(choice)
+        if selection == formatted or selection.startswith(choice.label):
+            return choice.value
+    raise ValueError(f"unrecognized enum selection: {selection!r}")
+
+
+def set_write_value(config: PrepareIssueConfig, write: str, value: Any) -> None:
+    """Write one answer into spec/plan/pr blocks."""
+    section, key = write.split(".", 1)
+    target = {"spec": config.spec, "plan": config.plan, "pr": config.pr}[section]
+    target[key] = value
+
+
+def empty_issue_config() -> PrepareIssueConfig:
+    return PrepareIssueConfig(spec={}, plan={}, pr={})
+
+
+def apply_quick_defaults(
+    parsed: ParsedPrepareFields,
+    ctx: PreparePromptContext,
+) -> PrepareIssueConfig:
+    """Apply quick-setup defaults from visible field definitions."""
+    quick_ctx = PreparePromptContext(
+        is_github_repo=ctx.is_github_repo,
+        issue_id=ctx.issue_id,
+        setup_mode="quick",
+        profile=ctx.profile,
+    )
+    config = empty_issue_config()
+    for field in visible_fields(parsed, quick_ctx):
+        if field.type in {"setup_mode", "enum"} and field.write is None:
+            continue
+        if field.id == "input_method":
+            continue
+        if field.default is None:
+            continue
+        if field.write is None:
+            continue
+        set_write_value(config, field.write, field.default)
+
+    if ctx.is_github_repo and "auto_create" not in config.pr:
+        auto_field = next(
+            (field for field in parsed.fields if field.write == "pr.auto_create"),
+            None,
+        )
+        if auto_field is not None and auto_field.default is not None:
+            set_write_value(config, "pr.auto_create", auto_field.default)
+            if config.pr.get("auto_create") and "post_todo_list" not in config.pr:
+                todo_field = next(
+                    (field for field in parsed.fields if field.write == "pr.post_todo_list"),
+                    None,
+                )
+                if todo_field is not None and todo_field.default is not None:
+                    set_write_value(config, "pr.post_todo_list", todo_field.default)
+    return config
+
+
+def format_quick_summary(
+    config: PrepareIssueConfig,
+    parsed: ParsedPrepareFields,
+    ctx: PreparePromptContext,
+) -> List[str]:
+    """Build human-readable quick-setup summary lines."""
+    quick_ctx = PreparePromptContext(
+        is_github_repo=ctx.is_github_repo,
+        issue_id=ctx.issue_id,
+        setup_mode="quick",
+        profile=ctx.profile,
+    )
+    lines: List[str] = []
+    for field in visible_fields(parsed, quick_ctx):
+        if field.write is None or field.type == "setup_mode":
+            continue
+        section, key = field.write.split(".", 1)
+        value = {"spec": config.spec, "plan": config.plan, "pr": config.pr}[section].get(key)
+        if value is None:
+            continue
+        lines.append(f"{field.label}: {value}")
+    if ctx.issue_id is not None:
+        lines.append(f"Input method: github")
+    elif "input_method" in config.spec:
+        lines.append(f"Input method: {config.spec['input_method']}")
+    return lines
+
+
+def _find_field(parsed: ParsedPrepareFields, field_id: str) -> Optional[PrepareField]:
+    return next((field for field in parsed.fields if field.id == field_id), None)
+
+
+def prompt_setup_mode(field: PrepareField, deps: RendererDeps) -> SetupMode:
+    """Prompt for setup mode using declarative field choices."""
+    labels = [choice.label for choice in field.choices]
+    default = labels[0] if labels else None
+    if field.default is not None:
+        for choice in field.choices:
+            if choice.value == field.default:
+                default = choice.label
+                break
+    selected = deps.prompt_list(message=field.label, choices=labels, default=default)
+    for choice in field.choices:
+        if selected == choice.label:
+            return "quick" if choice.value == "quick" else "custom"
+    return "quick"
+
+
+def _prompt_enum_field(field: PrepareField, ctx: PreparePromptContext, deps: RendererDeps) -> str:
+    allowed = set(ctx.profile.allowed_rigor_values())
+    choices = [
+        choice
+        for choice in field.choices
+        if field.write != "spec.rigor" or choice.value in allowed
+    ]
+    if not choices:
+        raise PrepareRigorError("no rigor choices available for this playbook")
+    formatted = [format_enum_choice(choice) for choice in choices]
+    default = formatted[0]
+    if field.default is not None:
+        for choice in choices:
+            if choice.value == field.default:
+                default = format_enum_choice(choice)
+                break
+    selected = deps.prompt_list(message=field.label, choices=formatted, default=default)
+    value = parse_enum_selection(selected, choices)
+    if field.write == "spec.rigor":
+        ctx.profile.validate_rigor(value)
+    return value
+
+
+def _prompt_template_field(field: PrepareField, deps: RendererDeps) -> Optional[str]:
+    manager = (
+        deps.spec_template_manager
+        if field.write and field.write.startswith("spec.")
+        else deps.plan_template_manager
+    )
+    templates_with_source = manager.list_templates()
+    template_names = [name for name, _ in templates_with_source]
+    if not template_names:
+        if deps.console is not None:
+            deps.console.print()
+            deps.console.print(
+                "[yellow]⚠️  No templates found. Using default template.[/yellow]"
+            )
+        return str(field.default) if field.default is not None else None
+    if deps.console is not None:
+        deps.console.print()
+        deps.console.print(f"[bold cyan]{field.label}[/bold cyan]")
+    template_paths = {name: manager.get_template_path(name) for name in template_names}
+    selected = deps.select_template(template_names, template_paths, templates_with_source)
+    return selected or (str(field.default) if field.default is not None else None)
+
+
+def prompt_custom_fields(
+    parsed: ParsedPrepareFields,
+    ctx: PreparePromptContext,
+    *,
+    deps: RendererDeps,
+) -> PrepareIssueConfig:
+    """Prompt for custom-setup fields in declaration order."""
+    custom_ctx = PreparePromptContext(
+        is_github_repo=ctx.is_github_repo,
+        issue_id=ctx.issue_id,
+        setup_mode="custom",
+        profile=ctx.profile,
+        pr_auto_create=ctx.pr_auto_create,
+    )
+    config = empty_issue_config()
+    for field in parsed.fields:
+        if field.type == "setup_mode" or field.id == "input_method":
+            continue
+        if field.write is None:
+            continue
+        if not field_is_visible(field, custom_ctx):
+            continue
+
+        if field.type == "boolean":
+            default = bool(field.default) if field.default is not None else False
+            value = deps.prompt_confirm(field.label, default=default)
+        elif field.type == "enum":
+            value = _prompt_enum_field(field, custom_ctx, deps)
+        elif field.type == "template":
+            value = _prompt_template_field(field, deps)
+            if value is None:
+                continue
+        else:
+            continue
+
+        set_write_value(config, field.write, value)
+        if field.write == "pr.auto_create":
+            custom_ctx.pr_auto_create = bool(value)
+    return config
+
+
+def run_field_driven_prepare_flow(
+    parsed: ParsedPrepareFields,
+    profile: PrepareProfile,
+    *,
+    deps: RendererDeps,
+) -> tuple[PrepareIssueConfig, Optional[int]]:
+    """Run the full interactive field-driven prepare configuration flow."""
+    ctx = PreparePromptContext(
+        is_github_repo=profile.is_github_repo,
+        issue_id=None,
+        setup_mode=None,
+        profile=profile,
+    )
+    spec_config = empty_issue_config()
+    issue_id: Optional[int] = None
+
+    input_field = _find_field(parsed, "input_method")
+    if input_field is not None and field_is_visible(
+        input_field,
+        PreparePromptContext(
+            is_github_repo=ctx.is_github_repo,
+            issue_id=None,
+            setup_mode=None,
+            profile=profile,
+        ),
+    ):
+        input_method, issue_id = deps.prompt_for_input_method(
+            deps.display,
+            deps.github_ops,
+            field=input_field,
+        )
+        spec_config.spec["input_method"] = input_method
+        if issue_id is not None:
+            spec_config.spec["issue_id"] = str(issue_id)
+    elif profile.should_prompt_input_method():
+        input_method, issue_id = deps.prompt_for_input_method(deps.display, deps.github_ops)
+        spec_config.spec["input_method"] = input_method
+        if issue_id is not None:
+            spec_config.spec["issue_id"] = str(issue_id)
+    else:
+        spec_config.spec["input_method"] = profile.default_input_method()
+
+    ctx.issue_id = issue_id
+
+    setup_field = _find_field(parsed, "setup_mode")
+    if setup_field is None:
+        raise ValueError("prepare fields document must declare setup_mode")
+    if deps.console is not None:
+        deps.console.print()
+    setup_mode = prompt_setup_mode(setup_field, deps)
+    ctx.setup_mode = setup_mode
+
+    if setup_mode == "quick":
+        quick_config = apply_quick_defaults(parsed, ctx)
+        spec_config.spec.update(quick_config.spec)
+        spec_config.plan.update(quick_config.plan)
+        spec_config.pr.update(quick_config.pr)
+        if deps.console is not None:
+            deps.console.print()
+            deps.console.print("[green]✓ Quick setup applied with recommended defaults:[/green]")
+            for line in format_quick_summary(spec_config, parsed, ctx):
+                deps.console.print(f"  • {line}")
+            deps.console.print()
+        return spec_config, issue_id
+
+    custom_config = prompt_custom_fields(parsed, ctx, deps=deps)
+    spec_config.spec.update(custom_config.spec)
+    spec_config.plan.update(custom_config.plan)
+    spec_config.pr.update(custom_config.pr)
+    if not profile.is_github_repo:
+        spec_config.pr.setdefault("auto_create", False)
+    return spec_config, issue_id

--- a/tests/integration/test_prepare_field_driven.py
+++ b/tests/integration/test_prepare_field_driven.py
@@ -1,0 +1,181 @@
+"""Integration tests for field-driven cafe prepare interactive prompts."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from cafe.ui.cli import app
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def temp_repo_dir(tmp_path):
+    from tests.conftest import create_minimal_config
+
+    create_minimal_config(tmp_path)
+    return tmp_path
+
+
+@pytest.fixture(autouse=True)
+def change_test_dir(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+
+@pytest.fixture
+def mock_git_ops():
+    with patch("cafe.ui.cli.GitOperations") as MockGitOperations, patch(
+        "cafe.utils.git_utils.is_github_repo"
+    ) as mock_is_github_repo, patch(
+        "cafe.ui.phase_prompts.is_github_repo"
+    ) as mock_is_github_repo_phase:
+        mock_git = MagicMock()
+        MockGitOperations.return_value = mock_git
+        mock_git.get_current_branch.return_value = "main"
+        mock_git.has_uncommitted_changes.return_value = False
+        mock_git.branch_exists.return_value = False
+        mock_git.worktree_exists.return_value = False
+        mock_is_github_repo.return_value = True
+        mock_is_github_repo_phase.return_value = True
+        yield mock_git
+
+
+def _write_config_with_playbook(base_dir: Path, playbook_id: str) -> None:
+    config_path = base_dir / ".cafe" / "config.yaml"
+    data = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    data["playbook"] = playbook_id
+    config_path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+
+
+def _write_custom_playbook(base_dir: Path, name: str, prepare_block: str) -> None:
+    playbooks_dir = base_dir / ".cafe" / "playbooks"
+    playbooks_dir.mkdir(parents=True, exist_ok=True)
+    content = f"""
+playbook:
+  id: {name}
+steps:
+  spec:
+    type: skill
+    skill: spec
+    role: pm
+    "on":
+      await_agent: _done
+{prepare_block}
+"""
+    (playbooks_dir / f"{name}.yaml").write_text(content, encoding="utf-8")
+
+
+class TestPrepareFieldDriven:
+    @patch("cafe.ui.phase_prompts.prompt_text")
+    @patch("cafe.ui.phase_prompts.GitHubOps")
+    @patch("cafe.ui.cli.GitHubOps")
+    @patch("cafe.ui.cli.prompt_confirm")
+    @patch("cafe.ui.template_selector.prompt_list")
+    @patch("cafe.ui.phase_prompts.prompt_list")
+    @patch("cafe.ui.cli.prompt_list")
+    @patch("cafe.ui.cli.prompt_text")
+    def test_custom_fields_playbook_overrides_rigor_default(
+        self,
+        mock_prompt_text_cli,
+        mock_cli_list,
+        mock_phase_list,
+        mock_template_list,
+        mock_prompt_confirm,
+        MockGitHubOps_cli,
+        MockGitHubOps_phase,
+        mock_prompt_text_phase,
+        temp_repo_dir,
+        mock_git_ops,
+    ):
+        prepare_block = """
+commands:
+  prepare:
+    fields:
+      - id: setup_mode
+        type: setup_mode
+        label: "Choose setup mode"
+        choices:
+          - value: quick
+            label: "Quick setup (use recommended defaults)"
+          - value: custom
+            label: "Custom configuration"
+      - id: custom_rigor
+        type: enum
+        label: "Custom rigor label"
+        write: spec.rigor
+        default: low
+        show_when:
+          setup_mode: custom
+        choices:
+          - value: low
+            label: "Low"
+          - value: medium
+            label: "Medium"
+          - value: high
+            label: "High"
+"""
+        _write_custom_playbook(temp_repo_dir, "fields-custom", prepare_block)
+        _write_config_with_playbook(temp_repo_dir, "fields-custom")
+
+        mock_prompt_text_cli.return_value = "fields-custom-issue"
+        mock_prompt_confirm.return_value = False
+        mock_phase_list.return_value = "1. Manual input"
+        mock_cli_list.side_effect = [
+            "Custom configuration",
+            "Low",
+        ]
+        mock_template_list.return_value = "auto (agent decides)"
+
+        result = runner.invoke(app, ["prepare"])
+
+        assert result.exit_code == 0
+        rigor_call = [
+            call
+            for call in mock_cli_list.call_args_list
+            if call.kwargs.get("message") == "Custom rigor label"
+        ]
+        assert rigor_call
+        config_file = temp_repo_dir / ".cafe" / "issues" / "fields-custom-issue" / "issue.yaml"
+        config_data = yaml.safe_load(config_file.read_text(encoding="utf-8"))
+        assert config_data["spec"]["rigor"] == "low"
+
+    @patch("cafe.ui.cli.prompt_confirm")
+    @patch("cafe.ui.cli.prompt_text")
+    def test_legacy_playbook_without_fields_keeps_legacy_path(
+        self,
+        mock_prompt_text,
+        mock_prompt_confirm,
+        temp_repo_dir,
+        mock_git_ops,
+    ):
+        prepare_block = """
+commands:
+  prepare:
+    quick_setup:
+      spec:
+        rigor: medium
+    constraints:
+      rigor: [medium]
+"""
+        _write_custom_playbook(temp_repo_dir, "legacy-only", prepare_block)
+        _write_config_with_playbook(temp_repo_dir, "legacy-only")
+
+        mock_prompt_text.return_value = "legacy-only-issue"
+        mock_prompt_confirm.return_value = False
+
+        with patch("cafe.ui.commands.lifecycle._run_field_driven_prepare_prompts") as mock_field:
+            with patch("cafe.ui.commands.lifecycle._run_legacy_prepare_prompts") as mock_legacy:
+                mock_legacy.return_value = (
+                    {"input_method": "manual", "rigor": "medium", "template": "auto"},
+                    {"template": "auto"},
+                    {"auto_create": False},
+                    None,
+                )
+                result = runner.invoke(app, ["prepare"])
+
+        assert result.exit_code == 0
+        mock_legacy.assert_called_once()
+        mock_field.assert_not_called()

--- a/tests/integration/test_prepare_non_github.py
+++ b/tests/integration/test_prepare_non_github.py
@@ -69,8 +69,8 @@ class TestPrepareNonGitHubRepo:
         # Note: Should NOT ask for input method or PR auto-create in non-GitHub repos
         mock_prompt_text.return_value = "test-issue"
         mock_prompt_confirm.return_value = False  # worktree (n)
-        mock_cli_list.return_value = "Custom configuration"  # setup mode
-        mock_phase_list.return_value = "Medium - Balanced mode [Default]\n   • Ask important details and key scenarios\n   • Balance speed and precision\n   • Suitable for: general feature development"
+        mock_cli_list.side_effect = ["Custom configuration", "Medium"]
+        mock_phase_list.return_value = "Medium"
         mock_template_list.return_value = "default (system default)"
 
         result = runner.invoke(app, ["prepare"])
@@ -102,8 +102,8 @@ class TestPrepareNonGitHubRepo:
         # Mock user inputs
         mock_prompt_text.return_value = "my-feature"
         mock_prompt_confirm.return_value = False  # worktree (n)
-        mock_cli_list.return_value = "Custom configuration"  # setup mode
-        mock_phase_list.return_value = "Medium - Balanced mode [Default]\n   • Ask important details and key scenarios\n   • Balance speed and precision\n   • Suitable for: general feature development"
+        mock_cli_list.side_effect = ["Custom configuration", "Medium"]
+        mock_phase_list.return_value = "Medium"
         mock_template_list.return_value = "default (system default)"
 
         result = runner.invoke(app, ["prepare"])
@@ -180,13 +180,13 @@ class TestPrepareGitHubRepo:
         """測試在 GitHub repo 中執行 prepare 會詢問 input method."""
         # Mock user inputs: issue name, worktree (n), input method (manual), rigor, template, pr (y)
         mock_prompt_text.return_value = "gh-issue"
-        mock_cli_confirm.return_value = False  # worktree (n)
-        mock_phase_confirm.return_value = True  # pr (y)
-        mock_cli_list.return_value = "Custom configuration"  # setup mode
+        mock_cli_confirm.side_effect = [False, True, True]  # worktree, pr auto_create, post_todo_list
+        mock_phase_confirm.return_value = True
+        mock_cli_list.side_effect = ["Custom configuration", "Medium"]
         # Note: phase_prompts has input method selection too, need to handle both
         mock_phase_list.side_effect = [
             "1. Manual input",  # input method
-            "Medium - Balanced mode [Default]\n   • Ask important details and key scenarios\n   • Balance speed and precision\n   • Suitable for: general feature development",  # rigor
+            "Medium",  # rigor from field choices
         ]
         mock_template_list.return_value = "default (system default)"  # template
 

--- a/tests/integration/test_prepare_playbook_driven.py
+++ b/tests/integration/test_prepare_playbook_driven.py
@@ -107,7 +107,7 @@ class TestPreparePlaybookDriven:
         mock_prompt_text_cli.return_value = "parity-quick"
         mock_prompt_text_phase.return_value = "123"
         mock_prompt_confirm.return_value = False
-        mock_phase_list.return_value = "2. Fetch from GitHub Issue"
+        mock_phase_list.return_value = "2. GitHub issue"
         mock_cli_list.return_value = "Quick setup (use recommended defaults)"
 
         result = runner.invoke(app, ["prepare"])

--- a/tests/unit/test_cli_prepare.py
+++ b/tests/unit/test_cli_prepare.py
@@ -99,13 +99,10 @@ class TestPrepareCommand:
         """測試互動式輸入 issue name"""
         # Mock user inputs
         mock_prompt_text.return_value = "my-feature"
-        mock_cli_confirm.return_value = False  # worktree (n)
-        mock_phase_confirm.return_value = True  # pr auto_create (y)
-        mock_cli_list.return_value = "Custom configuration"  # setup mode
-        mock_phase_list.side_effect = [
-            "1. Manual input",  # input method (manual)
-            "Medium - Balanced mode [Default]\n   • Ask important details and key scenarios\n   • Balance speed and precision\n   • Suitable for: general feature development",  # rigor
-        ]
+        mock_cli_confirm.side_effect = [False, True, True]  # worktree, pr auto_create, post_todo_list
+        mock_phase_confirm.return_value = True
+        mock_cli_list.side_effect = ["Custom configuration", "Medium"]
+        mock_phase_list.return_value = "1. Manual input"
         mock_template_list.return_value = "default (system default)"  # template
 
         result = runner.invoke(app, ["prepare"])
@@ -395,13 +392,10 @@ class TestPrepareCommandWorktree:
         """測試互動模式詢問是否使用 worktree, 使用者選擇 Yes"""
         # Mock user inputs: issue name, worktree path
         mock_prompt_text.side_effect = ["my-feature", "worktrees/my-feature"]
-        mock_cli_confirm.return_value = True  # worktree (y)
-        mock_phase_confirm.return_value = True  # pr auto_create (y)
-        mock_cli_list.return_value = "Custom configuration"  # setup mode
-        mock_phase_list.side_effect = [
-            "1. Manual input",  # input method (manual)
-            "Medium - Balanced mode [Default]\n   • Ask important details and key scenarios\n   • Balance speed and precision\n   • Suitable for: general feature development",  # rigor
-        ]
+        mock_cli_confirm.side_effect = [True, True, True]  # worktree, pr auto_create, post_todo_list
+        mock_phase_confirm.return_value = True
+        mock_cli_list.side_effect = ["Custom configuration", "Medium"]
+        mock_phase_list.return_value = "1. Manual input"
         mock_template_list.return_value = "default (system default)"
 
         result = runner.invoke(app, ["prepare"])
@@ -431,13 +425,10 @@ class TestPrepareCommandWorktree:
         """測試互動模式詢問是否使用 worktree, 使用者選擇 No"""
         # Mock user inputs
         mock_prompt_text.return_value = "normal-feature"
-        mock_cli_confirm.return_value = False  # worktree (n)
-        mock_phase_confirm.return_value = True  # pr auto_create (y)
-        mock_cli_list.return_value = "Custom configuration"  # setup mode
-        mock_phase_list.side_effect = [
-            "1. Manual input",  # input method (manual)
-            "Medium - Balanced mode [Default]\n   • Ask important details and key scenarios\n   • Balance speed and precision\n   • Suitable for: general feature development",  # rigor
-        ]
+        mock_cli_confirm.side_effect = [False, True, True]  # worktree, pr auto_create, post_todo_list
+        mock_phase_confirm.return_value = True
+        mock_cli_list.side_effect = ["Custom configuration", "Medium"]
+        mock_phase_list.return_value = "1. Manual input"
         mock_template_list.return_value = "default (system default)"
 
         result = runner.invoke(app, ["prepare"])
@@ -463,13 +454,10 @@ class TestPrepareCommandWorktree:
         """測試互動模式建議預設路徑 .cafe/worktrees/{issue-name}"""
         # Mock user inputs: issue name, default path (empty string)
         mock_prompt_text.side_effect = ["test-issue", ".cafe/worktrees/test-issue"]
-        mock_cli_confirm.return_value = True  # worktree (y)
-        mock_phase_confirm.return_value = True  # pr auto_create (y)
-        mock_cli_list.return_value = "Custom configuration"  # setup mode
-        mock_phase_list.side_effect = [
-            "1. Manual input",  # input method (manual)
-            "Medium - Balanced mode [Default]\n   • Ask important details and key scenarios\n   • Balance speed and precision\n   • Suitable for: general feature development",  # rigor
-        ]
+        mock_cli_confirm.side_effect = [True, True, True]  # worktree, pr auto_create, post_todo_list
+        mock_phase_confirm.return_value = True
+        mock_cli_list.side_effect = ["Custom configuration", "Medium"]
+        mock_phase_list.return_value = "1. Manual input"
         mock_template_list.return_value = "default (system default)"
 
         result = runner.invoke(app, ["prepare"])
@@ -531,13 +519,10 @@ class TestPrepareCommandWorktree:
         """測試互動模式選擇自動建立 PR (yes)"""
         # Mock user inputs
         mock_prompt_text.return_value = "test-issue"
-        mock_cli_confirm.return_value = False  # worktree (n)
-        mock_phase_confirm.return_value = True  # pr auto_create (y)
-        mock_cli_list.return_value = "Custom configuration"  # setup mode
-        mock_phase_list.side_effect = [
-            "1. Manual input",  # input method (manual)
-            "Medium - Balanced mode [Default]\n   • Ask important details and key scenarios\n   • Balance speed and precision\n   • Suitable for: general feature development",  # rigor
-        ]
+        mock_cli_confirm.side_effect = [False, True, True]  # worktree, pr auto_create, post_todo_list
+        mock_phase_confirm.return_value = True
+        mock_cli_list.side_effect = ["Custom configuration", "Medium"]
+        mock_phase_list.return_value = "1. Manual input"
         mock_template_list.return_value = "default (system default)"
 
         result = runner.invoke(app, ["prepare"])
@@ -562,13 +547,10 @@ class TestPrepareCommandWorktree:
         """測試互動模式選擇不自動建立 PR (no)"""
         # Mock user inputs
         mock_prompt_text.return_value = "test-issue"
-        mock_cli_confirm.return_value = False  # worktree (n)
-        mock_phase_confirm.return_value = False  # pr auto_create (n)
-        mock_cli_list.return_value = "Custom configuration"  # setup mode
-        mock_phase_list.side_effect = [
-            "1. Manual input",  # input method (manual)
-            "Medium - Balanced mode [Default]\n   • Ask important details and key scenarios\n   • Balance speed and precision\n   • Suitable for: general feature development",  # rigor
-        ]
+        mock_cli_confirm.side_effect = [False, False]  # worktree, pr auto_create
+        mock_phase_confirm.return_value = False
+        mock_cli_list.side_effect = ["Custom configuration", "Medium"]
+        mock_phase_list.return_value = "1. Manual input"
         mock_template_list.return_value = "default (system default)"
 
         result = runner.invoke(app, ["prepare"])
@@ -875,11 +857,8 @@ class TestPrepareCommandSetupMode:
         # Input method 選擇 -> Manual input (第一個 prompt)
         # Setup mode 選擇 -> Custom configuration (第二個 prompt)
         # Rigor 選擇 -> High (第三個 prompt)
-        mock_phase_list.side_effect = [
-            "1. Manual input",  # input method (manual)
-            "High - Precise specification mode\n   • Ask all details and edge cases\n   • Ensure requirements are testable, no ambiguity\n   • Suitable for: core features, API design, external products",  # rigor
-        ]
-        mock_cli_list.return_value = "Custom configuration"
+        mock_phase_list.return_value = "1. Manual input"
+        mock_cli_list.side_effect = ["Custom configuration", "High"]
         mock_template_list.return_value = "default (system default)"  # template selector parses this
 
         result = runner.invoke(app, ["prepare"])
@@ -896,10 +875,10 @@ class TestPrepareCommandSetupMode:
             assert config_data["spec"]["template"] == "default"
             assert config_data["plan"]["template"] == "default"
 
-        # 驗證詢問了 input method 和設定模式
-        assert mock_cli_list.call_count == 1  # setup mode
-        # 驗證詢問了 input method、rigor (2 個 prompt_list)
-        assert mock_phase_list.call_count == 2
+        # 驗證詢問了 setup mode 與 rigor
+        assert mock_cli_list.call_count == 2
+        # 驗證詢問了 input method
+        assert mock_phase_list.call_count == 1
         # 驗證詢問了 templates (2 次：spec 和 plan)
         assert mock_template_list.call_count == 2
 
@@ -990,7 +969,7 @@ class TestPrepareCommandSetupMode:
         mock_cli_confirm.return_value = False  # worktree (n)
         
         # Input method 選擇 -> Fetch from GitHub Issue (第一個 prompt)
-        mock_phase_list.return_value = "2. Fetch from GitHub Issue"
+        mock_phase_list.return_value = "2. GitHub issue"
         
         # Setup mode 選擇 -> Quick setup (第二個 prompt，在輸入 Issue ID 後)
         mock_cli_list.return_value = "Quick setup (use recommended defaults)"
@@ -1059,7 +1038,7 @@ class TestPrepareCommandPostPrTodoList:
         mock_prompt_text_phase.return_value = "123"
         mock_cli_confirm.return_value = False  # worktree (n)
 
-        mock_phase_list.return_value = "2. Fetch from GitHub Issue"
+        mock_phase_list.return_value = "2. GitHub issue"
         mock_cli_list.return_value = "Quick setup (use recommended defaults)"
 
         result = runner.invoke(app, ["prepare"])
@@ -1105,10 +1084,9 @@ class TestPrepareCommandPostPrTodoList:
         mock_prompt_text_phase.return_value = "42"
         # worktree=No, sync_spec=True, sync_plan=True, auto_create=True, post_todo_list=False
         mock_cli_confirm.side_effect = [False, True, True, True, False]
-        mock_phase_confirm.side_effect = [True]  # auto_create prompt in phase_prompts
 
-        mock_phase_list.return_value = "2. Fetch from GitHub Issue"
-        mock_cli_list.return_value = "Custom configuration"
+        mock_phase_list.return_value = "2. GitHub issue"
+        mock_cli_list.side_effect = ["Custom configuration", "Medium"]
         mock_template_list.return_value = "default (system default)"
 
         result = runner.invoke(app, ["prepare"])
@@ -1153,13 +1131,11 @@ class TestPrepareCommandPostPrTodoList:
 
         mock_prompt_text_cli.return_value = "custom-no-auto-create"
         mock_prompt_text_phase.return_value = "42"
-        # worktree=No, sync_spec=True, sync_plan=True
-        mock_cli_confirm.side_effect = [False, True, True]
-        # auto_create prompt in phase_prompts returns False
-        mock_phase_confirm.side_effect = [False]
+        # worktree=No, sync_spec=True, sync_plan=True, auto_create=False
+        mock_cli_confirm.side_effect = [False, True, True, False]
 
-        mock_phase_list.return_value = "2. Fetch from GitHub Issue"
-        mock_cli_list.return_value = "Custom configuration"
+        mock_phase_list.return_value = "2. GitHub issue"
+        mock_cli_list.side_effect = ["Custom configuration", "Medium"]
         mock_template_list.return_value = "default (system default)"
 
         result = runner.invoke(app, ["prepare"])

--- a/tests/unit/test_prepare_field_renderer.py
+++ b/tests/unit/test_prepare_field_renderer.py
@@ -1,0 +1,236 @@
+"""Tests for prepare field renderer."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from cafe.core.playbook import PlaybookDefinition, resolve_prepare_config
+from cafe.core.prepare_fields import (
+    ParsedPrepareFields,
+    PrepareField,
+    PrepareFieldChoice,
+    parse_prepare_fields,
+)
+from cafe.core.prepare_profile import PrepareProfile
+from cafe.playbooks.loader import PlaybookLoader
+from cafe.skills.loader import SkillLoader
+from cafe.ui.prepare_field_renderer import (
+    PreparePromptContext,
+    RendererDeps,
+    apply_quick_defaults,
+    field_is_visible,
+    format_enum_choice,
+    parse_enum_selection,
+    prompt_setup_mode,
+    prompt_custom_fields,
+    set_write_value,
+    visible_fields,
+)
+from cafe.core.prepare_profile import PrepareIssueConfig
+
+
+def _profile(*, is_github_repo: bool = True) -> PrepareProfile:
+    loader = PlaybookLoader()
+    loaded = loader.load_model("default")
+    return PrepareProfile.from_playbook(loaded.model, is_github_repo=is_github_repo)
+
+
+def _default_fields():
+    loader = PlaybookLoader()
+    loaded = loader.load_model("default")
+    profile = _profile()
+    return profile.resolved_prepare_fields(
+        playbook_path=loaded.path,
+        skill_loader=SkillLoader(),
+    )
+
+
+class TestShowWhenVisibility:
+    def test_github_repo_gate(self) -> None:
+        field = PrepareField.model_validate(
+            {
+                "id": "input_method",
+                "type": "enum",
+                "label": "Input method",
+                "write": "spec.input_method",
+                "show_when": {"github_repo": True},
+                "choices": [{"value": "manual", "label": "Manual"}],
+            }
+        )
+        assert field_is_visible(
+            field,
+            PreparePromptContext(True, None, None, _profile()),
+        )
+        assert not field_is_visible(
+            field,
+            PreparePromptContext(False, None, None, _profile(is_github_repo=False)),
+        )
+
+    def test_issue_id_and_setup_mode_gates(self) -> None:
+        field = PrepareField.model_validate(
+            {
+                "id": "sync",
+                "type": "boolean",
+                "label": "Sync",
+                "write": "spec.sync_github",
+                "show_when": {"issue_id_present": True, "setup_mode": "custom"},
+            }
+        )
+        visible_ctx = PreparePromptContext(True, 123, "custom", _profile())
+        hidden_ctx = PreparePromptContext(True, None, "custom", _profile())
+        assert field_is_visible(field, visible_ctx)
+        assert not field_is_visible(field, hidden_ctx)
+
+
+class TestVisibleFieldsOrdering:
+    def test_preserves_declaration_order(self) -> None:
+        parsed = ParsedPrepareFields(
+            fields=parse_prepare_fields(
+                [
+                    {"id": "a", "type": "boolean", "label": "A", "write": "spec.sync_github"},
+                    {
+                        "id": "b",
+                        "type": "boolean",
+                        "label": "B",
+                        "write": "plan.sync_github",
+                        "show_when": {"setup_mode": "quick"},
+                    },
+                ]
+            )
+        )
+        ctx = PreparePromptContext(True, None, "quick", _profile())
+        ids = [field.id for field in visible_fields(parsed, ctx)]
+        assert ids == ["a", "b"]
+
+
+class TestWriteTargetMapping:
+    def test_maps_nested_issue_config_paths(self) -> None:
+        config = PrepareIssueConfig(spec={}, plan={}, pr={})
+        set_write_value(config, "spec.rigor", "high")
+        set_write_value(config, "plan.template", "default")
+        set_write_value(config, "pr.auto_create", True)
+        assert config.spec["rigor"] == "high"
+        assert config.plan["template"] == "default"
+        assert config.pr["auto_create"] is True
+
+
+class TestQuickDefaults:
+    def test_matches_profile_quick_setup_for_github_issue(self) -> None:
+        parsed = _default_fields()
+        assert parsed is not None
+        profile = _profile()
+        ctx = PreparePromptContext(True, 337, None, profile)
+        rendered = apply_quick_defaults(parsed, ctx)
+        legacy = profile.quick_setup_issue_config(337)
+        assert rendered.spec == legacy.spec
+        assert rendered.plan == legacy.plan
+        assert rendered.pr == legacy.pr
+
+    def test_manual_input_uses_manual_sync_defaults(self) -> None:
+        parsed = _default_fields()
+        assert parsed is not None
+        profile = _profile()
+        ctx = PreparePromptContext(True, None, None, profile)
+        rendered = apply_quick_defaults(parsed, ctx)
+        assert rendered.spec["sync_github"] is False
+        assert rendered.plan["sync_github"] is False
+
+
+class TestEnumFormatting:
+    def test_formats_label_and_description(self) -> None:
+        choice = PrepareFieldChoice(value="high", label="High", description="Precise mode")
+        assert format_enum_choice(choice) == "High\n   Precise mode"
+
+    def test_parses_formatted_selection_back_to_value(self) -> None:
+        choices = [
+            PrepareFieldChoice(value="low", label="Low"),
+            PrepareFieldChoice(value="high", label="High", description="Precise mode"),
+        ]
+        assert parse_enum_selection("High\n   Precise mode", choices) == "high"
+
+
+class TestSetupModePrompt:
+    def test_uses_declarative_default_choice(self) -> None:
+        field = PrepareField.model_validate(
+            {
+                "id": "setup_mode",
+                "type": "setup_mode",
+                "label": "Mode",
+                "default": "custom",
+                "choices": [
+                    {"value": "quick", "label": "Quick setup"},
+                    {"value": "custom", "label": "Custom setup"},
+                ],
+            }
+        )
+        prompt_list = MagicMock(return_value="Custom setup")
+        deps = RendererDeps(
+            prompt_list=prompt_list,
+            prompt_confirm=MagicMock(),
+            prompt_text=MagicMock(),
+            prompt_for_input_method=MagicMock(),
+            select_template=MagicMock(),
+            spec_template_manager=MagicMock(),
+            plan_template_manager=MagicMock(),
+        )
+
+        assert prompt_setup_mode(field, deps) == "custom"
+        assert prompt_list.call_args.kwargs["default"] == "Custom setup"
+
+
+class TestPostTodoListVisibility:
+    def test_hidden_when_auto_create_false(self) -> None:
+        field = PrepareField.model_validate(
+            {
+                "id": "todo",
+                "type": "boolean",
+                "label": "Todo",
+                "write": "pr.post_todo_list",
+                "show_when": {"setup_mode": "custom", "github_repo": True},
+            }
+        )
+        ctx = PreparePromptContext(True, None, "custom", _profile(), pr_auto_create=False)
+        assert not field_is_visible(field, ctx)
+
+
+class TestPromptCustomFields:
+    def test_skips_post_todo_when_auto_create_disabled(self) -> None:
+        parsed = ParsedPrepareFields(
+            fields=parse_prepare_fields(
+                [
+                    {
+                        "id": "auto",
+                        "type": "boolean",
+                        "label": "Auto PR",
+                        "write": "pr.auto_create",
+                        "show_when": {"setup_mode": "custom", "github_repo": True},
+                    },
+                    {
+                        "id": "todo",
+                        "type": "boolean",
+                        "label": "Todo",
+                        "write": "pr.post_todo_list",
+                        "show_when": {"setup_mode": "custom", "github_repo": True},
+                        "default": True,
+                    },
+                ]
+            )
+        )
+        confirm = MagicMock(side_effect=[False])
+        deps = RendererDeps(
+            prompt_list=MagicMock(),
+            prompt_confirm=confirm,
+            prompt_text=MagicMock(),
+            prompt_for_input_method=MagicMock(),
+            select_template=MagicMock(),
+            spec_template_manager=MagicMock(),
+            plan_template_manager=MagicMock(),
+        )
+        ctx = PreparePromptContext(True, None, "custom", _profile())
+        config = prompt_custom_fields(parsed, ctx, deps=deps)
+        assert config.pr["auto_create"] is False
+        assert "post_todo_list" not in config.pr
+        assert confirm.call_count == 1


### PR DESCRIPTION
## Summary

Implements [issue #337](https://github.com/luyotw/cafe/issues/337): interactive `cafe prepare` now renders prompts from declarative `PrepareField` definitions when a playbook declares `fields` or `fields_ref`, building on the #335 schema and validation work.

Playbooks with declarative fields get field-driven quick/custom setup flows (labels, defaults, `show_when` visibility, rigor choices from field metadata). Playbooks without declarative fields keep the existing legacy interactive path unchanged. Host-owned behavior—GitHub issue ID parsing, template listing, and worktree handling—remains in the host layer.

Review approved on commit `ca035d0` (92 targeted tests passed).

## Changes

### Field-driven prepare renderer

- Add `src/cafe/ui/prepare_field_renderer.py` — `PreparePromptContext`, `visible_fields`, `apply_quick_defaults`, `prompt_custom_fields`, `format_quick_summary`, and `run_field_driven_prepare_flow`.
- Evaluate `show_when` (`github_repo`, `issue_id_present`, `setup_mode`) and dynamic `pr.post_todo_list` visibility after `pr.auto_create`.
- Map field `write` targets into `spec` / `plan` / `pr` issue.yaml blocks.

### Lifecycle integration

- Refactor `src/cafe/ui/commands/lifecycle.py` to branch on `resolved_prepare_fields()`:
  - `_run_field_driven_prepare_prompts` when fields are declared
  - `_run_legacy_prepare_prompts` when not (backward compatible)
- Default playbook (`fields_ref`) uses the new renderer; legacy-only playbooks unchanged.

### Host adapters

- Extend `prompt_for_input_method` in `src/cafe/ui/phase_prompts.py` to accept optional `PrepareField` metadata for labels/choices while preserving GitHub issue validation and retry.

### Documentation

- Update `docs/prepare_fields.md` to document that interactive rendering is enabled for declarative fields.

### Tests

- `tests/unit/test_prepare_field_renderer.py` — visibility, write mapping, quick defaults parity, enum formatting, post_todo_list gating.
- `tests/integration/test_prepare_field_driven.py` — custom inline `fields` playbook (label/default) and legacy-only playbook regression.
- Adjust existing prepare integration/unit tests for field-driven choice labels (`Medium`, `2. GitHub issue`, etc.).

### Commits (issue337 branch, ahead of `develop`)

| Commit | Subject |
| --- | --- |
| `ca035d0` | Render prepare prompts from PrepareField definitions |

Closes #337.

## Test Plan

- [x] `pytest tests/unit/test_prepare_field_renderer.py tests/integration/test_prepare_field_driven.py tests/integration/test_prepare_playbook_driven.py tests/integration/test_prepare_non_github.py tests/unit/test_cli_prepare.py tests/unit/test_phase_prompts.py` — 91+ passed at review.
- [x] Default playbook quick setup writes expected `issue.yaml` (rigor, templates, sync/PR defaults).
- [x] Custom playbook inline `fields` reflects overridden rigor label and default in interactive flow.
- [x] Non-GitHub repo skips GitHub-only fields; `spec.input_method=manual`.
- [x] Legacy playbook without `fields` uses legacy path (`_run_legacy_prepare_prompts`, not renderer).
- [x] `docs/prepare_fields.md` describes interactive rendering for declarative fields.
- [ ] Manual: `cafe prepare` on default playbook — quick setup summary and custom setup rigor choices from field definitions.
- [ ] Manual: custom playbook with inline `fields` label/default overrides visible in prompts and `issue.yaml`.