### PR TITLE
Add alignment checkpoint workflow support

### DIFF
--- a/docs/alignment-checkpoints.md
+++ b/docs/alignment-checkpoints.md
@@ -1,0 +1,67 @@
+# Alignment Checkpoints
+
+Alignment checkpoints pause a workflow before selected agent steps when policy says the work may affect product direction, roadmap scope, governance, principles, positioning, strategic context, user trust, or external mutation boundaries.
+
+They are separate from clarification. Clarification asks for missing facts. Alignment asks whether the intended direction and tradeoffs still match higher-level guidance.
+
+## Policy Levels
+
+- `must_align`: stop before agent execution and hand off to the user with `intent=alignment_checkpoint`.
+- `alignment_note`: record a structured blackboard event and continue.
+- `no_alignment`: continue normally.
+
+The decision is deterministic. Agents or formatting skills may add evidence and clearer wording, but they cannot downgrade a policy-required checkpoint.
+
+## Payload Files
+
+Required checkpoints write:
+
+- `.cafe/issues/<issue>/<step>/iteration_NNN/alignment_request.json`
+- `.cafe/issues/<issue>/<step>/iteration_NNN/strategic_document_update_request.json` when a strategic document update is required
+
+The request includes the interpreted goal, proposed scope, non-scope, triggered rules, affected documents, risks, assumptions, strategic document update recommendation, requested decision, allowed decisions, and a fingerprint.
+
+## User Decisions
+
+Supported outcomes are:
+
+- approve and continue
+- narrow scope and continue
+- revise the specification
+- revise the plan
+- update strategic documents first
+- strategic documents updated
+- pause for manual decision
+- reject or defer
+
+Approval resumes the original step only when no required strategic-document update remains unresolved. Narrowing writes correction text back to the blocked step and forces the policy gate to evaluate again. Revising spec or plan routes the workflow to that step.
+
+## Strategic Documents
+
+The gate reads `.cafe/strategic_context.yaml` and records configured document paths, statuses, and hashes. Missing or draft documents are surfaced when relevant.
+
+If a required update is identified, execution stays paused until one of these happens:
+
+- the affected document changes
+- scope is narrowed so the update is no longer required
+- the user explicitly rejects or defers the work
+
+## Non-Interactive Runs
+
+Plain `--user-input` text never approves an alignment checkpoint.
+
+Use an explicit JSON payload:
+
+```json
+{"decision":"approve"}
+```
+
+```json
+{"decision":"narrow","correction":"Keep this to technical plumbing; do not change roadmap scope."}
+```
+
+```json
+{"decision":"update_strategic_documents_first"}
+```
+
+If the payload is missing or invalid, the workflow remains paused at `user`.

