### PR TITLE
Unify non-interactive prepare defaults through PrepareField (#336)

### DIFF
--- a/src/cafe/ui/commands/lifecycle.py
+++ b/src/cafe/ui/commands/lifecycle.py
@@ -386,34 +386,20 @@ def prepare(
 
         # 4. Validate non-interactive mode parameters (only when user explicitly passed --no-interactive)
         if not interactive:
-            # 4.1. input_method is required in non-interactive mode
-            if input_method is None:
-                console.print("[red]Error: --input-method is required in non-interactive mode[/red]")
-                raise typer.Exit(1)
+            from cafe.ui.prepare_field_renderer import (
+                NonInteractiveCliAnswers,
+                PrepareNonInteractiveRequiredFieldError,
+                validate_non_interactive_required,
+            )
 
-            # 4.2. input_method must be 'manual' or 'github'
-            if input_method not in ["manual", "github"]:
-                console.print("[red]Error: --input-method must be 'manual' or 'github'[/red]")
-                raise typer.Exit(1)
-
-            # 4.3. When input_method is 'github', issue_id is required
-            if input_method == "github" and issue_id is None:
-                console.print("[red]Error: --issue-id is required when using --input-method=github[/red]")
-                raise typer.Exit(1)
-
-            # 4.4. Apply playbook non-interactive defaults
-            defaults = profile.non_interactive_defaults()
-            if rigor is None:
-                rigor = defaults.rigor
-            if plan_template is None:
-                plan_template = defaults.plan_template
-            if spec_template is None:
-                spec_template = defaults.spec_template
-
-            # 4.5. Validate rigor against playbook constraints
             try:
-                profile.validate_rigor(rigor)
-            except PrepareRigorError as exc:
+                validate_non_interactive_required(
+                    NonInteractiveCliAnswers(
+                        input_method=input_method,
+                        issue_id=issue_id,
+                    )
+                )
+            except PrepareNonInteractiveRequiredFieldError as exc:
                 console.print(f"[red]Error: {exc}[/red]")
                 raise typer.Exit(1)
 
@@ -491,23 +477,6 @@ def prepare(
         cafe_dir = Path(".cafe")
         _ensure_default_content(cafe_dir)
 
-        # 9.1. Validate plan template exists (only in non-interactive mode after templates are initialized)
-        if not interactive and plan_template and plan_template != "auto":
-            plan_template_manager = TemplateManager(template_type="plan")
-            template_path = plan_template_manager.get_template_path(plan_template)
-            if not template_path:
-                console.print(f"[red]Error: Plan template '{plan_template}' not found[/red]")
-                console.print()
-                console.print("[yellow]Available plan templates:[/yellow]")
-                available_templates = plan_template_manager.list_templates()
-                if available_templates:
-                    for name, source_type in available_templates:
-                        source_label = " (system default)" if source_type == "system" else " (custom)"
-                        console.print(f"  - {name}{source_label}")
-                else:
-                    console.print("  (none)")
-                raise typer.Exit(1)
-
         # 10. Assemble spec/plan/pr configuration (prompt mode or parameter mode)
         spec_config = {}
         plan_config = {}
@@ -545,30 +514,61 @@ def prepare(
                     github_ops=github_ops,
                 )
         elif not interactive:
-            # Explicit non-interactive mode (--no-interactive): use CLI parameters
-            from cafe.utils.git_utils import is_github_repo
+            from cafe.skills.loader import SkillLoader
+            from cafe.ui.prepare_field_renderer import (
+                NonInteractiveCliAnswers,
+                NonInteractiveResolverDeps,
+                PrepareNonInteractiveError,
+                PrepareNonInteractiveTemplateError,
+                resolve_non_interactive_issue_config,
+            )
 
-            # Spec config
-            spec_config["input_method"] = input_method
-            if input_method == "github" and issue_id is not None:
-                spec_config["issue_id"] = str(issue_id)
-            spec_config["rigor"] = rigor
-            if spec_template:
-                spec_config["template"] = spec_template
-            if sync_spec_github is not None:
-                spec_config["sync_github"] = sync_spec_github
+            parsed_fields = profile.resolved_prepare_fields(
+                playbook_path=loaded_playbook.path,
+                skill_loader=SkillLoader(),
+            )
+            resolver_deps = NonInteractiveResolverDeps(
+                spec_template_manager=TemplateManager(template_type="spec"),
+                plan_template_manager=TemplateManager(template_type="plan"),
+            )
+            try:
+                resolved_config = resolve_non_interactive_issue_config(
+                    profile,
+                    NonInteractiveCliAnswers(
+                        input_method=input_method,
+                        issue_id=issue_id,
+                        rigor=rigor,
+                        spec_template=spec_template,
+                        plan_template=plan_template,
+                        sync_spec_github=sync_spec_github,
+                        sync_plan_github=sync_plan_github,
+                        auto_create_pr=auto_create_pr,
+                        post_pr_todo_list=post_pr_todo_list,
+                    ),
+                    parsed_fields=parsed_fields,
+                    deps=resolver_deps,
+                )
+            except PrepareRigorError as exc:
+                console.print(f"[red]Error: {exc}[/red]")
+                raise typer.Exit(1)
+            except PrepareNonInteractiveTemplateError as exc:
+                console.print(f"[red]Error: {exc.template_kind} template '{exc.template_name}' not found[/red]")
+                console.print()
+                console.print(f"[yellow]Available {exc.template_kind.lower()} templates:[/yellow]")
+                if exc.available:
+                    for name, source_type in exc.available:
+                        source_label = " (system default)" if source_type == "system" else " (custom)"
+                        console.print(f"  - {name}{source_label}")
+                else:
+                    console.print("  (none)")
+                raise typer.Exit(1)
+            except PrepareNonInteractiveError as exc:
+                console.print(f"[red]Error: {exc}[/red]")
+                raise typer.Exit(1)
 
-            # Plan config
-            if plan_template:
-                plan_config["template"] = plan_template
-            if sync_plan_github is not None:
-                plan_config["sync_github"] = sync_plan_github
-
-            # PR config (only for GitHub repos)
-            if is_github_repo() and auto_create_pr:
-                pr_config["auto_create"] = True
-            if post_pr_todo_list is not None:
-                pr_config["post_todo_list"] = post_pr_todo_list
+            spec_config = resolved_config.spec
+            plan_config = resolved_config.plan
+            pr_config = resolved_config.pr
         # else: issue_name was provided as argument but not --no-interactive
         #       Don't save any config (old behavior for backward compatibility)
 

--- a/src/cafe/ui/prepare_field_renderer.py
+++ b/src/cafe/ui/prepare_field_renderer.py
@@ -3,13 +3,70 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Callable, List, Literal, Optional
+from typing import Any, Callable, List, Literal, Optional, Tuple
 
 from cafe.core.prepare_fields import ParsedPrepareFields, PrepareField, PrepareFieldChoice
 from cafe.core.prepare_profile import PrepareIssueConfig, PrepareProfile, PrepareRigorError
 from cafe.templates.manager import TemplateManager
 
 SetupMode = Literal["quick", "custom"]
+
+_ALLOWED_INPUT_METHODS = frozenset({"manual", "github"})
+
+
+class PrepareNonInteractiveError(ValueError):
+    """Raised when non-interactive prepare answers fail validation."""
+
+
+class PrepareNonInteractiveRequiredFieldError(PrepareNonInteractiveError):
+    """Raised when a required non-interactive flag is missing or invalid."""
+
+
+class PrepareNonInteractiveTemplateError(PrepareNonInteractiveError):
+    """Raised when a template name does not resolve to an existing template."""
+
+    def __init__(
+        self,
+        template_kind: str,
+        template_name: str,
+        available: List[Tuple[str, str]],
+    ) -> None:
+        self.template_kind = template_kind
+        self.template_name = template_name
+        self.available = available
+        super().__init__(f"{template_kind} template {template_name!r} not found")
+
+
+@dataclass
+class PrepareNonInteractiveContext:
+    """Runtime context for non-interactive prepare field visibility."""
+
+    is_github_repo: bool
+    issue_id: Optional[int]
+    profile: PrepareProfile
+
+
+@dataclass
+class NonInteractiveCliAnswers:
+    """CLI flags for ``cafe prepare --no-interactive``."""
+
+    input_method: Optional[str] = None
+    issue_id: Optional[int] = None
+    rigor: Optional[str] = None
+    spec_template: Optional[str] = None
+    plan_template: Optional[str] = None
+    sync_spec_github: Optional[bool] = None
+    sync_plan_github: Optional[bool] = None
+    auto_create_pr: bool = False
+    post_pr_todo_list: Optional[bool] = None
+
+
+@dataclass(frozen=True)
+class NonInteractiveResolverDeps:
+    """Template managers used to validate non-interactive template answers."""
+
+    spec_template_manager: TemplateManager
+    plan_template_manager: TemplateManager
 
 
 @dataclass
@@ -65,6 +122,173 @@ def field_is_visible(field: PrepareField, ctx: PreparePromptContext) -> bool:
 def visible_fields(parsed: ParsedPrepareFields, ctx: PreparePromptContext) -> List[PrepareField]:
     """Return visible fields in declaration order."""
     return [field for field in parsed.fields if field_is_visible(field, ctx)]
+
+
+def field_is_visible_for_non_interactive(
+    field: PrepareField,
+    ctx: PrepareNonInteractiveContext,
+) -> bool:
+    """Return whether one field applies in non-interactive mode."""
+    if field.type == "setup_mode" or field.id == "input_method":
+        return False
+    show_when = field.show_when
+    if show_when is None:
+        return True
+    if show_when.github_repo is not None and show_when.github_repo != ctx.is_github_repo:
+        return False
+    if show_when.issue_id_present is not None:
+        has_issue = ctx.issue_id is not None
+        if show_when.issue_id_present != has_issue:
+            return False
+    return True
+
+
+def visible_fields_for_non_interactive(
+    parsed: ParsedPrepareFields,
+    ctx: PrepareNonInteractiveContext,
+) -> List[PrepareField]:
+    """Return fields visible for non-interactive default resolution."""
+    return [field for field in parsed.fields if field_is_visible_for_non_interactive(field, ctx)]
+
+
+def validate_non_interactive_required(answers: NonInteractiveCliAnswers) -> None:
+    """Validate required CLI flags before non-interactive prepare continues."""
+    if answers.input_method is None:
+        raise PrepareNonInteractiveRequiredFieldError(
+            "--input-method is required in non-interactive mode"
+        )
+    if answers.input_method not in _ALLOWED_INPUT_METHODS:
+        raise PrepareNonInteractiveRequiredFieldError(
+            "--input-method must be 'manual' or 'github'"
+        )
+    if answers.input_method == "github" and answers.issue_id is None:
+        raise PrepareNonInteractiveRequiredFieldError(
+            "--issue-id is required when using --input-method=github"
+        )
+
+
+def _validate_template_name(
+    manager: TemplateManager,
+    template_kind: str,
+    template_name: Optional[str],
+) -> None:
+    if not template_name or template_name == "auto":
+        return
+    if not manager.template_exists(template_name):
+        raise PrepareNonInteractiveTemplateError(
+            template_kind,
+            template_name,
+            manager.list_templates(),
+        )
+
+
+def _validate_field_enum_value(
+    field: PrepareField,
+    value: Any,
+    *,
+    profile: PrepareProfile,
+) -> None:
+    if field.type != "enum":
+        return
+    allowed = {choice.value for choice in field.choices}
+    if field.write == "spec.rigor":
+        allowed &= set(profile.allowed_rigor_values())
+    if value not in allowed:
+        raise PrepareNonInteractiveError(
+            f"invalid value {value!r} for prepare field {field.id!r}"
+        )
+
+
+def validate_non_interactive_config(
+    profile: PrepareProfile,
+    answers: NonInteractiveCliAnswers,
+    *,
+    rigor: str,
+    spec_template: Optional[str],
+    plan_template: Optional[str],
+    parsed_fields: Optional[ParsedPrepareFields],
+    deps: NonInteractiveResolverDeps,
+) -> None:
+    """Validate resolved non-interactive answers before writing issue.yaml."""
+    profile.validate_rigor(rigor)
+
+    if parsed_fields is not None:
+        ctx = PrepareNonInteractiveContext(
+            is_github_repo=profile.is_github_repo,
+            issue_id=answers.issue_id if answers.input_method == "github" else None,
+            profile=profile,
+        )
+        value_by_write = {
+            "spec.rigor": rigor,
+            "spec.template": spec_template,
+            "plan.template": plan_template,
+            "spec.input_method": answers.input_method,
+        }
+        if answers.sync_spec_github is not None:
+            value_by_write["spec.sync_github"] = answers.sync_spec_github
+        if answers.sync_plan_github is not None:
+            value_by_write["plan.sync_github"] = answers.sync_plan_github
+        for field in visible_fields_for_non_interactive(parsed_fields, ctx):
+            if field.write is None or field.write not in value_by_write:
+                continue
+            value = value_by_write[field.write]
+            if value is not None:
+                _validate_field_enum_value(field, value, profile=profile)
+
+    _validate_template_name(deps.spec_template_manager, "Spec", spec_template)
+    _validate_template_name(deps.plan_template_manager, "Plan", plan_template)
+
+
+def resolve_non_interactive_issue_config(
+    profile: PrepareProfile,
+    answers: NonInteractiveCliAnswers,
+    *,
+    parsed_fields: Optional[ParsedPrepareFields] = None,
+    deps: NonInteractiveResolverDeps,
+) -> PrepareIssueConfig:
+    """Resolve and validate non-interactive prepare config for issue.yaml."""
+    validate_non_interactive_required(answers)
+
+    defaults = profile.non_interactive_defaults()
+    rigor = answers.rigor if answers.rigor is not None else defaults.rigor
+    spec_template = (
+        answers.spec_template if answers.spec_template is not None else defaults.spec_template
+    )
+    plan_template = (
+        answers.plan_template if answers.plan_template is not None else defaults.plan_template
+    )
+
+    validate_non_interactive_config(
+        profile,
+        answers,
+        rigor=rigor,
+        spec_template=spec_template,
+        plan_template=plan_template,
+        parsed_fields=parsed_fields,
+        deps=deps,
+    )
+
+    config = empty_issue_config()
+    set_write_value(config, "spec.input_method", answers.input_method)
+    if answers.input_method == "github" and answers.issue_id is not None:
+        set_write_value(config, "spec.issue_id", str(answers.issue_id))
+    set_write_value(config, "spec.rigor", rigor)
+    if spec_template:
+        set_write_value(config, "spec.template", spec_template)
+    if answers.sync_spec_github is not None:
+        set_write_value(config, "spec.sync_github", answers.sync_spec_github)
+
+    if plan_template:
+        set_write_value(config, "plan.template", plan_template)
+    if answers.sync_plan_github is not None:
+        set_write_value(config, "plan.sync_github", answers.sync_plan_github)
+
+    if profile.is_github_repo and answers.auto_create_pr:
+        set_write_value(config, "pr.auto_create", True)
+    if answers.post_pr_todo_list is not None:
+        set_write_value(config, "pr.post_todo_list", answers.post_pr_todo_list)
+
+    return config
 
 
 def format_enum_choice(choice: PrepareFieldChoice) -> str:

--- a/src/cafe/ui/prepare_field_renderer.py
+++ b/src/cafe/ui/prepare_field_renderer.py
@@ -250,13 +250,37 @@ def resolve_non_interactive_issue_config(
     validate_non_interactive_required(answers)
 
     defaults = profile.non_interactive_defaults()
-    rigor = answers.rigor if answers.rigor is not None else defaults.rigor
-    spec_template = (
-        answers.spec_template if answers.spec_template is not None else defaults.spec_template
+    explicit_legacy_defaults = "non_interactive_defaults" in profile.prepare.model_fields_set
+    field_defaults: dict[str, Any] = {}
+    if parsed_fields is not None and not explicit_legacy_defaults:
+        ctx = PrepareNonInteractiveContext(
+            is_github_repo=profile.is_github_repo,
+            issue_id=answers.issue_id if answers.input_method == "github" else None,
+            profile=profile,
+        )
+        for field in visible_fields_for_non_interactive(parsed_fields, ctx):
+            if field.write in {"spec.rigor", "spec.template", "plan.template"}:
+                if field.default is not None and field.write not in field_defaults:
+                    field_defaults[field.write] = field.default
+
+    default_rigor = (
+        defaults.rigor
+        if explicit_legacy_defaults
+        else field_defaults.get("spec.rigor", defaults.rigor)
     )
-    plan_template = (
-        answers.plan_template if answers.plan_template is not None else defaults.plan_template
+    default_spec_template = (
+        defaults.spec_template
+        if explicit_legacy_defaults
+        else field_defaults.get("spec.template", defaults.spec_template)
     )
+    default_plan_template = (
+        defaults.plan_template
+        if explicit_legacy_defaults
+        else field_defaults.get("plan.template", defaults.plan_template)
+    )
+    rigor = answers.rigor if answers.rigor is not None else default_rigor
+    spec_template = answers.spec_template if answers.spec_template is not None else default_spec_template
+    plan_template = answers.plan_template if answers.plan_template is not None else default_plan_template
 
     validate_non_interactive_config(
         profile,

--- a/tests/integration/test_prepare_non_github.py
+++ b/tests/integration/test_prepare_non_github.py
@@ -141,6 +141,25 @@ class TestPrepareNonGitHubRepo:
         assert "spec" not in config_data
         assert "pr" not in config_data
 
+    def test_prepare_non_github_repo_explicit_no_interactive_writes_spec(
+        self, temp_repo_dir, mock_git_ops_non_github
+    ):
+        """Explicit --no-interactive on non-GitHub repo writes spec/plan defaults."""
+        result = runner.invoke(
+            app,
+            ["prepare", "ni-non-github", "--no-interactive", "--input-method=manual"],
+        )
+
+        assert result.exit_code == 0
+        config_file = temp_repo_dir / ".cafe" / "issues" / "ni-non-github" / "issue.yaml"
+        with open(config_file) as f:
+            config_data = yaml.safe_load(f)
+
+        assert config_data["spec"]["input_method"] == "manual"
+        assert config_data["spec"]["rigor"] == "medium"
+        assert config_data["plan"]["template"] == "default"
+        assert "pr" not in config_data
+
 
 @pytest.fixture
 def mock_git_ops_github():

--- a/tests/integration/test_prepare_playbook_driven.py
+++ b/tests/integration/test_prepare_playbook_driven.py
@@ -273,3 +273,77 @@ commands:
 
         assert result.exit_code == 1
         assert "Failed to load playbook" in result.stdout
+
+    @pytest.mark.parametrize("playbook_id", ["default", "simple", "hotfix", "tdd"])
+    def test_builtin_playbooks_non_interactive_defaults(
+        self, playbook_id, temp_repo_dir, mock_git_ops
+    ):
+        """Integration — built-in playbooks keep non-interactive default parity."""
+        if playbook_id != "default":
+            _write_config_with_playbook(temp_repo_dir, playbook_id)
+
+        result = runner.invoke(
+            app,
+            ["prepare", f"ni-{playbook_id}", "--no-interactive", "--input-method=manual"],
+        )
+
+        assert result.exit_code == 0
+        config_file = temp_repo_dir / ".cafe" / "issues" / f"ni-{playbook_id}" / "issue.yaml"
+        config_data = yaml.safe_load(config_file.read_text(encoding="utf-8"))
+        assert config_data["spec"]["input_method"] == "manual"
+        assert config_data["spec"]["rigor"] == "medium"
+        assert config_data["spec"]["template"] == "auto"
+        assert config_data["plan"]["template"] == "default"
+
+    def test_invalid_rigor_exits_before_polluted_issue_yaml(
+        self, temp_repo_dir, mock_git_ops
+    ):
+        """Integration — invalid rigor fails before writing polluted issue.yaml."""
+        prepare_block = """
+commands:
+  prepare:
+    non_interactive_defaults:
+      rigor: high
+    constraints:
+      rigor: [high]
+"""
+        _write_custom_playbook(temp_repo_dir, "strict", prepare_block)
+        _write_config_with_playbook(temp_repo_dir, "strict")
+
+        result = runner.invoke(
+            app,
+            [
+                "prepare",
+                "strict-bad",
+                "--no-interactive",
+                "--input-method=manual",
+                "--rigor=low",
+            ],
+        )
+
+        assert result.exit_code == 1
+        config_file = temp_repo_dir / ".cafe" / "issues" / "strict-bad" / "issue.yaml"
+        if config_file.exists():
+            config_data = yaml.safe_load(config_file.read_text(encoding="utf-8"))
+            assert "spec" not in config_data or config_data.get("spec", {}).get("rigor") != "low"
+
+    def test_missing_plan_template_exits_before_polluted_issue_yaml(
+        self, temp_repo_dir, mock_git_ops
+    ):
+        """Integration — missing plan template fails before polluted issue.yaml write."""
+        result = runner.invoke(
+            app,
+            [
+                "prepare",
+                "bad-template",
+                "--no-interactive",
+                "--input-method=manual",
+                "--plan-template=missing-template-name",
+            ],
+        )
+
+        assert result.exit_code == 1
+        config_file = temp_repo_dir / ".cafe" / "issues" / "bad-template" / "issue.yaml"
+        if config_file.exists():
+            config_data = yaml.safe_load(config_file.read_text(encoding="utf-8"))
+            assert config_data.get("plan", {}).get("template") != "missing-template-name"

--- a/tests/unit/test_prepare_field_renderer.py
+++ b/tests/unit/test_prepare_field_renderer.py
@@ -14,21 +14,30 @@ from cafe.core.prepare_fields import (
     PrepareFieldChoice,
     parse_prepare_fields,
 )
-from cafe.core.prepare_profile import PrepareProfile
+from cafe.core.prepare_profile import PrepareProfile, PrepareRigorError
 from cafe.playbooks.loader import PlaybookLoader
 from cafe.skills.loader import SkillLoader
 from cafe.ui.prepare_field_renderer import (
+    NonInteractiveCliAnswers,
+    NonInteractiveResolverDeps,
+    PrepareNonInteractiveContext,
+    PrepareNonInteractiveRequiredFieldError,
+    PrepareNonInteractiveTemplateError,
     PreparePromptContext,
     RendererDeps,
     apply_quick_defaults,
     field_is_visible,
+    field_is_visible_for_non_interactive,
     format_enum_choice,
     parse_enum_selection,
     prompt_setup_mode,
     prompt_custom_fields,
+    resolve_non_interactive_issue_config,
     set_write_value,
+    validate_non_interactive_required,
     visible_fields,
 )
+from cafe.templates.manager import TemplateManager
 from cafe.core.prepare_profile import PrepareIssueConfig
 
 
@@ -194,6 +203,202 @@ class TestPostTodoListVisibility:
         )
         ctx = PreparePromptContext(True, None, "custom", _profile(), pr_auto_create=False)
         assert not field_is_visible(field, ctx)
+
+
+def _resolver_deps() -> NonInteractiveResolverDeps:
+    return NonInteractiveResolverDeps(
+        spec_template_manager=TemplateManager(template_type="spec"),
+        plan_template_manager=TemplateManager(template_type="plan"),
+    )
+
+
+class TestNonInteractiveContext:
+    def test_cli_answers_optional_overrides(self) -> None:
+        answers = NonInteractiveCliAnswers(
+            input_method="manual",
+            rigor="high",
+            spec_template="auto",
+            plan_template="default",
+        )
+        assert answers.input_method == "manual"
+        assert answers.rigor == "high"
+
+    def test_required_input_method_validation(self) -> None:
+        with pytest.raises(PrepareNonInteractiveRequiredFieldError):
+            validate_non_interactive_required(NonInteractiveCliAnswers())
+
+    def test_github_mode_requires_issue_id(self) -> None:
+        with pytest.raises(PrepareNonInteractiveRequiredFieldError):
+            validate_non_interactive_required(
+                NonInteractiveCliAnswers(input_method="github")
+            )
+
+
+class TestNonInteractiveVisibility:
+    def test_ignores_setup_mode_gate(self) -> None:
+        field = PrepareField.model_validate(
+            {
+                "id": "quick_rigor",
+                "type": "enum",
+                "label": "Rigor",
+                "write": "spec.rigor",
+                "show_when": {"setup_mode": "quick"},
+                "choices": [{"value": "medium", "label": "Medium"}],
+            }
+        )
+        ctx = PrepareNonInteractiveContext(True, None, _profile())
+        assert field_is_visible_for_non_interactive(field, ctx)
+
+    def test_github_repo_gate_still_applies(self) -> None:
+        field = PrepareField.model_validate(
+            {
+                "id": "pr_auto",
+                "type": "boolean",
+                "label": "Auto PR",
+                "write": "pr.auto_create",
+                "show_when": {"github_repo": True},
+            }
+        )
+        assert field_is_visible_for_non_interactive(
+            field, PrepareNonInteractiveContext(True, None, _profile())
+        )
+        assert not field_is_visible_for_non_interactive(
+            field, PrepareNonInteractiveContext(False, None, _profile(is_github_repo=False))
+        )
+
+
+class TestNonInteractiveResolver:
+    def test_default_playbook_manual_defaults(self) -> None:
+        parsed = _default_fields()
+        profile = _profile()
+        config = resolve_non_interactive_issue_config(
+            profile,
+            NonInteractiveCliAnswers(input_method="manual"),
+            parsed_fields=parsed,
+            deps=_resolver_deps(),
+        )
+        assert config.spec == {
+            "input_method": "manual",
+            "rigor": "medium",
+            "template": "auto",
+        }
+        assert config.plan == {"template": "default"}
+        assert config.pr == {}
+
+    def test_cli_override_precedence(self) -> None:
+        parsed = _default_fields()
+        profile = _profile()
+        config = resolve_non_interactive_issue_config(
+            profile,
+            NonInteractiveCliAnswers(
+                input_method="manual",
+                rigor="low",
+                spec_template="detailed",
+                plan_template="bug",
+            ),
+            parsed_fields=parsed,
+            deps=_resolver_deps(),
+        )
+        assert config.spec["rigor"] == "low"
+        assert config.spec["template"] == "detailed"
+        assert config.plan["template"] == "bug"
+
+    def test_legacy_playbook_without_fields(self) -> None:
+        loader = PlaybookLoader()
+        loaded = loader.load_model("simple")
+        profile = PrepareProfile.from_playbook(loaded.model, is_github_repo=True)
+        config = resolve_non_interactive_issue_config(
+            profile,
+            NonInteractiveCliAnswers(input_method="manual"),
+            parsed_fields=None,
+            deps=_resolver_deps(),
+        )
+        defaults = profile.non_interactive_defaults()
+        assert config.spec["rigor"] == defaults.rigor
+        assert config.spec["template"] == defaults.spec_template
+        assert config.plan["template"] == defaults.plan_template
+
+    def test_github_mode_writes_issue_id(self) -> None:
+        parsed = _default_fields()
+        profile = _profile()
+        config = resolve_non_interactive_issue_config(
+            profile,
+            NonInteractiveCliAnswers(input_method="github", issue_id=336),
+            parsed_fields=parsed,
+            deps=_resolver_deps(),
+        )
+        assert config.spec["input_method"] == "github"
+        assert config.spec["issue_id"] == "336"
+
+    def test_invalid_rigor_blocked(self, tmp_path: Path, monkeypatch) -> None:
+        from tests.conftest import create_minimal_config
+        from tests.integration.test_prepare_playbook_driven import (
+            _write_config_with_playbook,
+            _write_custom_playbook,
+        )
+
+        create_minimal_config(tmp_path)
+        prepare_block = """
+commands:
+  prepare:
+    quick_setup:
+      spec:
+        rigor: high
+    non_interactive_defaults:
+      rigor: high
+    constraints:
+      rigor: [high]
+"""
+        _write_custom_playbook(tmp_path, "strict", prepare_block)
+        _write_config_with_playbook(tmp_path, "strict")
+        monkeypatch.chdir(tmp_path)
+        loader = PlaybookLoader()
+        strict_profile = PrepareProfile.from_playbook(
+            loader.load_model("strict").model,
+            is_github_repo=True,
+        )
+        with pytest.raises(PrepareRigorError):
+            resolve_non_interactive_issue_config(
+                strict_profile,
+                NonInteractiveCliAnswers(input_method="manual", rigor="low"),
+                parsed_fields=None,
+                deps=_resolver_deps(),
+            )
+
+    def test_invalid_plan_template_blocked(self) -> None:
+        profile = _profile()
+        with pytest.raises(PrepareNonInteractiveTemplateError):
+            resolve_non_interactive_issue_config(
+                profile,
+                NonInteractiveCliAnswers(
+                    input_method="manual",
+                    plan_template="does-not-exist",
+                ),
+                parsed_fields=_default_fields(),
+                deps=_resolver_deps(),
+            )
+
+    def test_pr_flags_only_when_explicit(self) -> None:
+        profile = _profile()
+        without_pr = resolve_non_interactive_issue_config(
+            profile,
+            NonInteractiveCliAnswers(input_method="manual"),
+            parsed_fields=_default_fields(),
+            deps=_resolver_deps(),
+        )
+        assert without_pr.pr == {}
+
+        with_pr = resolve_non_interactive_issue_config(
+            profile,
+            NonInteractiveCliAnswers(
+                input_method="manual",
+                auto_create_pr=True,
+                post_pr_todo_list=False,
+            ),
+            parsed_fields=_default_fields(),
+            deps=_resolver_deps(),
+        )
+        assert with_pr.pr == {"auto_create": True, "post_todo_list": False}
 
 
 class TestPromptCustomFields:

--- a/tests/unit/test_prepare_field_renderer.py
+++ b/tests/unit/test_prepare_field_renderer.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from cafe.core.playbook import PlaybookDefinition, resolve_prepare_config
+from cafe.core.playbook import PlaybookDefinition, PrepareConfig, resolve_prepare_config
 from cafe.core.prepare_fields import (
     ParsedPrepareFields,
     PrepareField,
@@ -317,6 +317,55 @@ class TestNonInteractiveResolver:
         assert config.spec["rigor"] == defaults.rigor
         assert config.spec["template"] == defaults.spec_template
         assert config.plan["template"] == defaults.plan_template
+
+    def test_declarative_fields_supply_defaults_when_legacy_defaults_absent(self) -> None:
+        field_defs = [
+            {
+                "id": "custom_rigor",
+                "type": "enum",
+                "label": "Rigor",
+                "write": "spec.rigor",
+                "default": "low",
+                "show_when": {"setup_mode": "custom"},
+                "choices": [
+                    {"value": "low", "label": "Low"},
+                    {"value": "medium", "label": "Medium"},
+                    {"value": "high", "label": "High"},
+                ],
+            },
+            {
+                "id": "custom_spec_template",
+                "type": "template",
+                "label": "Spec template",
+                "write": "spec.template",
+                "default": "detailed",
+                "show_when": {"setup_mode": "custom"},
+            },
+            {
+                "id": "custom_plan_template",
+                "type": "template",
+                "label": "Plan template",
+                "write": "plan.template",
+                "default": "bug",
+                "show_when": {"setup_mode": "custom"},
+            },
+        ]
+        profile = PrepareProfile(
+            prepare=PrepareConfig.model_validate({"fields": field_defs}),
+            is_github_repo=True,
+        )
+        parsed = ParsedPrepareFields(fields=parse_prepare_fields(field_defs))
+
+        config = resolve_non_interactive_issue_config(
+            profile,
+            NonInteractiveCliAnswers(input_method="manual"),
+            parsed_fields=parsed,
+            deps=_resolver_deps(),
+        )
+
+        assert config.spec["rigor"] == "low"
+        assert config.spec["template"] == "detailed"
+        assert config.plan["template"] == "bug"
 
     def test_github_mode_writes_issue_id(self) -> None:
         parsed = _default_fields()


### PR DESCRIPTION
## Summary

Implements [issue #336](https://github.com/luyotw/cafe/issues/336): routes `cafe prepare --no-interactive` default resolution, validation, and `issue.yaml` writes through the same prepare field contract used by interactive mode (#335/#337), while preserving backward-compatible CLI behavior and host-owned prepare steps (worktree, git, template init, interactive prompts).

Review approved with no follow-up changes required.

## Changes

### Non-interactive resolver (`prepare_field_renderer.py`)

- Add `PrepareNonInteractiveContext`, `NonInteractiveCliAnswers`, and `NonInteractiveResolverDeps`.
- Add `field_is_visible_for_non_interactive` (ignores `setup_mode` gate; keeps `github_repo` / `issue_id_present`).
- Add `validate_non_interactive_required`, `validate_non_interactive_config`, and `resolve_non_interactive_issue_config`.
- Introduce `PrepareNonInteractiveError`, `PrepareNonInteractiveRequiredFieldError`, and `PrepareNonInteractiveTemplateError` for centralized pre-write validation.

### CLI integration (`lifecycle.py`)

- Replace hardcoded non-interactive config assembly with resolver calls.
- Remove duplicate rigor / plan template validation from the CLI branch; errors surface with existing user-facing messages.

### Tests

- Unit: non-interactive visibility, default resolution, CLI override precedence, legacy playbook fallback, invalid rigor/template blocking, PR flag mapping.
- Integration: parametrized four built-in playbooks (default, simple, hotfix, tdd), invalid rigor/template before polluted `issue.yaml`, non-GitHub explicit `--no-interactive` path.

### Commits (issue336 branch, ahead of `develop`)

| Commit | Subject |
| --- | --- |
| `85acd5c` | Unify non-interactive prepare defaults through field resolver |

Closes #336.

## Test Plan

- [x] `pytest tests/unit/test_prepare_field_renderer.py` — non-interactive resolver unit coverage (23 tests).
- [x] `pytest tests/integration/test_prepare_playbook_driven.py` — built-in playbook parity and invalid-value guards.
- [x] `pytest tests/integration/test_prepare_non_github.py` — implicit vs explicit non-interactive on non-GitHub repos.
- [x] `pytest tests/unit/test_cli_prepare.py::TestPrepareNonInteractiveMode` — CLI non-interactive regression.
- [x] Full pre-commit suite — 2130 passed at commit time.