### PR TITLE
Resolve per-phase models from the new clis: crew format

### DIFF
--- a/src/cafe/phases/generic_workflow_step.py
+++ b/src/cafe/phases/generic_workflow_step.py
@@ -493,6 +493,17 @@ class GenericWorkflowStepExecutor(Phase):
         if not isinstance(config, dict):
             return None
 
+        # New crew.yaml format: per-phase models live under clis[].<phase>.
+        # Delegate to the canonical chain resolver so this path stays in sync
+        # with setup_agents() instead of silently ignoring the clis list.
+        if isinstance(config.get("clis"), list):
+            from cafe.utils.crew import normalize_role_config
+
+            chain = normalize_role_config(config)
+            if chain:
+                return chain[0].resolve_model(step_name)
+            return None
+
         phase_config = config.get(step_name)
         if isinstance(phase_config, dict):
             model = phase_config.get("model")

--- a/tests/unit/test_generic_workflow_step.py
+++ b/tests/unit/test_generic_workflow_step.py
@@ -1701,6 +1701,74 @@ def test_generic_workflow_step_applies_phase_specific_model_per_step(tmp_path: P
     assert "claude-opus-4.6" in (agent_manager.preview_calls[1] or [])
 
 
+def test_generic_workflow_step_applies_phase_specific_model_from_clis_format(tmp_path: Path, monkeypatch) -> None:
+    # Regression: per-phase models declared in the new `clis:` list format must
+    # reach the CLI command. Previously _resolve_step_model only understood the
+    # old `role.<phase>.model` shape, so the clis list was silently ignored and
+    # the CLI fell back to its default model.
+    monkeypatch.chdir(tmp_path)
+    issue_dir = tmp_path / ".cafe" / "issues" / "issue-clis-models"
+    playbook = {
+        "playbook": {"id": "default"},
+        "roles": {"pm": {"default_agent": "Roger"}, "developer": {"default_agent": "David"}},
+        "steps": {
+            "spec": {
+                "skill": {"1": "spec_first", "default": "spec_first"},
+                "role": "pm",
+                "output_artifact": "spec",
+                "allowed_tools": ["Read"],
+                "valid_intents": ["confirmed"],
+                "on": {"await_agent": "plan"},
+            },
+            "plan": {
+                "skill": "plan",
+                "role": "developer",
+                "output_artifact": "plan",
+                "allowed_tools": ["Read"],
+                "input_artifacts": ["spec"],
+                "valid_intents": ["confirmed"],
+                "on": {"await_agent": "_done"},
+            },
+        },
+    }
+    store = BlackboardStore(issue_dir)
+    state = store.load_or_create("spec")
+
+    def _mark_checklist_complete(*, streaming_output_file, **kwargs) -> None:
+        iteration_dir = Path(streaming_output_file).parent
+        checklist_file = iteration_dir / "checklist.md"
+        checklist_file.write_text("- [x] completed\n", encoding="utf-8")
+
+    agent_manager = FakeAgentManager(
+        ["confirmed", "confirmed"],
+        on_execute=_mark_checklist_complete,
+    )
+    executor = GenericWorkflowStepExecutor(
+        issue_dir=issue_dir,
+        issue_name="issue-clis-models",
+        playbook=playbook,
+        generic_phase=_build_loader(tmp_path),
+        agent_manager=agent_manager,
+        git_ops=FakeGitOperations(),
+        role_agent_map={"pm": "Roger", "developer": "David"},
+        role_configs={
+            "pm": {"clis": [{"cli": "claude", "spec": "opus"}]},
+            "developer": {"clis": [{"cli": "claude", "plan": "opus", "develop": "sonnet"}]},
+        },
+    )
+
+    executor.execute_step("spec", playbook["steps"]["spec"], state)
+
+    spec_file = issue_dir / "spec" / "iteration_001" / "output.md"
+    store.set_artifact(state, "spec", str(spec_file))
+    executor.execute_step("plan", playbook["steps"]["plan"], state)
+
+    assert "--model" in (agent_manager.preview_calls[0] or [])
+    assert "opus" in (agent_manager.preview_calls[0] or [])
+    assert "--model" in (agent_manager.preview_calls[1] or [])
+    assert "opus" in (agent_manager.preview_calls[1] or [])
+
+
 def test_generic_workflow_step_develop_confirmed(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.chdir(tmp_path)
     issue_dir = tmp_path / ".cafe" / "issues" / "issue-develop-ready"


### PR DESCRIPTION
## 問題

crew.yaml 用新版 `clis:` 清單格式設定 per-phase model（如 `pm.clis[].spec: opus`、`developer.clis[].develop: sonnet`）時，model 設定被靜默忽略——cafe 沒把 `--model` 傳給 CLI，於是 CLI 用自己的預設 model 跑。

## 根因

model 解析有兩條路徑而且分岔了：

- `setup_agents()` 用 `CliEntry.resolve_model()`，看得懂新版 `clis:` 格式。
- 但每個 step 執行前 `_apply_step_agent_model()` → `_resolve_step_model()` 會再覆寫一次 `config.model`，而它只認舊版 `role.<phase>.model` / `role.model` 格式。新版 `clis:` 清單下 `config.get(step_name)`、`config.get("model")` 都是 None，於是把第一條路徑算好的 model 覆寫成 None。

結果：`config.model = None` → 不加 `--model` → CLI fallback 到預設 model。

## 修正

`_resolve_step_model()` 偵測到 `clis:` 清單時，委派給 canonical 的 `normalize_role_config()` + `CliEntry.resolve_model()`，與 `setup_agents()` 用同一套解析邏輯，不再分岔。舊格式路徑維持不變。

## 測試

新增 `test_generic_workflow_step_applies_phase_specific_model_from_clis_format`，驗證新版 `clis:` 格式的 per-phase model 會帶到 CLI 指令（沒有此修正時會失敗）。既有 model 測試與相關 unit 測試（test_cli_entry / test_crew_normalize / test_clis_chain_fallback / test_cli_setup_agents）全數通過。