--- a/src/cafe/core/alignment.py
+++ b/src/cafe/core/alignment.py
@@ -1,0 +1,559 @@
+"""Deterministic alignment policy and checkpoint payload models."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, Iterable, Optional, Sequence
+
+from cafe.core.strategic_context import StrategicContext, StrategicDocumentMetadata
+
+
+class AlignmentDecisionLevel(str, Enum):
+    """Policy result levels."""
+
+    MUST_ALIGN = "must_align"
+    ALIGNMENT_NOTE = "alignment_note"
+    NO_ALIGNMENT = "no_alignment"
+
+
+@dataclass(frozen=True)
+class AlignmentPolicyConfig:
+    """Threshold and document scope configuration for one step."""
+
+    pause_threshold: int = 5
+    note_threshold: int = 2
+    affected_document_categories: tuple[str, ...] = ()
+    reuse_approved: bool = True
+
+
+@dataclass(frozen=True)
+class AlignmentPolicyInput:
+    """Inputs evaluated by the deterministic alignment policy."""
+
+    step_name: str
+    user_input: str = ""
+    playbook_id: str = ""
+    artifacts: Dict[str, str] = field(default_factory=dict)
+    required_document_categories: tuple[str, ...] = ()
+    proposed_scope: str = ""
+    non_scope: str = ""
+
+
+@dataclass(frozen=True)
+class TriggeredRule:
+    """One hard trigger or scored policy signal."""
+
+    rule_id: str
+    description: str
+    risk_level: str
+    score: int = 0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "rule_id": self.rule_id,
+            "description": self.description,
+            "risk_level": self.risk_level,
+            "score": self.score,
+        }
+
+
+@dataclass(frozen=True)
+class StrategicDocumentUpdateRequirement:
+    """A required strategic-document update before execution can continue."""
+
+    category: str
+    configured_path: Optional[str]
+    current_status: str
+    current_sha256: Optional[str]
+    required_action: str
+    unblock_choices: tuple[str, ...] = (
+        "update_document",
+        "narrow_scope",
+        "defer_or_reject",
+    )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "category": self.category,
+            "configured_path": self.configured_path,
+            "current_status": self.current_status,
+            "current_sha256": self.current_sha256,
+            "required_action": self.required_action,
+            "unblock_choices": list(self.unblock_choices),
+        }
+
+
+@dataclass(frozen=True)
+class AlignmentCheckpointPayload:
+    """User-facing alignment checkpoint payload."""
+
+    interpreted_goal: str
+    proposed_scope: str
+    non_scope: str
+    triggered_rules: tuple[TriggeredRule, ...]
+    risk_level: str
+    affected_documents: tuple[StrategicDocumentMetadata, ...]
+    risks: tuple[str, ...]
+    assumptions: tuple[str, ...]
+    strategic_update_recommendation: str
+    decision_requested: str
+    recommended_resume_target: str
+    fingerprint: str
+    allowed_decisions: tuple[str, ...] = (
+        "approve",
+        "narrow_scope",
+        "revise_spec",
+        "revise_plan",
+        "update_strategic_documents_first",
+        "strategic_documents_updated",
+        "manual_pause",
+        "reject_or_defer",
+    )
+    strategic_document_update_requirements: tuple[StrategicDocumentUpdateRequirement, ...] = ()
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "interpreted_goal": self.interpreted_goal,
+            "proposed_scope": self.proposed_scope,
+            "non_scope": self.non_scope,
+            "triggered_rules": [rule.to_dict() for rule in self.triggered_rules],
+            "risk_level": self.risk_level,
+            "affected_documents": [doc.to_dict() for doc in self.affected_documents],
+            "risks": list(self.risks),
+            "assumptions": list(self.assumptions),
+            "strategic_update_recommendation": self.strategic_update_recommendation,
+            "decision_requested": self.decision_requested,
+            "recommended_resume_target": self.recommended_resume_target,
+            "fingerprint": self.fingerprint,
+            "allowed_decisions": list(self.allowed_decisions),
+            "strategic_document_update_requirements": [
+                requirement.to_dict()
+                for requirement in self.strategic_document_update_requirements
+            ],
+        }
+
+
+@dataclass(frozen=True)
+class AlignmentPolicyResult:
+    """Policy result returned to hooks and tests."""
+
+    level: AlignmentDecisionLevel
+    triggered_rules: tuple[TriggeredRule, ...] = ()
+    score: int = 0
+    payload: Optional[AlignmentCheckpointPayload] = None
+
+
+@dataclass(frozen=True)
+class AgentAlignmentEvidence:
+    """Optional agent-supplied details that can enrich but not downgrade policy."""
+
+    suggested_level: Optional[AlignmentDecisionLevel] = None
+    risks: tuple[str, ...] = ()
+    assumptions: tuple[str, ...] = ()
+
+
+AXIS_KEYWORDS: Dict[str, tuple[str, ...]] = {
+    "product_scope": (
+        "product",
+        "roadmap",
+        "scope",
+        "feature",
+        "positioning",
+        "governance",
+        "principles",
+        "product direction",
+        "user trust",
+        "business model",
+        "產品",
+        "產品方向",
+        "路線圖",
+        "範圍",
+        "產品範圍",
+        "定位",
+        "治理",
+        "原則",
+        "使用者信任",
+        "商業模式",
+    ),
+    "technical": ("architecture", "api", "runtime", "database", "schema", "dependency"),
+    "quality": ("quality", "test", "reliability", "regression"),
+}
+
+DOCUMENT_KEYWORDS: Dict[str, tuple[str, ...]] = {
+    "roadmap": ("roadmap", "路線圖"),
+    "product_direction": ("product direction", "product strategy", "產品方向", "產品策略"),
+    "principles": ("principles", "north star", "red line", "原則", "北極星", "紅線"),
+    "positioning": ("positioning", "messaging", "market", "audience", "定位", "市場", "受眾"),
+    "strategic_context": ("strategic_context", "strategic context", "mandate", "授權", "決策權限"),
+}
+
+
+def evaluate_alignment_policy(
+    input_data: AlignmentPolicyInput,
+    *,
+    strategic_context: StrategicContext,
+    config: Optional[AlignmentPolicyConfig] = None,
+) -> AlignmentPolicyResult:
+    """Evaluate deterministic rules and return an alignment result."""
+    cfg = config or AlignmentPolicyConfig()
+    text = _policy_text(input_data)
+    triggered: list[TriggeredRule] = []
+    risks: list[str] = []
+    assumptions: list[str] = []
+    required_categories = list(dict.fromkeys(input_data.required_document_categories))
+    affected_categories = _detect_document_categories(text)
+
+    if _explicit_alignment_requested(text):
+        triggered.append(
+            TriggeredRule(
+                "explicit_alignment_request",
+                "User explicitly requested alignment before execution.",
+                "high",
+            )
+        )
+        risks.append("The user requested an explicit direction check before continuing.")
+
+    for axis_name, axis in strategic_context.axes.items():
+        if axis.level != "escalate":
+            continue
+        if _matches_keywords(text, AXIS_KEYWORDS.get(axis_name, (axis_name,))):
+            triggered.append(
+                TriggeredRule(
+                    f"mandate_escalation:{axis_name}",
+                    f"Task touches escalated mandate axis '{axis_name}'.",
+                    "high",
+                )
+            )
+            risks.append(f"Work may affect escalated mandate axis '{axis_name}'.")
+            for category in axis.grounds:
+                if category not in affected_categories:
+                    affected_categories.append(category)
+
+    matched_out_of_mandate = [
+        item
+        for item in strategic_context.out_of_mandate
+        if item and item.lower() in text
+    ]
+    if matched_out_of_mandate:
+        triggered.append(
+            TriggeredRule(
+                "out_of_mandate",
+                "Task overlaps declared out-of-mandate items: "
+                + ", ".join(matched_out_of_mandate),
+                "high",
+            )
+        )
+        risks.append("The task overlaps declared out-of-mandate work.")
+
+    for category in _detect_required_update_categories(text, required_categories):
+        if category not in required_categories:
+            required_categories.append(category)
+        if category not in affected_categories:
+            affected_categories.append(category)
+    if required_categories:
+        triggered.append(
+            TriggeredRule(
+                "strategic_document_update_required",
+                "A relevant strategic document must be updated before execution.",
+                "high",
+            )
+        )
+        risks.append("Execution may proceed against stale or missing strategic guidance.")
+
+    if _should_include_configured_documents(
+        text=text,
+        triggered_rules=triggered,
+        required_categories=required_categories,
+    ):
+        for category in cfg.affected_document_categories:
+            if category not in affected_categories:
+                affected_categories.append(category)
+    score_rules = _score_signals(text, affected_categories, strategic_context)
+    triggered.extend(score_rules)
+
+    affected_documents = tuple(
+        strategic_context.document(category)
+        for category in affected_categories
+    )
+    requirements = tuple(
+        _document_requirement(strategic_context.document(category))
+        for category in required_categories
+    )
+
+    hard_required = any(rule.score == 0 and rule.risk_level == "high" for rule in triggered)
+    score = sum(rule.score for rule in triggered)
+    if hard_required or score >= cfg.pause_threshold:
+        level = AlignmentDecisionLevel.MUST_ALIGN
+    elif score >= cfg.note_threshold:
+        level = AlignmentDecisionLevel.ALIGNMENT_NOTE
+    else:
+        return AlignmentPolicyResult(level=AlignmentDecisionLevel.NO_ALIGNMENT)
+
+    payload = _build_payload(
+        input_data=input_data,
+        strategic_context=strategic_context,
+        triggered_rules=tuple(triggered),
+        risk_level="high" if level == AlignmentDecisionLevel.MUST_ALIGN else "medium",
+        affected_documents=affected_documents,
+        requirements=requirements,
+        risks=tuple(dict.fromkeys(risks or _default_risks(level))),
+        assumptions=tuple(dict.fromkeys(assumptions or ("Policy signals were derived from workflow input and artifacts.",))),
+    )
+    return AlignmentPolicyResult(
+        level=level,
+        triggered_rules=tuple(triggered),
+        score=score,
+        payload=payload,
+    )
+
+
+def merge_agent_alignment_evidence(
+    policy_result: AlignmentPolicyResult,
+    evidence: Optional[AgentAlignmentEvidence],
+) -> AlignmentPolicyResult:
+    """Merge agent evidence without allowing it to downgrade policy severity."""
+    if evidence is None or policy_result.payload is None:
+        return policy_result
+
+    level = policy_result.level
+    if evidence.suggested_level == AlignmentDecisionLevel.MUST_ALIGN:
+        level = AlignmentDecisionLevel.MUST_ALIGN
+    elif (
+        evidence.suggested_level == AlignmentDecisionLevel.ALIGNMENT_NOTE
+        and level == AlignmentDecisionLevel.NO_ALIGNMENT
+    ):
+        level = AlignmentDecisionLevel.ALIGNMENT_NOTE
+
+    payload = AlignmentCheckpointPayload(
+        interpreted_goal=policy_result.payload.interpreted_goal,
+        proposed_scope=policy_result.payload.proposed_scope,
+        non_scope=policy_result.payload.non_scope,
+        triggered_rules=policy_result.payload.triggered_rules,
+        risk_level=policy_result.payload.risk_level,
+        affected_documents=policy_result.payload.affected_documents,
+        risks=tuple(dict.fromkeys((*policy_result.payload.risks, *evidence.risks))),
+        assumptions=tuple(dict.fromkeys((*policy_result.payload.assumptions, *evidence.assumptions))),
+        strategic_update_recommendation=policy_result.payload.strategic_update_recommendation,
+        decision_requested=policy_result.payload.decision_requested,
+        recommended_resume_target=policy_result.payload.recommended_resume_target,
+        fingerprint=policy_result.payload.fingerprint,
+        allowed_decisions=policy_result.payload.allowed_decisions,
+        strategic_document_update_requirements=policy_result.payload.strategic_document_update_requirements,
+    )
+    return AlignmentPolicyResult(
+        level=level,
+        triggered_rules=policy_result.triggered_rules,
+        score=policy_result.score,
+        payload=payload,
+    )
+
+
+def _policy_text(input_data: AlignmentPolicyInput) -> str:
+    parts = [input_data.step_name, input_data.user_input, input_data.proposed_scope, input_data.non_scope]
+    parts.extend(input_data.artifacts.values())
+    return "\n".join(part for part in parts if part).lower()
+
+
+def _explicit_alignment_requested(text: str) -> bool:
+    return bool(
+        re.search(
+            r"\b(align first|alignment checkpoint|pre[- ]?align|align before|alignment first)\b",
+            text,
+        )
+        or any(
+            token in text
+            for token in (
+                "先對標",
+                "先校準",
+                "先確認方向",
+                "對標一下",
+                "校準一下",
+                "確認方向",
+                "對標",
+                "校準",
+            )
+        )
+    )
+
+
+def _matches_keywords(text: str, keywords: Sequence[str]) -> bool:
+    return any(keyword.lower() in text for keyword in keywords)
+
+
+def _detect_document_categories(text: str) -> list[str]:
+    categories: list[str] = []
+    for category, keywords in DOCUMENT_KEYWORDS.items():
+        if _matches_keywords(text, keywords):
+            categories.append(category)
+    return categories
+
+
+def _detect_required_update_categories(text: str, explicit: Sequence[str]) -> list[str]:
+    categories = list(dict.fromkeys(explicit))
+    update_requested = any(
+        token in text
+        for token in (
+            "update",
+            "revise",
+            "change",
+            "modify",
+            "更新",
+            "修訂",
+            "修改",
+            "調整",
+            "建立",
+            "新增",
+        )
+    )
+    if not update_requested:
+        return categories
+    for category in _detect_document_categories(text):
+        if category not in categories:
+            categories.append(category)
+    return categories
+
+
+def _score_signals(
+    text: str,
+    affected_categories: Sequence[str],
+    strategic_context: StrategicContext,
+) -> list[TriggeredRule]:
+    rules: list[TriggeredRule] = []
+    if _matches_keywords(
+        text,
+        (
+            "product",
+            "roadmap",
+            "governance",
+            "positioning",
+            "principles",
+            "產品",
+            "路線圖",
+            "治理",
+            "定位",
+            "原則",
+        ),
+    ):
+        rules.append(TriggeredRule("product_or_governance_impact", "Product or governance impact detected.", "medium", 3))
+    if _matches_keywords(text, ("external mutation", "external api", "publish", "deploy", "host-side")):
+        rules.append(TriggeredRule("external_mutation_risk", "External mutation risk detected.", "medium", 2))
+    if _matches_keywords(text, ("large", "ambiguous", "unclear", "broad")):
+        rules.append(TriggeredRule("large_ambiguous_issue", "Large or ambiguous issue signal detected.", "low", 1))
+    if _matches_keywords(text, ("architecture outside", "outside obvious scope", "cross-module architecture")):
+        rules.append(TriggeredRule("architecture_scope_risk", "Architecture scope risk detected.", "medium", 2))
+    for category in affected_categories:
+        doc = strategic_context.document(category)
+        if doc.status in {"missing", "draft"}:
+            rules.append(
+                TriggeredRule(
+                    f"strategic_document_{doc.status}:{category}",
+                    f"Relevant strategic document '{category}' is {doc.status}.",
+                    "medium",
+                    3,
+                )
+            )
+    return rules
+
+
+def _should_include_configured_documents(
+    *,
+    text: str,
+    triggered_rules: Sequence[TriggeredRule],
+    required_categories: Sequence[str],
+) -> bool:
+    if required_categories:
+        return True
+    if any(rule.risk_level == "high" for rule in triggered_rules):
+        return True
+    return _matches_keywords(
+        text,
+        (
+            "product",
+            "roadmap",
+            "governance",
+            "positioning",
+            "principles",
+            "product direction",
+            "strategic context",
+            "mandate",
+            "business model",
+            "產品",
+            "產品方向",
+            "路線圖",
+            "治理",
+            "定位",
+            "原則",
+            "商業模式",
+        ),
+    )
+
+
+def _document_requirement(doc: StrategicDocumentMetadata) -> StrategicDocumentUpdateRequirement:
+    return StrategicDocumentUpdateRequirement(
+        category=doc.category,
+        configured_path=doc.path,
+        current_status=doc.status,
+        current_sha256=doc.sha256,
+        required_action="update_or_create_document",
+    )
+
+
+def _build_payload(
+    *,
+    input_data: AlignmentPolicyInput,
+    strategic_context: StrategicContext,
+    triggered_rules: tuple[TriggeredRule, ...],
+    risk_level: str,
+    affected_documents: tuple[StrategicDocumentMetadata, ...],
+    requirements: tuple[StrategicDocumentUpdateRequirement, ...],
+    risks: tuple[str, ...],
+    assumptions: tuple[str, ...],
+) -> AlignmentCheckpointPayload:
+    if requirements:
+        recommendation = "Update affected strategic documents first, narrow scope, or explicitly defer/reject."
+    elif any(doc.status in {"missing", "draft"} for doc in affected_documents):
+        recommendation = "Review missing or draft strategic documents before relying on them."
+    else:
+        recommendation = "No strategic document update is required by policy."
+
+    payload_without_fingerprint = {
+        "step_name": input_data.step_name,
+        "playbook_id": input_data.playbook_id,
+        "user_input": input_data.user_input,
+        "artifacts": input_data.artifacts,
+        "triggered_rules": [rule.to_dict() for rule in triggered_rules],
+        "affected_documents": [doc.to_dict() for doc in affected_documents],
+        "requirements": [req.to_dict() for req in requirements],
+        "strategic_context_hashes": strategic_context.document_hashes(
+            [doc.category for doc in affected_documents] + [req.category for req in requirements]
+        ),
+    }
+    fingerprint = hashlib.sha256(
+        json.dumps(payload_without_fingerprint, sort_keys=True, ensure_ascii=False).encode("utf-8")
+    ).hexdigest()
+
+    return AlignmentCheckpointPayload(
+        interpreted_goal=input_data.user_input.strip() or f"Continue workflow step '{input_data.step_name}'.",
+        proposed_scope=input_data.proposed_scope.strip() or "Proceed with the current workflow step scope.",
+        non_scope=input_data.non_scope.strip() or "Do not treat alignment as host capability approval.",
+        triggered_rules=triggered_rules,
+        risk_level=risk_level,
+        affected_documents=affected_documents,
+        risks=risks,
+        assumptions=assumptions,
+        strategic_update_recommendation=recommendation,
+        decision_requested="Choose how the workflow should proceed from this alignment checkpoint.",
+        recommended_resume_target=input_data.step_name,
+        fingerprint=fingerprint,
+        strategic_document_update_requirements=requirements,
+    )
+
+
+def _default_risks(level: AlignmentDecisionLevel) -> Iterable[str]:
+    if level == AlignmentDecisionLevel.MUST_ALIGN:
+        return ("Policy requires a user decision before execution can continue.",)
+    return ("Policy recorded a medium-risk alignment note without pausing.",)

--- a/src/cafe/core/blackboard.py
+++ b/src/cafe/core/blackboard.py
@@ -43,6 +43,7 @@ class HandoffIntent(str, Enum):
 
     AWAIT_AGENT = "await_agent"
     CONFIRM_OUTPUT = "confirm_output"
+    ALIGNMENT_CHECKPOINT = "alignment_checkpoint"
     NEED_CLARIFICATION = "need_clarification"
     NEED_PERMISSION = "need_permission"
     NO_CHANGES_NEEDED = "no_changes_needed"
@@ -240,6 +241,11 @@ class HandoffContract:
 
         if self.intent == HandoffIntent.CONFIRM_OUTPUT and self.from_step not in allowed_steps:
             raise ValueError("intent=confirm_output is only valid when from_step is a playbook step")
+        if self.intent == HandoffIntent.ALIGNMENT_CHECKPOINT:
+            if self.to_owner != HandoffOwner.USER or self.to_step != "user":
+                raise ValueError("intent=alignment_checkpoint must be user-owned and target to_step=user")
+            if self.from_step not in allowed_steps:
+                raise ValueError("intent=alignment_checkpoint is only valid when from_step is a playbook step")
 
 
 @dataclass

--- a/src/cafe/core/hooks/__init__.py
+++ b/src/cafe/core/hooks/__init__.py
@@ -75,6 +75,7 @@ from cafe.core.hooks.native import (
     PRLinkOpener,
     UserInputCollector,
 )
+from cafe.core.hooks.alignment import AlignmentCheckpointGate
 
 
 BUILTIN_HOOKS = {
@@ -90,5 +91,6 @@ BUILTIN_HOOKS = {
         LocalPRReviewer,
         PRCommentPoster,
         PRLinkOpener,
+        AlignmentCheckpointGate,
     ]
 }

--- a/src/cafe/core/hooks/alignment.py
+++ b/src/cafe/core/hooks/alignment.py
@@ -1,0 +1,221 @@
+"""Alignment checkpoint hook."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+from cafe.core.alignment import (
+    AlignmentDecisionLevel,
+    AlignmentPolicyConfig,
+    AlignmentPolicyInput,
+    evaluate_alignment_policy,
+)
+from cafe.core.blackboard import BlackboardState, BlackboardStore, HandoffIntent, HandoffOwner
+from cafe.core.hooks import HookResult, NoOpHook
+from cafe.core.status_codes import PhaseStatusCode
+from cafe.core.strategic_context import load_strategic_context
+
+
+class AlignmentCheckpointGate(NoOpHook):
+    """Run deterministic alignment policy before agent execution."""
+
+    name = "AlignmentCheckpointGate"
+
+    def run(self, **kwargs: Any) -> HookResult:
+        if kwargs.get("stage") != "prepare_input":
+            return HookResult()
+
+        step_def = kwargs.get("step_def") or {}
+        raw_alignment = step_def.get("alignment")
+        if not isinstance(raw_alignment, dict):
+            return HookResult()
+        if raw_alignment.get("enabled", True) is False:
+            return HookResult()
+        if raw_alignment.get("trigger_policy", "policy") == "disabled":
+            return HookResult()
+
+        phase = kwargs.get("phase")
+        step_name = str(kwargs.get("step_name") or "")
+        issue_dir = Path(getattr(phase, "issue_dir", "")) if phase is not None else None
+        if phase is None or issue_dir is None or not step_name:
+            return HookResult()
+
+        blackboard_state = kwargs.get("blackboard_state")
+        if not isinstance(blackboard_state, BlackboardState):
+            return HookResult()
+
+        context = kwargs.get("context") if isinstance(kwargs.get("context"), dict) else {}
+        user_input = self._resolve_user_input(phase=phase, step_name=step_name, context=context)
+        artifacts = self._load_artifacts(
+            blackboard_state=blackboard_state,
+            step_def=step_def,
+            output_file=kwargs.get("output_file"),
+        )
+        strategic_context = load_strategic_context(Path.cwd(), issue_name=getattr(phase, "issue_name", None))
+        config = AlignmentPolicyConfig(
+            pause_threshold=int(raw_alignment.get("pause_threshold", 5)),
+            note_threshold=int(raw_alignment.get("note_threshold", 2)),
+            affected_document_categories=tuple(raw_alignment.get("affected_document_categories", []) or []),
+            reuse_approved=bool(raw_alignment.get("reuse_approved", True)),
+        )
+        result = evaluate_alignment_policy(
+            AlignmentPolicyInput(
+                step_name=step_name,
+                playbook_id=str(getattr(phase, "playbook", {}).get("playbook", {}).get("id", "")),
+                user_input=user_input,
+                artifacts=artifacts,
+            ),
+            strategic_context=strategic_context,
+            config=config,
+        )
+        if result.level == AlignmentDecisionLevel.NO_ALIGNMENT or result.payload is None:
+            return HookResult()
+
+        store = BlackboardStore(issue_dir)
+        payload = result.payload.to_dict()
+        payload.update(
+            {
+                "from_step": step_name,
+                "playbook_id": str(getattr(phase, "playbook", {}).get("playbook", {}).get("id", "")),
+                "level": result.level.value,
+                "score": result.score,
+            }
+        )
+
+        if result.level == AlignmentDecisionLevel.ALIGNMENT_NOTE:
+            store.record_event(
+                blackboard_state,
+                "alignment_note",
+                {"step": step_name, "fingerprint": result.payload.fingerprint, "payload": payload},
+            )
+            return HookResult(
+                events=[
+                    {
+                        "type": "alignment_note",
+                        "step": step_name,
+                        "fingerprint": result.payload.fingerprint,
+                    }
+                ]
+            )
+
+        if config.reuse_approved and self._has_unblocking_decision(
+            blackboard_state,
+            result.payload.fingerprint,
+        ):
+            store.record_event(
+                blackboard_state,
+                "alignment_reused",
+                {"step": step_name, "fingerprint": result.payload.fingerprint},
+            )
+            return HookResult(
+                events=[
+                    {
+                        "type": "alignment_reused",
+                        "step": step_name,
+                        "fingerprint": result.payload.fingerprint,
+                    }
+                ]
+            )
+
+        iteration_dir = Path(kwargs.get("iteration_dir") or issue_dir / step_name / "iteration_001")
+        iteration_dir.mkdir(parents=True, exist_ok=True)
+        request_file = iteration_dir / "alignment_request.json"
+        request_file.write_text(
+            json.dumps(payload, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+        if payload.get("strategic_document_update_requirements"):
+            (iteration_dir / "strategic_document_update_request.json").write_text(
+                json.dumps(
+                    {
+                        "fingerprint": result.payload.fingerprint,
+                        "from_step": step_name,
+                        "requirements": payload["strategic_document_update_requirements"],
+                    },
+                    ensure_ascii=False,
+                    indent=2,
+                ),
+                encoding="utf-8",
+            )
+
+        store.set_current_step(blackboard_state, "user")
+        store.set_handoff_summary(blackboard_state, f"Alignment checkpoint required before {step_name}")
+        store.update_handoff_contract(
+            blackboard_state,
+            from_step=step_name,
+            to_owner=HandoffOwner.USER,
+            to_step="user",
+            intent=HandoffIntent.ALIGNMENT_CHECKPOINT,
+            status_code=PhaseStatusCode.ALIGNMENT_CHECKPOINT.value,
+            source="alignment.checkpoint_gate",
+        )
+        store.record_event(
+            blackboard_state,
+            "alignment_checkpoint_required",
+            {
+                "step": step_name,
+                "fingerprint": result.payload.fingerprint,
+                "request_file": str(request_file),
+                "payload": payload,
+            },
+        )
+        return HookResult(
+            continue_pipeline=False,
+            artifact_ready=False,
+            override_status_code=PhaseStatusCode.ALIGNMENT_CHECKPOINT,
+            events=[
+                {
+                    "type": "alignment_checkpoint_required",
+                    "step": step_name,
+                    "fingerprint": result.payload.fingerprint,
+                    "request_file": str(request_file),
+                }
+            ],
+        )
+
+    @staticmethod
+    def _resolve_user_input(*, phase: Any, step_name: str, context: Dict[str, str]) -> str:
+        resolver = getattr(phase, "_get_resolved_iteration_user_input", None)
+        if callable(resolver):
+            try:
+                return str(resolver(step_name) or "")
+            except Exception:
+                pass
+        return str(context.get("user_input") or "")
+
+    @staticmethod
+    def _load_artifacts(
+        *,
+        blackboard_state: BlackboardState,
+        step_def: Dict[str, Any],
+        output_file: Any,
+    ) -> Dict[str, str]:
+        artifacts: Dict[str, str] = {}
+        for name in step_def.get("input_artifacts", []) or []:
+            entry = blackboard_state.artifacts.get(str(name))
+            if entry is not None:
+                artifacts[str(name)] = _read_text_sample(Path(entry.path))
+        if output_file is not None:
+            artifacts["current_output"] = _read_text_sample(Path(output_file))
+        return {key: value for key, value in artifacts.items() if value}
+
+    @staticmethod
+    def _has_unblocking_decision(blackboard_state: BlackboardState, fingerprint: str) -> bool:
+        for event in reversed(blackboard_state.events):
+            if event.event_type != "alignment_decision":
+                continue
+            data = event.data or {}
+            if data.get("fingerprint") == fingerprint and data.get("unblocks_execution") is True:
+                return True
+        return False
+
+
+def _read_text_sample(path: Path, limit: int = 12000) -> str:
+    try:
+        if not path.exists() or not path.is_file():
+            return ""
+        return path.read_text(encoding="utf-8", errors="replace")[:limit]
+    except OSError:
+        return ""

--- a/src/cafe/core/playbook.py
+++ b/src/cafe/core/playbook.py
@@ -61,6 +61,32 @@ class StepHooks(BaseModel):
 SkillSelector = Union[str, Dict[str, str]]
 
 
+class StepAlignmentConfig(BaseModel):
+    """Policy gate configuration for pre-execution alignment checkpoints."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = True
+    trigger_policy: Literal["policy", "disabled"] = "policy"
+    pause_threshold: int = 5
+    note_threshold: int = 2
+    affected_document_categories: List[str] = Field(default_factory=list)
+    reuse_approved: bool = True
+
+    @field_validator("pause_threshold", "note_threshold")
+    @classmethod
+    def _validate_thresholds(cls, value: int) -> int:
+        if value < 0:
+            raise ValueError("alignment thresholds must be non-negative")
+        return value
+
+    @field_validator("affected_document_categories")
+    @classmethod
+    def _validate_categories(cls, value: List[str]) -> List[str]:
+        cleaned = [str(item).strip() for item in value if str(item).strip()]
+        return list(dict.fromkeys(cleaned))
+
+
 class StepConfig(BaseModel):
     """One playbook step."""
 
@@ -80,6 +106,7 @@ class StepConfig(BaseModel):
     auto_snapshot: bool = True
     handoff_label: Optional[str] = None
     chat_role: Optional[str] = None
+    alignment: Optional[StepAlignmentConfig] = None
     on: Dict[str, str]
 
     @field_validator("on")

--- a/src/cafe/core/status_codes.py
+++ b/src/cafe/core/status_codes.py
@@ -22,6 +22,7 @@ PLAYBOOK_INTENT_KEYS: frozenset[str] = frozenset(
     {
         "await_agent",
         "confirm_output",
+        "alignment_checkpoint",
         "need_clarification",
         "need_permission",
         "no_changes_needed",
@@ -41,6 +42,7 @@ class PhaseStatusCode(str, Enum):
 
     AWAIT_AGENT = "await_agent"
     CONFIRM_OUTPUT = "confirm_output"
+    ALIGNMENT_CHECKPOINT = "alignment_checkpoint"
     NEED_CLARIFICATION = "need_clarification"
     NEED_PERMISSION = "need_permission"
     WORKFLOW_COMPLETE = "workflow_complete"
@@ -64,6 +66,7 @@ def transition_map_key(code: PhaseStatusCode) -> str:
         PhaseStatusCode.NO_CHANGES_NEEDED: "no_changes_needed",
         PhaseStatusCode.NO_RESPONSE: "await_agent",
         PhaseStatusCode.READY_FOR_REVIEW: "confirm_output",
+        PhaseStatusCode.ALIGNMENT_CHECKPOINT: "alignment_checkpoint",
         PhaseStatusCode.NEED_CLARIFICATION: "need_clarification",
         PhaseStatusCode.NEED_PERMISSION: "need_permission",
         PhaseStatusCode.NEEDS_CHANGES: "manual_handoff",
@@ -164,6 +167,7 @@ class StatusCodeParser:
         return code in {
             PhaseStatusCode.NEED_PERMISSION,
             PhaseStatusCode.NEED_CLARIFICATION,
+            PhaseStatusCode.ALIGNMENT_CHECKPOINT,
             PhaseStatusCode.READY_FOR_REVIEW,
             PhaseStatusCode.CONFIRM_OUTPUT,
         }

--- a/src/cafe/core/strategic_context.py
+++ b/src/cafe/core/strategic_context.py
@@ -1,0 +1,219 @@
+"""Strategic context loading for policy-based workflow decisions."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional
+
+import yaml
+
+
+DEFAULT_DOCUMENT_CATEGORIES = (
+    "roadmap",
+    "product_direction",
+    "principles",
+    "positioning",
+    "strategic_context",
+)
+
+
+@dataclass(frozen=True)
+class StrategicDocumentMetadata:
+    """Metadata for one strategic document category."""
+
+    category: str
+    path: Optional[str] = None
+    status: str = "missing"
+    sha256: Optional[str] = None
+    exists: bool = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "category": self.category,
+            "path": self.path,
+            "status": self.status,
+            "sha256": self.sha256,
+            "exists": self.exists,
+        }
+
+
+@dataclass(frozen=True)
+class AxisRule:
+    """Effective authority level for one mandate axis."""
+
+    name: str
+    level: str
+    grounds: tuple[str, ...] = ()
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"name": self.name, "level": self.level, "grounds": list(self.grounds)}
+
+
+@dataclass(frozen=True)
+class StrategicContext:
+    """Resolved repo and issue-level strategic context."""
+
+    version: int
+    project_root: Path
+    issue_name: Optional[str]
+    playbook_id: Optional[str]
+    documents: Dict[str, StrategicDocumentMetadata]
+    axes: Dict[str, AxisRule]
+    out_of_mandate: tuple[str, ...]
+    notes: str = ""
+
+    def document(self, category: str) -> StrategicDocumentMetadata:
+        key = str(category).strip()
+        return self.documents.get(key) or StrategicDocumentMetadata(category=key)
+
+    def document_hashes(self, categories: Optional[Iterable[str]] = None) -> Dict[str, Optional[str]]:
+        selected = categories if categories is not None else self.documents.keys()
+        return {category: self.document(category).sha256 for category in selected}
+
+
+def load_strategic_context(project_root: Path | str = Path.cwd(), issue_name: Optional[str] = None) -> StrategicContext:
+    """Load `.cafe/strategic_context.yaml` and resolve issue overrides."""
+    root = Path(project_root).resolve()
+    config_path = root / ".cafe" / "strategic_context.yaml"
+    if not config_path.exists():
+        return StrategicContext(
+            version=1,
+            project_root=root,
+            issue_name=issue_name,
+            playbook_id=None,
+            documents=_default_documents(root, config_path, config_exists=False),
+            axes={},
+            out_of_mandate=(),
+        )
+
+    raw = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    if not isinstance(raw, dict):
+        raw = {}
+    mandate = _as_dict(raw.get("mandate"))
+    issue_overrides = _as_dict(_as_dict(raw.get("issues")).get(str(issue_name))) if issue_name else {}
+
+    documents_raw = _deep_merge(_as_dict(raw.get("documents")), _as_dict(issue_overrides.get("documents")))
+    documents = _resolve_documents(
+        root=root,
+        config_path=config_path,
+        documents_raw=documents_raw,
+    )
+
+    axes = _resolve_axes(
+        _deep_merge(
+            _as_dict(mandate.get("axes")),
+            _as_dict(issue_overrides.get("axes")),
+        )
+    )
+    out_of_mandate = _resolve_out_of_mandate(mandate, issue_overrides)
+    notes = "\n\n".join(
+        item.strip()
+        for item in (str(mandate.get("notes", "")), str(issue_overrides.get("notes", "")))
+        if item.strip()
+    )
+
+    return StrategicContext(
+        version=int(raw.get("version", 1) or 1),
+        project_root=root,
+        issue_name=issue_name,
+        playbook_id=str(issue_overrides.get("playbook_id") or mandate.get("playbook_id") or "")
+        or None,
+        documents=documents,
+        axes=axes,
+        out_of_mandate=out_of_mandate,
+        notes=notes,
+    )
+
+
+def _as_dict(value: Any) -> Dict[str, Any]:
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _as_string_tuple(value: Any) -> tuple[str, ...]:
+    if isinstance(value, list):
+        return tuple(str(item).strip() for item in value if str(item).strip())
+    if isinstance(value, tuple):
+        return tuple(str(item).strip() for item in value if str(item).strip())
+    if isinstance(value, str) and value.strip():
+        return (value.strip(),)
+    return ()
+
+
+def _deep_merge(base: Dict[str, Any], override: Dict[str, Any]) -> Dict[str, Any]:
+    merged = dict(base)
+    for key, value in override.items():
+        if isinstance(value, dict) and isinstance(merged.get(key), dict):
+            merged[key] = _deep_merge(dict(merged[key]), value)
+        else:
+            merged[key] = value
+    return merged
+
+
+def _default_documents(root: Path, config_path: Path, *, config_exists: bool) -> Dict[str, StrategicDocumentMetadata]:
+    documents = {
+        category: StrategicDocumentMetadata(category=category)
+        for category in DEFAULT_DOCUMENT_CATEGORIES
+    }
+    documents["strategic_context"] = StrategicDocumentMetadata(
+        category="strategic_context",
+        path=str(config_path.relative_to(root)),
+        status="exists" if config_exists else "missing",
+        sha256=_sha256(config_path) if config_exists else None,
+        exists=config_exists,
+    )
+    return documents
+
+
+def _resolve_documents(
+    *,
+    root: Path,
+    config_path: Path,
+    documents_raw: Dict[str, Any],
+) -> Dict[str, StrategicDocumentMetadata]:
+    documents = _default_documents(root, config_path, config_exists=True)
+    for category, raw_value in documents_raw.items():
+        raw_doc = _as_dict(raw_value)
+        rel_path = raw_doc.get("path")
+        path = str(rel_path).strip() if rel_path else None
+        status = str(raw_doc.get("status") or ("exists" if path else "missing")).strip() or "missing"
+        absolute = (root / path).resolve() if path else None
+        exists = bool(absolute and absolute.exists())
+        documents[str(category)] = StrategicDocumentMetadata(
+            category=str(category),
+            path=path,
+            status=status,
+            sha256=_sha256(absolute) if exists and absolute is not None else None,
+            exists=exists,
+        )
+    return documents
+
+
+def _resolve_axes(axes_raw: Dict[str, Any]) -> Dict[str, AxisRule]:
+    axes: Dict[str, AxisRule] = {}
+    for name, raw_value in axes_raw.items():
+        raw_axis = _as_dict(raw_value)
+        axes[str(name)] = AxisRule(
+            name=str(name),
+            level=str(raw_axis.get("level", "agent")),
+            grounds=_as_string_tuple(raw_axis.get("grounds")),
+        )
+    return axes
+
+
+def _resolve_out_of_mandate(mandate: Dict[str, Any], issue_overrides: Dict[str, Any]) -> tuple[str, ...]:
+    if "out_of_mandate" in issue_overrides:
+        return _as_string_tuple(issue_overrides.get("out_of_mandate"))
+    return _as_string_tuple(mandate.get("out_of_mandate"))
+
+
+def _sha256(path: Path) -> Optional[str]:
+    try:
+        digest = hashlib.sha256()
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(65536), b""):
+                digest.update(chunk)
+        return digest.hexdigest()
+    except OSError:
+        return None

--- a/src/cafe/core/workflow_models.py
+++ b/src/cafe/core/workflow_models.py
@@ -14,6 +14,7 @@ class StepExecutionResult:
     artifacts: dict[str, str]
     status_code: str | None = None
     auto_continue: bool = False
+    artifact_ready: bool = True
     events: list[dict[str, Any]] = field(default_factory=list)
 
 

--- a/src/cafe/core/workflow_runtime.py
+++ b/src/cafe/core/workflow_runtime.py
@@ -36,6 +36,7 @@ GOTO_PATTERN = re.compile(r"GOTO\s*:\s*([a-zA-Z0-9_-]+)")
 PAUSE_STATUS_CODES = {
     PhaseStatusCode.READY_FOR_REVIEW.value,
     PhaseStatusCode.CONFIRM_OUTPUT.value,
+    PhaseStatusCode.ALIGNMENT_CHECKPOINT.value,
     PhaseStatusCode.NEED_CLARIFICATION.value,
     PhaseStatusCode.NEED_PERMISSION.value,
 }
@@ -137,6 +138,8 @@ class BlackboardWorkflowRuntime:
             return HandoffIntent.CONFIRM_OUTPUT
         if status_code == PhaseStatusCode.NEED_CLARIFICATION.value:
             return HandoffIntent.NEED_CLARIFICATION
+        if status_code == PhaseStatusCode.ALIGNMENT_CHECKPOINT.value:
+            return HandoffIntent.ALIGNMENT_CHECKPOINT
         if status_code == PhaseStatusCode.NEED_PERMISSION.value:
             return HandoffIntent.NEED_PERMISSION
         return HandoffIntent.MANUAL_HANDOFF

--- a/src/cafe/data/playbooks/default.yaml
+++ b/src/cafe/data/playbooks/default.yaml
@@ -61,10 +61,17 @@ steps:
     output_artifact: spec
     allowed_tools: [Read, Grep, Glob, WebFetch, WebSearch]
     hooks:
-      prepare_input: [GitHubIssueFetcher, UserInputCollector]
+      prepare_input: [GitHubIssueFetcher, UserInputCollector, AlignmentCheckpointGate]
       after_execute: [InteractiveQAHandler]
+    alignment:
+      trigger_policy: policy
+      pause_threshold: 5
+      note_threshold: 2
+      affected_document_categories: [roadmap, product_direction, principles, positioning, strategic_context]
+      reuse_approved: true
     "on":
       confirm_output: spec
+      alignment_checkpoint: spec
       need_clarification: spec
       need_permission: spec
       await_agent: plan
@@ -80,7 +87,7 @@ steps:
     output_artifact: plan
     allowed_tools: [Read, Grep, Glob, WebFetch, WebSearch]
     hooks:
-      prepare_input: [UserInputCollector]
+      prepare_input: [UserInputCollector, AlignmentCheckpointGate]
       after_execute:
         - script: sync_github.sh
           when_intents: [confirmed]
@@ -97,8 +104,15 @@ steps:
                 enum: [spec, plan]
               output:
                 type: string
+    alignment:
+      trigger_policy: policy
+      pause_threshold: 5
+      note_threshold: 2
+      affected_document_categories: [roadmap, product_direction, principles, strategic_context]
+      reuse_approved: true
     "on":
       confirm_output: plan
+      alignment_checkpoint: plan
       need_clarification: plan
       need_permission: plan
       await_agent: develop
@@ -114,10 +128,17 @@ steps:
     output_artifact: code
     allowed_tools: [Read, Edit, Write, Grep, Glob, Bash, WebFetch, WebSearch]
     hooks:
-      prepare_input: [UserInputCollector]
+      prepare_input: [UserInputCollector, AlignmentCheckpointGate]
       after_execute: [NoChangesNeededHandler, PermissionRetryHandler]
+    alignment:
+      trigger_policy: policy
+      pause_threshold: 5
+      note_threshold: 2
+      affected_document_categories: [roadmap, product_direction, principles, strategic_context]
+      reuse_approved: true
     "on":
       await_agent: review
+      alignment_checkpoint: develop
       manual_handoff: pr
       need_clarification: develop
       need_permission: develop

--- a/src/cafe/data/playbooks/editorial.yaml
+++ b/src/cafe/data/playbooks/editorial.yaml
@@ -45,9 +45,19 @@ steps:
     valid_intents:
       - confirmed
       - need_clarification
+      - alignment_checkpoint
     allowed_tools: [Read, Edit, Write, Grep, Glob, WebFetch, WebSearch]
+    hooks:
+      prepare_input: [AlignmentCheckpointGate]
+    alignment:
+      trigger_policy: policy
+      pause_threshold: 5
+      note_threshold: 2
+      affected_document_categories: [positioning]
+      reuse_approved: true
     "on":
       await_agent: review
+      alignment_checkpoint: draft
       need_clarification: draft
 
   review:

--- a/src/cafe/data/skills/alignment/SKILL.md
+++ b/src/cafe/data/skills/alignment/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: alignment
+description: Format a policy-produced alignment checkpoint payload for user review.
+---
+
+# Alignment Checkpoint Formatter
+
+Use this skill only to make an existing alignment checkpoint payload clearer.
+The deterministic policy result is authoritative.
+
+## Guardrails
+
+- Do not decide whether alignment is required.
+- Do not downgrade, skip, or auto-approve a policy-required checkpoint.
+- Do not treat alignment as approval for host-side capability execution.
+- Preserve all triggered rules, affected documents, risks, assumptions, and allowed decisions.
+
+## Output Shape
+
+When asked to format a checkpoint, include:
+
+- interpreted goal
+- proposed scope
+- non-scope
+- triggered rules and risk level
+- affected strategic documents
+- risks and assumptions
+- strategic document update recommendation
+- exact user decision requested
+- recommended resume target
+
+If the payload says strategic documents must be updated first, make that block obvious and keep the workflow paused until the user updates guidance, narrows scope, or explicitly rejects/defer the work.

--- a/src/cafe/phases/generic_phase.py
+++ b/src/cafe/phases/generic_phase.py
@@ -364,6 +364,9 @@ class GenericPhase:
                 raise ValueError(f"Unsupported hook entry type '{type(hook_entry).__name__}' in stage '{stage}'")
 
             aggregate.context_updates.update(result.context_updates)
+            stage_context = kwargs.get("context")
+            if isinstance(stage_context, dict):
+                stage_context.update(result.context_updates)
             aggregate.events.extend(result.events)
             aggregate.artifact_ready = aggregate.artifact_ready and result.artifact_ready
             aggregate.retry_requested = aggregate.retry_requested or result.retry_requested

--- a/src/cafe/phases/generic_workflow_step.py
+++ b/src/cafe/phases/generic_workflow_step.py
@@ -287,7 +287,7 @@ class GenericWorkflowStepExecutor(Phase):
 
         output_key = str(step_def.get("output_artifact", step_name))
         artifacts: Dict[str, str] = {}
-        if output_file.exists():
+        if execution.artifact_ready and output_file.exists():
             output_path = str(output_file)
             artifacts[output_key] = output_path
             self._write_artifact_record(
@@ -629,7 +629,8 @@ class GenericWorkflowStepExecutor(Phase):
         # 這條 playbook 實際可用的 to_step（= 所有 step 名 + 內建 user/done），
         # 與 baton 驗證器一致。注入 prompt 讓 agent 不會憑共用 skill 的範例（如 pr）
         # 猜出本 playbook 不存在的 step。
-        valid_to_steps = list(self.playbook.get("steps", {}).keys()) + ["user", "done"]
+        playbook = getattr(self, "playbook", {})
+        valid_to_steps = list(playbook.get("steps", {}).keys()) + ["user", "done"]
         # 本 step 依 intent 定義的下一步（含 _done → done 正規化），給 agent 明確指向。
         step_on = step_def.get("on", {}) if isinstance(step_def.get("on"), dict) else {}
         step_transitions = {
@@ -854,6 +855,8 @@ class GenericWorkflowStepExecutor(Phase):
             return "manual_handoff"
         if status_code == PhaseStatusCode.NEED_CLARIFICATION:
             return "need_clarification"
+        if status_code == PhaseStatusCode.ALIGNMENT_CHECKPOINT:
+            return "alignment_checkpoint"
         if status_code == PhaseStatusCode.NEED_PERMISSION:
             return "need_permission"
         if status_code == PhaseStatusCode.NO_CHANGES_NEEDED:
@@ -944,6 +947,7 @@ class GenericWorkflowStepExecutor(Phase):
         if not auto_continue and status_code.value in {
             PhaseStatusCode.READY_FOR_REVIEW.value,
             PhaseStatusCode.CONFIRM_OUTPUT.value,
+            PhaseStatusCode.ALIGNMENT_CHECKPOINT.value,
             PhaseStatusCode.NEED_CLARIFICATION.value,
             PhaseStatusCode.NEED_PERMISSION.value,
         }:

--- a/src/cafe/ui/cli_shared.py
+++ b/src/cafe/ui/cli_shared.py
@@ -727,6 +727,16 @@ def _handle_user_phase(
             summary=summary,
         )
 
+    if handoff_intent == HandoffIntent.ALIGNMENT_CHECKPOINT and from_step in playbook_data.get("steps", {}):
+        return _handle_alignment_checkpoint_handoff(
+            issue_dir=issue_dir,
+            playbook_data=playbook_data,
+            blackboard=blackboard,
+            store=store,
+            from_step=from_step,
+            summary=summary,
+        )
+
     if handoff_intent == HandoffIntent.NEED_CLARIFICATION and from_step in playbook_data.get("steps", {}):
         return _handle_clarification_handoff(
             issue_name=issue_name,
@@ -797,6 +807,350 @@ def _handle_develop_no_changes_needed_handoff(
     )
     console.print(f"[green]Resuming[/green] {from_step}")
     return from_step
+
+
+def parse_alignment_decision_payload(user_input: Optional[str]) -> Optional[Dict[str, Any]]:
+    """Parse explicit non-interactive alignment decisions.
+
+    Plain text must not approve alignment checkpoints. Non-interactive callers
+    have to send JSON so approval is deliberate, for example
+    `{"decision":"approve"}` or `{"decision":"narrow","correction":"..."}`.
+    """
+    if not isinstance(user_input, str) or not user_input.strip():
+        return None
+    try:
+        payload = json.loads(user_input)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    decision = _normalize_alignment_decision(payload.get("decision"))
+    if not decision:
+        return None
+    parsed = dict(payload)
+    parsed["decision"] = decision
+    return parsed
+
+
+def apply_alignment_decision_from_payload(
+    *,
+    issue_dir: Path,
+    playbook_data: Dict[str, Any],
+    blackboard,
+    payload: Dict[str, Any],
+) -> Optional[str]:
+    """Apply a parsed non-interactive alignment decision payload."""
+    store = BlackboardStore(issue_dir)
+    contract = getattr(blackboard, "handoff_contract", None)
+    from_step = getattr(contract, "from_step", None) if contract else None
+    if not from_step or from_step not in playbook_data.get("steps", {}):
+        return None
+    request_payload, request_file = _load_latest_alignment_request(issue_dir, str(from_step))
+    return _apply_alignment_decision(
+        issue_dir=issue_dir,
+        playbook_data=playbook_data,
+        blackboard=blackboard,
+        store=store,
+        from_step=str(from_step),
+        request_payload=request_payload,
+        request_file=request_file,
+        decision=str(payload["decision"]),
+        correction=str(payload.get("correction") or payload.get("reason") or "").strip(),
+    )
+
+
+def _handle_alignment_checkpoint_handoff(
+    *,
+    issue_dir: Path,
+    playbook_data: Dict[str, Any],
+    blackboard,
+    store: BlackboardStore,
+    from_step: str,
+    summary: str,
+) -> Optional[str]:
+    """Handle alignment_checkpoint handoff with stable user decisions."""
+    console.print(f"[yellow]Alignment checkpoint requested[/yellow] step={from_step}")
+    if summary:
+        console.print(f"[dim]{summary}[/dim]")
+
+    request_payload, request_file = _load_latest_alignment_request(issue_dir, from_step)
+    if request_file is not None:
+        console.print(f"[dim]Request: {request_file}[/dim]")
+    if request_payload:
+        console.print()
+        console.print("[bold]Alignment summary[/bold]")
+        for key, label in (
+            ("interpreted_goal", "Goal"),
+            ("proposed_scope", "Scope"),
+            ("non_scope", "Non-scope"),
+            ("risk_level", "Risk"),
+            ("strategic_update_recommendation", "Strategic docs"),
+            ("decision_requested", "Decision"),
+        ):
+            value = request_payload.get(key)
+            if value:
+                console.print(f"  {label}: {value}")
+        affected = request_payload.get("affected_documents") or []
+        if affected:
+            names = [
+                f"{item.get('category')}:{item.get('status')}"
+                for item in affected
+                if isinstance(item, dict)
+            ]
+            console.print(f"  Affected docs: {', '.join(names)}")
+        console.print()
+
+    from cafe.ui.inquirer_prompts import prompt_list, prompt_multiline
+
+    choices = [
+        {"name": "Approve and continue", "value": "approve"},
+        {"name": "Narrow scope and continue", "value": "narrow_scope"},
+        {"name": "Revise specification", "value": "revise_spec"},
+        {"name": "Revise plan", "value": "revise_plan"},
+        {"name": "Update strategic documents first", "value": "update_strategic_documents_first"},
+        {"name": "Strategic documents updated", "value": "strategic_documents_updated"},
+        {"name": "Pause for manual decision", "value": "manual_pause"},
+        {"name": "Reject or defer", "value": "reject_or_defer"},
+    ]
+    decision = prompt_list("How should this alignment checkpoint continue?", choices, default="approve")
+    correction = ""
+    if decision in {"narrow_scope", "revise_spec", "revise_plan", "reject_or_defer", "manual_pause"}:
+        correction = prompt_multiline("Add context for this alignment decision", default="").strip()
+
+    return _apply_alignment_decision(
+        issue_dir=issue_dir,
+        playbook_data=playbook_data,
+        blackboard=blackboard,
+        store=store,
+        from_step=from_step,
+        request_payload=request_payload,
+        request_file=request_file,
+        decision=str(decision),
+        correction=correction,
+    )
+
+
+def _normalize_alignment_decision(raw: Any) -> Optional[str]:
+    normalized = str(raw or "").strip().lower().replace("-", "_")
+    aliases = {
+        "approve": "approve",
+        "continue": "approve",
+        "approve_and_continue": "approve",
+        "narrow": "narrow_scope",
+        "narrow_scope": "narrow_scope",
+        "revise_spec": "revise_spec",
+        "spec": "revise_spec",
+        "revise_plan": "revise_plan",
+        "plan": "revise_plan",
+        "update_docs": "update_strategic_documents_first",
+        "update_documents": "update_strategic_documents_first",
+        "update_strategic_documents_first": "update_strategic_documents_first",
+        "docs_updated": "strategic_documents_updated",
+        "strategic_documents_updated": "strategic_documents_updated",
+        "pause": "manual_pause",
+        "manual_pause": "manual_pause",
+        "reject": "reject_or_defer",
+        "defer": "reject_or_defer",
+        "reject_or_defer": "reject_or_defer",
+    }
+    return aliases.get(normalized)
+
+
+def _load_latest_alignment_request(issue_dir: Path, from_step: str) -> tuple[Dict[str, Any], Optional[Path]]:
+    step_dir = issue_dir / from_step
+    candidates = sorted(step_dir.glob("iteration_*/alignment_request.json")) if step_dir.exists() else []
+    for request_file in reversed(candidates):
+        try:
+            data = json.loads(request_file.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            continue
+        if isinstance(data, dict):
+            return data, request_file
+    return {}, None
+
+
+def _apply_alignment_decision(
+    *,
+    issue_dir: Path,
+    playbook_data: Dict[str, Any],
+    blackboard,
+    store: BlackboardStore,
+    from_step: str,
+    request_payload: Dict[str, Any],
+    request_file: Optional[Path],
+    decision: str,
+    correction: str = "",
+) -> Optional[str]:
+    decision = _normalize_alignment_decision(decision) or decision
+    fingerprint = str(request_payload.get("fingerprint") or "")
+    requirements = request_payload.get("strategic_document_update_requirements") or []
+
+    if decision == "approve" and requirements:
+        console.print("[yellow]Strategic document updates are required before approval can resume execution.[/yellow]")
+        store.record_event(
+            blackboard,
+            "alignment_decision_blocked",
+            {"step": from_step, "decision": decision, "fingerprint": fingerprint, "reason": "required_document_update"},
+        )
+        return None
+
+    if decision == "strategic_documents_updated":
+        if not _alignment_documents_changed(issue_dir, requirements):
+            console.print("[yellow]No affected strategic document change was detected; workflow remains paused.[/yellow]")
+            store.record_event(
+                blackboard,
+                "alignment_decision_blocked",
+                {"step": from_step, "decision": decision, "fingerprint": fingerprint, "reason": "document_hash_unchanged"},
+            )
+            return None
+        decision = "approve"
+
+    if decision == "update_strategic_documents_first":
+        store.set_current_step(blackboard, "user")
+        store.set_handoff_summary(blackboard, f"Waiting for strategic document updates before {from_step}")
+        store.update_handoff_contract(
+            blackboard,
+            from_step=from_step,
+            to_owner=HandoffOwner.USER,
+            to_step="user",
+            intent=HandoffIntent.ALIGNMENT_CHECKPOINT,
+            status_code="alignment_checkpoint",
+            source="user.alignment_update_docs_first",
+        )
+        store.record_event(
+            blackboard,
+            "alignment_decision",
+            {
+                "step": from_step,
+                "decision": decision,
+                "fingerprint": fingerprint,
+                "unblocks_execution": False,
+                "requirements": requirements,
+            },
+        )
+        console.print("[yellow]Workflow remains paused for strategic document updates.[/yellow]")
+        return None
+
+    if decision in {"manual_pause", "reject_or_defer"}:
+        store.set_current_step(blackboard, "user")
+        store.set_handoff_summary(blackboard, correction or f"Alignment decision: {decision}")
+        store.update_handoff_contract(
+            blackboard,
+            from_step=from_step,
+            to_owner=HandoffOwner.USER,
+            to_step="user",
+            intent=HandoffIntent.ALIGNMENT_CHECKPOINT,
+            status_code="alignment_checkpoint",
+            source=f"user.alignment_{decision}",
+        )
+        store.record_event(
+            blackboard,
+            "alignment_decision",
+            {
+                "step": from_step,
+                "decision": decision,
+                "fingerprint": fingerprint,
+                "correction": correction,
+                "unblocks_execution": False,
+            },
+        )
+        console.print("[yellow]Workflow remains paused.[/yellow]")
+        return None
+
+    target_step = from_step
+    if decision == "revise_spec":
+        target_step = "spec" if "spec" in playbook_data.get("steps", {}) else from_step
+    elif decision == "revise_plan":
+        target_step = "plan" if "plan" in playbook_data.get("steps", {}) else from_step
+
+    if decision == "narrow_scope":
+        correction = correction or "Narrow scope according to the alignment checkpoint decision."
+        _write_alignment_user_input(issue_dir=issue_dir, step_name=from_step, request_file=request_file, text=correction)
+    elif decision in {"revise_spec", "revise_plan"}:
+        _write_next_iteration_user_input(issue_dir=issue_dir, step_name=target_step, text=correction or f"Revise due to alignment decision from {from_step}.")
+
+    store.set_current_step(blackboard, target_step)
+    store.set_handoff_summary(blackboard, correction or f"Alignment decision '{decision}' for {from_step}")
+    store.update_handoff_contract(
+        blackboard,
+        from_step=from_step,
+        to_owner=HandoffOwner.AGENT,
+        to_step=target_step,
+        intent=HandoffIntent.AWAIT_AGENT,
+        status_code="",
+        source=f"user.alignment_{decision}",
+    )
+    store.record_event(
+        blackboard,
+        "alignment_decision",
+        {
+            "step": from_step,
+            "decision": decision,
+            "target_step": target_step,
+            "fingerprint": fingerprint,
+            "correction": correction,
+            "unblocks_execution": True,
+        },
+    )
+    console.print(f"[green]Alignment decision recorded[/green] {decision} -> {target_step}")
+    return target_step
+
+
+def _alignment_documents_changed(issue_dir: Path, requirements: Any) -> bool:
+    if not isinstance(requirements, list) or not requirements:
+        return True
+    from cafe.core.strategic_context import load_strategic_context
+
+    project_root, issue_name = _resolve_issue_context_root(issue_dir)
+    context = load_strategic_context(project_root, issue_name=issue_name)
+    for item in requirements:
+        if not isinstance(item, dict):
+            continue
+        category = str(item.get("category") or "")
+        if not category:
+            continue
+        previous_hash = item.get("current_sha256")
+        current = context.document(category)
+        if current.sha256 and current.sha256 != previous_hash:
+            return True
+    return False
+
+
+def _resolve_issue_context_root(issue_dir: Path) -> tuple[Path, str]:
+    resolved = issue_dir.resolve()
+    for parent in resolved.parents:
+        if parent.name == "issues" and parent.parent.name == ".cafe":
+            return parent.parent.parent, resolved.relative_to(parent).as_posix()
+    for parent in resolved.parents:
+        if parent.name == ".cafe":
+            return parent.parent, resolved.name
+    return issue_dir.parent.parent.parent, issue_dir.name
+
+
+def _write_alignment_user_input(*, issue_dir: Path, step_name: str, request_file: Optional[Path], text: str) -> None:
+    if request_file is not None:
+        target_dir = request_file.parent
+    else:
+        target_dir = _latest_or_next_iteration_dir(issue_dir=issue_dir, step_name=step_name)
+    target_dir.mkdir(parents=True, exist_ok=True)
+    (target_dir / "user_input.md").write_text(text, encoding="utf-8")
+
+
+def _write_next_iteration_user_input(*, issue_dir: Path, step_name: str, text: str) -> None:
+    step_dir = issue_dir / step_name
+    iteration_dirs = sorted(step_dir.glob("iteration_*")) if step_dir.exists() else []
+    next_iter = len(iteration_dirs) + 1
+    target_dir = step_dir / f"iteration_{next_iter:03d}"
+    target_dir.mkdir(parents=True, exist_ok=True)
+    (target_dir / "user_input.md").write_text(text, encoding="utf-8")
+
+
+def _latest_or_next_iteration_dir(*, issue_dir: Path, step_name: str) -> Path:
+    step_dir = issue_dir / step_name
+    iteration_dirs = sorted(step_dir.glob("iteration_*")) if step_dir.exists() else []
+    if iteration_dirs:
+        return iteration_dirs[-1]
+    return step_dir / "iteration_001"
 
 
 def _handle_clarification_handoff(

--- a/src/cafe/ui/commands/workflow.py
+++ b/src/cafe/ui/commands/workflow.py
@@ -21,7 +21,9 @@ from cafe.playbooks.loader import PlaybookLoader
 from cafe.skills.loader import SkillLoader
 from cafe.ui.cli_shared import (
     VALID_CONTENT_TYPES,
+    apply_alignment_decision_from_payload,
     get_show_file_path as _get_show_file_path,
+    parse_alignment_decision_payload,
     resolve_iteration_number as _resolve_iteration_number,
 )
 from cafe.agents.executor import AgentExecutionError
@@ -800,6 +802,29 @@ def workflow(
                             allowed_steps=step_keys,
                         )
                         from_step = getattr(contract, "from_step", None) or blackboard.current_step
+                        if contract.intent == HandoffIntent.ALIGNMENT_CHECKPOINT:
+                            decision_payload = parse_alignment_decision_payload(user_input)
+                            if decision_payload is None:
+                                console.print(
+                                    "[yellow]Workflow is waiting for an explicit alignment decision payload.[/yellow]"
+                                )
+                                console.print(
+                                    "[dim]Use JSON such as {\"decision\":\"approve\"}, "
+                                    "{\"decision\":\"narrow\",\"correction\":\"...\"}, "
+                                    "or {\"decision\":\"update_strategic_documents_first\"}.[/dim]"
+                                )
+                                return
+                            selected_step = apply_alignment_decision_from_payload(
+                                issue_dir=issue_dir,
+                                playbook_data=playbook_data,
+                                blackboard=blackboard,
+                                payload=decision_payload,
+                            )
+                            user_input = None
+                            if selected_step:
+                                pending_start_step = selected_step
+                                continue
+                            return
                         store = BlackboardStore(issue_dir)
                         from_step_dir = issue_dir / from_step
                         iteration_dirs = sorted(from_step_dir.glob("iteration_*")) if from_step_dir.exists() else []

--- a/tests/integration/test_alignment_checkpoint_runtime.py
+++ b/tests/integration/test_alignment_checkpoint_runtime.py
@@ -1,0 +1,55 @@
+"""Integration tests for alignment checkpoint runtime handoff semantics."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from cafe.core.blackboard import BlackboardStore, HandoffIntent, HandoffOwner
+from cafe.core.workflow_models import StepExecutionResult
+from cafe.core.workflow_runtime import BlackboardWorkflowRuntime
+
+
+def test_required_alignment_checkpoint_pauses_at_user(tmp_path: Path) -> None:
+    issue_dir = tmp_path / ".cafe" / "issues" / "issue-align-runtime"
+    playbook = {
+        "playbook": {"id": "tiny"},
+        "steps": {
+            "develop": {
+                "skill": "develop",
+                "role": "developer",
+                "on": {"await_agent": "_done", "alignment_checkpoint": "develop"},
+            }
+        },
+        "entry_point": "develop",
+    }
+
+    def executor(step_name: str, step_def: dict, state) -> StepExecutionResult:
+        store = BlackboardStore(issue_dir)
+        store.update_handoff_contract(
+            state,
+            from_step=step_name,
+            to_owner=HandoffOwner.USER,
+            to_step="user",
+            intent=HandoffIntent.ALIGNMENT_CHECKPOINT,
+            status_code="alignment_checkpoint",
+            source="test.alignment",
+        )
+        return StepExecutionResult(
+            response="",
+            artifacts={},
+            status_code="alignment_checkpoint",
+            auto_continue=False,
+            events=[{"type": "handoff_intent", "intent": "alignment_checkpoint"}],
+        )
+
+    result = BlackboardWorkflowRuntime(
+        issue_dir=issue_dir,
+        playbook=playbook,
+        executor=executor,
+    ).run(start_step="develop", max_transitions=3)
+
+    assert result.completed is False
+    blackboard = BlackboardStore(issue_dir).load_or_create("develop", playbook_id="tiny")
+    assert blackboard.current_step == "user"
+    assert blackboard.handoff_contract is not None
+    assert blackboard.handoff_contract.intent == HandoffIntent.ALIGNMENT_CHECKPOINT

--- a/tests/unit/test_alignment_policy.py
+++ b/tests/unit/test_alignment_policy.py
@@ -1,0 +1,214 @@
+"""Tests for deterministic alignment policy decisions."""
+
+from pathlib import Path
+
+from cafe.core.alignment import (
+    AlignmentDecisionLevel,
+    AlignmentPolicyConfig,
+    AlignmentPolicyInput,
+    AgentAlignmentEvidence,
+    evaluate_alignment_policy,
+    merge_agent_alignment_evidence,
+)
+from cafe.core.strategic_context import load_strategic_context
+
+
+def _context(tmp_path: Path):
+    (tmp_path / ".cafe").mkdir()
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "roadmap.md").write_text("roadmap v1", encoding="utf-8")
+    (tmp_path / ".cafe" / "strategic_context.yaml").write_text(
+        """
+version: 1
+documents:
+  roadmap:
+    path: docs/roadmap.md
+    status: exists
+  positioning:
+    path: docs/positioning.md
+    status: missing
+mandate:
+  axes:
+    product_scope:
+      level: escalate
+      grounds: [roadmap]
+    technical:
+      level: agent
+  out_of_mandate:
+    - pricing
+""",
+        encoding="utf-8",
+    )
+    return load_strategic_context(tmp_path)
+
+
+def test_explicit_alignment_request_forces_checkpoint(tmp_path: Path) -> None:
+    result = evaluate_alignment_policy(
+        AlignmentPolicyInput(step_name="plan", user_input="Please align first before planning."),
+        strategic_context=_context(tmp_path),
+    )
+
+    assert result.level == AlignmentDecisionLevel.MUST_ALIGN
+    assert any(rule.rule_id == "explicit_alignment_request" for rule in result.triggered_rules)
+
+
+def test_chinese_explicit_alignment_request_forces_checkpoint(tmp_path: Path) -> None:
+    result = evaluate_alignment_policy(
+        AlignmentPolicyInput(step_name="plan", user_input="這個 issue 請先對標再開始做。"),
+        strategic_context=_context(tmp_path),
+    )
+
+    assert result.level == AlignmentDecisionLevel.MUST_ALIGN
+    assert any(rule.rule_id == "explicit_alignment_request" for rule in result.triggered_rules)
+
+
+def test_mandate_escalation_trigger_forces_checkpoint(tmp_path: Path) -> None:
+    result = evaluate_alignment_policy(
+        AlignmentPolicyInput(step_name="spec", user_input="This changes roadmap scope."),
+        strategic_context=_context(tmp_path),
+    )
+
+    assert result.level == AlignmentDecisionLevel.MUST_ALIGN
+    assert any(rule.rule_id == "mandate_escalation:product_scope" for rule in result.triggered_rules)
+
+
+def test_out_of_mandate_overlap_forces_checkpoint(tmp_path: Path) -> None:
+    result = evaluate_alignment_policy(
+        AlignmentPolicyInput(step_name="develop", user_input="Add pricing approval automation."),
+        strategic_context=_context(tmp_path),
+    )
+
+    assert result.level == AlignmentDecisionLevel.MUST_ALIGN
+    assert any(rule.rule_id == "out_of_mandate" for rule in result.triggered_rules)
+
+
+def test_required_strategic_document_update_is_in_payload(tmp_path: Path) -> None:
+    result = evaluate_alignment_policy(
+        AlignmentPolicyInput(
+            step_name="plan",
+            user_input="Update strategic_context before implementation.",
+            required_document_categories=("strategic_context",),
+        ),
+        strategic_context=_context(tmp_path),
+    )
+
+    assert result.level == AlignmentDecisionLevel.MUST_ALIGN
+    assert result.payload is not None
+    assert result.payload.strategic_document_update_requirements[0].category == "strategic_context"
+    assert "update_strategic_documents_first" in result.payload.allowed_decisions
+
+
+def test_chinese_roadmap_update_is_in_payload(tmp_path: Path) -> None:
+    result = evaluate_alignment_policy(
+        AlignmentPolicyInput(step_name="plan", user_input="這個結論需要先更新路線圖。"),
+        strategic_context=_context(tmp_path),
+    )
+
+    assert result.level == AlignmentDecisionLevel.MUST_ALIGN
+    assert result.payload is not None
+    requirements = {
+        requirement.category
+        for requirement in result.payload.strategic_document_update_requirements
+    }
+    assert "roadmap" in requirements
+
+
+def test_missing_positioning_document_is_surfaced_when_relevant(tmp_path: Path) -> None:
+    result = evaluate_alignment_policy(
+        AlignmentPolicyInput(step_name="draft", user_input="Draft positioning guidance for launch."),
+        strategic_context=_context(tmp_path),
+        config=AlignmentPolicyConfig(pause_threshold=5, note_threshold=2),
+    )
+
+    assert result.level == AlignmentDecisionLevel.MUST_ALIGN
+    assert result.payload is not None
+    assert result.payload.affected_documents[0].category == "positioning"
+    assert result.payload.affected_documents[0].status == "missing"
+
+
+def test_routine_low_risk_work_does_not_pause(tmp_path: Path) -> None:
+    result = evaluate_alignment_policy(
+        AlignmentPolicyInput(step_name="develop", user_input="Fix a typo in a unit test helper."),
+        strategic_context=_context(tmp_path),
+    )
+
+    assert result.level == AlignmentDecisionLevel.NO_ALIGNMENT
+    assert result.payload is None
+
+
+def test_configured_document_categories_do_not_trigger_by_themselves(tmp_path: Path) -> None:
+    result = evaluate_alignment_policy(
+        AlignmentPolicyInput(step_name="develop", user_input="Fix a typo in a unit test helper."),
+        strategic_context=_context(tmp_path),
+        config=AlignmentPolicyConfig(
+            affected_document_categories=("roadmap", "positioning"),
+            pause_threshold=5,
+            note_threshold=2,
+        ),
+    )
+
+    assert result.level == AlignmentDecisionLevel.NO_ALIGNMENT
+
+
+def test_configured_document_categories_apply_to_strategic_signals(tmp_path: Path) -> None:
+    result = evaluate_alignment_policy(
+        AlignmentPolicyInput(step_name="spec", user_input="Clarify product onboarding direction."),
+        strategic_context=_context(tmp_path),
+        config=AlignmentPolicyConfig(
+            affected_document_categories=("product_direction", "positioning"),
+            pause_threshold=5,
+            note_threshold=2,
+        ),
+    )
+
+    assert result.level == AlignmentDecisionLevel.MUST_ALIGN
+    assert result.payload is not None
+    categories = {doc.category for doc in result.payload.affected_documents}
+    assert {"product_direction", "positioning"} <= categories
+    assert any(
+        rule.rule_id == "strategic_document_missing:product_direction"
+        for rule in result.triggered_rules
+    )
+
+
+def test_medium_risk_records_note_only(tmp_path: Path) -> None:
+    result = evaluate_alignment_policy(
+        AlignmentPolicyInput(step_name="develop", user_input="Touch an external API wrapper boundary."),
+        strategic_context=_context(tmp_path),
+        config=AlignmentPolicyConfig(pause_threshold=5, note_threshold=2),
+    )
+
+    assert result.level == AlignmentDecisionLevel.ALIGNMENT_NOTE
+    assert result.payload is not None
+
+
+def test_agent_evidence_cannot_downgrade_policy_required_checkpoint(tmp_path: Path) -> None:
+    policy_result = evaluate_alignment_policy(
+        AlignmentPolicyInput(step_name="spec", user_input="Change product direction."),
+        strategic_context=_context(tmp_path),
+    )
+
+    merged = merge_agent_alignment_evidence(
+        policy_result,
+        AgentAlignmentEvidence(
+            suggested_level=AlignmentDecisionLevel.NO_ALIGNMENT,
+            risks=("Agent thinks this is routine.",),
+        ),
+    )
+
+    assert merged.level == AlignmentDecisionLevel.MUST_ALIGN
+    assert merged.payload is not None
+    assert "Agent thinks this is routine." in merged.payload.risks
+
+
+def test_fingerprint_changes_when_affected_document_changes(tmp_path: Path) -> None:
+    context = _context(tmp_path)
+    input_data = AlignmentPolicyInput(step_name="spec", user_input="This changes roadmap scope.")
+    first = evaluate_alignment_policy(input_data, strategic_context=context)
+
+    (tmp_path / "docs" / "roadmap.md").write_text("roadmap v2", encoding="utf-8")
+    second = evaluate_alignment_policy(input_data, strategic_context=load_strategic_context(tmp_path))
+
+    assert first.payload is not None
+    assert second.payload is not None
+    assert first.payload.fingerprint != second.payload.fingerprint

--- a/tests/unit/test_cli_workflow_command.py
+++ b/tests/unit/test_cli_workflow_command.py
@@ -359,6 +359,159 @@ def test_workflow_command_resume_user_input_targets_handoff_from_step(tmp_path: 
     assert reloaded.current_step == "develop"
 
 
+def test_user_phase_alignment_checkpoint_approve_resumes_step(tmp_path: Path) -> None:
+    issue_dir = tmp_path / ".cafe" / "issues" / "issue-align-user"
+    request_dir = issue_dir / "develop" / "iteration_001"
+    request_dir.mkdir(parents=True, exist_ok=True)
+    (request_dir / "alignment_request.json").write_text(
+        json.dumps(
+            {
+                "fingerprint": "fp-1",
+                "from_step": "develop",
+                "recommended_resume_target": "develop",
+                "strategic_document_update_requirements": [],
+                "allowed_decisions": ["approve"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    playbook_data = {
+        "playbook": {"id": "default"},
+        "steps": {"develop": {"role": "developer", "on": {"await_agent": "review"}}, "review": {"role": "reviewer", "on": {}}},
+    }
+    store = BlackboardStore(issue_dir)
+    blackboard = store.load_or_create("user", playbook_id="default")
+    store.set_current_step(blackboard, "user")
+    store.update_handoff_contract(
+        blackboard,
+        from_step="develop",
+        to_owner=HandoffOwner.USER,
+        to_step="user",
+        intent=HandoffIntent.ALIGNMENT_CHECKPOINT,
+        status_code="alignment_checkpoint",
+        source="test",
+    )
+
+    with patch("cafe.ui.inquirer_prompts.prompt_list", return_value="approve"):
+        result = _handle_user_phase(
+            issue_name="issue-align-user",
+            issue_dir=issue_dir,
+            playbook_data=playbook_data,
+            blackboard=blackboard,
+        )
+
+    assert result == "develop"
+    reloaded = store.load_or_create("develop", playbook_id="default")
+    assert reloaded.current_step == "develop"
+    assert reloaded.handoff_contract is not None
+    assert reloaded.handoff_contract.intent == HandoffIntent.AWAIT_AGENT
+
+
+def test_user_phase_alignment_checkpoint_accepts_updated_strategic_document(tmp_path: Path) -> None:
+    roadmap = tmp_path / "ROADMAP.md"
+    roadmap.write_text("Updated roadmap direction\n", encoding="utf-8")
+    cafe_dir = tmp_path / ".cafe"
+    cafe_dir.mkdir(parents=True, exist_ok=True)
+    (cafe_dir / "strategic_context.yaml").write_text(
+        "version: 1\n"
+        "documents:\n"
+        "  roadmap:\n"
+        "    path: ROADMAP.md\n",
+        encoding="utf-8",
+    )
+    issue_dir = cafe_dir / "issues" / "codex" / "issue-align-docs"
+    request_dir = issue_dir / "develop" / "iteration_001"
+    request_dir.mkdir(parents=True, exist_ok=True)
+    (request_dir / "alignment_request.json").write_text(
+        json.dumps(
+            {
+                "fingerprint": "fp-2",
+                "from_step": "develop",
+                "recommended_resume_target": "develop",
+                "strategic_document_update_requirements": [
+                    {"category": "roadmap", "current_sha256": "previous-roadmap-sha"}
+                ],
+                "allowed_decisions": ["strategic_documents_updated"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    playbook_data = {
+        "playbook": {"id": "default"},
+        "steps": {"develop": {"role": "developer", "on": {"await_agent": "review"}}, "review": {"role": "reviewer", "on": {}}},
+    }
+    store = BlackboardStore(issue_dir)
+    blackboard = store.load_or_create("user", playbook_id="default")
+    store.set_current_step(blackboard, "user")
+    store.update_handoff_contract(
+        blackboard,
+        from_step="develop",
+        to_owner=HandoffOwner.USER,
+        to_step="user",
+        intent=HandoffIntent.ALIGNMENT_CHECKPOINT,
+        status_code="alignment_checkpoint",
+        source="test",
+    )
+
+    with patch("cafe.ui.inquirer_prompts.prompt_list", return_value="strategic_documents_updated"):
+        result = _handle_user_phase(
+            issue_name="codex/issue-align-docs",
+            issue_dir=issue_dir,
+            playbook_data=playbook_data,
+            blackboard=blackboard,
+        )
+
+    assert result == "develop"
+    reloaded = store.load_or_create("develop", playbook_id="default")
+    assert reloaded.current_step == "develop"
+    assert reloaded.handoff_contract is not None
+    assert reloaded.handoff_contract.intent == HandoffIntent.AWAIT_AGENT
+
+
+def test_workflow_command_does_not_treat_generic_user_input_as_alignment_approval(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    issue_dir = tmp_path / ".cafe" / "issues" / "issue-align-resume"
+    issue_dir.mkdir(parents=True, exist_ok=True)
+    store = BlackboardStore(issue_dir)
+    blackboard = store.load_or_create("user", playbook_id="default")
+    store.set_current_step(blackboard, "user")
+    store.update_handoff_contract(
+        blackboard,
+        from_step="develop",
+        to_owner=HandoffOwner.USER,
+        to_step="user",
+        intent=HandoffIntent.ALIGNMENT_CHECKPOINT,
+        status_code="alignment_checkpoint",
+        source="test",
+    )
+
+    with patch("cafe.ui.cli.GitOperations") as mock_git_cls:
+        git = MagicMock()
+        git.get_current_branch.return_value = "issue-align-resume"
+        mock_git_cls.return_value = git
+
+        result = runner.invoke(
+            app,
+            [
+                "workflow",
+                "--playbook",
+                "default",
+                "--execute",
+                "--user-input",
+                "looks good",
+            ],
+        )
+
+    assert result.exit_code == 0
+    assert "alignment decision payload" in result.stdout
+    assert not (issue_dir / "develop" / "iteration_001" / "user_input.md").exists()
+    reloaded = store.load_or_create("spec", playbook_id="default")
+    assert reloaded.current_step == "user"
+
+
 def test_workflow_command_resume_confirm_output_keeps_await_agent_intent(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.chdir(tmp_path)
     issue_dir = tmp_path / ".cafe" / "issues" / "issue-resume-confirm"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -656,10 +656,16 @@ class TestValidateDirectoriesExist:
             validate_directories_exist(["notadir"], tmp_path)
         assert "notadir" in str(exc_info.value)
 
-    def test_validate_directories_exist_rejects_absolute_path(self, tmp_path: Path) -> None:
-        """絕對路徑即使存在也應拒絕，避免授權 worktree 外部目錄。"""
+    def test_validate_directories_exist_allows_existing_absolute_path(self, tmp_path: Path) -> None:
+        """絕對路徑可由 operator 授權給 cross-repo playbooks 使用。"""
         from cafe.utils.config import validate_directories_exist
         outside = tmp_path.parent
+        validate_directories_exist([str(outside)], tmp_path)
+
+    def test_validate_directories_exist_rejects_missing_absolute_path(self, tmp_path: Path) -> None:
+        """絕對路徑仍需存在且必須是目錄。"""
+        from cafe.utils.config import validate_directories_exist
+        outside = tmp_path.parent / "missing-absolute-dir"
         with pytest.raises(ConfigError) as exc_info:
             validate_directories_exist([str(outside)], tmp_path)
         assert str(outside) in str(exc_info.value)

--- a/tests/unit/test_generic_phase.py
+++ b/tests/unit/test_generic_phase.py
@@ -77,7 +77,7 @@ def test_build_prompt_includes_files_and_checklist_guard(tmp_path: Path) -> None
     assert "next_step_file=.cafe/issues/demo/next_step.txt" in prompt
     assert "Runtime context:" in prompt
     assert "Baton contract (single source of truth):" in prompt
-    assert "valid intent values: [await_agent, confirm_output, need_clarification, need_permission, no_changes_needed, manual_handoff, workflow_complete]" in prompt
+    assert "valid intent values: [await_agent, confirm_output, alignment_checkpoint, need_clarification, need_permission, no_changes_needed, manual_handoff, workflow_complete]" in prompt
     assert "do not invoke external workflow-driving skills (e.g. use-cafe-workflow)" in prompt
     assert "Do NOT finish this step until ALL checklist items are marked as [x]." in prompt
     assert "Do NOT return a status code" not in prompt
@@ -249,6 +249,15 @@ class PrepareHook:
         return HookResult(context_updates={"who": "prepared"})
 
 
+class CapturePreparedContextHook:
+    name = "CapturePreparedContextHook"
+    seen_context: dict[str, str] = {}
+
+    def run(self, **kwargs):
+        self.__class__.seen_context = dict(kwargs.get("context") or {})
+        return HookResult()
+
+
 class RetryHook:
     name = "RetryHook"
 
@@ -332,6 +341,31 @@ def test_execute_runs_prepare_input_and_after_execute_retry(tmp_path: Path) -> N
     assert "Shared skills:" in prompts[1]
     assert "Phase skill: /plan" in prompts[1]
     assert result.status_code is None
+
+
+def test_prepare_hooks_receive_prior_context_updates(tmp_path: Path) -> None:
+    CapturePreparedContextHook.seen_context = {}
+    phase = GenericPhase(
+        _setup_loader(tmp_path),
+        hook_registry={
+            "PrepareHook": PrepareHook,
+            "CapturePreparedContextHook": CapturePreparedContextHook,
+        },
+    )
+
+    phase.execute(
+        skill_name="plan",
+        skill_invocation="/plan",
+        step_def={
+            "hooks": {"prepare_input": ["PrepareHook", "CapturePreparedContextHook"]},
+            "valid_intents": ["confirmed"],
+        },
+        context={"existing": "context"},
+        agent_executor=lambda prompt: "confirmed",
+    )
+
+    assert CapturePreparedContextHook.seen_context["existing"] == "context"
+    assert CapturePreparedContextHook.seen_context["who"] == "prepared"
 
 
 def test_execute_skips_publish_when_artifact_not_ready(tmp_path: Path) -> None:

--- a/tests/unit/test_generic_workflow_step.py
+++ b/tests/unit/test_generic_workflow_step.py
@@ -123,6 +123,75 @@ def _build_loader(tmp_path: Path) -> GenericPhase:
     )
 
 
+def test_alignment_checkpoint_gate_pauses_before_agent(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".cafe").mkdir(exist_ok=True)
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "roadmap.md").write_text("roadmap", encoding="utf-8")
+    (tmp_path / ".cafe" / "strategic_context.yaml").write_text(
+        """
+version: 1
+documents:
+  roadmap:
+    path: docs/roadmap.md
+    status: exists
+mandate:
+  axes:
+    product_scope:
+      level: escalate
+      grounds: [roadmap]
+""",
+        encoding="utf-8",
+    )
+    issue_dir = tmp_path / ".cafe" / "issues" / "issue-align-hook"
+    playbook = {
+        "playbook": {"id": "default"},
+        "roles": {"developer": {"default_agent": "David"}},
+        "steps": {
+            "develop": {
+                "skill": "develop",
+                "role": "developer",
+                "output_artifact": "code",
+                "allowed_tools": ["Read"],
+                "hooks": {"prepare_input": ["AlignmentCheckpointGate"]},
+                "alignment": {"affected_document_categories": ["roadmap"]},
+                "on": {"await_agent": "_done", "alignment_checkpoint": "develop"},
+            }
+        },
+    }
+    store = BlackboardStore(issue_dir)
+    state = store.load_or_create("develop")
+    spec_file = issue_dir / "spec" / "iteration_001" / "output.md"
+    plan_file = issue_dir / "plan" / "iteration_001" / "output.md"
+    spec_file.parent.mkdir(parents=True, exist_ok=True)
+    plan_file.parent.mkdir(parents=True, exist_ok=True)
+    spec_file.write_text("# Spec\n", encoding="utf-8")
+    plan_file.write_text("# Plan\n", encoding="utf-8")
+    store.set_artifact(state, "spec", str(spec_file))
+    store.set_artifact(state, "plan", str(plan_file))
+    agent_manager = FakeAgentManager("confirmed")
+    executor = GenericWorkflowStepExecutor(
+        issue_dir=issue_dir,
+        issue_name="issue-align-hook",
+        playbook=playbook,
+        generic_phase=_build_loader(tmp_path),
+        agent_manager=agent_manager,
+        git_ops=FakeGitOperations(),
+        role_agent_map={"developer": "David"},
+        step_user_inputs={"develop": "This changes roadmap scope."},
+    )
+
+    result = executor.execute_step("develop", playbook["steps"]["develop"], state)
+
+    assert result.status_code == "alignment_checkpoint"
+    assert agent_manager.prompts == []
+    assert (issue_dir / "develop" / "iteration_001" / "alignment_request.json").exists()
+    reloaded = BlackboardStore(issue_dir).load_or_create("develop")
+    assert reloaded.handoff_contract is not None
+    assert reloaded.handoff_contract.intent == HandoffIntent.ALIGNMENT_CHECKPOINT
+    assert "code" not in reloaded.artifacts
+
+
 def test_generic_workflow_step_executor_writes_iteration_files(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.chdir(tmp_path)
     issue_dir = tmp_path / ".cafe" / "issues" / "issue-1"

--- a/tests/unit/test_playbook_loader.py
+++ b/tests/unit/test_playbook_loader.py
@@ -162,6 +162,71 @@ steps:
     assert result.model.steps["brief"].chat_role == "writer"
 
 
+def test_load_supports_alignment_config(tmp_path: Path) -> None:
+    builtin_root = tmp_path / "builtin"
+    _write_skill(builtin_root / "skills", "develop")
+    _write_playbook(
+        builtin_root / "playbooks",
+        "default",
+        """
+playbook:
+  id: default
+steps:
+  develop:
+    skill: develop
+    role: developer
+    alignment:
+      trigger_policy: policy
+      pause_threshold: 5
+      note_threshold: 2
+      affected_document_categories: [roadmap, positioning]
+      reuse_approved: true
+    on:
+      await_agent: _done
+      alignment_checkpoint: develop
+""",
+    )
+
+    result = PlaybookLoader(
+        project_root=tmp_path / "project",
+        global_root=tmp_path / "global",
+        builtin_root=builtin_root,
+    ).load_model("default")
+
+    alignment = result.model.steps["develop"].alignment
+    assert alignment is not None
+    assert alignment.pause_threshold == 5
+    assert alignment.affected_document_categories == ["roadmap", "positioning"]
+
+
+def test_load_rejects_unknown_alignment_config_key(tmp_path: Path) -> None:
+    builtin_root = tmp_path / "builtin"
+    _write_skill(builtin_root / "skills", "develop")
+    _write_playbook(
+        builtin_root / "playbooks",
+        "default",
+        """
+playbook:
+  id: default
+steps:
+  develop:
+    skill: develop
+    role: developer
+    alignment:
+      unknown: true
+    on:
+      await_agent: _done
+""",
+    )
+
+    with pytest.raises(ValueError, match="unknown"):
+        PlaybookLoader(
+            project_root=tmp_path / "project",
+            global_root=tmp_path / "global",
+            builtin_root=builtin_root,
+        ).load_model("default")
+
+
 def test_load_rejects_unknown_step_chat_role(tmp_path: Path) -> None:
     builtin_root = tmp_path / "builtin"
     _write_skill(builtin_root / "skills", "brief_first")

--- a/tests/unit/test_strategic_context.py
+++ b/tests/unit/test_strategic_context.py
@@ -1,0 +1,58 @@
+"""Tests for strategic context loading and document metadata."""
+
+from pathlib import Path
+
+from cafe.core.strategic_context import load_strategic_context
+
+
+def test_loads_repo_context_and_document_hashes(tmp_path: Path) -> None:
+    (tmp_path / ".cafe").mkdir()
+    (tmp_path / "docs").mkdir()
+    roadmap = tmp_path / "docs" / "roadmap.md"
+    roadmap.write_text("# Roadmap\n\nCurrent product direction.\n", encoding="utf-8")
+    (tmp_path / ".cafe" / "strategic_context.yaml").write_text(
+        """
+version: 1
+documents:
+  roadmap:
+    path: docs/roadmap.md
+    status: exists
+  positioning:
+    path: docs/positioning.md
+    status: missing
+mandate:
+  playbook_id: default
+  axes:
+    product_scope:
+      level: escalate
+      grounds: [roadmap]
+    technical:
+      level: agent
+  out_of_mandate:
+    - pricing
+issues:
+  issue-1:
+    axes:
+      product_scope:
+        level: agent
+        grounds: [roadmap]
+""",
+        encoding="utf-8",
+    )
+
+    context = load_strategic_context(tmp_path, issue_name="issue-1")
+
+    assert context.axes["product_scope"].level == "agent"
+    assert context.axes["technical"].level == "agent"
+    assert context.out_of_mandate == ("pricing",)
+    assert context.document("roadmap").sha256
+    assert context.document("positioning").status == "missing"
+    assert context.document("principles").path is None
+
+
+def test_missing_config_degrades_to_empty_context(tmp_path: Path) -> None:
+    context = load_strategic_context(tmp_path, issue_name="missing")
+
+    assert context.version == 1
+    assert context.axes == {}
+    assert context.document("principles").status == "missing"

--- a/tests/unit/test_workflow_models.py
+++ b/tests/unit/test_workflow_models.py
@@ -157,6 +157,38 @@ def test_blackboard_load_or_create_persists_current_step_and_playbook(tmp_path: 
     assert loaded.playbook_id == "default"
 
 
+def test_alignment_checkpoint_baton_must_be_user_owned_user_target(tmp_path: Path) -> None:
+    issue_dir = tmp_path / ".cafe" / "issues" / "issue-align-baton"
+    store = BlackboardStore(issue_dir)
+    state = store.load_or_create("develop")
+
+    _write_baton(
+        issue_dir,
+        _base_payload(
+            from_step="develop",
+            to_owner="user",
+            to_step="user",
+            intent="alignment_checkpoint",
+            status_code="alignment_checkpoint",
+        ),
+    )
+    valid = store.load_handoff_contract(state, allowed_steps=["develop", "review"])
+    assert valid.intent == HandoffIntent.ALIGNMENT_CHECKPOINT
+
+    _write_baton(
+        issue_dir,
+        _base_payload(
+            from_step="develop",
+            to_owner="agent",
+            to_step="review",
+            intent="alignment_checkpoint",
+            status_code="alignment_checkpoint",
+        ),
+    )
+    with pytest.raises(ValueError, match="alignment_checkpoint"):
+        store.load_handoff_contract(state, allowed_steps=["develop", "review"])
+
+
 def test_blackboard_store_records_artifacts_events_and_decisions(tmp_path: Path) -> None:
     issue_dir = tmp_path / ".cafe" / "issues" / "issue-2"
     store = BlackboardStore(issue_dir)


### PR DESCRIPTION
# Add alignment checkpoint workflow support

## Summary

Implements the pre-execution alignment checkpoint flow requested in GitHub issue #351. The new flow uses deterministic policy to decide when strategic alignment is required, when an alignment note is enough, and when routine work can continue without interruption.

The implementation keeps alignment separate from ordinary clarification and host-side capability approval, while adding guided handling for affected strategic documents.

## Changes

- Commit: `286d9f7 issue351: add alignment checkpoint workflow`.
- Added deterministic alignment policy and payload models, including hard triggers, scored signals, note-only outcomes, no-alignment outcomes, and fingerprint reuse checks.
- Added Chinese trigger coverage for direct alignment requests such as "先對標", "先校準", and roadmap update wording such as "更新路線圖".
- Added strategic context loading with document metadata and missing/draft document handling.
- Added `alignment_checkpoint` status, baton validation, workflow runtime handling, and strict playbook alignment configuration.
- Added an `AlignmentCheckpointGate` prepare hook that can pause before agent execution, write checkpoint payloads, record note-only events, and continue routine work.
- Added CLI decision handling for approve, narrow scope, revise spec, revise plan, update strategic documents first, strategic documents updated, manual pause, and reject/defer.
- Added non-interactive alignment decision handling so generic user input cannot auto-approve a required checkpoint.
- Configured default and editorial playbook examples, added the formatting-only alignment skill, and documented the checkpoint flow.
- Added unit and integration coverage for policy, strategic context, playbook loading, runtime handoff, hook behavior, CLI decisions, and workflow examples.

## Test Plan

- `uv run pytest tests/unit/test_alignment_policy.py tests/unit/test_generic_workflow_step.py tests/unit/test_cli_workflow_command.py tests/integration/test_alignment_checkpoint_runtime.py --no-cov -q`
- `uv run pytest`
- `uv run cafe playbook simulate default`
- `uv run cafe playbook simulate editorial`
- `uv run cafe audit`
