### PR TITLE
Generalize host capability publish contracts

### DIFF
--- a/docs/alignment-checkpoints.md
+++ b/docs/alignment-checkpoints.md
@@ -64,4 +64,12 @@ Use an explicit JSON payload:
 {"decision":"update_strategic_documents_first"}
 ```
 
+```json
+{"decision":"strategic_documents_updated","user_confirmed":true,"user_confirmation":"User confirmed the final strategic document content."}
+```
+
+`strategic_documents_updated` requires confirmation evidence in non-interactive
+runs unless the update is mechanically copied from already confirmed strategic
+material.
+
 If the payload is missing or invalid, the workflow remains paused at `user`.

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -1,0 +1,129 @@
+# CAFE Positioning
+
+> Confirmed strategic positioning document.
+
+## Core Positioning
+
+CAFE is a repo-first human-agent workflow system.
+
+It helps technical founders, operators, and small agent-native teams keep workflow definitions, execution state, handoffs, decisions, and strategic documents in a versioned workspace. Agents can move automatable work forward, while human judgment, approval, and trusted host-side execution are separated into explicit workflow boundaries.
+
+CAFE is not just a coding assistant or a general chat assistant. Its long-term direction is to help a company define, execute, track, and revise its operating workflows over time.
+
+## Primary Users
+
+- Technical founders and operators who need agents to help with long-running work, not only one-off tasks.
+- Small agent-native teams that need workflow decisions, artifacts, and handoffs to remain reviewable and durable inside a repository.
+- Engineers and workflow authors who define playbooks, skills, hooks, policies, and capability contracts.
+
+CAFE can start with engineering-heavy users, but product decisions should preserve room for non-development workflows such as recruiting, onboarding, content production, operations, and internal SOPs.
+
+## What CAFE Is Not
+
+CAFE is not positioned as:
+
+- An arbitrary shell or host-privilege executor for agents.
+- An assistant that stores critical state only in chat context.
+- A fixed-phase tool that only serves software development workflows.
+- An immediate replacement for Notion, Jira, Linear, spreadsheets, or full management platforms.
+- A no-code automation product where users can trigger external mutations without understanding the workflow model and authorization boundary.
+
+These boundaries matter because CAFE should support stronger automation without turning workflow authoring into implicit host execution.
+
+## Differentiation
+
+CAFE's differentiation comes from five product commitments:
+
+1. **Versioned workflow definitions**
+   Playbooks, skills, templates, policies, SOPs, and strategic documents should live primarily in the repo so workflow changes can be reviewed, audited, and rolled back.
+
+2. **Recoverable execution state**
+   A workflow instance should have explicit state, artifacts, events, decisions, and handoffs instead of depending on a single chat session.
+
+3. **Human-agent division of labor as a first-class concept**
+   Work that an agent can perform, work that needs human judgment, and work that requires trusted host capability must be modeled separately instead of being collapsed into generic clarification.
+
+4. **External mutation through capability contracts**
+   Agents may declare the desired outcome, but the host-side capability layer decides whether and how to execute with trusted system permissions. Workflow artifacts should be declarative contracts, not shell privilege.
+
+5. **Long-term orientation toward company workflows**
+   The roadmap should move from a software-development workflow foundation toward human tasks, subflows, business objects, organizational memory, and governance only as those needs are validated.
+
+## Product Boundaries
+
+### Repo-first, not repo-only
+
+CAFE uses the repository as the definition layer for:
+
+- playbooks
+- skills
+- templates
+- policies and SOPs
+- versioned strategic documents
+
+Runtime stores, task inboxes, analytics, dashboards, and business object stores do not need to stay bound to the repository interface forever. In the short and medium term, `.cafe/issues/` plus JSON, YAML, and Markdown are acceptable execution storage. Longer term, CAFE should preserve the option to move selected runtime state into a structured store.
+
+### Agent authoring is not host trust
+
+CAFE should allow agents to author workflows, skills, artifacts, contracts, and sandbox scripts.
+
+An agent-authored script does not become trusted for host execution merely because it exists in the repository.
+
+Host execution requires:
+
+- a capability name or registry reference
+- a manifest and argument schema
+- policy checks
+- risk classification
+- human approval when required
+- an auditable execution record
+
+### Human tasks are not just clarification
+
+When work requires a human to perform an action, make a judgment, approve a risk, or provide an external result, CAFE should move toward explicit `HumanTask`, `TaskResult`, and `WaitState` models instead of representing every human intervention as a one-off question.
+
+## Roadmap Alignment
+
+- `v0.2`
+  Establish the generic workflow engine foundation: Skill, Playbook, Blackboard, Hook, GenericPhase, PlaybookRunner, and suspend/resume.
+
+- `v0.2.x`
+  Build the supporting surface around custom hooks, tooling, validation, simulation, dry runs, and an initial host-side capability contract prototype.
+
+- `v0.3`
+  Advance into human-agent workflow: HumanTask, trusted capability registry, host-executed script policy, and approval flow.
+
+- `v0.4`
+  Validate subflows and business object references so workflows can compose recursively.
+
+- `v0.5`
+  Evaluate organizational memory, governance, analytics, and operating-layer value.
+
+## Capability Contract Positioning
+
+Capability contracts exist primarily to protect the trusted host capability boundary.
+
+Their secondary purpose is to reduce external mutation risk by making side effects explicit, reviewable, policy-checkable, and auditable.
+
+When a design touches trusted capabilities, host execution, GitHub mutation, browser opening, deployment, credentials, network calls, or other external side effects, it should follow these boundaries:
+
+- The agent layer produces intent, artifacts, and declarative contracts.
+- The contract layer describes the capability, arguments, inputs, outputs, permissions, and side effects.
+- The host capability layer decides whether execution is allowed according to registry, manifest, policy, and approval requirements.
+- Arbitrary script paths are not execution authority.
+- An agent-authored script is not automatically a trusted host-side script.
+- External mutations should be auditable, limitable, deniable, and explainable to the user.
+
+This positioning lets CAFE evolve toward stronger automation while preventing capability contracts from becoming a privilege-escalation mechanism.
+
+## Decision Principles
+
+When a feature or issue affects product positioning, ask:
+
+1. Does this move CAFE toward a versioned, recoverable, auditable workflow system?
+2. Does this preserve the distinction between agent work, human work, and trusted host capability?
+3. Does this maintain the boundary between the agent layer, contract layer, and host capability layer?
+4. Does this serve the next roadmap validation question instead of prematurely productizing a full platform?
+5. Does this reduce the user's cognitive burden when understanding authorization and external side effects?
+
+If the answer is no, the work should be narrowed, deferred, or preceded by a strategic document update.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -108,6 +108,9 @@ CAFE 長期採 **repo-first** 的 definition model，但不預設最終所有流
 核心能力：
 - custom hooks / scripts automation
 - host-side capability execution 雛型
+- capability contract consolidation：可把 PR-specific publish plumbing 收斂成
+  generic request validation 與 execution receipt handling，但必須維持既有 PR
+  publish 行為穩定，且不得放寬 trusted host capability boundary
 - playbook / skill tooling
 - validation / simulation / dry-run 強化
 - 更多 custom playbook 驗證樣本
@@ -121,7 +124,7 @@ CAFE 長期採 **repo-first** 的 definition model，但不預設最終所有流
 - 可用至少一條非軟體開發流程做 validate / dry-run 驗證
 
 建議先用 `pr` phase 做雛型：
-- agent 只負責產生本地 artifact 與 `publish_request.json`
+- agent 只負責產生本地 artifact 與 `capability_request.json`（`publish_request.json` 作為 PR legacy alias 保留）
 - host-side hook 讀 contract 後才執行受信任 script（例如 `sync_pr.sh`）
 - 第一期只允許 **agent 選擇既有 trusted script 並填參數**
 - 不在 v0.2.x 直接開放 agent 任意新寫 script 後自動拿 host 權限執行

--- a/src/cafe/core/alignment.py
+++ b/src/cafe/core/alignment.py
@@ -131,8 +131,7 @@ class AlignmentCheckpointPayload:
             "fingerprint": self.fingerprint,
             "allowed_decisions": list(self.allowed_decisions),
             "strategic_document_update_requirements": [
-                requirement.to_dict()
-                for requirement in self.strategic_document_update_requirements
+                requirement.to_dict() for requirement in self.strategic_document_update_requirements
             ],
         }
 
@@ -191,6 +190,33 @@ DOCUMENT_KEYWORDS: Dict[str, tuple[str, ...]] = {
     "strategic_context": ("strategic_context", "strategic context", "mandate", "授權", "決策權限"),
 }
 
+TRUSTED_CAPABILITY_BOUNDARY_KEYWORDS: tuple[str, ...] = (
+    "capability contract",
+    "capability contracts",
+    "capability-contract",
+    "capability-contracts",
+    "capability registry",
+    "trusted capability",
+    "trusted capabilities",
+    "trusted host",
+    "trusted host-side",
+    "host-side capability",
+    "host-side capabilities",
+    "host-side execution",
+    "host-side action",
+    "host-side actions",
+    "execution request",
+    "trust boundary",
+    "host 端",
+    "主機端",
+    "主機端執行",
+    "可信能力",
+    "受信任能力",
+    "能力合約",
+    "能力契約",
+    "信任邊界",
+)
+
 
 def evaluate_alignment_policy(
     input_data: AlignmentPolicyInput,
@@ -234,16 +260,13 @@ def evaluate_alignment_policy(
                     affected_categories.append(category)
 
     matched_out_of_mandate = [
-        item
-        for item in strategic_context.out_of_mandate
-        if item and item.lower() in text
+        item for item in strategic_context.out_of_mandate if item and item.lower() in text
     ]
     if matched_out_of_mandate:
         triggered.append(
             TriggeredRule(
                 "out_of_mandate",
-                "Task overlaps declared out-of-mandate items: "
-                + ", ".join(matched_out_of_mandate),
+                "Task overlaps declared out-of-mandate items: " + ", ".join(matched_out_of_mandate),
                 "high",
             )
         )
@@ -276,8 +299,7 @@ def evaluate_alignment_policy(
     triggered.extend(score_rules)
 
     affected_documents = tuple(
-        strategic_context.document(category)
-        for category in affected_categories
+        strategic_context.document(category) for category in affected_categories
     )
     requirements = tuple(
         _document_requirement(strategic_context.document(category))
@@ -301,7 +323,11 @@ def evaluate_alignment_policy(
         affected_documents=affected_documents,
         requirements=requirements,
         risks=tuple(dict.fromkeys(risks or _default_risks(level))),
-        assumptions=tuple(dict.fromkeys(assumptions or ("Policy signals were derived from workflow input and artifacts.",))),
+        assumptions=tuple(
+            dict.fromkeys(
+                assumptions or ("Policy signals were derived from workflow input and artifacts.",)
+            )
+        ),
     )
     return AlignmentPolicyResult(
         level=level,
@@ -336,7 +362,9 @@ def merge_agent_alignment_evidence(
         risk_level=policy_result.payload.risk_level,
         affected_documents=policy_result.payload.affected_documents,
         risks=tuple(dict.fromkeys((*policy_result.payload.risks, *evidence.risks))),
-        assumptions=tuple(dict.fromkeys((*policy_result.payload.assumptions, *evidence.assumptions))),
+        assumptions=tuple(
+            dict.fromkeys((*policy_result.payload.assumptions, *evidence.assumptions))
+        ),
         strategic_update_recommendation=policy_result.payload.strategic_update_recommendation,
         decision_requested=policy_result.payload.decision_requested,
         recommended_resume_target=policy_result.payload.recommended_resume_target,
@@ -353,7 +381,12 @@ def merge_agent_alignment_evidence(
 
 
 def _policy_text(input_data: AlignmentPolicyInput) -> str:
-    parts = [input_data.step_name, input_data.user_input, input_data.proposed_scope, input_data.non_scope]
+    parts = [
+        input_data.step_name,
+        input_data.user_input,
+        input_data.proposed_scope,
+        input_data.non_scope,
+    ]
     parts.extend(input_data.artifacts.values())
     return "\n".join(part for part in parts if part).lower()
 
@@ -394,27 +427,32 @@ def _detect_document_categories(text: str) -> list[str]:
 
 def _detect_required_update_categories(text: str, explicit: Sequence[str]) -> list[str]:
     categories = list(dict.fromkeys(explicit))
-    update_requested = any(
-        token in text
-        for token in (
-            "update",
-            "revise",
-            "change",
-            "modify",
-            "更新",
-            "修訂",
-            "修改",
-            "調整",
-            "建立",
-            "新增",
-        )
-    )
-    if not update_requested:
-        return categories
-    for category in _detect_document_categories(text):
+    for category, keywords in DOCUMENT_KEYWORDS.items():
+        if not _mentions_document_update(text, keywords):
+            continue
         if category not in categories:
             categories.append(category)
     return categories
+
+
+def _mentions_document_update(text: str, keywords: Sequence[str]) -> bool:
+    english_verbs = r"(?:update|revise|change|modify|create|add)"
+    english_nouns = (
+        r"(?:update|updates|revision|revisions|change|changes|modification|modifications)"
+    )
+    chinese_verbs = "(?:更新|修訂|修改|調整|建立|新增)"
+
+    for keyword in keywords:
+        escaped = re.escape(keyword.lower())
+        if re.search(rf"\b{english_verbs}\b[^\n]{{0,48}}\b{escaped}\b", text):
+            return True
+        if re.search(rf"\b{escaped}\b[^\n]{{0,48}}\b{english_nouns}\b", text):
+            return True
+        if re.search(rf"{chinese_verbs}.{{0,24}}{escaped}", text):
+            return True
+        if re.search(rf"{escaped}.{{0,24}}{chinese_verbs}", text):
+            return True
+    return False
 
 
 def _score_signals(
@@ -423,6 +461,15 @@ def _score_signals(
     strategic_context: StrategicContext,
 ) -> list[TriggeredRule]:
     rules: list[TriggeredRule] = []
+    if _matches_keywords(text, TRUSTED_CAPABILITY_BOUNDARY_KEYWORDS):
+        rules.append(
+            TriggeredRule(
+                "trusted_capability_boundary",
+                "Trusted host capability or trust boundary change detected.",
+                "high",
+                5,
+            )
+        )
     if _matches_keywords(
         text,
         (
@@ -438,13 +485,34 @@ def _score_signals(
             "原則",
         ),
     ):
-        rules.append(TriggeredRule("product_or_governance_impact", "Product or governance impact detected.", "medium", 3))
-    if _matches_keywords(text, ("external mutation", "external api", "publish", "deploy", "host-side")):
-        rules.append(TriggeredRule("external_mutation_risk", "External mutation risk detected.", "medium", 2))
+        rules.append(
+            TriggeredRule(
+                "product_or_governance_impact",
+                "Product or governance impact detected.",
+                "medium",
+                3,
+            )
+        )
+    if _matches_keywords(
+        text, ("external mutation", "external api", "publish", "deploy", "host-side")
+    ):
+        rules.append(
+            TriggeredRule("external_mutation_risk", "External mutation risk detected.", "medium", 2)
+        )
     if _matches_keywords(text, ("large", "ambiguous", "unclear", "broad")):
-        rules.append(TriggeredRule("large_ambiguous_issue", "Large or ambiguous issue signal detected.", "low", 1))
-    if _matches_keywords(text, ("architecture outside", "outside obvious scope", "cross-module architecture")):
-        rules.append(TriggeredRule("architecture_scope_risk", "Architecture scope risk detected.", "medium", 2))
+        rules.append(
+            TriggeredRule(
+                "large_ambiguous_issue", "Large or ambiguous issue signal detected.", "low", 1
+            )
+        )
+    if _matches_keywords(
+        text, ("architecture outside", "outside obvious scope", "cross-module architecture")
+    ):
+        rules.append(
+            TriggeredRule(
+                "architecture_scope_risk", "Architecture scope risk detected.", "medium", 2
+            )
+        )
     for category in affected_categories:
         doc = strategic_context.document(category)
         if doc.status in {"missing", "draft"}:
@@ -468,6 +536,8 @@ def _should_include_configured_documents(
     if required_categories:
         return True
     if any(rule.risk_level == "high" for rule in triggered_rules):
+        return True
+    if _matches_keywords(text, TRUSTED_CAPABILITY_BOUNDARY_KEYWORDS):
         return True
     return _matches_keywords(
         text,
@@ -514,7 +584,9 @@ def _build_payload(
     assumptions: tuple[str, ...],
 ) -> AlignmentCheckpointPayload:
     if requirements:
-        recommendation = "Update affected strategic documents first, narrow scope, or explicitly defer/reject."
+        recommendation = (
+            "Update affected strategic documents first, narrow scope, or explicitly defer/reject."
+        )
     elif any(doc.status in {"missing", "draft"} for doc in affected_documents):
         recommendation = "Review missing or draft strategic documents before relying on them."
     else:
@@ -537,9 +609,12 @@ def _build_payload(
     ).hexdigest()
 
     return AlignmentCheckpointPayload(
-        interpreted_goal=input_data.user_input.strip() or f"Continue workflow step '{input_data.step_name}'.",
-        proposed_scope=input_data.proposed_scope.strip() or "Proceed with the current workflow step scope.",
-        non_scope=input_data.non_scope.strip() or "Do not treat alignment as host capability approval.",
+        interpreted_goal=input_data.user_input.strip()
+        or f"Continue workflow step '{input_data.step_name}'.",
+        proposed_scope=input_data.proposed_scope.strip()
+        or "Proceed with the current workflow step scope.",
+        non_scope=input_data.non_scope.strip()
+        or "Do not treat alignment as host capability approval.",
         triggered_rules=triggered_rules,
         risk_level=risk_level,
         affected_documents=affected_documents,

--- a/src/cafe/core/capabilities.py
+++ b/src/cafe/core/capabilities.py
@@ -109,6 +109,49 @@ def _validate_outputs(payload: Mapping[str, Any], schema: Mapping[str, Any]) -> 
     return None
 
 
+def _git_ref_exists(repo_root: Path, ref: str) -> bool:
+    """Return True when a git ref can be resolved locally."""
+    try:
+        return (
+            subprocess.run(
+                ["git", "show-ref", "--verify", "--quiet", ref],
+                cwd=str(repo_root),
+                capture_output=True,
+                text=True,
+                check=False,
+            ).returncode
+            == 0
+        )
+    except (FileNotFoundError, OSError):
+        return False
+
+
+def _resolve_publish_base(base_arg: str, *, repo_root: Path) -> str:
+    """Return a publish base ref that resolves to a known GitHub branch.
+
+    Keep legacy behavior for valid remote base refs, but avoid passing local-only
+    branch names that GitHub cannot use as PR bases.
+    """
+    base = str(base_arg or "").strip()
+    if not base:
+        return ""
+
+    candidates = [base, base.removeprefix("refs/heads/"), base.removeprefix("refs/remotes/origin/")]
+    if base.startswith("refs/remotes/"):
+        first_slash = base.find("/")
+        if first_slash >= 0:
+            candidates.append(base[first_slash + 1 :])
+    elif "/" in base:
+        candidates.append(base.rsplit("/", 1)[-1])
+
+    for candidate in dict.fromkeys(candidates):
+        if not candidate:
+            continue
+        if _git_ref_exists(repo_root, f"refs/remotes/origin/{candidate}"):
+            return candidate
+    return ""
+
+
 def resolve_repo_relative_path(*, repo_root: Path, raw_path: str, field_name: str) -> Path:
     if not str(raw_path).strip():
         raise ValueError(f"missing_{field_name}")
@@ -299,7 +342,10 @@ def run_pr_publish_capability(
         return PrPublishRun(receipt=receipt, pr_synced_event=None, error_message=str(exc))
 
     cmd: List[str] = ["/bin/bash", str(script_path), "--output", str(output_arg)]
-    base_arg = str(args.get("base") or "").strip()
+    base_arg = _resolve_publish_base(
+        str(args.get("base") or ""),
+        repo_root=repo_root,
+    )
     if base_arg:
         cmd.extend(["--base", base_arg])
 

--- a/src/cafe/core/capabilities.py
+++ b/src/cafe/core/capabilities.py
@@ -8,7 +8,7 @@ import uuid
 from datetime import datetime
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Mapping, Optional, Sequence
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
 
 import yaml
 
@@ -45,7 +45,9 @@ def load_capability_registry(capabilities_dirs: Sequence[Path]) -> Dict[str, Dic
     for base in capabilities_dirs:
         if not base.is_dir():
             continue
-        paths = sorted(base.glob("*.yaml")) + sorted(base.glob("*.yml")) + sorted(base.glob("*.json"))
+        paths = (
+            sorted(base.glob("*.yaml")) + sorted(base.glob("*.yml")) + sorted(base.glob("*.json"))
+        )
         for path in paths:
             try:
                 raw = path.read_text(encoding="utf-8")
@@ -95,6 +97,10 @@ def _validate_string_args(args: Mapping[str, Any], required: Sequence[str]) -> O
     return None
 
 
+def _receipt_inputs(raw_args: Any) -> Dict[str, Any]:
+    return dict(raw_args) if isinstance(raw_args, Mapping) else {}
+
+
 def _validate_outputs(payload: Mapping[str, Any], schema: Mapping[str, Any]) -> Optional[str]:
     required = _schema_required(schema, label="expected_outputs")
     for key in required:
@@ -119,7 +125,14 @@ def resolve_sync_pr_script(repo_root: Path) -> Path:
     script_path = skill_dir / "scripts" / "sync_pr.sh"
     if script_path.exists():
         return script_path
-    fallback = Path(__file__).resolve().parents[1] / "data" / "skills" / "cafe-pr" / "scripts" / "sync_pr.sh"
+    fallback = (
+        Path(__file__).resolve().parents[1]
+        / "data"
+        / "skills"
+        / "cafe-pr"
+        / "scripts"
+        / "sync_pr.sh"
+    )
     if fallback.exists():
         return fallback
     raise FileNotFoundError(f"PR sync script not found: {script_path}")
@@ -201,10 +214,12 @@ def run_pr_publish_capability(
             success=False,
             category=VALIDATION_ERROR,
             code="unknown_capability",
-            inputs=dict(publish_request.get("args") or {}),
+            inputs=_receipt_inputs(publish_request.get("args")),
             outputs={},
         )
-        return PrPublishRun(receipt=receipt, pr_synced_event=None, error_message="unknown_capability")
+        return PrPublishRun(
+            receipt=receipt, pr_synced_event=None, error_message="unknown_capability"
+        )
 
     args = publish_request.get("args")
     if not isinstance(args, dict):
@@ -217,7 +232,9 @@ def run_pr_publish_capability(
             inputs={},
             outputs={},
         )
-        return PrPublishRun(receipt=receipt, pr_synced_event=None, error_message="missing_args_object")
+        return PrPublishRun(
+            receipt=receipt, pr_synced_event=None, error_message="missing_args_object"
+        )
 
     args_schema = definition.get("args_schema") or {}
     if not isinstance(args_schema, dict):
@@ -315,7 +332,10 @@ def run_pr_publish_capability(
             category=SCRIPT_EXIT_ERROR,
             code=f"exit_{result.returncode}",
             inputs=dict(args),
-            outputs={"stderr": (result.stderr or "")[:4000], "stdout": (result.stdout or "")[:4000]},
+            outputs={
+                "stderr": (result.stderr or "")[:4000],
+                "stdout": (result.stdout or "")[:4000],
+            },
         )
         return PrPublishRun(receipt=receipt, pr_synced_event=None, error_message="script_failed")
 
@@ -331,7 +351,9 @@ def run_pr_publish_capability(
             inputs=dict(args),
             outputs={"stdout": (result.stdout or "")[:4000]},
         )
-        return PrPublishRun(receipt=receipt, pr_synced_event=None, error_message="invalid_stdout_json")
+        return PrPublishRun(
+            receipt=receipt, pr_synced_event=None, error_message="invalid_stdout_json"
+        )
 
     out_schema = definition.get("expected_outputs") or {}
     if not isinstance(out_schema, dict):
@@ -377,6 +399,44 @@ def run_pr_publish_capability(
         },
     }
     return PrPublishRun(receipt=receipt, pr_synced_event=pr_synced, error_message=None)
+
+
+def run_capability_request(
+    *,
+    repo_root: Path,
+    registry: Mapping[str, Any],
+    capability_request: Mapping[str, Any],
+    output_file: Path,
+    timeout_sec: float = 600.0,
+) -> PrPublishRun:
+    """Execute one trusted capability request or return a validation receipt.
+
+    The generic entry point intentionally only dispatches allow-listed
+    implementations. Unknown or not-yet-implemented capability ids become
+    validation receipts and never execute host-side scripts.
+    """
+    cap_id = str(capability_request.get("capability") or "").strip()
+    if cap_id == CAPABILITY_PR_PUBLISH_ID:
+        return run_pr_publish_capability(
+            repo_root=repo_root,
+            registry=registry,
+            publish_request=capability_request,
+            pr_markdown_file=output_file,
+            timeout_sec=timeout_sec,
+        )
+
+    definition = registry.get(cap_id)
+    code = "unknown_capability" if definition is None else "unsupported_capability"
+    receipt = _base_receipt(
+        correlation_id=uuid.uuid4().hex[:20],
+        capability=cap_id or "unknown",
+        success=False,
+        category=VALIDATION_ERROR,
+        code=code,
+        inputs=_receipt_inputs(capability_request.get("args")),
+        outputs={},
+    )
+    return PrPublishRun(receipt=receipt, pr_synced_event=None, error_message=code)
 
 
 def capability_receipt_hook_event(receipt: Mapping[str, Any]) -> Dict[str, Any]:

--- a/src/cafe/core/hooks/native.py
+++ b/src/cafe/core/hooks/native.py
@@ -111,7 +111,68 @@ def _pr_publish_requested(
         contract.from_step == "pr"
         and contract.to_owner == HandoffOwner.DONE
         and contract.to_step == "done"
-        and contract.intent == HandoffIntent.WORKFLOW_COMPLETE
+        and contract.intent in {HandoffIntent.AWAIT_AGENT, HandoffIntent.WORKFLOW_COMPLETE}
+    )
+
+
+def _declared_capability_ids(step_def: Any) -> list[str]:
+    if not isinstance(step_def, dict):
+        return []
+    raw = step_def.get("capability_requests") or []
+    if not isinstance(raw, list):
+        return []
+    return [str(item).strip() for item in raw if str(item).strip()]
+
+
+def _effective_capability_ids(*, step_name: str, step_def: Any) -> list[str]:
+    declared = _declared_capability_ids(step_def)
+    if declared:
+        return declared
+    if step_name == "pr":
+        return ["cafe.pr.publish"]
+    return []
+
+
+def _capability_execution_requested(
+    *,
+    phase: Any,
+    step_name: str,
+    step_def: Any,
+    status_code: Any,
+    context: Optional[dict[str, Any]] = None,
+) -> bool:
+    capability_ids = _effective_capability_ids(step_name=step_name, step_def=step_def)
+    if not capability_ids:
+        return False
+    if step_name == "pr" and "cafe.pr.publish" in capability_ids:
+        return _pr_publish_requested(
+            phase=phase,
+            step_name=step_name,
+            status_code=status_code,
+            context=context,
+        )
+    if _hook_status_value(status_code) == PhaseStatusCode.CONFIRMED.value:
+        return True
+
+    baton_file: Optional[Path] = None
+    if isinstance(context, dict):
+        next_step_path = context.get("next_step_path")
+        if next_step_path:
+            baton_file = Path(str(next_step_path))
+    if baton_file is None:
+        issue_dir = getattr(phase, "issue_dir", None)
+        if isinstance(issue_dir, Path):
+            baton_file = issue_dir / "next_step.txt"
+    if baton_file is None or not baton_file.exists():
+        return False
+    try:
+        contract = HandoffContract.from_dict(json.loads(baton_file.read_text(encoding="utf-8")))
+    except Exception:
+        return False
+    return (
+        contract.from_step == step_name
+        and contract.to_step != step_name
+        and contract.to_owner in {HandoffOwner.AGENT, HandoffOwner.DONE}
     )
 
 
@@ -158,7 +219,9 @@ class UserInputCollector(NoOpHook):
         return phase._get_versioned_file_path(step_name, phase.iteration - 1, phase.phase_dir)
 
     @staticmethod
-    def _display_previous_output(phase: Any, step_name: str, previous_output_file: Optional[Path]) -> None:
+    def _display_previous_output(
+        phase: Any, step_name: str, previous_output_file: Optional[Path]
+    ) -> None:
         if previous_output_file is None:
             return
         title_map = {
@@ -236,9 +299,7 @@ class UserInputCollector(NoOpHook):
                         "- Key background information\n"
                         "(Press Esc + Enter to finish)"
                     )
-                    user_input = prompt_multiline(
-                        development_guide_prompt
-                    ).strip()
+                    user_input = prompt_multiline(development_guide_prompt).strip()
                 else:
                     user_input = ""
                 phase.step_user_inputs[step_name] = user_input
@@ -296,8 +357,7 @@ class UserInputCollector(NoOpHook):
         previous_output_file = self._get_previous_output_file(phase, step_name)
         # Steps that declare confirm_output use delta view on READY_FOR_REVIEW (less noisy).
         if not (
-            step_on_declares(step_def, "confirm_output")
-            and previous_status == "ready_for_review"
+            step_on_declares(step_def, "confirm_output") and previous_status == "ready_for_review"
         ):
             self._display_previous_output(phase, step_name, previous_output_file)
 
@@ -308,12 +368,12 @@ class UserInputCollector(NoOpHook):
             prev_data = phase._load_previous_iteration_data() or {}
             # Show diff again after returning from chat/edit, but never print full output.
             if delta_displayed:
-                redisplay_callback = (
-                    lambda: self._display_previous_iteration_delta(phase, previous_output_file)
+                redisplay_callback = lambda: self._display_previous_iteration_delta(
+                    phase, previous_output_file
                 )
             else:
-                redisplay_callback = (
-                    lambda: self._display_previous_output(phase, step_name, previous_output_file)
+                redisplay_callback = lambda: self._display_previous_output(
+                    phase, step_name, previous_output_file
                 )
             choice = phase._ask_user_for_review_decision(
                 self._resolve_review_item_name(step_name),
@@ -457,9 +517,7 @@ class UserInputCollector(NoOpHook):
             iteration = getattr(phase, "iteration", None)
             if phase_dir is not None and iteration is not None:
                 current_input_file = (
-                    Path(phase_dir)
-                    / f"iteration_{int(iteration):03d}"
-                    / "user_input.md"
+                    Path(phase_dir) / f"iteration_{int(iteration):03d}" / "user_input.md"
                 )
 
         if current_input_file and current_input_file.exists():
@@ -567,9 +625,7 @@ class GitHubIssueFetcher(NoOpHook):
         )
         if content is not None:
             output_file.parent.mkdir(parents=True, exist_ok=True)
-            output_file.write_text(
-                f"# Initial Requirements\n\n{content}\n", encoding="utf-8"
-            )
+            output_file.write_text(f"# Initial Requirements\n\n{content}\n", encoding="utf-8")
             return HookResult(
                 context_updates={"user_input": content},
                 events=[
@@ -607,9 +663,7 @@ class GitHubIssueFetcher(NoOpHook):
             content = ""
 
         output_file.parent.mkdir(parents=True, exist_ok=True)
-        output_file.write_text(
-            f"# Initial Requirements\n\n{content}\n", encoding="utf-8"
-        )
+        output_file.write_text(f"# Initial Requirements\n\n{content}\n", encoding="utf-8")
 
         return HookResult(
             context_updates={"user_input": content},
@@ -659,9 +713,7 @@ class GitHubIssueFetcher(NoOpHook):
         return method, int(raw_id) if raw_id else None
 
     @staticmethod
-    def _save_input_config(
-        config_file: Path, method: str, issue_id: Optional[int]
-    ) -> None:
+    def _save_input_config(config_file: Path, method: str, issue_id: Optional[int]) -> None:
         import yaml
 
         try:
@@ -724,11 +776,7 @@ class GitHubIssueFetcher(NoOpHook):
         if lines[0].startswith("# "):
             title = lines[0][2:].strip()
             body = lines[1].strip() if len(lines) > 1 else ""
-            content = (
-                f"**Issue Title:** {title}\n\n{body}"
-                if body
-                else f"**Issue Title:** {title}"
-            )
+            content = f"**Issue Title:** {title}\n\n{body}" if body else f"**Issue Title:** {title}"
         else:
             content = fetched_content
 
@@ -829,16 +877,18 @@ class GitHubPRCreator(NoOpHook):
             capability_receipt_hook_event,
             default_capability_definition_dirs,
             load_capability_registry,
-            run_pr_publish_capability,
+            run_capability_request,
         )
 
         phase = kwargs.get("phase")
         step_name = str(kwargs.get("step_name") or "")
+        step_def = kwargs.get("step_def") or {}
         if phase is None:
             return HookResult()
-        if not _pr_publish_requested(
+        if not _capability_execution_requested(
             phase=phase,
             step_name=step_name,
+            step_def=step_def,
             status_code=kwargs.get("status_code"),
             context=kwargs.get("context"),
         ):
@@ -850,22 +900,32 @@ class GitHubPRCreator(NoOpHook):
             return HookResult()
 
         repo_root = self._resolve_repo_root(phase)
+        capability_request_file = kwargs.get("capability_request_file")
         publish_request_file = kwargs.get("publish_request_file")
         blackboard_state = kwargs.get("blackboard_state")
         issue_dir = getattr(phase, "issue_dir", None)
+        fallback_capability = (
+            _effective_capability_ids(step_name=step_name, step_def=step_def)
+            or [CAPABILITY_PR_PUBLISH_ID]
+        )[0]
 
         def persist_receipt(receipt: dict[str, Any]) -> None:
             if isinstance(blackboard_state, BlackboardState) and isinstance(issue_dir, Path):
                 BlackboardStore(issue_dir).append_capability_receipt(blackboard_state, receipt)
 
         try:
-            request = self._load_publish_request(
-                publish_request_file=publish_request_file if isinstance(publish_request_file, Path) else None,
+            request_payload = self._load_publish_request(
+                publish_request_file=(
+                    capability_request_file
+                    if isinstance(capability_request_file, Path)
+                    else publish_request_file if isinstance(publish_request_file, Path) else None
+                ),
                 repo_root=repo_root,
             )
+            requests = self._normalize_capability_requests(request_payload)
         except RuntimeError:
             receipt = {
-                "capability": CAPABILITY_PR_PUBLISH_ID,
+                "capability": fallback_capability,
                 "correlation_id": uuid.uuid4().hex[:20],
                 "success": False,
                 "category": VALIDATION_ERROR,
@@ -880,55 +940,63 @@ class GitHubPRCreator(NoOpHook):
         try:
             registry = load_capability_registry(default_capability_definition_dirs(repo_root))
         except CapabilityRegistryError:
-            receipt = {
-                "capability": CAPABILITY_PR_PUBLISH_ID,
-                "correlation_id": uuid.uuid4().hex[:20],
-                "success": False,
-                "category": VALIDATION_ERROR,
-                "code": "registry_load_error",
-                "inputs": dict(request.get("args") or {}),
-                "outputs": {},
-                "finished_at": datetime.now().astimezone().isoformat(),
-            }
-            persist_receipt(receipt)
-            return HookResult(events=[capability_receipt_hook_event(receipt)])
-
-        run = run_pr_publish_capability(
-            repo_root=repo_root,
-            registry=registry,
-            publish_request=request,
-            pr_markdown_file=output_file,
-        )
-        persist_receipt(run.receipt)
-
-        events: list[dict[str, Any]] = [capability_receipt_hook_event(run.receipt)]
-        if run.pr_synced_event is not None:
-            events.insert(0, run.pr_synced_event)
-
-        if not run.receipt.get("success"):
-            category = run.receipt.get("category")
-            if category == SCRIPT_EXIT_ERROR:
-                details = (run.receipt.get("outputs") or {}).get("stderr") or ""
-                raise RuntimeError(f"PR sync script failed: {details}")
-            if category == TIMEOUT_ERROR:
-                raise RuntimeError("PR sync timed out")
+            events: list[dict[str, Any]] = []
+            for request in requests:
+                receipt = {
+                    "capability": str(request.get("capability") or fallback_capability),
+                    "correlation_id": uuid.uuid4().hex[:20],
+                    "success": False,
+                    "category": VALIDATION_ERROR,
+                    "code": "registry_load_error",
+                    "inputs": self._request_inputs_for_receipt(request),
+                    "outputs": {},
+                    "finished_at": datetime.now().astimezone().isoformat(),
+                }
+                persist_receipt(receipt)
+                events.append(capability_receipt_hook_event(receipt))
             return HookResult(events=events)
 
-        pr_url = str((run.receipt.get("outputs") or {}).get("pr_url") or "").strip()
-        pr_number = str((run.receipt.get("outputs") or {}).get("pr_number") or "").strip()
-        action = str((run.receipt.get("outputs") or {}).get("action") or "synced").strip()
-        return HookResult(
-            context_updates={
-                key: value
-                for key, value in {
-                    "pr_url": pr_url,
-                    "pr_number": pr_number,
-                    "pr_sync_action": action,
-                }.items()
-                if value
-            },
-            events=events,
-        )
+        events: list[dict[str, Any]] = []
+        context_updates: dict[str, str] = {}
+        for request in requests:
+            run = run_capability_request(
+                repo_root=repo_root,
+                registry=registry,
+                capability_request=request,
+                output_file=output_file,
+            )
+            persist_receipt(run.receipt)
+
+            if run.pr_synced_event is not None:
+                events.append(run.pr_synced_event)
+            events.append(capability_receipt_hook_event(run.receipt))
+
+            if not run.receipt.get("success"):
+                category = run.receipt.get("category")
+                if category == SCRIPT_EXIT_ERROR:
+                    details = (run.receipt.get("outputs") or {}).get("stderr") or ""
+                    raise RuntimeError(f"PR sync script failed: {details}")
+                if category == TIMEOUT_ERROR:
+                    raise RuntimeError("PR sync timed out")
+                continue
+
+            if run.receipt.get("capability") == CAPABILITY_PR_PUBLISH_ID:
+                pr_url = str((run.receipt.get("outputs") or {}).get("pr_url") or "").strip()
+                pr_number = str((run.receipt.get("outputs") or {}).get("pr_number") or "").strip()
+                action = str((run.receipt.get("outputs") or {}).get("action") or "synced").strip()
+                context_updates.update(
+                    {
+                        key: value
+                        for key, value in {
+                            "pr_url": pr_url,
+                            "pr_number": pr_number,
+                            "pr_sync_action": action,
+                        }.items()
+                        if value
+                    }
+                )
+
+        return HookResult(context_updates=context_updates, events=events)
 
     @staticmethod
     def _is_local_pr_mode(phase: Any) -> bool:
@@ -997,10 +1065,35 @@ class GitHubPRCreator(NoOpHook):
             raise RuntimeError(f"PR publish request is invalid JSON: {request_file}") from exc
         if not isinstance(payload, dict):
             raise RuntimeError("PR publish request must be a JSON object")
+        return payload
+
+    @staticmethod
+    def _normalize_capability_requests(payload: dict[str, Any]) -> list[dict[str, Any]]:
+        raw_requests = payload.get("requests")
+        if raw_requests is None:
+            GitHubPRCreator._validate_capability_request_payload(payload)
+            return [dict(payload)]
+        if not isinstance(raw_requests, list) or not raw_requests:
+            raise RuntimeError("Capability requests must be a non-empty list")
+
+        requests: list[dict[str, Any]] = []
+        for raw_request in raw_requests:
+            if not isinstance(raw_request, dict):
+                raise RuntimeError("Capability request entries must be JSON objects")
+            GitHubPRCreator._validate_capability_request_payload(raw_request)
+            requests.append(dict(raw_request))
+        return requests
+
+    @staticmethod
+    def _validate_capability_request_payload(payload: dict[str, Any]) -> None:
         permissions = payload.get("permissions")
         if permissions is not None and not isinstance(permissions, dict):
             raise RuntimeError("PR publish request permissions must be an object")
-        return payload
+
+    @staticmethod
+    def _request_inputs_for_receipt(request: dict[str, Any]) -> dict[str, Any]:
+        args = request.get("args")
+        return dict(args) if isinstance(args, dict) else {}
 
 
 class PRCommentPoster(NoOpHook):
@@ -1112,7 +1205,7 @@ class LocalPRReviewer(NoOpHook):
             normalized = line
             for prefix in ("- [ ]", "- [x]", "-", "*"):
                 if normalized.startswith(prefix):
-                    normalized = normalized[len(prefix):].strip()
+                    normalized = normalized[len(prefix) :].strip()
                     break
             if normalized:
                 todos.append(f"- [ ] {normalized}")
@@ -1146,7 +1239,9 @@ class LocalPRReviewer(NoOpHook):
             )
 
         try:
-            base_branch = phase._get_issue_config_value(phase.issue_dir / "issue.yaml", "base_branch")
+            base_branch = phase._get_issue_config_value(
+                phase.issue_dir / "issue.yaml", "base_branch"
+            )
             resolved_base = str(base_branch or phase.git_ops.get_default_base_branch())
             diff_output = phase.git_ops.get_diff(resolved_base, "HEAD")
         except Exception:

--- a/src/cafe/core/playbook.py
+++ b/src/cafe/core/playbook.py
@@ -20,7 +20,6 @@ from cafe.skills.exceptions import SkillDiscoveryError
 from cafe.skills.loader import SkillLoader
 from cafe.templates.manager import TemplateManager
 
-
 DONE_TARGET = "_done"
 SCRIPT_HOOK_STAGES = {"before_execute", "after_execute"}
 
@@ -99,6 +98,7 @@ class StepConfig(BaseModel):
     input_artifacts: List[str] = Field(default_factory=list)
     output_artifact: Optional[str] = None
     allowed_tools: List[str] = Field(default_factory=list)
+    capability_requests: List[str] = Field(default_factory=list)
     valid_intents: List[str] = Field(default_factory=list)
     max_iterations: Optional[Union[int, str]] = None
     allowed_goto: List[str] = Field(default_factory=list)
@@ -116,7 +116,9 @@ class StepConfig(BaseModel):
             if key == "default":
                 continue
             if key.startswith("CAFE_"):
-                raise ValueError(f"Legacy CAFE_ transition key is not allowed in playbook on: {key!r}")
+                raise ValueError(
+                    f"Legacy CAFE_ transition key is not allowed in playbook on: {key!r}"
+                )
             if key not in PLAYBOOK_INTENT_KEYS:
                 raise ValueError(
                     f"Invalid playbook transition key {key!r}; "
@@ -138,6 +140,19 @@ class StepConfig(BaseModel):
             except ValueError as exc:
                 raise ValueError(f"Unknown step outcome token in valid_intents: {token!r}") from exc
         return [item.strip() for item in value]
+
+    @field_validator("capability_requests")
+    @classmethod
+    def _validate_capability_requests(cls, value: List[str]) -> List[str]:
+        cleaned: List[str] = []
+        for item in value:
+            if not isinstance(item, str) or not item.strip():
+                raise ValueError("capability_requests entries must be non-empty strings")
+            token = item.strip()
+            if token in cleaned:
+                raise ValueError(f"duplicate capability_requests entry: {token!r}")
+            cleaned.append(token)
+        return cleaned
 
     @field_validator("skill")
     @classmethod
@@ -279,7 +294,9 @@ class PrepareConfig(BaseModel):
     @model_validator(mode="after")
     def _validate_fields_source(self) -> "PrepareConfig":
         if self.fields and self.fields_ref:
-            raise ValueError("commands.prepare.fields and commands.prepare.fields_ref are mutually exclusive")
+            raise ValueError(
+                "commands.prepare.fields and commands.prepare.fields_ref are mutually exclusive"
+            )
         return self
 
 
@@ -523,7 +540,9 @@ def _validate_step_role(step_name: str, step: StepConfig, roles: Dict[str, Playb
         raise ValueError(f"Step '{step_name}' references unknown role '{step.role}'")
 
 
-def _validate_step_chat_role(step_name: str, step: StepConfig, roles: Dict[str, PlaybookRole]) -> None:
+def _validate_step_chat_role(
+    step_name: str, step: StepConfig, roles: Dict[str, PlaybookRole]
+) -> None:
     if roles and step.chat_role and step.chat_role not in roles:
         raise ValueError(f"Step '{step_name}' references unknown chat_role '{step.chat_role}'")
 
@@ -534,9 +553,7 @@ def _validate_step_skills(step_name: str, step: StepConfig, skill_loader: SkillL
         try:
             skill_loader.get_skill_dir(skill_name)
         except (SkillDiscoveryError, FileNotFoundError) as exc:
-            raise ValueError(
-                f"Step '{step_name}' references unknown skill '{skill_name}'"
-            ) from exc
+            raise ValueError(f"Step '{step_name}' references unknown skill '{skill_name}'") from exc
 
 
 def _validate_script_hook_stages(step_name: str, hooks: StepHooks) -> None:
@@ -564,9 +581,7 @@ def _validate_targets(
 ) -> None:
     for target in targets:
         if target not in steps:
-            raise ValueError(
-                f"Step '{step_name}' has invalid {field_name} target '{target}'"
-            )
+            raise ValueError(f"Step '{step_name}' has invalid {field_name} target '{target}'")
 
 
 def _validate_transition_targets(
@@ -589,9 +604,7 @@ def _collect_tool_warnings(step_name: str, allowed_tools: List[str]) -> List[str
     warnings: List[str] = []
     seen: Dict[str, str] = {}
     broad_tools = {
-        tool.strip(): tool.strip()
-        for tool in allowed_tools
-        if "(" not in tool and tool.strip()
+        tool.strip(): tool.strip() for tool in allowed_tools if "(" not in tool and tool.strip()
     }
 
     for tool in allowed_tools:

--- a/src/cafe/core/workflow_runtime.py
+++ b/src/cafe/core/workflow_runtime.py
@@ -16,6 +16,7 @@ from typing import Any, Dict, Optional
 
 from cafe.core.active_issue import clear_marker_if_matches
 from cafe.core.blackboard import BlackboardStore, HandoffContract, HandoffIntent, HandoffOwner
+from cafe.core.capabilities import CAPABILITY_PR_PUBLISH_ID
 from cafe.core.questions_schema import validate_questions_xml
 from cafe.core.status_codes import (
     PhaseStatusCode,
@@ -111,9 +112,14 @@ class BlackboardWorkflowRuntime:
         return any(isinstance(event, dict) and event.get("type") == event_type for event in events)
 
     @staticmethod
-    def _pr_publish_receipt_satisfied(execution_result: Any) -> bool:
-        """True when PR publish left a host receipt or legacy ``pr_synced`` marker."""
-        if BlackboardWorkflowRuntime._has_event(execution_result, "pr_synced"):
+    def _capability_receipt_satisfied(execution_result: Any, capability_id: str) -> bool:
+        """True when a capability left a success receipt.
+
+        ``pr_synced`` remains a legacy success marker for ``cafe.pr.publish``.
+        """
+        if capability_id == CAPABILITY_PR_PUBLISH_ID and BlackboardWorkflowRuntime._has_event(
+            execution_result, "pr_synced"
+        ):
             return True
         events = getattr(execution_result, "events", None)
         if not isinstance(events, list):
@@ -123,11 +129,34 @@ class BlackboardWorkflowRuntime:
                 continue
             if event.get("type") != "capability_receipt":
                 continue
-            if event.get("capability") != "cafe.pr.publish":
+            if event.get("capability") != capability_id:
                 continue
             if event.get("success") is True:
                 return True
         return False
+
+    @staticmethod
+    def _step_declared_capability_ids(step_def: Dict) -> list[str]:
+        raw = step_def.get("capability_requests") or []
+        if not isinstance(raw, list):
+            return []
+        return [str(item).strip() for item in raw if str(item).strip()]
+
+    def _required_capability_ids(self, current_step: str) -> list[str]:
+        step_def = self.steps.get(current_step, {})
+        if current_step == "pr" and not self._pr_step_requires_publish_receipt(current_step):
+            return []
+        declared = self._step_declared_capability_ids(step_def)
+        if declared:
+            return declared
+        if current_step == "pr":
+            return [CAPABILITY_PR_PUBLISH_ID]
+        return []
+
+    def _is_baton_driven_step(self, current_step: str) -> bool:
+        return current_step in self.BATON_DRIVEN_STEPS or bool(
+            self._required_capability_ids(current_step)
+        )
 
     def _default_pause_intent(self, current_step: str, status_code: str) -> HandoffIntent:
         step_def = self.steps.get(current_step, {})
@@ -156,7 +185,9 @@ class BlackboardWorkflowRuntime:
             "to_step='user', and intent='need_clarification'."
         )
         if br.field == "to_step":
-            message += " The baton must target a valid next step and cannot point back to the same phase."
+            message += (
+                " The baton must target a valid next step and cannot point back to the same phase."
+            )
         return message
 
     def _same_step_baton_rejected(self, *, current_step: str) -> BatonRejected:
@@ -292,9 +323,7 @@ class BlackboardWorkflowRuntime:
             },
         )
 
-    def _load_agent_written_handoff_contract(
-        self, *, current_step: str
-    ) -> HandoffContract:
+    def _load_agent_written_handoff_contract(self, *, current_step: str) -> HandoffContract:
         """Load and normalize a baton written by a just-finished agent step.
 
         ``allow_legacy_text=True`` is kept so that sessions started by older
@@ -341,9 +370,7 @@ class BlackboardWorkflowRuntime:
             or f"BATON_{contract.intent.value.upper()}"
         )
 
-    def _load_step_handoff_contract(
-        self, *, current_step: str
-    ) -> Optional[HandoffContract]:
+    def _load_step_handoff_contract(self, *, current_step: str) -> Optional[HandoffContract]:
         contract = self._load_agent_written_handoff_contract(current_step=current_step)
         if contract.from_step != current_step:
             return None
@@ -361,7 +388,9 @@ class BlackboardWorkflowRuntime:
         return None
 
     @staticmethod
-    def _extract_status_like_tokens(*, response: str, explicit_status_code: Optional[str]) -> set[str]:
+    def _extract_status_like_tokens(
+        *, response: str, explicit_status_code: Optional[str]
+    ) -> set[str]:
         tokens = set(STATUS_TOKEN_PATTERN.findall(response or ""))
         haystack = f"{response or ''}\n{explicit_status_code or ''}"
         if explicit_status_code:
@@ -390,7 +419,9 @@ class BlackboardWorkflowRuntime:
         return None
 
     @staticmethod
-    def _normalize_execution_result(execution_result: Any) -> tuple[str, Dict[str, str], Optional[str], bool]:
+    def _normalize_execution_result(
+        execution_result: Any,
+    ) -> tuple[str, Dict[str, str], Optional[str], bool]:
         auto_continue = False
         explicit_status_code: Optional[str] = None
         if isinstance(execution_result, StepExecutionResult):
@@ -469,7 +500,9 @@ class BlackboardWorkflowRuntime:
 
         try:
             try:
-                execution_result = self.executor(current_step, step_def, self.blackboard, extra_prompt=extra_prompt)
+                execution_result = self.executor(
+                    current_step, step_def, self.blackboard, extra_prompt=extra_prompt
+                )
             except TypeError:
                 execution_result = self.executor(current_step, step_def, self.blackboard)
         except KeyboardInterrupt:
@@ -517,7 +550,9 @@ class BlackboardWorkflowRuntime:
         if validate_assignee_type:
             self._validate_assignee_type(current_step, step_def)
 
-        response, artifacts, explicit_status_code, auto_continue = self._normalize_execution_result(execution_result)
+        response, artifacts, explicit_status_code, auto_continue = self._normalize_execution_result(
+            execution_result
+        )
         return StepIterationFrame(
             execution_result=execution_result,
             response=response,
@@ -742,26 +777,44 @@ class BlackboardWorkflowRuntime:
             or status_code == PhaseStatusCode.NEED_CLARIFICATION.value
         )
 
-    def _pr_publish_receipt_recorded(self) -> bool:
+    def _capability_receipt_recorded(self, capability_id: str) -> bool:
         for receipt in getattr(self.blackboard, "capability_receipts", []):
             if (
                 isinstance(receipt, dict)
-                and receipt.get("capability") == "cafe.pr.publish"
+                and receipt.get("capability") == capability_id
                 and receipt.get("success") is True
             ):
                 return True
         for event in getattr(self.blackboard, "events", []):
             data = getattr(event, "data", {})
-            if getattr(event, "event_type", "") == "pr_synced":
+            if (
+                capability_id == CAPABILITY_PR_PUBLISH_ID
+                and getattr(event, "event_type", "") == "pr_synced"
+            ):
                 return True
             if (
                 getattr(event, "event_type", "") == "capability_receipt"
                 and isinstance(data, dict)
-                and data.get("capability") == "cafe.pr.publish"
+                and data.get("capability") == capability_id
                 and data.get("success") is True
             ):
                 return True
         return False
+
+    def _missing_capability_receipts(
+        self,
+        *,
+        current_step: str,
+        execution_result: Any,
+    ) -> list[str]:
+        missing: list[str] = []
+        for capability_id in self._required_capability_ids(current_step):
+            if self._capability_receipt_satisfied(execution_result, capability_id):
+                continue
+            if self._capability_receipt_recorded(capability_id):
+                continue
+            missing.append(capability_id)
+        return missing
 
     def _validate_reconciled_handoff(self, *, current_step: str) -> HandoffReconciliationResult:
         missing: list[str] = []
@@ -795,13 +848,10 @@ class BlackboardWorkflowRuntime:
             else:
                 validated.append("baton")
 
-            if (
-                current_step == "pr"
-                and contract.to_owner == HandoffOwner.DONE
-                and self._pr_step_requires_publish_receipt(current_step)
-                and not self._pr_publish_receipt_recorded()
-            ):
-                missing.append("capability_receipt")
+            if contract.to_owner in {HandoffOwner.AGENT, HandoffOwner.DONE}:
+                for capability_id in self._required_capability_ids(current_step):
+                    if not self._capability_receipt_recorded(capability_id):
+                        missing.append(f"capability_receipt:{capability_id}")
 
         iteration_dir = self._latest_iteration_dir(current_step)
         if iteration_dir is None:
@@ -823,7 +873,9 @@ class BlackboardWorkflowRuntime:
             except FileNotFoundError:
                 missing.append("checklist_complete")
 
-            if contract is not None and self._questions_required_for_reconciliation(contract, status_code):
+            if contract is not None and self._questions_required_for_reconciliation(
+                contract, status_code
+            ):
                 questions_path = iteration_dir / "questions.xml"
                 if validate_questions_xml(questions_path):
                     validated.append("questions")
@@ -895,7 +947,9 @@ class BlackboardWorkflowRuntime:
             data["end_time"] = self._now_iso()
             changed = True
         if changed:
-            iteration_file.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+            iteration_file.write_text(
+                json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8"
+            )
 
     def _apply_reconciled_handoff(
         self,
@@ -1167,10 +1221,16 @@ class BlackboardWorkflowRuntime:
                     completed=False,
                 )
 
-            if next_step == "done":
-                if self._pr_step_requires_publish_receipt(current_step) and not self._pr_publish_receipt_satisfied(
-                    frame.execution_result
-                ):
+            require_capability_receipts = next_step != "user"
+            if current_step == "pr" and next_step != "done":
+                require_capability_receipts = False
+
+            if require_capability_receipts:
+                missing_capabilities = self._missing_capability_receipts(
+                    current_step=current_step,
+                    execution_result=frame.execution_result,
+                )
+                if missing_capabilities:
                     self.blackboard_store.update_handoff_contract(
                         self.blackboard,
                         from_step=current_step,
@@ -1187,7 +1247,12 @@ class BlackboardWorkflowRuntime:
                             "step": current_step,
                             "status_code": status_code,
                             "reason": "missing_capability_receipt",
-                            "required_event": "pr_synced",
+                            "required_event": (
+                                "pr_synced"
+                                if missing_capabilities == [CAPABILITY_PR_PUBLISH_ID]
+                                else "capability_receipt:" + ",".join(missing_capabilities)
+                            ),
+                            "missing_capabilities": missing_capabilities,
                         },
                     )
                     self.blackboard_store.set_current_step(self.blackboard, current_step)
@@ -1197,6 +1262,7 @@ class BlackboardWorkflowRuntime:
                         completed=False,
                     )
 
+            if next_step == "done":
                 return self._emit_complete(
                     current_step=current_step,
                     status_code=status_code,
@@ -1262,8 +1328,10 @@ class BlackboardWorkflowRuntime:
         step_visits: Counter[str] = Counter()
 
         for hop_count in range(1, max_transitions + 1):
-            if current_step in self.BATON_DRIVEN_STEPS:
-                return self._run_baton_driven_pr(current_step=current_step, max_transitions=max_transitions - hop_count + 1)
+            if self._is_baton_driven_step(current_step):
+                return self._run_baton_driven_pr(
+                    current_step=current_step, max_transitions=max_transitions - hop_count + 1
+                )
 
             step_def = self.steps[current_step]
             _baton_retry_extra_prompt: Optional[str] = None
@@ -1298,7 +1366,9 @@ class BlackboardWorkflowRuntime:
                         "runtime": runtime_label,
                     },
                 )
-                raise RuntimeError(f"Step '{current_step}' exceeded max_iterations={max_iterations}")
+                raise RuntimeError(
+                    f"Step '{current_step}' exceeded max_iterations={max_iterations}"
+                )
 
             for _baton_attempt in range(3):
                 try:
@@ -1347,7 +1417,8 @@ class BlackboardWorkflowRuntime:
                         post_contract is not None
                         and post_contract.to_owner == HandoffOwner.AGENT
                         and post_contract.to_step == current_step
-                        and post_contract.source not in {"bootstrap", "workflow.start_step_override"}
+                        and post_contract.source
+                        not in {"bootstrap", "workflow.start_step_override"}
                     ):
                         status_code_obj, goto_target, valid_codes = self._parse_legacy_status(
                             step_def=step_def,
@@ -1362,10 +1433,17 @@ class BlackboardWorkflowRuntime:
                             explicit_status_code=frame.explicit_status_code,
                         )
                         invalid_intents = {
-                            token for token in status_like_tokens if token not in allowed_status_codes
+                            token
+                            for token in status_like_tokens
+                            if token not in allowed_status_codes
                         }
                         has_default_transition = bool(step_def.get("on", {}).get("default"))
-                        if status_code_obj is None and not goto_target and not invalid_intents and not has_default_transition:
+                        if (
+                            status_code_obj is None
+                            and not goto_target
+                            and not invalid_intents
+                            and not has_default_transition
+                        ):
                             raise self._same_step_baton_rejected(current_step=current_step)
                     break
                 except BatonRejected as br:
@@ -1392,7 +1470,8 @@ class BlackboardWorkflowRuntime:
             else:
                 post_contract = None
             if post_contract is not None and not (
-                post_contract.to_owner == HandoffOwner.AGENT and post_contract.to_step == current_step
+                post_contract.to_owner == HandoffOwner.AGENT
+                and post_contract.to_step == current_step
             ):
                 status_code = (
                     post_contract.status_code
@@ -1434,9 +1513,7 @@ class BlackboardWorkflowRuntime:
                 response=frame.response,
                 explicit_status_code=frame.explicit_status_code,
             )
-            allowed_status_codes = {
-                code.value for code in (valid_codes or list(PhaseStatusCode))
-            }
+            allowed_status_codes = {code.value for code in (valid_codes or list(PhaseStatusCode))}
             if status_code_obj is None:
                 handoff_next_step: Optional[str] = None
                 handoff_transition_source = "terminal"
@@ -1552,9 +1629,9 @@ class BlackboardWorkflowRuntime:
                     continue
 
             if not frame.auto_continue and status_code in PAUSE_STATUS_CODES:
-                pause_intent = self._extract_handoff_intent(frame.execution_result) or self._default_pause_intent(
-                    current_step, status_code
-                )
+                pause_intent = self._extract_handoff_intent(
+                    frame.execution_result
+                ) or self._default_pause_intent(current_step, status_code)
                 return self._emit_pause(
                     current_step=current_step,
                     status_code=status_code,
@@ -1582,7 +1659,9 @@ class BlackboardWorkflowRuntime:
                 next_step, transition_source = self._resolve_next_step(
                     current_step=current_step,
                     response=(
-                        frame.response if goto_target is None else f"{frame.response}\nGOTO:{goto_target}"
+                        frame.response
+                        if goto_target is None
+                        else f"{frame.response}\nGOTO:{goto_target}"
                     ),
                     status_code=status_code,
                 )
@@ -1597,7 +1676,7 @@ class BlackboardWorkflowRuntime:
                     final_status_code=status_code,
                     completed=False,
                 )
-            if next_step in self.BATON_DRIVEN_STEPS:
+            if self._is_baton_driven_step(next_step):
                 self._emit_transition(
                     current_step=current_step,
                     next_step=next_step,
@@ -1636,7 +1715,9 @@ class BlackboardWorkflowRuntime:
                         contract_source=transition_contract_source,
                     )
 
-                raise RuntimeError(f"Unknown terminal target '{next_step}' from step '{current_step}'")
+                raise RuntimeError(
+                    f"Unknown terminal target '{next_step}' from step '{current_step}'"
+                )
 
             self._emit_transition(
                 current_step=current_step,
@@ -1667,7 +1748,7 @@ class BlackboardWorkflowRuntime:
         raise RuntimeError(f"Playbook run reached max transition limit ({max_transitions})")
 
     def _run_single_step(self, *, current_step: str) -> PlaybookRunResult:
-        if current_step in self.BATON_DRIVEN_STEPS:
+        if self._is_baton_driven_step(current_step):
             return self._run_baton_driven_pr(
                 current_step=current_step,
                 max_transitions=1,
@@ -1733,7 +1814,9 @@ class BlackboardWorkflowRuntime:
                 source="workflow.start_step_override",
             )
 
-        if current_step not in self.BATON_DRIVEN_STEPS:
-            return self._run_legacy_until_boundary(current_step=current_step, max_transitions=max_transitions)
+        if not self._is_baton_driven_step(current_step):
+            return self._run_legacy_until_boundary(
+                current_step=current_step, max_transitions=max_transitions
+            )
 
         return self._run_baton_driven_pr(current_step=current_step, max_transitions=max_transitions)

--- a/src/cafe/data/playbooks/default.yaml
+++ b/src/cafe/data/playbooks/default.yaml
@@ -174,6 +174,7 @@ steps:
     input_artifacts: [spec, code, review_feedback]
     output_artifact: pr_result
     allowed_tools: [Read, Edit, Write, Grep, Glob]
+    capability_requests: [cafe.pr.publish]
     allowed_goto: [develop, review]
     hooks:
       prepare_input: [GitHubPRCreator, UserInputCollector]

--- a/src/cafe/data/skills/cafe-chat-alignment-decision/SKILL.md
+++ b/src/cafe/data/skills/cafe-chat-alignment-decision/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: cafe-chat-alignment-decision
+description: "Guide a CAFE alignment checkpoint conversation inside cafe chat"
+version: 1.0.0
+---
+
+# Chat Alignment Decision
+
+## Use This Skill When
+- `CAFE_CHAT_MODE=alignment` is present in the environment.
+- The user is discussing an `alignment_checkpoint` inside `cafe chat`.
+
+## Purpose
+- Help the user understand why the workflow paused for alignment.
+- Discuss whether the current issue should continue, narrow scope, revise spec/plan,
+  update strategic documents first, pause, reject, or defer.
+- Produce a structured decision proposal for CAFE to validate after chat exits.
+
+## Runtime Inputs
+- Read `CAFE_ALIGNMENT_REQUEST_FILE` for the policy-generated checkpoint payload.
+- Write the final decision to `CAFE_ALIGNMENT_DECISION_FILE` only after the user has
+  clearly chosen a direction.
+- Treat `CAFE_ALIGNMENT_FROM_STEP`, `CAFE_ISSUE_NAME`, and `CAFE_ISSUE_DIR` as
+  workflow context.
+
+## Rules
+- Do not approve or resume the workflow by editing the blackboard directly.
+- Do not write `next_step.txt` for alignment decisions.
+- Do not treat alignment approval as permission to execute host-side capabilities.
+- Use the request payload's `allowed_decisions` when recommending choices.
+- If strategic documents are missing or stale, explain the tradeoff before suggesting
+  approval.
+- If the user wants strategic docs updated first, treat that as the start of a
+  strategic alignment conversation, not as approval of document content.
+- Before finalizing high-level strategy documents, ask at least one concrete
+  alignment question about product direction, positioning, audience, non-goals,
+  principles, or roadmap tradeoffs.
+- You may draft or update the relevant strategic document files in this chat, but
+  draft content is not final until the user explicitly confirms it after seeing
+  the draft or a concrete summary of the final content.
+- Decision mapping in chat:
+  - User chooses "update docs first" / option 2: ask alignment questions and draft
+    or revise the documents. This choice alone is not content confirmation.
+  - User explicitly confirms the final strategic document content after review:
+    final JSON decision may be `strategic_documents_updated`.
+  - User chooses to pause without edits: final JSON decision is
+    `update_strategic_documents_first`.
+- When drafting a configured missing strategic document without final user
+  confirmation, keep `.cafe/strategic_context.yaml` status as `draft` or
+  `missing`; do not mark it `exists`.
+- When the user explicitly confirms the final strategic document content, update
+  `.cafe/strategic_context.yaml` so confirmed documents have `status: exists` and
+  `path` points to the file.
+- After confirmed strategic documents are updated, write
+  `strategic_documents_updated` with confirmation evidence in the JSON payload.
+- Write `update_strategic_documents_first` only when the user explicitly wants to
+  pause without having you edit the documents now, or when the documents cannot be
+  safely updated in this chat.
+
+## Decision Payload
+Write JSON to `CAFE_ALIGNMENT_DECISION_FILE`:
+
+```json
+{
+  "decision": "approve",
+  "reason": "Short rationale for the decision.",
+  "correction": "Optional scope/spec/plan guidance for narrow_scope, revise_spec, revise_plan, manual_pause, or reject_or_defer.",
+  "user_confirmed": false,
+  "user_confirmation": ""
+}
+```
+
+For `strategic_documents_updated` from chat, `user_confirmed` must be `true` and
+`user_confirmation` must summarize the user's explicit confirmation after they
+reviewed the final draft or concrete final-content summary. Do not set these
+fields merely because the user selected option 2.
+
+Allowed `decision` values:
+- `approve`
+- `narrow_scope`
+- `revise_spec`
+- `revise_plan`
+- `update_strategic_documents_first`
+- `strategic_documents_updated`
+- `manual_pause`
+- `reject_or_defer`
+
+## Closing
+- Tell the user to exit chat and run `cafe make`.
+- Explain that CAFE will validate and apply the decision after chat exits.

--- a/src/cafe/data/skills/use-cafe-workflow/SKILL.md
+++ b/src/cafe/data/skills/use-cafe-workflow/SKILL.md
@@ -131,6 +131,90 @@ Re-read `.cafe/strategic_context.yaml` and linked documents before answering que
    cafe workflow --execute --start-step <step> --single-step
    ```
 
+## Alignment Checkpoints
+
+When CAFE pauses with `intent=alignment_checkpoint`, the workflow driver should
+try to resolve the checkpoint on behalf of the user when the decision is clear
+from confirmed project context. Do not automatically hand off every checkpoint
+to the user.
+
+### Inspect
+
+1. Read the latest `.cafe/issues/<issue>/<step>/iteration_*/alignment_request.json`.
+2. Re-read `.cafe/strategic_context.yaml` and every referenced strategic document
+   that is relevant to the request.
+3. Read the current issue artifacts needed to understand the proposed scope
+   (`spec`, `plan`, or the blocked step output).
+4. Classify the checkpoint against the repo mandate:
+   - **Resolvable by driver:** the decision follows directly from confirmed
+     strategic docs, issue acceptance criteria, and existing mandate.
+   - **Needs user:** the decision changes or confirms product positioning,
+     roadmap direction, principles, trusted capability boundaries beyond existing
+     docs, business/legal/pricing/production access, or any ambiguous tradeoff.
+
+### Driver-owned Decisions
+
+If the checkpoint is resolvable by the driver, continue non-interactively with an
+explicit JSON decision payload. Plain text must not be used for alignment approval.
+
+Examples:
+
+```bash
+cafe make --user-input '{"decision":"approve","reason":"Within confirmed roadmap and capability boundary."}'
+```
+
+```bash
+cafe make --user-input '{"decision":"narrow_scope","correction":"Keep this to PR publish plumbing; do not introduce a broader product-level contract model."}'
+```
+
+```bash
+cafe make --user-input '{"decision":"revise_spec","correction":"Specify that capability contracts protect trusted host execution boundaries; broad product ontology is out of scope."}'
+```
+
+Use `approve` only when no missing or draft strategic document blocks the
+decision. Use `narrow_scope`, `revise_spec`, or `revise_plan` when the desired
+alignment correction is clear from confirmed context.
+
+### Strategic Document Updates
+
+If a strategic document is `missing` or `draft`, the driver may draft or revise
+the document, but must not treat its own draft as confirmed strategy.
+
+The driver may mark a document `status: exists` and continue with
+`strategic_documents_updated` only when one of these is true:
+
+- the user explicitly confirmed the final document content in the current
+  thread/chat; or
+- the document content is copied or mechanically split from an already confirmed
+  strategic document, with no new product judgment.
+
+When finalizing confirmed strategic documents non-interactively, include
+confirmation evidence in the JSON payload:
+
+```bash
+cafe make --user-input '{"decision":"strategic_documents_updated","reason":"Positioning doc confirmed and strategic_context updated.","user_confirmed":true,"user_confirmation":"User confirmed the positioning framing: primary trusted host capability boundary, secondary external mutation risk; broad product contract model is out of scope."}'
+```
+
+If the document requires product judgment and the user has not confirmed it,
+leave the document as `draft` or `missing` and ask the user concise questions.
+Do not write `strategic_documents_updated`.
+
+### Ask The User When Uncertain
+
+When the driver cannot resolve the checkpoint confidently, stop and ask the user
+one focused question with a recommended answer and tradeoff. Good questions name
+the decision axis directly, for example:
+
+```text
+For #347, should capability contracts be positioned primarily as:
+1. trusted host capability boundary protection (recommended),
+2. external mutation risk reduction, or
+3. a broader product-level contract model?
+```
+
+After the user answers, apply the answer through the same JSON decision flow
+instead of opening the interactive menu unless the user asks for chat.
+
 ## Useful Options
 - Use `--fallback-preset <preset>` when the primary CLI is rate-limited, unavailable, missing, or configured with a bad model.
 - Use repeated `--add-dir <path>` for extra directories the agents must read or edit.

--- a/src/cafe/phases/generic_workflow_step.py
+++ b/src/cafe/phases/generic_workflow_step.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from cafe.agents.manager import AgentManager
+from cafe.core.capabilities import CAPABILITY_PR_PUBLISH_ID
 from cafe.core.blackboard import (
     ArtifactEntry,
     ArtifactKind,
@@ -126,7 +127,9 @@ class GenericWorkflowStepExecutor(Phase):
 
     def _get_allowed_directories(self) -> List[str]:
         base = super()._get_allowed_directories()
-        merged = list(dict.fromkeys(base + self._config_allowed_directories + self._extra_allowed_directories))
+        merged = list(
+            dict.fromkeys(base + self._config_allowed_directories + self._extra_allowed_directories)
+        )
         return merged
 
     def execute(self) -> Any:
@@ -151,17 +154,25 @@ class GenericWorkflowStepExecutor(Phase):
         output_file = self._get_versioned_file_path(step_name, self.iteration, self.phase_dir)
         checklist_file = iteration_dir / "checklist.md"
         questions_xml_file = iteration_dir / "questions.xml"
+        capability_request_file = iteration_dir / "capability_request.json"
         publish_request_file = iteration_dir / "publish_request.json"
         self._current_output_file = output_file
 
         if self.iteration > 1:
             self._copy_previous_version(step_name, self.iteration, self.phase_dir)
         self._ensure_output_file_initialized(step_name, output_file)
-        if step_name == "pr":
-            self._write_publish_request(
+        capability_ids = self._effective_capability_ids(step_name, step_def)
+        if capability_ids:
+            self._write_capability_request(
                 output_file=output_file,
-                publish_request_file=publish_request_file,
+                capability_request_file=capability_request_file,
+                capability_ids=capability_ids,
             )
+            if step_name == "pr":
+                self._write_publish_request(
+                    output_file=output_file,
+                    publish_request_file=publish_request_file,
+                )
 
         skill_name = self._resolve_skill_name(step_def, self.iteration)
         valid_intents = self._resolve_valid_intents(step_def)
@@ -173,7 +184,9 @@ class GenericWorkflowStepExecutor(Phase):
             skill_names=self.SHARED_WORKFLOW_SKILLS,
             agent_cli=agent_cli,
         )
-        skill_invocation = self.generic_phase.prepare_skill(skill_name=skill_name, agent_cli=agent_cli)
+        skill_invocation = self.generic_phase.prepare_skill(
+            skill_name=skill_name, agent_cli=agent_cli
+        )
         context = self._build_context(
             step_name=step_name,
             step_def=step_def,
@@ -212,7 +225,9 @@ class GenericWorkflowStepExecutor(Phase):
             resolved_user_input = self._get_resolved_iteration_user_input(step_name)
             if extra_prompt:
                 resolved_user_input = (
-                    f"{extra_prompt}\n\n{resolved_user_input}" if resolved_user_input else extra_prompt
+                    f"{extra_prompt}\n\n{resolved_user_input}"
+                    if resolved_user_input
+                    else extra_prompt
                 )
             attempt_allowed_tools = (
                 self._build_baton_retry_allowed_tools()
@@ -248,6 +263,7 @@ class GenericWorkflowStepExecutor(Phase):
                 "iteration_dir": iteration_dir,
                 "output_file": output_file,
                 "questions_xml_file": questions_xml_file,
+                "capability_request_file": capability_request_file if capability_ids else None,
                 "publish_request_file": publish_request_file if step_name == "pr" else None,
                 "blackboard_state": blackboard_state,
                 "transform_runtime_context": (
@@ -268,20 +284,21 @@ class GenericWorkflowStepExecutor(Phase):
         agent_was_invoked = bool(last_prompt)
         if (
             require_status_code
-            and
-            agent_was_invoked
+            and agent_was_invoked
             and execution.status_code is not None
             and status_code is not None
             and self._should_validate_checklist(status_code)
         ):
             resolved_user_input = self._get_resolved_iteration_user_input(step_name)
-            response, validated_status, validation_passed = self._validate_and_retry_checklist_completion(
-                agent_name=agent_name,
-                prompt=last_prompt[0] if last_prompt else "",
-                user_input=resolved_user_input,
-                valid_intents=valid_intents,
-                allowed_tools=allowed_tools,
-                max_retries=3,
+            response, validated_status, validation_passed = (
+                self._validate_and_retry_checklist_completion(
+                    agent_name=agent_name,
+                    prompt=last_prompt[0] if last_prompt else "",
+                    user_input=resolved_user_input,
+                    valid_intents=valid_intents,
+                    allowed_tools=allowed_tools,
+                    max_retries=3,
+                )
             )
             if validation_passed and validated_status is not None:
                 status_code = validated_status
@@ -312,11 +329,7 @@ class GenericWorkflowStepExecutor(Phase):
 
         effective_status = status_code
 
-        events = [
-            event
-            for event in execution.events
-            if isinstance(event, dict)
-        ]
+        events = [event for event in execution.events if isinstance(event, dict)]
         store = BlackboardStore(self.issue_dir)
         for event in events:
             if event.get("type") != "script_hook":
@@ -415,7 +428,9 @@ class GenericWorkflowStepExecutor(Phase):
             if hasattr(execution_config.cli, "value")
             else str(execution_config.cli)
         )
-        current_session_id = execution_config.session_id if isinstance(execution_config.session_id, str) else None
+        current_session_id = (
+            execution_config.session_id if isinstance(execution_config.session_id, str) else None
+        )
 
         return resolve_resume_user_input(
             candidate=candidate,
@@ -493,7 +508,9 @@ class GenericWorkflowStepExecutor(Phase):
 
         raise ValueError(f"Unsupported playbook role '{role}' for workflow execution")
 
-    def _apply_step_agent_model(self, *, step_name: str, step_def: Dict[str, Any], agent_name: str) -> None:
+    def _apply_step_agent_model(
+        self, *, step_name: str, step_def: Dict[str, Any], agent_name: str
+    ) -> None:
         model = self._resolve_step_model(step_name=step_name, step_def=step_def)
         self.agent_manager.get_agent(agent_name).config.model = model
 
@@ -552,7 +569,9 @@ class GenericWorkflowStepExecutor(Phase):
                 continue
             if "(" in tool:
                 tool_name, remainder = tool.split("(", 1)
-                normalized_name = tool_name_map.get(tool_name, tool_name[:1].lower() + tool_name[1:])
+                normalized_name = tool_name_map.get(
+                    tool_name, tool_name[:1].lower() + tool_name[1:]
+                )
                 normalized.append(f"{normalized_name}({remainder}")
                 continue
             normalized.append(tool_name_map.get(tool, tool[:1].lower() + tool[1:]))
@@ -635,8 +654,7 @@ class GenericWorkflowStepExecutor(Phase):
         # 本 step 依 intent 定義的下一步（含 _done → done 正規化），給 agent 明確指向。
         step_on = step_def.get("on", {}) if isinstance(step_def.get("on"), dict) else {}
         step_transitions = {
-            str(k): ("done" if str(v) in ("_done", "done") else str(v))
-            for k, v in step_on.items()
+            str(k): ("done" if str(v) in ("_done", "done") else str(v)) for k, v in step_on.items()
         }
         context = {
             "agent_file": AgentManager.get_agent_file_path(agent_name, role_dir),
@@ -704,16 +722,17 @@ class GenericWorkflowStepExecutor(Phase):
         questions_display = self._display_path(questions_xml_file)
         spec_path = self._artifact_or_latest_path(blackboard_state, "spec", "spec")
         plan_path = self._artifact_or_latest_path(blackboard_state, "plan", "plan")
-        review_feedback = (
-            self._artifact_path(blackboard_state, "review_feedback")
-            or self._artifact_path(blackboard_state, "pr_result")
-        )
+        review_feedback = self._artifact_path(
+            blackboard_state, "review_feedback"
+        ) or self._artifact_path(blackboard_state, "pr_result")
 
         skill_name = canonical_skill_name(skill_name)
         if skill_name == "cafe-spec":
             prev_spec = None
             if self.iteration > 1:
-                prev_spec_file = self._get_versioned_file_path(step_name, self.iteration - 1, self.phase_dir)
+                prev_spec_file = self._get_versioned_file_path(
+                    step_name, self.iteration - 1, self.phase_dir
+                )
                 prev_spec = self._display_path(prev_spec_file)
             generate_spec_checklist(
                 iteration=self.iteration,
@@ -730,7 +749,9 @@ class GenericWorkflowStepExecutor(Phase):
                 raise ValueError("Plan step requires spec artifact")
             prev_plan = None
             if self.iteration > 1:
-                prev_plan_file = self._get_versioned_file_path(step_name, self.iteration - 1, self.phase_dir)
+                prev_plan_file = self._get_versioned_file_path(
+                    step_name, self.iteration - 1, self.phase_dir
+                )
                 prev_plan = self._display_path(prev_plan_file)
             generate_plan_checklist(
                 agent_name=agent_name,
@@ -778,7 +799,9 @@ class GenericWorkflowStepExecutor(Phase):
                 raise ValueError("PR step requires spec and plan artifacts")
             prev_pr = None
             if self.iteration > 1:
-                prev_pr_file = self._get_versioned_file_path(step_name, self.iteration - 1, self.phase_dir)
+                prev_pr_file = self._get_versioned_file_path(
+                    step_name, self.iteration - 1, self.phase_dir
+                )
                 prev_pr = self._display_path(prev_pr_file)
             generate_pr_checklist(
                 agent_name=agent_name,
@@ -847,7 +870,9 @@ class GenericWorkflowStepExecutor(Phase):
         return step_name != "pr"
 
     @staticmethod
-    def _resolve_handoff_intent(step_def: Dict[str, Any], status_code: PhaseStatusCode) -> Optional[str]:
+    def _resolve_handoff_intent(
+        step_def: Dict[str, Any], status_code: PhaseStatusCode
+    ) -> Optional[str]:
         if status_code in {
             PhaseStatusCode.READY_FOR_REVIEW,
             PhaseStatusCode.CONFIRM_OUTPUT,
@@ -1066,6 +1091,49 @@ class GenericWorkflowStepExecutor(Phase):
             return
         output_file.write_text("", encoding="utf-8")
 
+    @staticmethod
+    def _declared_capability_ids(step_def: Dict[str, Any]) -> List[str]:
+        raw = step_def.get("capability_requests") or []
+        if not isinstance(raw, list):
+            return []
+        return [str(item).strip() for item in raw if str(item).strip()]
+
+    def _effective_capability_ids(self, step_name: str, step_def: Dict[str, Any]) -> List[str]:
+        declared = self._declared_capability_ids(step_def)
+        if declared:
+            return declared
+        if step_name == "pr":
+            return [CAPABILITY_PR_PUBLISH_ID]
+        return []
+
+    def _write_capability_request(
+        self,
+        *,
+        output_file: Path,
+        capability_request_file: Path,
+        capability_ids: List[str],
+    ) -> None:
+        requests = [
+            self._build_capability_request(
+                output_file=output_file,
+                capability_id=capability_id,
+            )
+            for capability_id in capability_ids
+        ]
+        payload: Dict[str, Any]
+        if len(requests) == 1:
+            payload = requests[0]
+        else:
+            payload = {"requests": requests}
+        capability_request_file.write_text(
+            json.dumps(
+                payload,
+                ensure_ascii=False,
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+
     def _write_publish_request(
         self,
         *,
@@ -1074,7 +1142,10 @@ class GenericWorkflowStepExecutor(Phase):
     ) -> None:
         publish_request_file.write_text(
             json.dumps(
-                self._build_publish_request(output_file=output_file),
+                self._build_capability_request(
+                    output_file=output_file,
+                    capability_id=CAPABILITY_PR_PUBLISH_ID,
+                ),
                 ensure_ascii=False,
                 indent=2,
             ),
@@ -1082,10 +1153,28 @@ class GenericWorkflowStepExecutor(Phase):
         )
 
     def _build_publish_request(self, *, output_file: Path) -> Dict[str, Any]:
+        return self._build_capability_request(
+            output_file=output_file,
+            capability_id=CAPABILITY_PR_PUBLISH_ID,
+        )
+
+    def _build_capability_request(
+        self,
+        *,
+        output_file: Path,
+        capability_id: str,
+    ) -> Dict[str, Any]:
+        if capability_id != CAPABILITY_PR_PUBLISH_ID:
+            return {
+                "capability": capability_id,
+                "args": {},
+                "permissions": {},
+            }
+
         base_branch = self._get_issue_config_value(self.issue_dir / "issue.yaml", "base_branch")
         resolved_base = str(base_branch or self.git_ops.get_default_base_branch())
         return {
-            "capability": "cafe.pr.publish",
+            "capability": CAPABILITY_PR_PUBLISH_ID,
             "args": {
                 "output": self._repo_relative_path(output_file),
                 "base": resolved_base,

--- a/src/cafe/ui/chat.py
+++ b/src/cafe/ui/chat.py
@@ -15,12 +15,12 @@ from cafe.skills.native_bridge import NativeSkillBridge
 from cafe.utils.config import ConfigManager
 from cafe.utils.crew import CrewManager, normalize_role_config
 
-
 CHAT_SKILL_NAMES = [
     "cafe-common-chat-handoff",
     "cafe-chat-develop-change",
     "cafe-chat-spec-revision",
     "cafe-chat-plan-revision",
+    "cafe-chat-alignment-decision",
 ]
 
 CURSOR_NATIVE_MODULE_HINT = "@anysphere/file-service-"
@@ -56,11 +56,14 @@ def _extract_latest_codex_session_id(
 
     return latest_session_id
 
+
 def get_chat_next_step_path(issue_dir: Path) -> Path:
     return issue_dir / "next_step.txt"
 
 
-def _load_chat_role_config(config_manager: ConfigManager, role: str, issue_dir: Optional[Path] = None) -> Optional[dict]:
+def _load_chat_role_config(
+    config_manager: ConfigManager, role: str, issue_dir: Optional[Path] = None
+) -> Optional[dict]:
     """Load role config from crew.yaml first, then config.yaml."""
     try:
         cafe_dir = Path(getattr(config_manager, "config_dir"))
@@ -361,7 +364,9 @@ def _format_cli_specific_error(agent_cli: AgentCLI, stderr: str, stdout: str) ->
     return None
 
 
-def _handle_chat_launch_failure(agent_cli: AgentCLI, result: subprocess.CompletedProcess[object]) -> int:
+def _handle_chat_launch_failure(
+    agent_cli: AgentCLI, result: subprocess.CompletedProcess[object]
+) -> int:
     """Print a concise launch failure and return the CLI's exit code."""
     stderr = (getattr(result, "stderr", None) or "").strip()
     stdout = (getattr(result, "stdout", None) or "").strip()
@@ -378,7 +383,14 @@ def _handle_chat_launch_failure(agent_cli: AgentCLI, result: subprocess.Complete
     return result.returncode
 
 
-def launch_chat_session(role: str, issue_name: str) -> int:
+def launch_chat_session(
+    role: str,
+    issue_name: str,
+    *,
+    chat_mode: Optional[str] = None,
+    extra_env: Optional[dict[str, str]] = None,
+    initial_prompt: Optional[str] = None,
+) -> int:
     """Launch an inline chat session with the agent for the given role.
 
     Resolves agent config from ConfigManager, loads the existing session,
@@ -389,6 +401,7 @@ def launch_chat_session(role: str, issue_name: str) -> int:
     Args:
         role: Agent role ("pm", "developer", or "reviewer")
         issue_name: Current issue name (used to load issue-specific session)
+        initial_prompt: Optional first message to send when the interactive CLI supports it.
     """
     issue_dir = Path.cwd() / ".cafe" / "issues" / issue_name
 
@@ -460,7 +473,21 @@ def launch_chat_session(role: str, issue_name: str) -> int:
         if agent_cli_str in ("claude", "copilot", "gemini"):
             cli_command.extend(["--model", agent_model])
 
+    if initial_prompt and agent_cli_str in {"codex", "claude"}:
+        cli_command.append(initial_prompt)
+
     env = cli_strategy.build_environment()
+    env["CAFE_ISSUE_NAME"] = issue_name
+    env["CAFE_ISSUE_DIR"] = str(issue_dir)
+    env["CAFE_CHAT_CURRENT_STEP"] = _current_step
+    env["CAFE_CHAT_PLAYBOOK_ID"] = _playbook_id
+    if initial_prompt:
+        env["CAFE_CHAT_INITIAL_PROMPT"] = initial_prompt
+    if chat_mode:
+        env["CAFE_CHAT_MODE"] = chat_mode
+    if extra_env:
+        for key, value in extra_env.items():
+            env[str(key)] = str(value)
     print(f"\nOpening chat with {role} ({agent_name})...")
     if session_id:
         print(f"Resuming session: {session_id}")
@@ -503,6 +530,9 @@ def launch_chat_session(role: str, issue_name: str) -> int:
         allow_legacy_text=True,
     )
     if contract.source == "chat.bootstrap":
-        print("\n⚠️  Chat ended without writing a next-step baton. The agent did not complete workflow handoff.\n")
+        print(
+            "\n⚠️  Chat ended without writing a next-step baton. "
+            "The agent did not complete workflow handoff.\n"
+        )
 
     return result.returncode

--- a/src/cafe/ui/cli_shared.py
+++ b/src/cafe/ui/cli_shared.py
@@ -29,8 +29,6 @@ from cafe.phases.generic_workflow_step import GenericWorkflowStepExecutor
 from cafe.playbooks.loader import PlaybookLoader
 from cafe.services.delta_display import DeltaDisplay
 from cafe.skills.loader import SkillLoader
-from cafe.ui.chat import launch_chat_session  # noqa: F401 — re-exported via cli for test-patch compat
-from cafe.ui.inquirer_prompts import prompt_confirm, prompt_list, prompt_multiline  # noqa: F401 — re-exported via cli for test-patch compat
 from cafe.utils.config import ConfigError, ConfigManager
 from cafe.utils.crew import CrewManager, normalize_role_config
 
@@ -63,6 +61,12 @@ ALL_PHASES = ["spec", "plan", "develop", "review", "pr"]
 
 console = Console()
 
+_ALIGNMENT_DIRECT_MENU_DECISIONS = (
+    ("approve", "Approve and continue"),
+    ("strategic_documents_updated", "Strategic documents updated"),
+    ("manual_pause", "Pause for manual decision"),
+)
+
 
 def _get_git_operations_cls():
     """Lazy import of GitOperations from cafe.ui.cli for test-patch compatibility.
@@ -71,18 +75,21 @@ def _get_git_operations_cls():
     ensures the patched version is picked up.
     """
     from cafe.ui.cli import GitOperations
+
     return GitOperations
 
 
 def _get_is_branch_initialized():
     """Lazy import of is_branch_initialized from cafe.ui.cli for test-patch compatibility."""
     from cafe.ui.cli import is_branch_initialized
+
     return is_branch_initialized
 
 
 def _get_github_ops_cls():
     """Lazy import of GitHubOps from cafe.ui.cli for test-patch compatibility."""
     from cafe.ui.cli import GitHubOps
+
     return GitHubOps
 
 
@@ -92,6 +99,7 @@ def _get_github_helpers():
         filter_unresolved_comments,
         get_all_pr_comments,
     )
+
     return get_all_pr_comments, filter_unresolved_comments
 
 
@@ -266,8 +274,7 @@ def resolve_iteration_number(phase_dir: Path, iteration_input: int, content_type
 
     iter_dirs = sorted(d for d in phase_dir.glob("iteration_*") if d.is_dir())
     existing_iter_dirs = [
-        d for d in iter_dirs
-        if (d / "iteration.json").exists() or (d / "context.json").exists()
+        d for d in iter_dirs if (d / "iteration.json").exists() or (d / "context.json").exists()
     ]
     if not existing_iter_dirs:
         raise ValueError(f"No iterations found in {phase_dir}")
@@ -362,6 +369,7 @@ _get_latest_versioned_file = get_latest_versioned_file
 # Workflow and phase helper functions (moved from cli.py)
 # ---------------------------------------------------------------------------
 
+
 def _resolve_issue_playbook_name(issue_name: str) -> str:
     """Resolve the playbook id associated with an issue."""
     blackboard_file = Path.cwd() / ".cafe" / "issues" / issue_name / "blackboard.json"
@@ -414,7 +422,9 @@ def _resolve_selected_playbook(playbook_name: Optional[str]) -> str:
     return str(selected) if selected else "default"
 
 
-def _build_workflow_role_agent_map(config_manager: ConfigManager, playbook_data: Dict[str, Any]) -> Dict[str, str]:
+def _build_workflow_role_agent_map(
+    config_manager: ConfigManager, playbook_data: Dict[str, Any]
+) -> Dict[str, str]:
     """Resolve playbook roles to configured agent names."""
     try:
         crew_data = CrewManager(cafe_dir=Path(config_manager.config_dir)).load()
@@ -531,7 +541,10 @@ def _consume_pending_chat_handoff(
         return None
 
     target_step = contract.to_step
-    if target_step not in {"user", "done"} and _get_git_operations_cls()().has_uncommitted_changes():
+    if (
+        target_step not in {"user", "done"}
+        and _get_git_operations_cls()().has_uncommitted_changes()
+    ):
         console.print(
             "[yellow]Chat handoff was not consumed because the worktree still has uncommitted changes.[/yellow]"
         )
@@ -574,7 +587,9 @@ def _consume_pending_chat_handoff(
     return target_step
 
 
-def _find_incomplete_workflow_step(*, issue_dir: Path, playbook_data: Dict[str, Any]) -> Optional[str]:
+def _find_incomplete_workflow_step(
+    *, issue_dir: Path, playbook_data: Dict[str, Any]
+) -> Optional[str]:
     """Return the most recent workflow step with an unfinished iteration context."""
     latest_incomplete: tuple[float, str] | None = None
 
@@ -716,7 +731,9 @@ def _handle_user_phase(
     handoff_intent = getattr(contract, "intent", None) if contract else None
     from_step = getattr(contract, "from_step", None) if contract else None
 
-    if handoff_intent == HandoffIntent.CONFIRM_OUTPUT and from_step in playbook_data.get("steps", {}):
+    if handoff_intent == HandoffIntent.CONFIRM_OUTPUT and from_step in playbook_data.get(
+        "steps", {}
+    ):
         return _handle_review_confirmation(
             issue_name=issue_name,
             issue_dir=issue_dir,
@@ -727,8 +744,11 @@ def _handle_user_phase(
             summary=summary,
         )
 
-    if handoff_intent == HandoffIntent.ALIGNMENT_CHECKPOINT and from_step in playbook_data.get("steps", {}):
+    if handoff_intent == HandoffIntent.ALIGNMENT_CHECKPOINT and from_step in playbook_data.get(
+        "steps", {}
+    ):
         return _handle_alignment_checkpoint_handoff(
+            issue_name=issue_name,
             issue_dir=issue_dir,
             playbook_data=playbook_data,
             blackboard=blackboard,
@@ -737,7 +757,9 @@ def _handle_user_phase(
             summary=summary,
         )
 
-    if handoff_intent == HandoffIntent.NEED_CLARIFICATION and from_step in playbook_data.get("steps", {}):
+    if handoff_intent == HandoffIntent.NEED_CLARIFICATION and from_step in playbook_data.get(
+        "steps", {}
+    ):
         return _handle_clarification_handoff(
             issue_name=issue_name,
             issue_dir=issue_dir,
@@ -846,6 +868,7 @@ def apply_alignment_decision_from_payload(
     if not from_step or from_step not in playbook_data.get("steps", {}):
         return None
     request_payload, request_file = _load_latest_alignment_request(issue_dir, str(from_step))
+    decision = _normalize_alignment_decision(payload.get("decision")) or str(payload["decision"])
     return _apply_alignment_decision(
         issue_dir=issue_dir,
         playbook_data=playbook_data,
@@ -854,13 +877,16 @@ def apply_alignment_decision_from_payload(
         from_step=str(from_step),
         request_payload=request_payload,
         request_file=request_file,
-        decision=str(payload["decision"]),
+        decision=decision,
         correction=str(payload.get("correction") or payload.get("reason") or "").strip(),
+        requires_user_confirmation=decision == "strategic_documents_updated",
+        user_confirmation=_alignment_chat_user_confirmation(payload),
     )
 
 
 def _handle_alignment_checkpoint_handoff(
     *,
+    issue_name: str,
     issue_dir: Path,
     playbook_data: Dict[str, Any],
     blackboard,
@@ -898,23 +924,89 @@ def _handle_alignment_checkpoint_handoff(
                 if isinstance(item, dict)
             ]
             console.print(f"  Affected docs: {', '.join(names)}")
+            existing_docs, missing_docs = _alignment_document_status_groups(affected)
+            if existing_docs:
+                console.print(f"  Existing strategic docs: {', '.join(existing_docs)}")
+            if missing_docs:
+                console.print(f"  Missing/unconfigured strategic docs: {', '.join(missing_docs)}")
+        rules = request_payload.get("triggered_rules") or []
+        if rules:
+            names = [
+                str(item.get("rule_id"))
+                for item in rules
+                if isinstance(item, dict) and item.get("rule_id")
+            ]
+            console.print(f"  Triggered rules: {', '.join(names)}")
         console.print()
 
     from cafe.ui.inquirer_prompts import prompt_list, prompt_multiline
 
-    choices = [
-        {"name": "Approve and continue", "value": "approve"},
-        {"name": "Narrow scope and continue", "value": "narrow_scope"},
-        {"name": "Revise specification", "value": "revise_spec"},
-        {"name": "Revise plan", "value": "revise_plan"},
-        {"name": "Update strategic documents first", "value": "update_strategic_documents_first"},
-        {"name": "Strategic documents updated", "value": "strategic_documents_updated"},
-        {"name": "Pause for manual decision", "value": "manual_pause"},
-        {"name": "Reject or defer", "value": "reject_or_defer"},
-    ]
-    decision = prompt_list("How should this alignment checkpoint continue?", choices, default="approve")
+    chat_role = _resolve_step_chat_role(playbook_data, from_step)
+    chat_agent = _resolve_role_agent_name(playbook_data, chat_role)
+    choices = _alignment_checkpoint_menu_choices(
+        chat_agent,
+        request_payload.get("allowed_decisions") if request_payload else None,
+    )
+    decision = prompt_list(
+        "How should this alignment checkpoint continue?", choices, default="chat_alignment"
+    )
+    if decision == "chat_alignment":
+        decision_file = _alignment_chat_decision_file(
+            issue_dir=issue_dir,
+            from_step=from_step,
+            request_file=request_file,
+        )
+        if decision_file.exists():
+            decision_file.unlink()
+        from cafe.ui.cli import launch_chat_session as _lcs
+
+        _lcs(
+            chat_role,
+            issue_name,
+            chat_mode="alignment",
+            initial_prompt=_build_alignment_chat_initial_prompt(
+                request_payload=request_payload,
+                request_file=request_file,
+                decision_file=decision_file,
+                from_step=from_step,
+            ),
+            extra_env={
+                "CAFE_ALIGNMENT_FROM_STEP": from_step,
+                "CAFE_ALIGNMENT_REQUEST_FILE": str(request_file) if request_file else "",
+                "CAFE_ALIGNMENT_DECISION_FILE": str(decision_file),
+            },
+        )
+        decision_payload = _load_alignment_chat_decision_payload(decision_file)
+        if decision_payload is None:
+            console.print(
+                "[yellow]Chat ended without a valid alignment decision payload; "
+                "workflow remains paused.[/yellow]"
+            )
+            return None
+        return _apply_alignment_decision(
+            issue_dir=issue_dir,
+            playbook_data=playbook_data,
+            blackboard=blackboard,
+            store=store,
+            from_step=from_step,
+            request_payload=request_payload,
+            request_file=request_file,
+            decision=str(decision_payload["decision"]),
+            correction=str(
+                decision_payload.get("correction") or decision_payload.get("reason") or ""
+            ).strip(),
+            requires_user_confirmation=True,
+            user_confirmation=_alignment_chat_user_confirmation(decision_payload),
+        )
+
     correction = ""
-    if decision in {"narrow_scope", "revise_spec", "revise_plan", "reject_or_defer", "manual_pause"}:
+    if decision in {
+        "narrow_scope",
+        "revise_spec",
+        "revise_plan",
+        "reject_or_defer",
+        "manual_pause",
+    }:
         correction = prompt_multiline("Add context for this alignment decision", default="").strip()
 
     return _apply_alignment_decision(
@@ -928,6 +1020,25 @@ def _handle_alignment_checkpoint_handoff(
         decision=str(decision),
         correction=correction,
     )
+
+
+def _alignment_checkpoint_menu_choices(
+    chat_agent: str, allowed_decisions: Any = None
+) -> list[dict[str, str]]:
+    allowed: set[str] = set()
+    if isinstance(allowed_decisions, list):
+        allowed = {
+            normalized
+            for normalized in (_normalize_alignment_decision(item) for item in allowed_decisions)
+            if normalized
+        }
+
+    choices = [{"name": f"Chat with {chat_agent} about alignment", "value": "chat_alignment"}]
+    for decision, label in _ALIGNMENT_DIRECT_MENU_DECISIONS:
+        if allowed and decision not in allowed:
+            continue
+        choices.append({"name": label, "value": decision})
+    return choices
 
 
 def _normalize_alignment_decision(raw: Any) -> Optional[str]:
@@ -956,9 +1067,159 @@ def _normalize_alignment_decision(raw: Any) -> Optional[str]:
     return aliases.get(normalized)
 
 
-def _load_latest_alignment_request(issue_dir: Path, from_step: str) -> tuple[Dict[str, Any], Optional[Path]]:
+def _alignment_chat_decision_file(
+    *,
+    issue_dir: Path,
+    from_step: str,
+    request_file: Optional[Path],
+) -> Path:
+    if request_file is not None:
+        return request_file.with_name("alignment_decision.json")
+    return (
+        _latest_or_next_iteration_dir(issue_dir=issue_dir, step_name=from_step)
+        / "alignment_decision.json"
+    )
+
+
+def _build_alignment_chat_initial_prompt(
+    *,
+    request_payload: Dict[str, Any],
+    request_file: Optional[Path],
+    decision_file: Path,
+    from_step: str,
+) -> str:
+    rules = [
+        str(item.get("rule_id"))
+        for item in request_payload.get("triggered_rules") or []
+        if isinstance(item, dict) and item.get("rule_id")
+    ]
+    affected_documents = [
+        f"{item.get('category')}:{item.get('status')}"
+        for item in request_payload.get("affected_documents") or []
+        if isinstance(item, dict) and item.get("category")
+    ]
+    allowed_decisions = [
+        str(item) for item in request_payload.get("allowed_decisions") or [] if str(item).strip()
+    ]
+    existing_docs, missing_docs = _alignment_document_status_groups(
+        request_payload.get("affected_documents") or []
+    )
+    request_ref = str(request_file) if request_file is not None else "the latest request file"
+
+    summary_parts = [
+        f"level={request_payload.get('level', 'unknown')}",
+        f"score={request_payload.get('score', 'unknown')}",
+        f"risk={request_payload.get('risk_level', 'unknown')}",
+    ]
+    if rules:
+        summary_parts.append("rules=" + ", ".join(rules[:8]))
+    if affected_documents:
+        summary_parts.append("docs=" + ", ".join(affected_documents[:8]))
+
+    return "\n".join(
+        [
+            "You are opening a CAFE alignment checkpoint chat.",
+            "",
+            f"Step: {from_step}",
+            f"Alignment request file: {request_ref}",
+            f"Decision output file: {decision_file}",
+            "Checkpoint summary: " + "; ".join(summary_parts),
+            "Allowed decisions: " + ", ".join(allowed_decisions or ["none listed"]),
+            "Existing strategic docs: " + ", ".join(existing_docs or ["none listed"]),
+            "Missing/unconfigured strategic categories: "
+            + ", ".join(missing_docs or ["none listed"]),
+            "Chat-mode decision mapping:",
+            "- Option 2 starts strategic document alignment; it does not by itself approve document content.",
+            "- Before writing strategic_documents_updated from chat, the user must explicitly confirm the final document content after seeing the draft or summary.",
+            "- If strategic docs are drafted but not confirmed, keep them as draft/missing and write update_strategic_documents_first or manual_pause.",
+            "- User chooses to pause without document edits: final JSON decision is update_strategic_documents_first.",
+            "",
+            "Read the alignment request file first. Then start the conversation yourself:",
+            "1. Briefly explain why CAFE paused and what decision is needed.",
+            "2. Distinguish existing strategic docs from missing/unconfigured categories; do not say all strategic docs are missing when existing docs are listed.",
+            "3. If the user chooses to update strategic documents first, ask at least one concrete strategic alignment question before treating the document as final.",
+            "4. You may draft or update strategic document files in this chat, but do not mark a missing configured document as status=exists until the user has confirmed the final content.",
+            "5. For unconfirmed drafts, keep .cafe/strategic_context.yaml status as draft or missing and do not write strategic_documents_updated.",
+            "6. After the user explicitly confirms the final strategic document content, update .cafe/strategic_context.yaml so confirmed configured documents have status=exists.",
+            "7. Only then may you write strategic_documents_updated. The JSON must include user_confirmed=true and user_confirmation with the user's confirmation summary.",
+            "8. Write update_strategic_documents_first only when the user wants the workflow to remain paused for document work, or when documents cannot be safely finalized in this chat.",
+            "9. Ask the user one or two concrete questions to choose an allowed decision.",
+            "10. Once the user chooses, requested document edits are done, and required confirmation is present, write JSON to the decision output file with decision, reason, optional correction, and confirmation fields when needed.",
+            "",
+            "Do not edit the blackboard or next_step.txt. Do not wait for the user to guess the opening prompt.",
+            "Use the user's language when possible.",
+        ]
+    )
+
+
+def _alignment_document_status_groups(documents: Any) -> tuple[list[str], list[str]]:
+    existing_docs: list[str] = []
+    missing_docs: list[str] = []
+
+    if not isinstance(documents, list):
+        return existing_docs, missing_docs
+
+    for item in documents:
+        if not isinstance(item, dict):
+            continue
+        category = str(item.get("category") or "").strip()
+        if not category:
+            continue
+        status = str(item.get("status") or "missing").strip() or "missing"
+        path = item.get("path")
+        path_label = str(path).strip() if path else ""
+        label = f"{category}:{status}"
+        if path_label:
+            label = f"{label} ({path_label})"
+        else:
+            label = f"{label} (unconfigured)"
+
+        if status == "exists" and item.get("exists") is not False:
+            existing_docs.append(label)
+        else:
+            missing_docs.append(label)
+
+    return existing_docs, missing_docs
+
+
+def _load_alignment_chat_decision_payload(decision_file: Path) -> Optional[Dict[str, Any]]:
+    try:
+        payload = json.loads(decision_file.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    decision = _normalize_alignment_decision(payload.get("decision"))
+    if not decision:
+        return None
+    parsed = dict(payload)
+    parsed["decision"] = decision
+    return parsed
+
+
+def _alignment_chat_user_confirmation(payload: Dict[str, Any]) -> str:
+    confirmed = payload.get("user_confirmed")
+    if isinstance(confirmed, str):
+        confirmed_value = confirmed.strip().lower() in {"1", "true", "yes", "y", "confirmed"}
+    else:
+        confirmed_value = bool(confirmed)
+    if not confirmed_value:
+        return ""
+
+    for key in ("user_confirmation", "confirmation_summary", "confirmation"):
+        value = str(payload.get(key) or "").strip()
+        if value:
+            return value
+    return ""
+
+
+def _load_latest_alignment_request(
+    issue_dir: Path, from_step: str
+) -> tuple[Dict[str, Any], Optional[Path]]:
     step_dir = issue_dir / from_step
-    candidates = sorted(step_dir.glob("iteration_*/alignment_request.json")) if step_dir.exists() else []
+    candidates = (
+        sorted(step_dir.glob("iteration_*/alignment_request.json")) if step_dir.exists() else []
+    )
     for request_file in reversed(candidates):
         try:
             data = json.loads(request_file.read_text(encoding="utf-8"))
@@ -980,34 +1241,98 @@ def _apply_alignment_decision(
     request_file: Optional[Path],
     decision: str,
     correction: str = "",
+    requires_user_confirmation: bool = False,
+    user_confirmation: str = "",
 ) -> Optional[str]:
     decision = _normalize_alignment_decision(decision) or decision
     fingerprint = str(request_payload.get("fingerprint") or "")
     requirements = request_payload.get("strategic_document_update_requirements") or []
+    allowed_decisions = request_payload.get("allowed_decisions") or []
+    if isinstance(allowed_decisions, list):
+        allowed = {
+            normalized
+            for normalized in (_normalize_alignment_decision(item) for item in allowed_decisions)
+            if normalized
+        }
+        if allowed and decision not in allowed:
+            console.print(
+                f"[yellow]Alignment decision '{decision}' is not allowed for this "
+                "checkpoint.[/yellow]"
+            )
+            store.record_event(
+                blackboard,
+                "alignment_decision_blocked",
+                {
+                    "step": from_step,
+                    "decision": decision,
+                    "fingerprint": fingerprint,
+                    "reason": "decision_not_allowed",
+                    "allowed_decisions": sorted(allowed),
+                },
+            )
+            return None
 
     if decision == "approve" and requirements:
-        console.print("[yellow]Strategic document updates are required before approval can resume execution.[/yellow]")
+        console.print(
+            "[yellow]Strategic document updates are required before approval can "
+            "resume execution.[/yellow]"
+        )
         store.record_event(
             blackboard,
             "alignment_decision_blocked",
-            {"step": from_step, "decision": decision, "fingerprint": fingerprint, "reason": "required_document_update"},
+            {
+                "step": from_step,
+                "decision": decision,
+                "fingerprint": fingerprint,
+                "reason": "required_document_update",
+            },
         )
         return None
 
     if decision == "strategic_documents_updated":
-        if not _alignment_documents_changed(issue_dir, requirements):
-            console.print("[yellow]No affected strategic document change was detected; workflow remains paused.[/yellow]")
+        if requires_user_confirmation and not user_confirmation.strip():
+            console.print(
+                "[yellow]Strategic document updates from chat require explicit "
+                "user confirmation after the final content is presented.[/yellow]"
+            )
             store.record_event(
                 blackboard,
                 "alignment_decision_blocked",
-                {"step": from_step, "decision": decision, "fingerprint": fingerprint, "reason": "document_hash_unchanged"},
+                {
+                    "step": from_step,
+                    "decision": decision,
+                    "fingerprint": fingerprint,
+                    "reason": "missing_user_confirmation",
+                },
+            )
+            return None
+        if not _alignment_documents_changed(
+            issue_dir,
+            requirements,
+            request_payload.get("affected_documents") or [],
+        ):
+            console.print(
+                "[yellow]No affected strategic document change was detected; "
+                "workflow remains paused.[/yellow]"
+            )
+            store.record_event(
+                blackboard,
+                "alignment_decision_blocked",
+                {
+                    "step": from_step,
+                    "decision": decision,
+                    "fingerprint": fingerprint,
+                    "reason": "document_hash_unchanged",
+                },
             )
             return None
         decision = "approve"
 
     if decision == "update_strategic_documents_first":
         store.set_current_step(blackboard, "user")
-        store.set_handoff_summary(blackboard, f"Waiting for strategic document updates before {from_step}")
+        store.set_handoff_summary(
+            blackboard, f"Waiting for strategic document updates before {from_step}"
+        )
         store.update_handoff_contract(
             blackboard,
             from_step=from_step,
@@ -1065,12 +1390,20 @@ def _apply_alignment_decision(
 
     if decision == "narrow_scope":
         correction = correction or "Narrow scope according to the alignment checkpoint decision."
-        _write_alignment_user_input(issue_dir=issue_dir, step_name=from_step, request_file=request_file, text=correction)
+        _write_alignment_user_input(
+            issue_dir=issue_dir, step_name=from_step, request_file=request_file, text=correction
+        )
     elif decision in {"revise_spec", "revise_plan"}:
-        _write_next_iteration_user_input(issue_dir=issue_dir, step_name=target_step, text=correction or f"Revise due to alignment decision from {from_step}.")
+        _write_next_iteration_user_input(
+            issue_dir=issue_dir,
+            step_name=target_step,
+            text=correction or f"Revise due to alignment decision from {from_step}.",
+        )
 
     store.set_current_step(blackboard, target_step)
-    store.set_handoff_summary(blackboard, correction or f"Alignment decision '{decision}' for {from_step}")
+    store.set_handoff_summary(
+        blackboard, correction or f"Alignment decision '{decision}' for {from_step}"
+    )
     store.update_handoff_contract(
         blackboard,
         from_step=from_step,
@@ -1096,23 +1429,53 @@ def _apply_alignment_decision(
     return target_step
 
 
-def _alignment_documents_changed(issue_dir: Path, requirements: Any) -> bool:
-    if not isinstance(requirements, list) or not requirements:
-        return True
+def _alignment_documents_changed(
+    issue_dir: Path,
+    requirements: Any,
+    affected_documents: Any = None,
+) -> bool:
     from cafe.core.strategic_context import load_strategic_context
 
     project_root, issue_name = _resolve_issue_context_root(issue_dir)
     context = load_strategic_context(project_root, issue_name=issue_name)
-    for item in requirements:
+    checked_any = False
+
+    for item in (requirements if isinstance(requirements, list) else []):
         if not isinstance(item, dict):
             continue
         category = str(item.get("category") or "")
         if not category:
             continue
+        checked_any = True
         previous_hash = item.get("current_sha256")
         current = context.document(category)
         if current.sha256 and current.sha256 != previous_hash:
             return True
+
+    for item in (affected_documents if isinstance(affected_documents, list) else []):
+        if not isinstance(item, dict):
+            continue
+        category = str(item.get("category") or "")
+        if not category:
+            continue
+        previous_status = str(item.get("status") or "").strip()
+        previous_exists = item.get("exists")
+        previous_hash = item.get("sha256") or item.get("current_sha256")
+        current = context.document(category)
+
+        if previous_status in {"missing", "draft"} or previous_exists is False:
+            checked_any = True
+            if current.status == "exists" and current.exists and current.sha256:
+                return True
+            if previous_status == "draft" and current.sha256 and current.sha256 != previous_hash:
+                return True
+        elif previous_hash:
+            checked_any = True
+            if current.sha256 and current.sha256 != previous_hash:
+                return True
+
+    if not checked_any:
+        return True
     return False
 
 
@@ -1127,7 +1490,9 @@ def _resolve_issue_context_root(issue_dir: Path) -> tuple[Path, str]:
     return issue_dir.parent.parent.parent, issue_dir.name
 
 
-def _write_alignment_user_input(*, issue_dir: Path, step_name: str, request_file: Optional[Path], text: str) -> None:
+def _write_alignment_user_input(
+    *, issue_dir: Path, step_name: str, request_file: Optional[Path], text: str
+) -> None:
     if request_file is not None:
         target_dir = request_file.parent
     else:
@@ -1186,7 +1551,9 @@ def _handle_clarification_handoff(
     def _reload_after_chat():
         _display_latest_output()
         current_iter_dir = latest_iter_dir
-        current_questions_file = current_iter_dir / "questions.xml" if current_iter_dir is not None else None
+        current_questions_file = (
+            current_iter_dir / "questions.xml" if current_iter_dir is not None else None
+        )
         if current_questions_file is None or not current_questions_file.exists():
             return None
         from cafe.core.questions_schema import parse_questions_xml, validate_questions_xml
@@ -1245,7 +1612,10 @@ def _handle_clarification_handoff(
     store.record_event(
         blackboard,
         "clarification_answered",
-        {"step": from_step, "source": "questions_xml" if questions_file and questions_file.exists() else "prompt"},
+        {
+            "step": from_step,
+            "source": "questions_xml" if questions_file and questions_file.exists() else "prompt",
+        },
     )
     console.print(f"[green]Clarification answered[/green] -> back to {from_step}")
     return from_step
@@ -1268,7 +1638,9 @@ def _handle_review_confirmation(
 
     # Display the output file
     from_step_dir = issue_dir / from_step
-    output_files = sorted(from_step_dir.glob("iteration_*/output.md")) if from_step_dir.exists() else []
+    output_files = (
+        sorted(from_step_dir.glob("iteration_*/output.md")) if from_step_dir.exists() else []
+    )
     if output_files:
         latest_output = output_files[-1]
         # Show delta if there's a previous iteration
@@ -1354,7 +1726,9 @@ def _handle_review_confirmation(
                 source="user.review_modification",
             )
             # Write feedback as user_input for the next iteration
-            iteration_dirs = sorted(from_step_dir.glob("iteration_*")) if from_step_dir.exists() else []
+            iteration_dirs = (
+                sorted(from_step_dir.glob("iteration_*")) if from_step_dir.exists() else []
+            )
             next_iter = len(iteration_dirs) + 1
             next_iter_dir = from_step_dir / f"iteration_{next_iter:03d}"
             next_iter_dir.mkdir(parents=True, exist_ok=True)
@@ -1369,8 +1743,10 @@ def _handle_review_confirmation(
 
         if action == "chat":
             from cafe.ui.cli import launch_chat_session as _lcs
+
             _lcs(role_map, issue_name)
             from cafe.ui.cli import _consume_pending_chat_handoff as _cpch
+
             target_step = _cpch(
                 issue_dir=issue_dir,
                 playbook_data=playbook_data,
@@ -1431,6 +1807,7 @@ def _handle_user_phase_generic(
         console.print(f"[dim]{summary}[/dim]")
 
     from cafe.ui.cli import prompt_list as _pl
+
     action = _pl(
         "Select next action",
         [
@@ -1444,6 +1821,7 @@ def _handle_user_phase_generic(
 
     if action == "Leave a handoff note and continue the workflow":
         from cafe.ui.cli import prompt_multiline as _pml
+
         note = _pml(
             "What should be written to the blackboard before continuing?",
             default=summary,
@@ -1456,9 +1834,14 @@ def _handle_user_phase_generic(
             f"{_resolve_step_handoff_label(playbook_data, step_name)} ({step_name})"
             for step_name in step_names
         ]
-        default_step = str(playbook_data.get("entry_point") or next(iter(playbook_data["steps"].keys())))
-        default_label = f"{_resolve_step_handoff_label(playbook_data, default_step)} ({default_step})"
+        default_step = str(
+            playbook_data.get("entry_point") or next(iter(playbook_data["steps"].keys()))
+        )
+        default_label = (
+            f"{_resolve_step_handoff_label(playbook_data, default_step)} ({default_step})"
+        )
         from cafe.ui.cli import prompt_list as _pl2
+
         selected_label = _pl2(
             "Which phase should continue next?",
             step_labels,
@@ -1471,6 +1854,7 @@ def _handle_user_phase_generic(
         console.print(f"  Note: {note}")
         console.print()
         from cafe.ui.cli import prompt_confirm as _pc
+
         if not _pc("Write this handoff to the blackboard and continue now?"):
             console.print("[dim]No workflow action taken.[/dim]")
             return ""
@@ -1492,12 +1876,19 @@ def _handle_user_phase_generic(
         return str(target_step)
 
     if action == "Open chat with a role":
-        role_choices = list(playbook_data.get("roles", {}).keys()) or ["pm", "developer", "reviewer"]
+        role_choices = list(playbook_data.get("roles", {}).keys()) or [
+            "pm",
+            "developer",
+            "reviewer",
+        ]
         from cafe.ui.cli import prompt_list as _pl3
+
         role = _pl3("Select role", role_choices)
         from cafe.ui.cli import launch_chat_session as _lcs
+
         _lcs(str(role), issue_name)
         from cafe.ui.cli import _consume_pending_chat_handoff as _cpch
+
         target_step = _cpch(
             issue_dir=issue_dir,
             playbook_data=playbook_data,
@@ -1561,28 +1952,40 @@ def _handle_phase_exception(e: Exception, phase_name: str) -> None:
             console.print("[yellow]⚠️  API rate limit reached[/yellow]")
             console.print()
             if all_agents_exhausted:
-                console.print("[dim]All configured agents (primary + backups) have been exhausted.[/dim]")
+                console.print(
+                    "[dim]All configured agents (primary + backups) have been exhausted.[/dim]"
+                )
                 console.print()
                 console.print(f"[dim]{error_msg}[/dim]")
             else:
                 console.print(f"[dim]{error_msg}[/dim]")
-                console.print("[dim]The workflow has been stopped to prevent wasting resources.[/dim]")
+                console.print(
+                    "[dim]The workflow has been stopped to prevent wasting resources.[/dim]"
+                )
             console.print()
             console.print("[bold]Next steps (choose one):[/bold]")
             console.print("  • Wait for quota reset or switch to a different account, OR")
-            console.print("  • Use [cyan]cafe config edit[/cyan] to add backup agents or switch CLI tool")
+            console.print(
+                "  • Use [cyan]cafe config edit[/cyan] to add backup agents or switch CLI tool"
+            )
             console.print()
             console.print("Then run [cyan]cafe make[/cyan] again to resume from where it stopped")
             console.print()
         elif e.error_type == "cli_not_found":
-            console.print("[yellow]⚠️  Required CLI tool not found. Please install it and try again.[/yellow]")
+            console.print(
+                "[yellow]⚠️  Required CLI tool not found. Please install it and try again.[/yellow]"
+            )
             console.print()
-            console.print("[dim]ℹ️  The workflow has been stopped to prevent wasting resources.[/dim]")
+            console.print(
+                "[dim]ℹ️  The workflow has been stopped to prevent wasting resources.[/dim]"
+            )
             console.print()
         else:
             console.print(f"[yellow]⚠️  {e}[/yellow]")
             console.print()
-            console.print("[dim]ℹ️  The workflow has been stopped to prevent wasting resources.[/dim]")
+            console.print(
+                "[dim]ℹ️  The workflow has been stopped to prevent wasting resources.[/dim]"
+            )
             console.print()
     else:
         console.print(f"[bold red]❌ Error in {phase_name} phase: {e}[/bold red]")
@@ -1628,6 +2031,7 @@ def _execute_single_step_alias(
     generic_phase = GenericPhase(SkillLoader())
     # Use late import from cli for test-patch compatibility
     from cafe.ui.cli import _build_workflow_step_executor as _bwse
+
     step_executor = _bwse(
         config_manager=config_manager,
         issue_dir=issue_dir,
@@ -1686,7 +2090,10 @@ def _build_workflow_pause_guidance(*, blackboard: object, final_status_code: str
         for event in reversed(events):
             event_type = getattr(event, "event_type", "")
             data = getattr(event, "data", {}) or {}
-            if event_type == "workflow_blocked" and data.get("reason") == "missing_capability_receipt":
+            if (
+                event_type == "workflow_blocked"
+                and data.get("reason") == "missing_capability_receipt"
+            ):
                 required_event = str(data.get("required_event", "")).strip()
                 if required_event:
                     return (
@@ -1748,7 +2155,9 @@ def _alias_targets(alias_result: Dict[str, Any], step_name: str) -> bool:
 
 
 def _alias_pause_intent(alias_result: Dict[str, Any], *intents: str) -> bool:
-    return _alias_is_user_pause(alias_result) and _alias_handoff_intent(alias_result) in set(intents)
+    return _alias_is_user_pause(alias_result) and _alias_handoff_intent(alias_result) in set(
+        intents
+    )
 
 
 def _alias_is_confirmed_transition(alias_result: Dict[str, Any], step_name: str) -> bool:
@@ -1756,18 +2165,29 @@ def _alias_is_confirmed_transition(alias_result: Dict[str, Any], step_name: str)
 
 
 def _alias_needs_clarification(alias_result: Dict[str, Any]) -> bool:
-    return _alias_pause_intent(alias_result, "need_clarification") or _alias_status(alias_result) == "need_clarification"
+    return (
+        _alias_pause_intent(alias_result, "need_clarification")
+        or _alias_status(alias_result) == "need_clarification"
+    )
 
 
 def _alias_needs_permission(alias_result: Dict[str, Any]) -> bool:
-    return _alias_pause_intent(alias_result, "need_permission") or _alias_status(alias_result) == "need_permission"
+    return (
+        _alias_pause_intent(alias_result, "need_permission")
+        or _alias_status(alias_result) == "need_permission"
+    )
 
 
 def _alias_confirm_output_pause(alias_result: Dict[str, Any]) -> bool:
-    return _alias_pause_intent(alias_result, "confirm_output") or _alias_status(alias_result) == "ready_for_review"
+    return (
+        _alias_pause_intent(alias_result, "confirm_output")
+        or _alias_status(alias_result) == "ready_for_review"
+    )
 
 
-def _reject_unsupported_phase_options(phase_name: str, unsupported_options: Dict[str, bool]) -> None:
+def _reject_unsupported_phase_options(
+    phase_name: str, unsupported_options: Dict[str, bool]
+) -> None:
     """Exit when a legacy-only CLI option is requested."""
     unsupported = [name for name, enabled in unsupported_options.items() if enabled]
     if not unsupported:
@@ -1776,9 +2196,7 @@ def _reject_unsupported_phase_options(phase_name: str, unsupported_options: Dict
     console.print(
         f"[red]Error: {phase_name} no longer supports legacy phase options: {rendered}[/red]"
     )
-    console.print(
-        "[dim]Use the workflow runtime directly or rerun without those flags.[/dim]"
-    )
+    console.print("[dim]Use the workflow runtime directly or rerun without those flags.[/dim]")
     raise typer.Exit(1)
 
 
@@ -1794,9 +2212,7 @@ def _print_legacy_phase_command_notice(
         f"[yellow]Legacy workflow alias:[/yellow] [bold]cafe {phase_name}[/bold] runs the same "
         f"runtime path as [bold]cafe workflow --start-step {step} --execute[/bold]."
     )
-    console.print(
-        f"[dim]Preferred entrypoint:[/dim] [bold]{preferred_command}[/bold]"
-    )
+    console.print(f"[dim]Preferred entrypoint:[/dim] [bold]{preferred_command}[/bold]")
     console.print()
 
 
@@ -1832,6 +2248,7 @@ def _edit_latest_phase_artifact(
 ) -> None:
     """Open the latest phase artifact in the user's editor."""
     from cafe.ui.cli import _get_and_validate_branch as _gavb
+
     issue_name = _gavb(ctx, phase_name)
     phase_file = get_latest_versioned_file(phase_name, issue_name)
     if not phase_file:
@@ -1840,16 +2257,26 @@ def _edit_latest_phase_artifact(
         raise typer.Exit(1)
 
     from cafe.ui.cli import _edit_file_with_editor as _efe
+
     _efe(phase_file)
 
 
-def _display_iteration_questions(*, issue_name: str, step_name: str, alias_result: Dict[str, Any]) -> None:
+def _display_iteration_questions(
+    *, issue_name: str, step_name: str, alias_result: Dict[str, Any]
+) -> None:
     """Render clarification questions from the latest iteration when available."""
     iteration = alias_result.get("iterations")
     if not isinstance(iteration, int) or iteration <= 0:
         return
 
-    questions_file = Path(".cafe") / "issues" / issue_name / step_name / f"iteration_{iteration:03d}" / "questions.xml"
+    questions_file = (
+        Path(".cafe")
+        / "issues"
+        / issue_name
+        / step_name
+        / f"iteration_{iteration:03d}"
+        / "questions.xml"
+    )
     if not questions_file.exists():
         return
 
@@ -1895,6 +2322,7 @@ def _run_iterative_alias_step(
             console.print(f"\n[bold cyan]━━━ Iteration {iteration_count} ━━━[/bold cyan]\n")
 
         from cafe.ui.cli import _execute_single_step_alias as _essa
+
         alias_result = _essa(
             issue_name=issue_name,
             step_name=step_name,
@@ -1917,18 +2345,24 @@ def _run_iterative_alias_step(
         console.print()
         if handoff_intent == "need_clarification" or status_code == "need_clarification":
             console.print("[yellow]💬 Agent needs clarification[/yellow]")
-            _display_iteration_questions(issue_name=issue_name, step_name=step_name, alias_result=alias_result)
+            _display_iteration_questions(
+                issue_name=issue_name, step_name=step_name, alias_result=alias_result
+            )
         else:
             console.print("[yellow]📝 Draft ready for review[/yellow]")
 
         from cafe.ui.cli import prompt_confirm as _pc2
+
         should_continue = auto or _pc2("Continue to next iteration?", default=True)
         if not should_continue:
             console.print("[dim]Stopped by user.[/dim]")
             return alias_result
 
-        if (handoff_intent == "need_clarification" or status_code == "need_clarification") and clarification_prompt:
+        if (
+            handoff_intent == "need_clarification" or status_code == "need_clarification"
+        ) and clarification_prompt:
             from cafe.ui.cli import prompt_multiline as _pml2
+
             current_input = _pml2(clarification_prompt).strip() or current_input
         iteration_count += 1
         console.print("[dim]Continuing...[/dim]")
@@ -2019,7 +2453,9 @@ def _print_workflow_pause_guidance(*, step_name: str, status_code: Optional[str]
         return
 
     if status_code == "NO_BATON_TRANSITION":
-        console.print("[dim]Agent finished without updating the workflow baton for this step.[/dim]")
+        console.print(
+            "[dim]Agent finished without updating the workflow baton for this step.[/dim]"
+        )
         if step_name == "pr":
             console.print("[bold]Recommended next action:[/bold] Open chat with role `developer`")
             console.print("[bold]Suggested prompt:[/bold]")
@@ -2034,7 +2470,9 @@ def _print_workflow_pause_guidance(*, step_name: str, status_code: Optional[str]
                 "[bold]Recommended next action:[/bold] Open chat with the role responsible for this step,"
             )
             console.print("  or leave a handoff note in the workflow UI before resuming.")
-        console.print("[dim]After the chat or handoff is written back, run cafe make again to resume.[/dim]")
+        console.print(
+            "[dim]After the chat or handoff is written back, run cafe make again to resume.[/dim]"
+        )
         return
 
     if status_code == "NO_STATUS_TRANSITION":

--- a/tests/integration/test_pr_e2e_with_mock.py
+++ b/tests/integration/test_pr_e2e_with_mock.py
@@ -57,6 +57,7 @@ def _seed_pr_artifacts(issue_dir: Path) -> None:
 def test_pr_runtime_completes_with_capability_receipt(tmp_path: Path) -> None:
     issue_dir = tmp_path / ".cafe" / "issues" / "issue-pr-e2e"
     playbook = _load_default_playbook()
+    assert playbook["steps"]["pr"]["capability_requests"] == ["cafe.pr.publish"]
     _seed_pr_artifacts(issue_dir)
 
     def executor(step_name: str, step_def: dict, state: object) -> StepExecutionResult:
@@ -95,7 +96,9 @@ def test_pr_runtime_completes_with_capability_receipt(tmp_path: Path) -> None:
     assert result.final_step == "pr"
     blackboard = json.loads((issue_dir / "blackboard.json").read_text(encoding="utf-8"))
     receipts = blackboard.get("capability_receipts") or []
-    assert any(r.get("capability") == "cafe.pr.publish" for r in receipts) or result.final_status_code in {
+    assert any(
+        r.get("capability") == "cafe.pr.publish" for r in receipts
+    ) or result.final_status_code in {
         "BATON_WORKFLOW_COMPLETE",
         "confirmed",
     }

--- a/tests/unit/test_alignment_policy.py
+++ b/tests/unit/test_alignment_policy.py
@@ -3,10 +3,10 @@
 from pathlib import Path
 
 from cafe.core.alignment import (
+    AgentAlignmentEvidence,
     AlignmentDecisionLevel,
     AlignmentPolicyConfig,
     AlignmentPolicyInput,
-    AgentAlignmentEvidence,
     evaluate_alignment_policy,
     merge_agent_alignment_evidence,
 )
@@ -42,6 +42,77 @@ mandate:
     return load_strategic_context(tmp_path)
 
 
+def _context_with_roadmap_mapped_strategy(tmp_path: Path):
+    (tmp_path / ".cafe").mkdir()
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "roadmap.md").write_text(
+        "# Roadmap\n\nNorth star and product direction.", encoding="utf-8"
+    )
+    (tmp_path / ".cafe" / "strategic_context.yaml").write_text(
+        """
+version: 1
+documents:
+  roadmap:
+    path: docs/roadmap.md
+    status: exists
+  product_direction:
+    path: docs/roadmap.md
+    status: exists
+  principles:
+    path: docs/roadmap.md
+    status: exists
+  positioning:
+    path: docs/positioning.md
+    status: missing
+mandate:
+  axes:
+    product_scope:
+      level: escalate
+      grounds: [roadmap]
+""",
+        encoding="utf-8",
+    )
+    return load_strategic_context(tmp_path)
+
+
+def _context_with_confirmed_strategy(tmp_path: Path):
+    (tmp_path / ".cafe").mkdir()
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "roadmap.md").write_text(
+        "# Roadmap\n\nCapability contract consolidation is in scope.",
+        encoding="utf-8",
+    )
+    (tmp_path / "docs" / "positioning.md").write_text(
+        "# Positioning\n\nCapability contracts protect trusted host boundaries.",
+        encoding="utf-8",
+    )
+    (tmp_path / ".cafe" / "strategic_context.yaml").write_text(
+        """
+version: 1
+documents:
+  roadmap:
+    path: docs/roadmap.md
+    status: exists
+  product_direction:
+    path: docs/roadmap.md
+    status: exists
+  principles:
+    path: docs/roadmap.md
+    status: exists
+  positioning:
+    path: docs/positioning.md
+    status: exists
+mandate:
+  axes:
+    product_scope:
+      level: escalate
+      grounds: [roadmap, principles]
+""",
+        encoding="utf-8",
+    )
+    return load_strategic_context(tmp_path)
+
+
 def test_explicit_alignment_request_forces_checkpoint(tmp_path: Path) -> None:
     result = evaluate_alignment_policy(
         AlignmentPolicyInput(step_name="plan", user_input="Please align first before planning."),
@@ -69,7 +140,9 @@ def test_mandate_escalation_trigger_forces_checkpoint(tmp_path: Path) -> None:
     )
 
     assert result.level == AlignmentDecisionLevel.MUST_ALIGN
-    assert any(rule.rule_id == "mandate_escalation:product_scope" for rule in result.triggered_rules)
+    assert any(
+        rule.rule_id == "mandate_escalation:product_scope" for rule in result.triggered_rules
+    )
 
 
 def test_out_of_mandate_overlap_forces_checkpoint(tmp_path: Path) -> None:
@@ -115,7 +188,9 @@ def test_chinese_roadmap_update_is_in_payload(tmp_path: Path) -> None:
 
 def test_missing_positioning_document_is_surfaced_when_relevant(tmp_path: Path) -> None:
     result = evaluate_alignment_policy(
-        AlignmentPolicyInput(step_name="draft", user_input="Draft positioning guidance for launch."),
+        AlignmentPolicyInput(
+            step_name="draft", user_input="Draft positioning guidance for launch."
+        ),
         strategic_context=_context(tmp_path),
         config=AlignmentPolicyConfig(pause_threshold=5, note_threshold=2),
     )
@@ -171,9 +246,125 @@ def test_configured_document_categories_apply_to_strategic_signals(tmp_path: Pat
     )
 
 
+def test_trusted_host_capability_contract_forces_checkpoint(tmp_path: Path) -> None:
+    issue_text = """
+    Replace PR-specific publish hooks with generic capability contracts.
+    CAFE should keep the long-term direction for host-side execution: agents
+    produce declarative requests and trusted host capabilities perform external
+    mutations. Preserve a strict trust boundary while broadening capability
+    request and receipt handling.
+    """
+
+    result = evaluate_alignment_policy(
+        AlignmentPolicyInput(step_name="spec", artifacts={"issue": issue_text}),
+        strategic_context=_context(tmp_path),
+        config=AlignmentPolicyConfig(
+            affected_document_categories=(
+                "roadmap",
+                "product_direction",
+                "principles",
+                "positioning",
+                "strategic_context",
+            ),
+            pause_threshold=5,
+            note_threshold=2,
+        ),
+    )
+
+    assert result.level == AlignmentDecisionLevel.MUST_ALIGN
+    assert result.payload is not None
+    rule_ids = {rule.rule_id for rule in result.triggered_rules}
+    assert "trusted_capability_boundary" in rule_ids
+    assert "external_mutation_risk" in rule_ids
+    affected_categories = {doc.category for doc in result.payload.affected_documents}
+    assert {
+        "roadmap",
+        "product_direction",
+        "principles",
+        "positioning",
+        "strategic_context",
+    } <= affected_categories
+
+
+def test_trusted_capability_uses_mapped_roadmap_docs_without_missing_false_positive(
+    tmp_path: Path,
+) -> None:
+    issue_text = """
+    Replace PR-specific publish hooks with generic capability contracts.
+    Keep trusted host-side execution and a strict trust boundary.
+    """
+
+    result = evaluate_alignment_policy(
+        AlignmentPolicyInput(step_name="spec", artifacts={"issue": issue_text}),
+        strategic_context=_context_with_roadmap_mapped_strategy(tmp_path),
+        config=AlignmentPolicyConfig(
+            affected_document_categories=(
+                "roadmap",
+                "product_direction",
+                "principles",
+                "positioning",
+                "strategic_context",
+            ),
+            pause_threshold=5,
+            note_threshold=2,
+        ),
+    )
+
+    assert result.level == AlignmentDecisionLevel.MUST_ALIGN
+    rule_ids = {rule.rule_id for rule in result.triggered_rules}
+    assert "strategic_document_missing:product_direction" not in rule_ids
+    assert "strategic_document_missing:principles" not in rule_ids
+    assert "strategic_document_missing:positioning" in rule_ids
+    assert result.payload is not None
+    docs = {doc.category: doc for doc in result.payload.affected_documents}
+    assert docs["product_direction"].path == "docs/roadmap.md"
+    assert docs["principles"].path == "docs/roadmap.md"
+    assert docs["positioning"].status == "missing"
+
+
+def test_confirmed_strategy_signal_does_not_force_document_update_requirement(
+    tmp_path: Path,
+) -> None:
+    spec_text = """
+    Issue #347 is limited to generic capability request validation, execution
+    receipt handling, and preserving existing PR publish behavior. Out of scope:
+    expanding the work into policy, strategy, or execution-surface changes
+    outside the confirmed capability-contract boundary.
+    """
+
+    result = evaluate_alignment_policy(
+        AlignmentPolicyInput(
+            step_name="spec",
+            user_input="Q1: select 1. Q2: select all. Q3: select 1.",
+            artifacts={"spec": spec_text},
+        ),
+        strategic_context=_context_with_confirmed_strategy(tmp_path),
+        config=AlignmentPolicyConfig(
+            affected_document_categories=(
+                "roadmap",
+                "product_direction",
+                "principles",
+                "positioning",
+                "strategic_context",
+            ),
+            pause_threshold=5,
+            note_threshold=2,
+        ),
+    )
+
+    assert result.level == AlignmentDecisionLevel.MUST_ALIGN
+    rule_ids = {rule.rule_id for rule in result.triggered_rules}
+    assert "trusted_capability_boundary" in rule_ids
+    assert "strategic_document_update_required" not in rule_ids
+    assert result.payload is not None
+    assert result.payload.strategic_document_update_requirements == ()
+
+
 def test_medium_risk_records_note_only(tmp_path: Path) -> None:
     result = evaluate_alignment_policy(
-        AlignmentPolicyInput(step_name="develop", user_input="Touch an external API wrapper boundary."),
+        AlignmentPolicyInput(
+            step_name="develop", user_input="Touch an external API wrapper boundary."
+        ),
         strategic_context=_context(tmp_path),
         config=AlignmentPolicyConfig(pause_threshold=5, note_threshold=2),
     )
@@ -207,7 +398,9 @@ def test_fingerprint_changes_when_affected_document_changes(tmp_path: Path) -> N
     first = evaluate_alignment_policy(input_data, strategic_context=context)
 
     (tmp_path / "docs" / "roadmap.md").write_text("roadmap v2", encoding="utf-8")
-    second = evaluate_alignment_policy(input_data, strategic_context=load_strategic_context(tmp_path))
+    second = evaluate_alignment_policy(
+        input_data, strategic_context=load_strategic_context(tmp_path)
+    )
 
     assert first.payload is not None
     assert second.payload is not None

--- a/tests/unit/test_capability_registry.py
+++ b/tests/unit/test_capability_registry.py
@@ -9,6 +9,7 @@ from cafe.core.capabilities import (
     CAPABILITY_PR_PUBLISH_ID,
     CapabilityRegistryError,
     load_capability_registry,
+    run_capability_request,
     run_pr_publish_capability,
 )
 
@@ -16,7 +17,12 @@ from cafe.core.capabilities import (
 def test_load_registry_duplicate_ids(tmp_path: Path) -> None:
     cap_dir = tmp_path / "caps"
     cap_dir.mkdir()
-    one = {"id": "dup", "script_ref": "sync_pr", "args_schema": {"required": []}, "expected_outputs": {"required": ["pr_url", "pr_number"]}}
+    one = {
+        "id": "dup",
+        "script_ref": "sync_pr",
+        "args_schema": {"required": []},
+        "expected_outputs": {"required": ["pr_url", "pr_number"]},
+    }
     two = dict(one)
     (cap_dir / "a.yaml").write_text(yaml.safe_dump(one), encoding="utf-8")
     (cap_dir / "b.yaml").write_text(yaml.safe_dump(two), encoding="utf-8")
@@ -44,6 +50,91 @@ def test_run_pr_publish_unknown_capability(tmp_path: Path) -> None:
     )
     assert run.receipt["success"] is False
     assert run.receipt["category"] == "validation_error"
+
+
+def test_run_generic_capability_request_rejects_unknown_without_script(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    import cafe.core.capabilities as cap_mod
+
+    called = False
+
+    def _fake_run(*_a: object, **_k: object) -> object:
+        nonlocal called
+        called = True
+        raise AssertionError("unknown capability must not run subprocess")
+
+    monkeypatch.setattr(cap_mod.subprocess, "run", _fake_run)
+
+    run = run_capability_request(
+        repo_root=tmp_path,
+        registry={},
+        capability_request={"capability": "demo.unknown", "args": {"output": "x.md"}},
+        output_file=tmp_path / "x.md",
+    )
+
+    assert called is False
+    assert run.receipt["success"] is False
+    assert run.receipt["category"] == "validation_error"
+    assert run.receipt["code"] == "unknown_capability"
+
+
+def test_run_generic_capability_request_rejects_unknown_with_malformed_args(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    import cafe.core.capabilities as cap_mod
+
+    called = False
+
+    def _fake_run(*_a: object, **_k: object) -> object:
+        nonlocal called
+        called = True
+        raise AssertionError("unknown capability must not run subprocess")
+
+    monkeypatch.setattr(cap_mod.subprocess, "run", _fake_run)
+
+    run = run_capability_request(
+        repo_root=tmp_path,
+        registry={},
+        capability_request={"capability": "demo.unknown", "args": "bad"},
+        output_file=tmp_path / "x.md",
+    )
+
+    assert called is False
+    assert run.receipt["success"] is False
+    assert run.receipt["category"] == "validation_error"
+    assert run.receipt["code"] == "unknown_capability"
+    assert run.receipt["inputs"] == {}
+
+
+def test_run_generic_capability_request_rejects_unsupported_without_script(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    import cafe.core.capabilities as cap_mod
+
+    called = False
+
+    def _fake_run(*_a: object, **_k: object) -> object:
+        nonlocal called
+        called = True
+        raise AssertionError("unsupported capability must not run subprocess")
+
+    monkeypatch.setattr(cap_mod.subprocess, "run", _fake_run)
+
+    run = run_capability_request(
+        repo_root=tmp_path,
+        registry={"demo.unsupported": {"id": "demo.unsupported", "script_ref": "sync_pr"}},
+        capability_request={"capability": "demo.unsupported", "args": {}},
+        output_file=tmp_path / "output.md",
+    )
+
+    assert called is False
+    assert run.receipt["success"] is False
+    assert run.receipt["category"] == "validation_error"
+    assert run.receipt["code"] == "unsupported_capability"
 
 
 def test_run_pr_publish_validation_missing_output(tmp_path: Path) -> None:
@@ -82,7 +173,9 @@ def test_blackboard_capability_receipts_roundtrip(tmp_path: Path) -> None:
     assert loaded.capability_receipts[0]["correlation_id"] == "abc"
 
 
-def test_run_pr_publish_success_mocked_subprocess(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_run_pr_publish_success_mocked_subprocess(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     import cafe.core.capabilities as cap_mod
 
     out = tmp_path / "pr.md"

--- a/tests/unit/test_capability_registry.py
+++ b/tests/unit/test_capability_registry.py
@@ -209,3 +209,113 @@ def test_run_pr_publish_success_mocked_subprocess(
     assert run.receipt["success"] is True
     assert run.pr_synced_event is not None
     assert run.pr_synced_event["url"] == "https://example/pr/1"
+
+
+def test_run_pr_publish_skips_invalid_base_reference(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import cafe.core.capabilities as cap_mod
+
+    out = tmp_path / "pr.md"
+    out.write_text("# Title\n", encoding="utf-8")
+    rel = str(out.relative_to(tmp_path))
+    calls: list[list[str]] = []
+
+    class _Result:
+        def __init__(self, returncode: int, stdout: str = "", stderr: str = "") -> None:
+            self.returncode = returncode
+            self.stdout = stdout
+            self.stderr = stderr
+
+    def _fake_run(*cmd_args: object, **_kwargs: object) -> _Result:
+        cmd = list(cmd_args[0])
+        calls.append(cmd)
+        if cmd and cmd[0] == "git":
+            return _Result(returncode=1)
+        if cmd and cmd[0] == "/bin/bash":
+            return _Result(
+                returncode=0,
+                stdout='{"pr_url":"https://example/pr/1","pr_number":"1","action":"synced"}\n',
+            )
+        raise AssertionError(f"Unexpected command: {cmd}")
+
+    monkeypatch.setattr(cap_mod.subprocess, "run", _fake_run)
+
+    reg = {
+        CAPABILITY_PR_PUBLISH_ID: {
+            "id": CAPABILITY_PR_PUBLISH_ID,
+            "script_ref": "sync_pr",
+            "args_schema": {"required": ["output"]},
+            "expected_outputs": {"required": ["pr_url", "pr_number"]},
+        }
+    }
+    run = cap_mod.run_pr_publish_capability(
+        repo_root=tmp_path,
+        registry=reg,
+        publish_request={
+            "capability": CAPABILITY_PR_PUBLISH_ID,
+            "args": {"output": rel, "base": "codex/alignment-policy-escalation"},
+        },
+        pr_markdown_file=out,
+    )
+    assert run.receipt["success"] is True
+
+    bash_calls = [cmd for cmd in calls if cmd and cmd[0] == "/bin/bash"]
+    assert bash_calls, "sync_pr command was not invoked"
+    assert "--base" not in bash_calls[0]
+
+
+def test_run_pr_publish_skips_local_only_base_reference(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    import cafe.core.capabilities as cap_mod
+
+    out = tmp_path / "pr.md"
+    out.write_text("# Title\n", encoding="utf-8")
+    rel = str(out.relative_to(tmp_path))
+    calls: list[list[str]] = []
+
+    class _Result:
+        def __init__(self, returncode: int, stdout: str = "", stderr: str = "") -> None:
+            self.returncode = returncode
+            self.stdout = stdout
+            self.stderr = stderr
+
+    def _fake_run(*cmd_args: object, **_kwargs: object) -> _Result:
+        cmd = list(cmd_args[0])
+        calls.append(cmd)
+        if cmd and cmd[0] == "git":
+            ref = str(cmd[-1])
+            return _Result(returncode=0 if ref.startswith("refs/heads/") else 1)
+        if cmd and cmd[0] == "/bin/bash":
+            return _Result(
+                returncode=0,
+                stdout='{"pr_url":"https://example/pr/1","pr_number":"1","action":"synced"}\n',
+            )
+        raise AssertionError(f"Unexpected command: {cmd}")
+
+    monkeypatch.setattr(cap_mod.subprocess, "run", _fake_run)
+
+    reg = {
+        CAPABILITY_PR_PUBLISH_ID: {
+            "id": CAPABILITY_PR_PUBLISH_ID,
+            "script_ref": "sync_pr",
+            "args_schema": {"required": ["output"]},
+            "expected_outputs": {"required": ["pr_url", "pr_number"]},
+        }
+    }
+    run = cap_mod.run_pr_publish_capability(
+        repo_root=tmp_path,
+        registry=reg,
+        publish_request={
+            "capability": CAPABILITY_PR_PUBLISH_ID,
+            "args": {"output": rel, "base": "codex/alignment-policy-escalation"},
+        },
+        pr_markdown_file=out,
+    )
+    assert run.receipt["success"] is True
+
+    bash_calls = [cmd for cmd in calls if cmd and cmd[0] == "/bin/bash"]
+    assert bash_calls, "sync_pr command was not invoked"
+    assert "--base" not in bash_calls[0]

--- a/tests/unit/test_chat.py
+++ b/tests/unit/test_chat.py
@@ -2,7 +2,6 @@
 
 import json
 import os
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -72,13 +71,17 @@ class TestLaunchChatSession:
     @patch("cafe.ui.chat.subprocess.run")
     @patch("cafe.ui.chat.ConfigManager")
     @patch("cafe.ui.chat.AgentManager")
-    def test_claude_cli_with_session_and_model(self, mock_agent_manager_cls, mock_config_manager_cls, mock_run):
+    def test_claude_cli_with_session_and_model(
+        self, mock_agent_manager_cls, mock_config_manager_cls, mock_run
+    ):
         """Test building CLI command for claude with session and model."""
         mock_config = MagicMock()
         mock_config.get.return_value = {"name": "David", "cli": "claude", "model": "sonnet"}
         mock_config_manager_cls.return_value = mock_config
 
-        agent_manager = self._make_agent_manager("David", "claude", session_id="sess-abc", model="sonnet")
+        agent_manager = self._make_agent_manager(
+            "David", "claude", session_id="sess-abc", model="sonnet"
+        )
         mock_agent_manager_cls.return_value = agent_manager
 
         mock_run.return_value = MagicMock(returncode=0)
@@ -91,7 +94,9 @@ class TestLaunchChatSession:
     @patch("cafe.ui.chat.subprocess.run")
     @patch("cafe.ui.chat.ConfigManager")
     @patch("cafe.ui.chat.AgentManager")
-    def test_copilot_cli_with_session(self, mock_agent_manager_cls, mock_config_manager_cls, mock_run):
+    def test_copilot_cli_with_session(
+        self, mock_agent_manager_cls, mock_config_manager_cls, mock_run
+    ):
         """Test building CLI command for copilot with session."""
         mock_config = MagicMock()
         mock_config.get.return_value = {"name": "Roger", "cli": "copilot"}
@@ -137,7 +142,9 @@ class TestLaunchChatSession:
         }
         mock_config_manager_cls.return_value = mock_config
 
-        agent_manager = self._make_agent_manager("David", "codex", session_id=None, model="gpt-5.3-codex")
+        agent_manager = self._make_agent_manager(
+            "David", "codex", session_id=None, model="gpt-5.3-codex"
+        )
         mock_agent_manager_cls.return_value = agent_manager
         mock_run.return_value = MagicMock(returncode=0)
 
@@ -152,26 +159,76 @@ class TestLaunchChatSession:
     @patch("cafe.ui.chat.subprocess.run")
     @patch("cafe.ui.chat.ConfigManager")
     @patch("cafe.ui.chat.AgentManager")
-    def test_gemini_cli_with_session_and_model(self, mock_agent_manager_cls, mock_config_manager_cls, mock_run):
-        """Test building CLI command for gemini with session and model."""
+    def test_chat_session_accepts_alignment_context_env(
+        self,
+        mock_agent_manager_cls,
+        mock_config_manager_cls,
+        mock_run,
+    ):
         mock_config = MagicMock()
-        mock_config.get.return_value = {"name": "Richard", "cli": "gemini", "model": "gemini-2.5-pro"}
+        mock_config.get.return_value = {"name": "Roger", "cli": "claude"}
         mock_config_manager_cls.return_value = mock_config
 
-        agent_manager = self._make_agent_manager("Richard", "gemini", session_id="sess-gem", model="gemini-2.5-pro")
+        agent_manager = self._make_agent_manager("Roger", "claude", session_id=None)
+        mock_agent_manager_cls.return_value = agent_manager
+        mock_run.return_value = MagicMock(returncode=0)
+
+        result = launch_chat_session(
+            "pm",
+            "issue123",
+            chat_mode="alignment",
+            extra_env={
+                "CAFE_ALIGNMENT_REQUEST_FILE": "/tmp/request.json",
+                "CAFE_ALIGNMENT_DECISION_FILE": "/tmp/decision.json",
+            },
+        )
+
+        assert result == 0
+        env = mock_run.call_args.kwargs["env"]
+        assert env["CAFE_CHAT_MODE"] == "alignment"
+        assert env["CAFE_ISSUE_NAME"] == "issue123"
+        assert env["CAFE_ALIGNMENT_REQUEST_FILE"] == "/tmp/request.json"
+        assert env["CAFE_ALIGNMENT_DECISION_FILE"] == "/tmp/decision.json"
+
+    @patch("cafe.ui.chat.subprocess.run")
+    @patch("cafe.ui.chat.ConfigManager")
+    @patch("cafe.ui.chat.AgentManager")
+    def test_gemini_cli_with_session_and_model(
+        self, mock_agent_manager_cls, mock_config_manager_cls, mock_run
+    ):
+        """Test building CLI command for gemini with session and model."""
+        mock_config = MagicMock()
+        mock_config.get.return_value = {
+            "name": "Richard",
+            "cli": "gemini",
+            "model": "gemini-2.5-pro",
+        }
+        mock_config_manager_cls.return_value = mock_config
+
+        agent_manager = self._make_agent_manager(
+            "Richard", "gemini", session_id="sess-gem", model="gemini-2.5-pro"
+        )
         mock_agent_manager_cls.return_value = agent_manager
 
         mock_run.return_value = MagicMock(returncode=0)
 
         launch_chat_session("reviewer", "issue123")
 
-        assert mock_run.call_args.args[0] == ["gemini", "--resume", "sess-gem", "--model", "gemini-2.5-pro"]
+        assert mock_run.call_args.args[0] == [
+            "gemini",
+            "--resume",
+            "sess-gem",
+            "--model",
+            "gemini-2.5-pro",
+        ]
         assert "env" in mock_run.call_args.kwargs
 
     @patch("cafe.ui.chat.subprocess.run")
     @patch("cafe.ui.chat.ConfigManager")
     @patch("cafe.ui.chat.AgentManager")
-    def test_cursor_agent_cli_with_session(self, mock_agent_manager_cls, mock_config_manager_cls, mock_run):
+    def test_cursor_agent_cli_with_session(
+        self, mock_agent_manager_cls, mock_config_manager_cls, mock_run
+    ):
         """Test building CLI command for cursor-agent with session (uses --resume flag)."""
         mock_config = MagicMock()
         mock_config.get.return_value = {"name": "David", "cli": "cursor-agent"}
@@ -190,7 +247,9 @@ class TestLaunchChatSession:
     @patch("builtins.print")
     @patch("cafe.ui.chat.ConfigManager")
     @patch("cafe.ui.chat.AgentManager")
-    def test_missing_cli_tool_prints_warning(self, mock_agent_manager_cls, mock_config_manager_cls, mock_print):
+    def test_missing_cli_tool_prints_warning(
+        self, mock_agent_manager_cls, mock_config_manager_cls, mock_print
+    ):
         """Test that a missing CLI tool prints a warning and does not raise."""
         mock_config = MagicMock()
         mock_config.get.return_value = {"name": "David", "cli": "claude"}
@@ -209,7 +268,9 @@ class TestLaunchChatSession:
     @patch("builtins.print")
     @patch("cafe.ui.chat.ConfigManager")
     @patch("cafe.ui.chat.AgentManager")
-    def test_no_agent_config_prints_warning(self, mock_agent_manager_cls, mock_config_manager_cls, mock_print):
+    def test_no_agent_config_prints_warning(
+        self, mock_agent_manager_cls, mock_config_manager_cls, mock_print
+    ):
         """Test that missing agent config prints a warning and does not raise."""
         mock_config = MagicMock()
         mock_config.get.return_value = None  # No agent config
@@ -223,7 +284,9 @@ class TestLaunchChatSession:
     @patch("cafe.ui.chat.subprocess.run")
     @patch("cafe.ui.chat.ConfigManager")
     @patch("cafe.ui.chat.AgentManager")
-    def test_passes_issue_name_to_agent_manager(self, mock_agent_manager_cls, mock_config_manager_cls, mock_run):
+    def test_passes_issue_name_to_agent_manager(
+        self, mock_agent_manager_cls, mock_config_manager_cls, mock_run
+    ):
         """Test that issue_name is passed to AgentManager for session resolution."""
         mock_config = MagicMock()
         mock_config.get.return_value = {"name": "David", "cli": "claude"}
@@ -308,7 +371,9 @@ class TestLaunchChatSession:
         mock_config.get.return_value = {"name": "Nick", "cli": "codex", "model": "gpt-5.4"}
         mock_config_manager_cls.return_value = mock_config
 
-        agent_manager = self._make_agent_manager("Nick", "codex", session_id="sess-codex", model="gpt-5.4")
+        agent_manager = self._make_agent_manager(
+            "Nick", "codex", session_id="sess-codex", model="gpt-5.4"
+        )
         mock_agent_manager_cls.return_value = agent_manager
         mock_run.return_value = MagicMock(returncode=0)
 
@@ -324,11 +389,52 @@ class TestLaunchChatSession:
             "issue123",
         )
 
+    @patch("cafe.ui.chat.subprocess.run")
+    @patch("cafe.ui.chat.ConfigManager")
+    @patch("cafe.ui.chat.AgentManager")
+    def test_codex_chat_accepts_initial_prompt(
+        self,
+        mock_agent_manager_cls,
+        mock_config_manager_cls,
+        mock_run,
+    ):
+        """Test Codex interactive launch receives an initial prompt."""
+        mock_config = MagicMock()
+        mock_config.get.return_value = {"name": "Nick", "cli": "codex", "model": "gpt-5.4"}
+        mock_config_manager_cls.return_value = mock_config
+
+        agent_manager = self._make_agent_manager(
+            "Nick", "codex", session_id="sess-codex", model="gpt-5.4"
+        )
+        mock_agent_manager_cls.return_value = agent_manager
+        mock_run.return_value = MagicMock(returncode=0)
+
+        result = launch_chat_session(
+            "developer",
+            "issue123",
+            initial_prompt="Please guide this alignment decision.",
+        )
+
+        assert result == 0
+        assert mock_run.call_args.args[0] == [
+            "codex",
+            "--model",
+            "gpt-5.4",
+            "resume",
+            "sess-codex",
+            "Please guide this alignment decision.",
+        ]
+        assert (
+            mock_run.call_args.kwargs["env"]["CAFE_CHAT_INITIAL_PROMPT"]
+            == "Please guide this alignment decision."
+        )
+
 
 def test_prepare_chat_environment_installs_chat_skills_only() -> None:
-    with patch("cafe.ui.chat.SkillLoader.discover"), patch(
-        "cafe.ui.chat.NativeSkillBridge.install_skill"
-    ) as mock_install:
+    with (
+        patch("cafe.ui.chat.SkillLoader.discover"),
+        patch("cafe.ui.chat.NativeSkillBridge.install_skill") as mock_install,
+    ):
         _prepare_chat_environment(
             agent_cli=AgentCLI.CODEX,
         )
@@ -339,10 +445,13 @@ def test_prepare_chat_environment_installs_chat_skills_only() -> None:
         "cafe-chat-develop-change",
         "cafe-chat-spec-revision",
         "cafe-chat-plan-revision",
+        "cafe-chat-alignment-decision",
     ]
 
 
-def test_latest_role_iteration_cli_infers_codex_for_legacy_fallback_metadata(tmp_path, monkeypatch) -> None:
+def test_latest_role_iteration_cli_infers_codex_for_legacy_fallback_metadata(
+    tmp_path, monkeypatch
+) -> None:
     monkeypatch.chdir(tmp_path)
     issue_dir = tmp_path / ".cafe" / "issues" / "issue123"
     iteration_dir = issue_dir / "develop" / "iteration_001"
@@ -452,7 +561,9 @@ def test_launch_chat_session_uses_playbook_role_defaults(
     assert registered_config.cli == AgentCLI.CLAUDE
 
 
-def test_prepare_chat_handoff_state_creates_blackboard_and_clears_stale_baton(tmp_path, monkeypatch) -> None:
+def test_prepare_chat_handoff_state_creates_blackboard_and_clears_stale_baton(
+    tmp_path, monkeypatch
+) -> None:
     monkeypatch.chdir(tmp_path)
     issue_dir = tmp_path / ".cafe" / "issues" / "issue123"
     next_step_path = get_chat_next_step_path(issue_dir)
@@ -472,7 +583,9 @@ def test_prepare_chat_handoff_state_creates_blackboard_and_clears_stale_baton(tm
     assert next_step_path.exists()
 
 
-def test_prepare_chat_handoff_state_preserves_user_clarification_baton(tmp_path, monkeypatch) -> None:
+def test_prepare_chat_handoff_state_preserves_user_clarification_baton(
+    tmp_path, monkeypatch
+) -> None:
     monkeypatch.chdir(tmp_path)
     issue_dir = tmp_path / ".cafe" / "issues" / "issue123"
     store = BlackboardStore(issue_dir)

--- a/tests/unit/test_cli_workflow_command.py
+++ b/tests/unit/test_cli_workflow_command.py
@@ -4,17 +4,24 @@ import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import pytest
 from typer.testing import CliRunner
 
 from cafe.agents.executor import AgentExecutionError
 from cafe.core.blackboard import BlackboardStore, HandoffIntent, HandoffOwner
 from cafe.core.git import BranchHealth
 from cafe.core.workflow_models import StepExecutionResult
-from cafe.ui.cli import app, _execute_single_step_alias, _find_external_resume_step, _handle_user_phase
-from cafe.ui.cli_shared import _build_workflow_step_executor
+from cafe.ui.cli import (
+    app,
+    _execute_single_step_alias,
+    _find_external_resume_step,
+    _handle_user_phase,
+)
+from cafe.ui.cli_shared import (
+    _alignment_checkpoint_menu_choices,
+    _build_workflow_step_executor,
+    apply_alignment_decision_from_payload,
+)
 from cafe.utils.config import ConfigManager
-
 
 runner = CliRunner()
 
@@ -29,7 +36,11 @@ def _result(
 ) -> StepExecutionResult:
     return StepExecutionResult(
         response=status_code,
-        artifacts=artifacts if artifacts is not None else {str(step_def.get("output_artifact", step_name)): f"{step_name}/output.md"},
+        artifacts=(
+            artifacts
+            if artifacts is not None
+            else {str(step_def.get("output_artifact", step_name)): f"{step_name}/output.md"}
+        ),
         status_code=status_code,
         events=events or [],
     )
@@ -57,7 +68,41 @@ def _handoff_to_step(
     )
 
 
-def test_single_step_alias_updates_workflow_pointer_to_requested_step(tmp_path: Path, monkeypatch) -> None:
+def test_alignment_checkpoint_menu_is_chat_first_and_concise() -> None:
+    choices = _alignment_checkpoint_menu_choices(
+        "Roger",
+        [
+            "approve",
+            "narrow_scope",
+            "revise_spec",
+            "revise_plan",
+            "update_strategic_documents_first",
+            "strategic_documents_updated",
+            "manual_pause",
+            "reject_or_defer",
+        ],
+    )
+
+    assert choices == [
+        {"name": "Chat with Roger about alignment", "value": "chat_alignment"},
+        {"name": "Approve and continue", "value": "approve"},
+        {"name": "Strategic documents updated", "value": "strategic_documents_updated"},
+        {"name": "Pause for manual decision", "value": "manual_pause"},
+    ]
+
+
+def test_alignment_checkpoint_menu_hides_disallowed_direct_decisions() -> None:
+    choices = _alignment_checkpoint_menu_choices("Roger", ["approve"])
+
+    assert choices == [
+        {"name": "Chat with Roger about alignment", "value": "chat_alignment"},
+        {"name": "Approve and continue", "value": "approve"},
+    ]
+
+
+def test_single_step_alias_updates_workflow_pointer_to_requested_step(
+    tmp_path: Path, monkeypatch
+) -> None:
     monkeypatch.chdir(tmp_path)
     issue_dir = tmp_path / ".cafe" / "issues" / "issue-210"
     issue_dir.mkdir(parents=True, exist_ok=True)
@@ -81,8 +126,15 @@ def test_single_step_alias_updates_workflow_pointer_to_requested_step(tmp_path: 
         def __init__(self) -> None:
             self.agent_manager = MagicMock()
 
-        def execute_step(self, step_name: str, step_def: dict, blackboard_state: object, **kwargs) -> StepExecutionResult:
-            return _result(status_code="no_changes_needed", step_name=step_name, step_def=step_def, artifacts={})
+        def execute_step(
+            self, step_name: str, step_def: dict, blackboard_state: object, **kwargs
+        ) -> StepExecutionResult:
+            return _result(
+                status_code="no_changes_needed",
+                step_name=step_name,
+                step_def=step_def,
+                artifacts={},
+            )
 
     with patch("cafe.ui.cli._build_workflow_step_executor", return_value=FakeExecutor()):
         result = _execute_single_step_alias(
@@ -119,7 +171,9 @@ def test_workflow_command_runs_execute_mode(tmp_path: Path, monkeypatch) -> None
     executed_steps: list[str] = []
 
     class FakeExecutor:
-        def execute_step(self, step_name: str, step_def: dict, blackboard_state: object, **kwargs) -> StepExecutionResult:
+        def execute_step(
+            self, step_name: str, step_def: dict, blackboard_state: object, **kwargs
+        ) -> StepExecutionResult:
             executed_steps.append(step_name)
             if step_name == "pr":
                 _handoff_to_step(
@@ -134,7 +188,9 @@ def test_workflow_command_runs_execute_mode(tmp_path: Path, monkeypatch) -> None
 
     with (
         patch("cafe.ui.cli.GitOperations") as mock_git_cls,
-        patch("cafe.ui.cli._build_workflow_step_executor", return_value=FakeExecutor()) as mock_builder,
+        patch(
+            "cafe.ui.cli._build_workflow_step_executor", return_value=FakeExecutor()
+        ) as mock_builder,
     ):
         git = MagicMock()
         git.get_current_branch.return_value = "issue-200"
@@ -154,16 +210,22 @@ def test_workflow_command_runs_execute_mode(tmp_path: Path, monkeypatch) -> None
         assert executed_steps == ["spec", "plan", "develop", "review", "pr"]
 
 
-def test_workflow_command_passes_initial_user_input_to_spec_step(tmp_path: Path, monkeypatch) -> None:
+def test_workflow_command_passes_initial_user_input_to_spec_step(
+    tmp_path: Path, monkeypatch
+) -> None:
     monkeypatch.chdir(tmp_path)
 
     class FakeExecutor:
-        def execute_step(self, step_name: str, step_def: dict, blackboard_state: object, **kwargs) -> StepExecutionResult:
+        def execute_step(
+            self, step_name: str, step_def: dict, blackboard_state: object, **kwargs
+        ) -> StepExecutionResult:
             return _result(status_code="confirmed", step_name=step_name, step_def=step_def)
 
     with (
         patch("cafe.ui.cli.GitOperations") as mock_git_cls,
-        patch("cafe.ui.cli._build_workflow_step_executor", return_value=FakeExecutor()) as mock_builder,
+        patch(
+            "cafe.ui.cli._build_workflow_step_executor", return_value=FakeExecutor()
+        ) as mock_builder,
     ):
         git = MagicMock()
         git.get_current_branch.return_value = "issue-201"
@@ -188,16 +250,22 @@ def test_workflow_command_passes_initial_user_input_to_spec_step(tmp_path: Path,
     }
 
 
-def test_workflow_command_passes_initial_user_input_to_question_step(tmp_path: Path, monkeypatch) -> None:
+def test_workflow_command_passes_initial_user_input_to_question_step(
+    tmp_path: Path, monkeypatch
+) -> None:
     monkeypatch.chdir(tmp_path)
 
     class FakeExecutor:
-        def execute_step(self, step_name: str, step_def: dict, blackboard_state: object, **kwargs) -> StepExecutionResult:
+        def execute_step(
+            self, step_name: str, step_def: dict, blackboard_state: object, **kwargs
+        ) -> StepExecutionResult:
             return _result(status_code="confirmed", step_name=step_name, step_def=step_def)
 
     with (
         patch("cafe.ui.cli.GitOperations") as mock_git_cls,
-        patch("cafe.ui.cli._build_workflow_step_executor", return_value=FakeExecutor()) as mock_builder,
+        patch(
+            "cafe.ui.cli._build_workflow_step_executor", return_value=FakeExecutor()
+        ) as mock_builder,
     ):
         git = MagicMock()
         git.get_current_branch.return_value = "issue-research-input"
@@ -221,16 +289,22 @@ def test_workflow_command_passes_initial_user_input_to_question_step(tmp_path: P
     }
 
 
-def test_workflow_command_passes_initial_user_input_to_brief_step(tmp_path: Path, monkeypatch) -> None:
+def test_workflow_command_passes_initial_user_input_to_brief_step(
+    tmp_path: Path, monkeypatch
+) -> None:
     monkeypatch.chdir(tmp_path)
 
     class FakeExecutor:
-        def execute_step(self, step_name: str, step_def: dict, blackboard_state: object, **kwargs) -> StepExecutionResult:
+        def execute_step(
+            self, step_name: str, step_def: dict, blackboard_state: object, **kwargs
+        ) -> StepExecutionResult:
             return _result(status_code="confirmed", step_name=step_name, step_def=step_def)
 
     with (
         patch("cafe.ui.cli.GitOperations") as mock_git_cls,
-        patch("cafe.ui.cli._build_workflow_step_executor", return_value=FakeExecutor()) as mock_builder,
+        patch(
+            "cafe.ui.cli._build_workflow_step_executor", return_value=FakeExecutor()
+        ) as mock_builder,
     ):
         git = MagicMock()
         git.get_current_branch.return_value = "issue-editorial-input"
@@ -254,7 +328,9 @@ def test_workflow_command_passes_initial_user_input_to_brief_step(tmp_path: Path
     }
 
 
-def test_workflow_fallback_rebuild_passes_entry_point_user_input(tmp_path: Path, monkeypatch) -> None:
+def test_workflow_fallback_rebuild_passes_entry_point_user_input(
+    tmp_path: Path, monkeypatch
+) -> None:
     """Fallback executor rebuild should keep entry-point keyed step_user_inputs."""
     monkeypatch.chdir(tmp_path)
     cafe_dir = tmp_path / ".cafe"
@@ -271,7 +347,9 @@ def test_workflow_fallback_rebuild_passes_entry_point_user_input(tmp_path: Path,
     execute_calls = {"count": 0}
 
     class FakeExecutor:
-        def execute_step(self, step_name: str, step_def: dict, blackboard_state: object, **kwargs) -> StepExecutionResult:
+        def execute_step(
+            self, step_name: str, step_def: dict, blackboard_state: object, **kwargs
+        ) -> StepExecutionResult:
             execute_calls["count"] += 1
             if execute_calls["count"] == 1:
                 raise AgentExecutionError("rate limit", error_type="rate_limit")
@@ -308,7 +386,9 @@ def test_workflow_fallback_rebuild_passes_entry_point_user_input(tmp_path: Path,
     assert builder_calls == [{"develop": user_text}, {"develop": user_text}]
 
 
-def test_workflow_command_resume_user_input_targets_handoff_from_step(tmp_path: Path, monkeypatch) -> None:
+def test_workflow_command_resume_user_input_targets_handoff_from_step(
+    tmp_path: Path, monkeypatch
+) -> None:
     monkeypatch.chdir(tmp_path)
     issue_dir = tmp_path / ".cafe" / "issues" / "issue-resume-plan"
     issue_dir.mkdir(parents=True, exist_ok=True)
@@ -326,12 +406,16 @@ def test_workflow_command_resume_user_input_targets_handoff_from_step(tmp_path: 
     )
 
     class FakeExecutor:
-        def execute_step(self, step_name: str, step_def: dict, blackboard_state: object, **kwargs) -> StepExecutionResult:
+        def execute_step(
+            self, step_name: str, step_def: dict, blackboard_state: object, **kwargs
+        ) -> StepExecutionResult:
             return _result(status_code="confirmed", step_name=step_name, step_def=step_def)
 
     with (
         patch("cafe.ui.cli.GitOperations") as mock_git_cls,
-        patch("cafe.ui.cli._build_workflow_step_executor", return_value=FakeExecutor()) as mock_builder,
+        patch(
+            "cafe.ui.cli._build_workflow_step_executor", return_value=FakeExecutor()
+        ) as mock_builder,
     ):
         git = MagicMock()
         git.get_current_branch.return_value = "issue-resume-plan"
@@ -377,7 +461,10 @@ def test_user_phase_alignment_checkpoint_approve_resumes_step(tmp_path: Path) ->
     )
     playbook_data = {
         "playbook": {"id": "default"},
-        "steps": {"develop": {"role": "developer", "on": {"await_agent": "review"}}, "review": {"role": "reviewer", "on": {}}},
+        "steps": {
+            "develop": {"role": "developer", "on": {"await_agent": "review"}},
+            "review": {"role": "reviewer", "on": {}},
+        },
     }
     store = BlackboardStore(issue_dir)
     blackboard = store.load_or_create("user", playbook_id="default")
@@ -392,7 +479,13 @@ def test_user_phase_alignment_checkpoint_approve_resumes_step(tmp_path: Path) ->
         source="test",
     )
 
-    with patch("cafe.ui.inquirer_prompts.prompt_list", return_value="approve"):
+    def fake_prompt_list(message: str, choices: list[dict[str, str]], default: str | None = None):
+        assert message == "How should this alignment checkpoint continue?"
+        assert choices[0]["value"] == "chat_alignment"
+        assert default == "chat_alignment"
+        return "approve"
+
+    with patch("cafe.ui.inquirer_prompts.prompt_list", side_effect=fake_prompt_list):
         result = _handle_user_phase(
             issue_name="issue-align-user",
             issue_dir=issue_dir,
@@ -407,16 +500,543 @@ def test_user_phase_alignment_checkpoint_approve_resumes_step(tmp_path: Path) ->
     assert reloaded.handoff_contract.intent == HandoffIntent.AWAIT_AGENT
 
 
+def test_user_phase_alignment_checkpoint_chat_decision_uses_host_apply(
+    tmp_path: Path,
+) -> None:
+    issue_dir = tmp_path / ".cafe" / "issues" / "issue-align-chat"
+    request_dir = issue_dir / "spec" / "iteration_001"
+    request_dir.mkdir(parents=True, exist_ok=True)
+    request_file = request_dir / "alignment_request.json"
+    request_file.write_text(
+        json.dumps(
+            {
+                "fingerprint": "fp-chat",
+                "from_step": "spec",
+                "recommended_resume_target": "spec",
+                "strategic_document_update_requirements": [],
+                "allowed_decisions": ["narrow_scope"],
+                "affected_documents": [
+                    {
+                        "category": "roadmap",
+                        "path": "docs/roadmap.md",
+                        "status": "exists",
+                        "exists": True,
+                    },
+                    {
+                        "category": "positioning",
+                        "path": "docs/positioning.md",
+                        "status": "missing",
+                        "exists": False,
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    playbook_data = {
+        "playbook": {"id": "default"},
+        "roles": {"pm": {"default_agent": "Roger"}},
+        "steps": {
+            "spec": {"role": "pm", "chat_role": "pm", "on": {"await_agent": "plan"}},
+            "plan": {"role": "developer", "on": {}},
+        },
+    }
+    store = BlackboardStore(issue_dir)
+    blackboard = store.load_or_create("user", playbook_id="default")
+    store.set_current_step(blackboard, "user")
+    store.update_handoff_contract(
+        blackboard,
+        from_step="spec",
+        to_owner=HandoffOwner.USER,
+        to_step="user",
+        intent=HandoffIntent.ALIGNMENT_CHECKPOINT,
+        status_code="alignment_checkpoint",
+        source="test",
+    )
+
+    def fake_chat(role: str, issue_name: str, **kwargs):
+        assert role == "pm"
+        assert issue_name == "issue-align-chat"
+        assert kwargs["chat_mode"] == "alignment"
+        initial_prompt = kwargs["initial_prompt"]
+        assert "alignment checkpoint chat" in initial_prompt
+        assert str(request_file) in initial_prompt
+        assert "Decision output file:" in initial_prompt
+        assert "narrow_scope" in initial_prompt
+        assert "Existing strategic docs:" in initial_prompt
+        assert "roadmap:exists (docs/roadmap.md)" in initial_prompt
+        assert "Missing/unconfigured strategic categories:" in initial_prompt
+        assert "positioning:missing (docs/positioning.md)" in initial_prompt
+        assert "Chat-mode decision mapping:" in initial_prompt
+        assert "Option 2 starts strategic document alignment" in initial_prompt
+        assert "does not by itself approve document content" in initial_prompt
+        assert "strategic_documents_updated" in initial_prompt
+        assert "user_confirmed" in initial_prompt
+        assert "user_confirmation" in initial_prompt
+        assert "Write update_strategic_documents_first only" in initial_prompt
+        assert "Do not edit the blackboard" in initial_prompt
+        extra_env = kwargs["extra_env"]
+        assert extra_env["CAFE_ALIGNMENT_REQUEST_FILE"] == str(request_file)
+        decision_file = Path(extra_env["CAFE_ALIGNMENT_DECISION_FILE"])
+        decision_file.write_text(
+            json.dumps(
+                {
+                    "decision": "narrow_scope",
+                    "correction": "Keep this issue limited to capability request UX.",
+                }
+            ),
+            encoding="utf-8",
+        )
+        return 0
+
+    with (
+        patch("cafe.ui.inquirer_prompts.prompt_list", return_value="chat_alignment"),
+        patch("cafe.ui.cli.launch_chat_session", side_effect=fake_chat),
+    ):
+        result = _handle_user_phase(
+            issue_name="issue-align-chat",
+            issue_dir=issue_dir,
+            playbook_data=playbook_data,
+            blackboard=blackboard,
+        )
+
+    assert result == "spec"
+    assert (request_dir / "user_input.md").read_text(encoding="utf-8") == (
+        "Keep this issue limited to capability request UX."
+    )
+    reloaded = store.load_or_create("spec", playbook_id="default")
+    assert reloaded.current_step == "spec"
+    assert reloaded.handoff_contract is not None
+    assert reloaded.handoff_contract.intent == HandoffIntent.AWAIT_AGENT
+
+
+def test_user_phase_alignment_checkpoint_rejects_chat_decision_outside_allowed_choices(
+    tmp_path: Path,
+) -> None:
+    issue_dir = tmp_path / ".cafe" / "issues" / "issue-align-chat-blocked"
+    request_dir = issue_dir / "spec" / "iteration_001"
+    request_dir.mkdir(parents=True, exist_ok=True)
+    (request_dir / "alignment_request.json").write_text(
+        json.dumps(
+            {
+                "fingerprint": "fp-chat-blocked",
+                "from_step": "spec",
+                "recommended_resume_target": "spec",
+                "strategic_document_update_requirements": [],
+                "allowed_decisions": ["approve"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    playbook_data = {
+        "playbook": {"id": "default"},
+        "roles": {"pm": {"default_agent": "Roger"}},
+        "steps": {
+            "spec": {"role": "pm", "chat_role": "pm", "on": {"await_agent": "plan"}},
+            "plan": {"role": "developer", "on": {}},
+        },
+    }
+    store = BlackboardStore(issue_dir)
+    blackboard = store.load_or_create("user", playbook_id="default")
+    store.set_current_step(blackboard, "user")
+    store.update_handoff_contract(
+        blackboard,
+        from_step="spec",
+        to_owner=HandoffOwner.USER,
+        to_step="user",
+        intent=HandoffIntent.ALIGNMENT_CHECKPOINT,
+        status_code="alignment_checkpoint",
+        source="test",
+    )
+
+    def fake_chat(_role: str, _issue_name: str, **kwargs):
+        Path(kwargs["extra_env"]["CAFE_ALIGNMENT_DECISION_FILE"]).write_text(
+            json.dumps({"decision": "narrow_scope", "correction": "Try to narrow anyway."}),
+            encoding="utf-8",
+        )
+        return 0
+
+    with (
+        patch("cafe.ui.inquirer_prompts.prompt_list", return_value="chat_alignment"),
+        patch("cafe.ui.cli.launch_chat_session", side_effect=fake_chat),
+    ):
+        result = _handle_user_phase(
+            issue_name="issue-align-chat-blocked",
+            issue_dir=issue_dir,
+            playbook_data=playbook_data,
+            blackboard=blackboard,
+        )
+
+    assert result is None
+    reloaded = store.load_or_create("user", playbook_id="default")
+    assert reloaded.current_step == "user"
+    assert reloaded.handoff_contract is not None
+    assert reloaded.handoff_contract.intent == HandoffIntent.ALIGNMENT_CHECKPOINT
+    assert not (request_dir / "user_input.md").exists()
+
+
+def test_user_phase_alignment_checkpoint_rejects_unconfirmed_chat_strategic_docs(
+    tmp_path: Path,
+) -> None:
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir(parents=True)
+    (docs_dir / "positioning.md").write_text(
+        "# Positioning\n\nDraft positioning.\n", encoding="utf-8"
+    )
+    cafe_dir = tmp_path / ".cafe"
+    cafe_dir.mkdir(parents=True, exist_ok=True)
+    (cafe_dir / "strategic_context.yaml").write_text(
+        "version: 1\n"
+        "documents:\n"
+        "  positioning:\n"
+        "    path: docs/positioning.md\n"
+        "    status: exists\n",
+        encoding="utf-8",
+    )
+    issue_dir = cafe_dir / "issues" / "issue-align-unconfirmed-docs"
+    request_dir = issue_dir / "spec" / "iteration_001"
+    request_dir.mkdir(parents=True, exist_ok=True)
+    (request_dir / "alignment_request.json").write_text(
+        json.dumps(
+            {
+                "fingerprint": "fp-unconfirmed-docs",
+                "from_step": "spec",
+                "recommended_resume_target": "spec",
+                "strategic_document_update_requirements": [],
+                "affected_documents": [
+                    {
+                        "category": "positioning",
+                        "path": "docs/positioning.md",
+                        "status": "missing",
+                        "sha256": None,
+                        "exists": False,
+                    }
+                ],
+                "allowed_decisions": ["strategic_documents_updated"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    playbook_data = {
+        "playbook": {"id": "default"},
+        "roles": {"pm": {"default_agent": "Roger"}},
+        "steps": {
+            "spec": {"role": "pm", "chat_role": "pm", "on": {"await_agent": "plan"}},
+            "plan": {"role": "developer", "on": {}},
+        },
+    }
+    store = BlackboardStore(issue_dir)
+    blackboard = store.load_or_create("user", playbook_id="default")
+    store.set_current_step(blackboard, "user")
+    store.update_handoff_contract(
+        blackboard,
+        from_step="spec",
+        to_owner=HandoffOwner.USER,
+        to_step="user",
+        intent=HandoffIntent.ALIGNMENT_CHECKPOINT,
+        status_code="alignment_checkpoint",
+        source="test",
+    )
+
+    def fake_chat(_role: str, _issue_name: str, **kwargs):
+        Path(kwargs["extra_env"]["CAFE_ALIGNMENT_DECISION_FILE"]).write_text(
+            json.dumps(
+                {
+                    "decision": "strategic_documents_updated",
+                    "reason": "Created positioning from existing roadmap context.",
+                }
+            ),
+            encoding="utf-8",
+        )
+        return 0
+
+    with (
+        patch("cafe.ui.inquirer_prompts.prompt_list", return_value="chat_alignment"),
+        patch("cafe.ui.cli.launch_chat_session", side_effect=fake_chat),
+    ):
+        result = _handle_user_phase(
+            issue_name="issue-align-unconfirmed-docs",
+            issue_dir=issue_dir,
+            playbook_data=playbook_data,
+            blackboard=blackboard,
+        )
+
+    assert result is None
+    reloaded = store.load_or_create("user", playbook_id="default")
+    assert reloaded.current_step == "user"
+    assert reloaded.handoff_contract is not None
+    assert reloaded.handoff_contract.intent == HandoffIntent.ALIGNMENT_CHECKPOINT
+    assert any(
+        event.event_type == "alignment_decision_blocked"
+        and event.data.get("reason") == "missing_user_confirmation"
+        for event in reloaded.events
+    )
+
+
+def test_user_phase_alignment_checkpoint_accepts_confirmed_chat_strategic_docs(
+    tmp_path: Path,
+) -> None:
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir(parents=True)
+    (docs_dir / "positioning.md").write_text(
+        "# Positioning\n\nConfirmed positioning.\n",
+        encoding="utf-8",
+    )
+    cafe_dir = tmp_path / ".cafe"
+    cafe_dir.mkdir(parents=True, exist_ok=True)
+    (cafe_dir / "strategic_context.yaml").write_text(
+        "version: 1\n"
+        "documents:\n"
+        "  positioning:\n"
+        "    path: docs/positioning.md\n"
+        "    status: exists\n",
+        encoding="utf-8",
+    )
+    issue_dir = cafe_dir / "issues" / "issue-align-confirmed-docs"
+    request_dir = issue_dir / "spec" / "iteration_001"
+    request_dir.mkdir(parents=True, exist_ok=True)
+    (request_dir / "alignment_request.json").write_text(
+        json.dumps(
+            {
+                "fingerprint": "fp-confirmed-docs",
+                "from_step": "spec",
+                "recommended_resume_target": "spec",
+                "strategic_document_update_requirements": [],
+                "affected_documents": [
+                    {
+                        "category": "positioning",
+                        "path": "docs/positioning.md",
+                        "status": "missing",
+                        "sha256": None,
+                        "exists": False,
+                    }
+                ],
+                "allowed_decisions": ["strategic_documents_updated"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    playbook_data = {
+        "playbook": {"id": "default"},
+        "roles": {"pm": {"default_agent": "Roger"}},
+        "steps": {
+            "spec": {"role": "pm", "chat_role": "pm", "on": {"await_agent": "plan"}},
+            "plan": {"role": "developer", "on": {}},
+        },
+    }
+    store = BlackboardStore(issue_dir)
+    blackboard = store.load_or_create("user", playbook_id="default")
+    store.set_current_step(blackboard, "user")
+    store.update_handoff_contract(
+        blackboard,
+        from_step="spec",
+        to_owner=HandoffOwner.USER,
+        to_step="user",
+        intent=HandoffIntent.ALIGNMENT_CHECKPOINT,
+        status_code="alignment_checkpoint",
+        source="test",
+    )
+
+    def fake_chat(_role: str, _issue_name: str, **kwargs):
+        Path(kwargs["extra_env"]["CAFE_ALIGNMENT_DECISION_FILE"]).write_text(
+            json.dumps(
+                {
+                    "decision": "strategic_documents_updated",
+                    "reason": "User approved the final positioning document.",
+                    "user_confirmed": True,
+                    "user_confirmation": "User confirmed the final positioning draft after review.",
+                }
+            ),
+            encoding="utf-8",
+        )
+        return 0
+
+    with (
+        patch("cafe.ui.inquirer_prompts.prompt_list", return_value="chat_alignment"),
+        patch("cafe.ui.cli.launch_chat_session", side_effect=fake_chat),
+    ):
+        result = _handle_user_phase(
+            issue_name="issue-align-confirmed-docs",
+            issue_dir=issue_dir,
+            playbook_data=playbook_data,
+            blackboard=blackboard,
+        )
+
+    assert result == "spec"
+    reloaded = store.load_or_create("spec", playbook_id="default")
+    assert reloaded.current_step == "spec"
+    assert reloaded.handoff_contract is not None
+    assert reloaded.handoff_contract.intent == HandoffIntent.AWAIT_AGENT
+
+
+def test_alignment_payload_rejects_unconfirmed_strategic_documents_updated(
+    tmp_path: Path,
+) -> None:
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir(parents=True)
+    (docs_dir / "positioning.md").write_text(
+        "# Positioning\n\nDraft positioning.\n",
+        encoding="utf-8",
+    )
+    cafe_dir = tmp_path / ".cafe"
+    cafe_dir.mkdir(parents=True, exist_ok=True)
+    (cafe_dir / "strategic_context.yaml").write_text(
+        "version: 1\n"
+        "documents:\n"
+        "  positioning:\n"
+        "    path: docs/positioning.md\n"
+        "    status: exists\n",
+        encoding="utf-8",
+    )
+    issue_dir = cafe_dir / "issues" / "issue-align-payload-unconfirmed"
+    request_dir = issue_dir / "spec" / "iteration_001"
+    request_dir.mkdir(parents=True, exist_ok=True)
+    (request_dir / "alignment_request.json").write_text(
+        json.dumps(
+            {
+                "fingerprint": "fp-payload-unconfirmed",
+                "from_step": "spec",
+                "recommended_resume_target": "spec",
+                "strategic_document_update_requirements": [],
+                "affected_documents": [
+                    {
+                        "category": "positioning",
+                        "path": "docs/positioning.md",
+                        "status": "missing",
+                        "sha256": None,
+                        "exists": False,
+                    }
+                ],
+                "allowed_decisions": ["strategic_documents_updated"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    playbook_data = {
+        "playbook": {"id": "default"},
+        "steps": {
+            "spec": {"role": "pm", "on": {"await_agent": "plan"}},
+            "plan": {"role": "developer", "on": {}},
+        },
+    }
+    store = BlackboardStore(issue_dir)
+    blackboard = store.load_or_create("user", playbook_id="default")
+    store.set_current_step(blackboard, "user")
+    store.update_handoff_contract(
+        blackboard,
+        from_step="spec",
+        to_owner=HandoffOwner.USER,
+        to_step="user",
+        intent=HandoffIntent.ALIGNMENT_CHECKPOINT,
+        status_code="alignment_checkpoint",
+        source="test",
+    )
+
+    result = apply_alignment_decision_from_payload(
+        issue_dir=issue_dir,
+        playbook_data=playbook_data,
+        blackboard=blackboard,
+        payload={"decision": "docs_updated"},
+    )
+
+    assert result is None
+    reloaded = store.load_or_create("user", playbook_id="default")
+    assert reloaded.current_step == "user"
+    assert any(
+        event.event_type == "alignment_decision_blocked"
+        and event.data.get("reason") == "missing_user_confirmation"
+        for event in reloaded.events
+    )
+
+
+def test_alignment_payload_accepts_confirmed_strategic_documents_updated(
+    tmp_path: Path,
+) -> None:
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir(parents=True)
+    (docs_dir / "positioning.md").write_text(
+        "# Positioning\n\nConfirmed positioning.\n",
+        encoding="utf-8",
+    )
+    cafe_dir = tmp_path / ".cafe"
+    cafe_dir.mkdir(parents=True, exist_ok=True)
+    (cafe_dir / "strategic_context.yaml").write_text(
+        "version: 1\n"
+        "documents:\n"
+        "  positioning:\n"
+        "    path: docs/positioning.md\n"
+        "    status: exists\n",
+        encoding="utf-8",
+    )
+    issue_dir = cafe_dir / "issues" / "issue-align-payload-confirmed"
+    request_dir = issue_dir / "spec" / "iteration_001"
+    request_dir.mkdir(parents=True, exist_ok=True)
+    (request_dir / "alignment_request.json").write_text(
+        json.dumps(
+            {
+                "fingerprint": "fp-payload-confirmed",
+                "from_step": "spec",
+                "recommended_resume_target": "spec",
+                "strategic_document_update_requirements": [],
+                "affected_documents": [
+                    {
+                        "category": "positioning",
+                        "path": "docs/positioning.md",
+                        "status": "missing",
+                        "sha256": None,
+                        "exists": False,
+                    }
+                ],
+                "allowed_decisions": ["strategic_documents_updated"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    playbook_data = {
+        "playbook": {"id": "default"},
+        "steps": {
+            "spec": {"role": "pm", "on": {"await_agent": "plan"}},
+            "plan": {"role": "developer", "on": {}},
+        },
+    }
+    store = BlackboardStore(issue_dir)
+    blackboard = store.load_or_create("user", playbook_id="default")
+    store.set_current_step(blackboard, "user")
+    store.update_handoff_contract(
+        blackboard,
+        from_step="spec",
+        to_owner=HandoffOwner.USER,
+        to_step="user",
+        intent=HandoffIntent.ALIGNMENT_CHECKPOINT,
+        status_code="alignment_checkpoint",
+        source="test",
+    )
+
+    result = apply_alignment_decision_from_payload(
+        issue_dir=issue_dir,
+        playbook_data=playbook_data,
+        blackboard=blackboard,
+        payload={
+            "decision": "strategic_documents_updated",
+            "user_confirmed": True,
+            "user_confirmation": "User confirmed the final strategic document.",
+        },
+    )
+
+    assert result == "spec"
+    reloaded = store.load_or_create("spec", playbook_id="default")
+    assert reloaded.current_step == "spec"
+    assert reloaded.handoff_contract is not None
+    assert reloaded.handoff_contract.intent == HandoffIntent.AWAIT_AGENT
+
+
 def test_user_phase_alignment_checkpoint_accepts_updated_strategic_document(tmp_path: Path) -> None:
     roadmap = tmp_path / "ROADMAP.md"
     roadmap.write_text("Updated roadmap direction\n", encoding="utf-8")
     cafe_dir = tmp_path / ".cafe"
     cafe_dir.mkdir(parents=True, exist_ok=True)
     (cafe_dir / "strategic_context.yaml").write_text(
-        "version: 1\n"
-        "documents:\n"
-        "  roadmap:\n"
-        "    path: ROADMAP.md\n",
+        "version: 1\n" "documents:\n" "  roadmap:\n" "    path: ROADMAP.md\n",
         encoding="utf-8",
     )
     issue_dir = cafe_dir / "issues" / "codex" / "issue-align-docs"
@@ -438,7 +1058,10 @@ def test_user_phase_alignment_checkpoint_accepts_updated_strategic_document(tmp_
     )
     playbook_data = {
         "playbook": {"id": "default"},
-        "steps": {"develop": {"role": "developer", "on": {"await_agent": "review"}}, "review": {"role": "reviewer", "on": {}}},
+        "steps": {
+            "develop": {"role": "developer", "on": {"await_agent": "review"}},
+            "review": {"role": "reviewer", "on": {}},
+        },
     }
     store = BlackboardStore(issue_dir)
     blackboard = store.load_or_create("user", playbook_id="default")
@@ -464,6 +1087,84 @@ def test_user_phase_alignment_checkpoint_accepts_updated_strategic_document(tmp_
     assert result == "develop"
     reloaded = store.load_or_create("develop", playbook_id="default")
     assert reloaded.current_step == "develop"
+    assert reloaded.handoff_contract is not None
+    assert reloaded.handoff_contract.intent == HandoffIntent.AWAIT_AGENT
+
+
+def test_user_phase_alignment_checkpoint_accepts_newly_created_missing_affected_document(
+    tmp_path: Path,
+) -> None:
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir(parents=True)
+    (docs_dir / "positioning.md").write_text(
+        "# Positioning\n\nCAFE serves workflow builders who need human-agent handoffs.\n",
+        encoding="utf-8",
+    )
+    cafe_dir = tmp_path / ".cafe"
+    cafe_dir.mkdir(parents=True, exist_ok=True)
+    (cafe_dir / "strategic_context.yaml").write_text(
+        "version: 1\n"
+        "documents:\n"
+        "  positioning:\n"
+        "    path: docs/positioning.md\n"
+        "    status: exists\n",
+        encoding="utf-8",
+    )
+    issue_dir = cafe_dir / "issues" / "issue-align-positioning"
+    request_dir = issue_dir / "spec" / "iteration_001"
+    request_dir.mkdir(parents=True, exist_ok=True)
+    (request_dir / "alignment_request.json").write_text(
+        json.dumps(
+            {
+                "fingerprint": "fp-positioning",
+                "from_step": "spec",
+                "recommended_resume_target": "spec",
+                "strategic_document_update_requirements": [],
+                "affected_documents": [
+                    {
+                        "category": "positioning",
+                        "path": "docs/positioning.md",
+                        "status": "missing",
+                        "sha256": None,
+                        "exists": False,
+                    }
+                ],
+                "allowed_decisions": ["strategic_documents_updated"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    playbook_data = {
+        "playbook": {"id": "default"},
+        "steps": {
+            "spec": {"role": "pm", "on": {"await_agent": "plan"}},
+            "plan": {"role": "developer", "on": {}},
+        },
+    }
+    store = BlackboardStore(issue_dir)
+    blackboard = store.load_or_create("user", playbook_id="default")
+    store.set_current_step(blackboard, "user")
+    store.update_handoff_contract(
+        blackboard,
+        from_step="spec",
+        to_owner=HandoffOwner.USER,
+        to_step="user",
+        intent=HandoffIntent.ALIGNMENT_CHECKPOINT,
+        status_code="alignment_checkpoint",
+        source="test",
+    )
+
+    with patch("cafe.ui.inquirer_prompts.prompt_list", return_value="strategic_documents_updated"):
+        result = _handle_user_phase(
+            issue_name="issue-align-positioning",
+            issue_dir=issue_dir,
+            playbook_data=playbook_data,
+            blackboard=blackboard,
+        )
+
+    assert result == "spec"
+    reloaded = store.load_or_create("spec", playbook_id="default")
+    assert reloaded.current_step == "spec"
     assert reloaded.handoff_contract is not None
     assert reloaded.handoff_contract.intent == HandoffIntent.AWAIT_AGENT
 
@@ -512,7 +1213,9 @@ def test_workflow_command_does_not_treat_generic_user_input_as_alignment_approva
     assert reloaded.current_step == "user"
 
 
-def test_workflow_command_resume_confirm_output_keeps_await_agent_intent(tmp_path: Path, monkeypatch) -> None:
+def test_workflow_command_resume_confirm_output_keeps_await_agent_intent(
+    tmp_path: Path, monkeypatch
+) -> None:
     monkeypatch.chdir(tmp_path)
     issue_dir = tmp_path / ".cafe" / "issues" / "issue-resume-confirm"
     issue_dir.mkdir(parents=True, exist_ok=True)
@@ -530,7 +1233,9 @@ def test_workflow_command_resume_confirm_output_keeps_await_agent_intent(tmp_pat
     )
 
     class FakeExecutor:
-        def execute_step(self, step_name: str, step_def: dict, blackboard_state: object, **kwargs) -> StepExecutionResult:
+        def execute_step(
+            self, step_name: str, step_def: dict, blackboard_state: object, **kwargs
+        ) -> StepExecutionResult:
             return _result(status_code="confirmed", step_name=step_name, step_def=step_def)
 
     with (
@@ -580,7 +1285,9 @@ def test_make_help_describes_user_input_without_spec_only_wording() -> None:
     assert "handoff" in help_text
 
 
-def test_build_workflow_step_executor_passes_allowed_directories(tmp_path: Path, monkeypatch) -> None:
+def test_build_workflow_step_executor_passes_allowed_directories(
+    tmp_path: Path, monkeypatch
+) -> None:
     """Builder should read config dirs and preserve CLI-provided dirs on the executor."""
     monkeypatch.chdir(tmp_path)
     cafe_dir = tmp_path / ".cafe"
@@ -618,12 +1325,16 @@ def test_workflow_accepts_add_dir_and_passes_through(tmp_path: Path, monkeypatch
     (tmp_path / "src").mkdir()
 
     class FakeExecutor:
-        def execute_step(self, step_name: str, step_def: dict, blackboard_state: object, **kwargs) -> StepExecutionResult:
+        def execute_step(
+            self, step_name: str, step_def: dict, blackboard_state: object, **kwargs
+        ) -> StepExecutionResult:
             return _result(status_code="confirmed", step_name=step_name, step_def=step_def)
 
     with (
         patch("cafe.ui.cli.GitOperations") as mock_git_cls,
-        patch("cafe.ui.cli._build_workflow_step_executor", return_value=FakeExecutor()) as mock_builder,
+        patch(
+            "cafe.ui.cli._build_workflow_step_executor", return_value=FakeExecutor()
+        ) as mock_builder,
     ):
         git = MagicMock()
         git.get_current_branch.return_value = "issue-add-dir"
@@ -661,7 +1372,9 @@ def test_workflow_command_prints_generic_event_display(tmp_path: Path, monkeypat
                 ]
             return StepExecutionResult(
                 response="confirmed",
-                artifacts={str(step_def.get("output_artifact", step_name)): f"{step_name}/output.md"},
+                artifacts={
+                    str(step_def.get("output_artifact", step_name)): f"{step_name}/output.md"
+                },
                 status_code="confirmed",
                 events=events,
             )
@@ -682,7 +1395,9 @@ def test_workflow_command_prints_generic_event_display(tmp_path: Path, monkeypat
     assert executed_steps == ["spec", "plan", "develop", "review", "pr"]
 
 
-def test_workflow_command_does_not_duplicate_pr_url_without_display(tmp_path: Path, monkeypatch) -> None:
+def test_workflow_command_does_not_duplicate_pr_url_without_display(
+    tmp_path: Path, monkeypatch
+) -> None:
     monkeypatch.chdir(tmp_path)
 
     class FakeExecutor:
@@ -708,7 +1423,9 @@ def test_workflow_command_does_not_duplicate_pr_url_without_display(tmp_path: Pa
                 ]
             return StepExecutionResult(
                 response="confirmed",
-                artifacts={str(step_def.get("output_artifact", step_name)): f"{step_name}/output.md"},
+                artifacts={
+                    str(step_def.get("output_artifact", step_name)): f"{step_name}/output.md"
+                },
                 status_code="confirmed",
                 events=events,
             )
@@ -751,7 +1468,9 @@ def test_workflow_command_consumes_chat_baton_before_execution(tmp_path: Path, m
     next_step_file.write_text("plan\n", encoding="utf-8")
 
     class FakeExecutor:
-        def execute_step(self, step_name: str, step_def: dict, blackboard_state: object, **kwargs) -> StepExecutionResult:
+        def execute_step(
+            self, step_name: str, step_def: dict, blackboard_state: object, **kwargs
+        ) -> StepExecutionResult:
             executed_steps.append(step_name)
             if step_name == "pr":
                 _handoff_to_step(
@@ -785,7 +1504,9 @@ def test_workflow_command_consumes_chat_baton_before_execution(tmp_path: Path, m
     assert blackboard_data["current_step"] == "user"
 
 
-def test_workflow_command_does_not_consume_chat_baton_with_uncommitted_changes(tmp_path: Path, monkeypatch) -> None:
+def test_workflow_command_does_not_consume_chat_baton_with_uncommitted_changes(
+    tmp_path: Path, monkeypatch
+) -> None:
     monkeypatch.chdir(tmp_path)
     executed_steps: list[str] = []
 
@@ -808,9 +1529,13 @@ def test_workflow_command_does_not_consume_chat_baton_with_uncommitted_changes(t
     next_step_file.write_text("develop\n", encoding="utf-8")
 
     class FakeExecutor:
-        def execute_step(self, step_name: str, step_def: dict, blackboard_state: object, **kwargs) -> StepExecutionResult:
+        def execute_step(
+            self, step_name: str, step_def: dict, blackboard_state: object, **kwargs
+        ) -> StepExecutionResult:
             executed_steps.append(step_name)
-            return _result(status_code="confirmed", step_name=step_name, step_def=step_def, artifacts={})
+            return _result(
+                status_code="confirmed", step_name=step_name, step_def=step_def, artifacts={}
+            )
 
     with (
         patch("cafe.ui.cli.GitOperations") as mock_git_cls,
@@ -904,9 +1629,12 @@ def test_workflow_command_start_step_rebuilds_stale_text_baton(tmp_path: Path, m
                 artifacts={},
             )
 
-    with patch("cafe.ui.cli.GitOperations") as mock_git_cls, patch(
-        "cafe.ui.cli._build_workflow_step_executor",
-        return_value=FakeExecutor(),
+    with (
+        patch("cafe.ui.cli.GitOperations") as mock_git_cls,
+        patch(
+            "cafe.ui.cli._build_workflow_step_executor",
+            return_value=FakeExecutor(),
+        ),
     ):
         git = MagicMock()
         git.get_current_branch.return_value = "issue-206c"
@@ -963,10 +1691,14 @@ def test_workflow_command_prints_guidance_for_invalid_runtime_baton(
                 "Invalid baton contract payload: Expecting value: line 1 column 1 (char 0)"
             )
 
-    with patch("cafe.ui.cli.GitOperations") as mock_git_cls, patch(
-        "cafe.ui.cli._build_workflow_step_executor",
-        return_value=FakeExecutor(),
-    ), patch("cafe.ui.commands.workflow.BlackboardWorkflowRuntime", FailingRuntime):
+    with (
+        patch("cafe.ui.cli.GitOperations") as mock_git_cls,
+        patch(
+            "cafe.ui.cli._build_workflow_step_executor",
+            return_value=FakeExecutor(),
+        ),
+        patch("cafe.ui.commands.workflow.BlackboardWorkflowRuntime", FailingRuntime),
+    ):
         git = MagicMock()
         git.get_current_branch.return_value = "issue-206d"
         mock_git_cls.return_value = git
@@ -982,12 +1714,21 @@ def test_workflow_command_prints_guidance_for_invalid_runtime_baton(
     assert "Error: workflow run failed: Invalid baton contract payload" in result.stdout
 
 
-def test_workflow_command_prints_paused_when_human_input_is_needed(tmp_path: Path, monkeypatch) -> None:
+def test_workflow_command_prints_paused_when_human_input_is_needed(
+    tmp_path: Path, monkeypatch
+) -> None:
     monkeypatch.chdir(tmp_path)
 
     class FakeExecutor:
-        def execute_step(self, step_name: str, step_def: dict, blackboard_state: object, **kwargs) -> StepExecutionResult:
-            return _result(status_code="need_clarification", step_name=step_name, step_def=step_def, artifacts={})
+        def execute_step(
+            self, step_name: str, step_def: dict, blackboard_state: object, **kwargs
+        ) -> StepExecutionResult:
+            return _result(
+                status_code="need_clarification",
+                step_name=step_name,
+                step_def=step_def,
+                artifacts={},
+            )
 
     with (
         patch("cafe.ui.cli.GitOperations") as mock_git_cls,
@@ -1002,7 +1743,9 @@ def test_workflow_command_prints_paused_when_human_input_is_needed(tmp_path: Pat
         assert "Workflow is waiting for user input" in result.stdout
 
 
-def test_workflow_command_prints_recovery_guidance_for_pr_baton_pause(tmp_path: Path, monkeypatch) -> None:
+def test_workflow_command_prints_recovery_guidance_for_pr_baton_pause(
+    tmp_path: Path, monkeypatch
+) -> None:
     monkeypatch.chdir(tmp_path)
     issue_dir = tmp_path / ".cafe" / "issues" / "issue-233"
     issue_dir.mkdir(parents=True, exist_ok=True)
@@ -1021,7 +1764,9 @@ def test_workflow_command_prints_recovery_guidance_for_pr_baton_pause(tmp_path: 
     )
 
     class FakeExecutor:
-        def execute_step(self, step_name: str, step_def: dict, blackboard_state: object, **kwargs) -> StepExecutionResult:
+        def execute_step(
+            self, step_name: str, step_def: dict, blackboard_state: object, **kwargs
+        ) -> StepExecutionResult:
             return StepExecutionResult(response="no baton", artifacts={}, status_code=None)
 
     with (
@@ -1039,7 +1784,9 @@ def test_workflow_command_prints_recovery_guidance_for_pr_baton_pause(tmp_path: 
     assert "field 'to_step' got 'pr'" in result.stdout
 
 
-def test_workflow_command_offers_recovery_menu_for_baton_pause_in_interactive_mode(tmp_path: Path, monkeypatch) -> None:
+def test_workflow_command_offers_recovery_menu_for_baton_pause_in_interactive_mode(
+    tmp_path: Path, monkeypatch
+) -> None:
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("CAFE_FORCE_INTERACTIVE", "1")
     issue_dir = tmp_path / ".cafe" / "issues" / "issue-233"
@@ -1059,7 +1806,9 @@ def test_workflow_command_offers_recovery_menu_for_baton_pause_in_interactive_mo
     )
 
     class FakeExecutor:
-        def execute_step(self, step_name: str, step_def: dict, blackboard_state: object, **kwargs) -> StepExecutionResult:
+        def execute_step(
+            self, step_name: str, step_def: dict, blackboard_state: object, **kwargs
+        ) -> StepExecutionResult:
             return StepExecutionResult(response="no baton", artifacts={}, status_code=None)
 
     with (
@@ -1102,7 +1851,9 @@ def test_workflow_command_user_owner_can_set_next_phase(tmp_path: Path, monkeypa
     )
 
     class FakeExecutor:
-        def execute_step(self, step_name: str, step_def: dict, blackboard_state: object, **kwargs) -> StepExecutionResult:
+        def execute_step(
+            self, step_name: str, step_def: dict, blackboard_state: object, **kwargs
+        ) -> StepExecutionResult:
             executed_steps.append(step_name)
             if step_name == "pr":
                 _handoff_to_step(
@@ -1113,7 +1864,9 @@ def test_workflow_command_user_owner_can_set_next_phase(tmp_path: Path, monkeypa
                     status_code="confirmed",
                     intent=HandoffIntent.MANUAL_HANDOFF,
                 )
-            return _result(status_code="confirmed", step_name=step_name, step_def=step_def, artifacts={})
+            return _result(
+                status_code="confirmed", step_name=step_name, step_def=step_def, artifacts={}
+            )
 
     with (
         patch("cafe.ui.cli.GitOperations") as mock_git_cls,
@@ -1126,7 +1879,10 @@ def test_workflow_command_user_owner_can_set_next_phase(tmp_path: Path, monkeypa
                 "Mark the workflow complete",
             ],
         ),
-        patch("cafe.ui.cli.prompt_multiline", return_value="Please continue implementation with the new handoff context."),
+        patch(
+            "cafe.ui.cli.prompt_multiline",
+            return_value="Please continue implementation with the new handoff context.",
+        ),
         patch("cafe.ui.cli.prompt_confirm", return_value=True),
     ):
         git = MagicMock()
@@ -1142,11 +1898,18 @@ def test_workflow_command_user_owner_can_set_next_phase(tmp_path: Path, monkeypa
     assert executed_steps == ["develop", "review", "pr"]
     blackboard_data = json.loads((issue_dir / "blackboard.json").read_text(encoding="utf-8"))
     assert blackboard_data["handoff_summary"] == "workflow completed by user"
-    handoff_event = next(event for event in blackboard_data["events"] if event["event_type"] == "user_handoff")
-    assert handoff_event["data"]["note"] == "Please continue implementation with the new handoff context."
+    handoff_event = next(
+        event for event in blackboard_data["events"] if event["event_type"] == "user_handoff"
+    )
+    assert (
+        handoff_event["data"]["note"]
+        == "Please continue implementation with the new handoff context."
+    )
 
 
-def test_user_phase_uses_playbook_handoff_labels_and_generic_fallback(tmp_path: Path, monkeypatch) -> None:
+def test_user_phase_uses_playbook_handoff_labels_and_generic_fallback(
+    tmp_path: Path, monkeypatch
+) -> None:
     monkeypatch.chdir(tmp_path)
     issue_dir = tmp_path / ".cafe" / "issues" / "research-1"
     store = BlackboardStore(issue_dir)
@@ -1188,7 +1951,9 @@ def test_user_phase_uses_playbook_handoff_labels_and_generic_fallback(tmp_path: 
         )
 
     assert result == "collect"
-    step_prompt = next(choices for message, choices in prompts if message == "Which phase should continue next?")
+    step_prompt = next(
+        choices for message, choices in prompts if message == "Which phase should continue next?"
+    )
     assert "Refine research question (question)" in step_prompt
     assert "Continue collect (collect)" in step_prompt
     assert all("implementation" not in choice.lower() for choice in step_prompt)
@@ -1345,10 +2110,7 @@ def test_user_phase_no_changes_needed_resumes_develop_without_generic_menu(
     assert reloaded.handoff_contract.to_owner == HandoffOwner.AGENT
     assert reloaded.handoff_contract.to_step == "develop"
     assert reloaded.handoff_contract.intent == HandoffIntent.AWAIT_AGENT
-    assert any(
-        event.event_type == "no_changes_needed_resume"
-        for event in reloaded.events
-    )
+    assert any(event.event_type == "no_changes_needed_resume" for event in reloaded.events)
 
 
 def test_workflow_command_user_owner_can_complete_workflow(tmp_path: Path, monkeypatch) -> None:
@@ -1387,7 +2149,9 @@ def test_workflow_command_user_owner_can_complete_workflow(tmp_path: Path, monke
     assert blackboard_data["current_step"] == "done"
 
 
-def test_workflow_command_user_owner_can_chat_and_resume_from_baton(tmp_path: Path, monkeypatch) -> None:
+def test_workflow_command_user_owner_can_chat_and_resume_from_baton(
+    tmp_path: Path, monkeypatch
+) -> None:
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("CAFE_FORCE_INTERACTIVE", "1")
     executed_steps: list[str] = []
@@ -1409,7 +2173,9 @@ def test_workflow_command_user_owner_can_chat_and_resume_from_baton(tmp_path: Pa
     )
 
     class FakeExecutor:
-        def execute_step(self, step_name: str, step_def: dict, blackboard_state: object, **kwargs) -> StepExecutionResult:
+        def execute_step(
+            self, step_name: str, step_def: dict, blackboard_state: object, **kwargs
+        ) -> StepExecutionResult:
             executed_steps.append(step_name)
             if step_name == "pr":
                 _handoff_to_step(
@@ -1420,7 +2186,9 @@ def test_workflow_command_user_owner_can_chat_and_resume_from_baton(tmp_path: Pa
                     status_code="confirmed",
                     intent=HandoffIntent.MANUAL_HANDOFF,
                 )
-            return _result(status_code="confirmed", step_name=step_name, step_def=step_def, artifacts={})
+            return _result(
+                status_code="confirmed", step_name=step_name, step_def=step_def, artifacts={}
+            )
 
     def fake_launch_chat(role: str, issue_name: str) -> int:
         assert role == "developer"
@@ -1431,7 +2199,10 @@ def test_workflow_command_user_owner_can_chat_and_resume_from_baton(tmp_path: Pa
     with (
         patch("cafe.ui.cli.GitOperations") as mock_git_cls,
         patch("cafe.ui.cli._build_workflow_step_executor", return_value=FakeExecutor()),
-        patch("cafe.ui.cli.prompt_list", side_effect=["Open chat with a role", "developer", "Mark the workflow complete"]),
+        patch(
+            "cafe.ui.cli.prompt_list",
+            side_effect=["Open chat with a role", "developer", "Mark the workflow complete"],
+        ),
         patch("cafe.ui.cli.launch_chat_session", side_effect=fake_launch_chat),
     ):
         git = MagicMock()
@@ -1447,7 +2218,9 @@ def test_workflow_command_user_owner_can_chat_and_resume_from_baton(tmp_path: Pa
     assert (issue_dir / "next_step.txt").exists()
 
 
-def test_workflow_command_enters_user_phase_immediately_after_agent_handoff(tmp_path: Path, monkeypatch) -> None:
+def test_workflow_command_enters_user_phase_immediately_after_agent_handoff(
+    tmp_path: Path, monkeypatch
+) -> None:
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("CAFE_FORCE_INTERACTIVE", "1")
 
@@ -1468,7 +2241,9 @@ def test_workflow_command_enters_user_phase_immediately_after_agent_handoff(tmp_
     )
 
     class FakeExecutor:
-        def execute_step(self, step_name: str, step_def: dict, blackboard_state: object, **kwargs) -> StepExecutionResult:
+        def execute_step(
+            self, step_name: str, step_def: dict, blackboard_state: object, **kwargs
+        ) -> StepExecutionResult:
             assert step_name == "pr"
             _handoff_to_step(
                 issue_dir=issue_dir,
@@ -1478,7 +2253,9 @@ def test_workflow_command_enters_user_phase_immediately_after_agent_handoff(tmp_
                 status_code="confirmed",
                 intent=HandoffIntent.MANUAL_HANDOFF,
             )
-            return _result(status_code="confirmed", step_name=step_name, step_def=step_def, artifacts={})
+            return _result(
+                status_code="confirmed", step_name=step_name, step_def=step_def, artifacts={}
+            )
 
     with (
         patch("cafe.ui.cli.GitOperations") as mock_git_cls,
@@ -1500,7 +2277,9 @@ def test_workflow_command_enters_user_phase_immediately_after_agent_handoff(tmp_
     assert blackboard_data["current_step"] == "done"
 
 
-def test_workflow_command_noninteractive_stops_after_agent_handoff_to_user(tmp_path: Path, monkeypatch) -> None:
+def test_workflow_command_noninteractive_stops_after_agent_handoff_to_user(
+    tmp_path: Path, monkeypatch
+) -> None:
     monkeypatch.chdir(tmp_path)
 
     issue_dir = tmp_path / ".cafe" / "issues" / "issue-211b"
@@ -1520,7 +2299,9 @@ def test_workflow_command_noninteractive_stops_after_agent_handoff_to_user(tmp_p
     )
 
     class FakeExecutor:
-        def execute_step(self, step_name: str, step_def: dict, blackboard_state: object, **kwargs) -> StepExecutionResult:
+        def execute_step(
+            self, step_name: str, step_def: dict, blackboard_state: object, **kwargs
+        ) -> StepExecutionResult:
             assert step_name == "pr"
             _handoff_to_step(
                 issue_dir=issue_dir,
@@ -1530,7 +2311,9 @@ def test_workflow_command_noninteractive_stops_after_agent_handoff_to_user(tmp_p
                 status_code="confirmed",
                 intent=HandoffIntent.MANUAL_HANDOFF,
             )
-            return _result(status_code="confirmed", step_name=step_name, step_def=step_def, artifacts={})
+            return _result(
+                status_code="confirmed", step_name=step_name, step_def=step_def, artifacts={}
+            )
 
     with (
         patch("cafe.ui.cli.GitOperations") as mock_git_cls,
@@ -1549,12 +2332,16 @@ def test_workflow_command_noninteractive_stops_after_agent_handoff_to_user(tmp_p
     assert mock_external_resume.call_count == 0
 
 
-def test_user_phase_need_clarification_collects_questions_and_resumes_step(tmp_path: Path, capsys) -> None:
+def test_user_phase_need_clarification_collects_questions_and_resumes_step(
+    tmp_path: Path, capsys
+) -> None:
     issue_dir = tmp_path / ".cafe" / "issues" / "issue-clarification"
     issue_dir.mkdir(parents=True, exist_ok=True)
     spec_iter_dir = issue_dir / "spec" / "iteration_001"
     spec_iter_dir.mkdir(parents=True)
-    (spec_iter_dir / "output.md").write_text("# Spec Draft\n\nNeeds confirmation.", encoding="utf-8")
+    (spec_iter_dir / "output.md").write_text(
+        "# Spec Draft\n\nNeeds confirmation.", encoding="utf-8"
+    )
     (spec_iter_dir / "questions.xml").write_text(
         """<?xml version="1.0" encoding="UTF-8"?>
 <questions>
@@ -1595,7 +2382,9 @@ def test_user_phase_need_clarification_collects_questions_and_resumes_step(tmp_p
 
     def fake_interactive_qa(questions, **kwargs):
         assert questions[0].title == "Confirm scope?"
-        (spec_iter_dir / "output.md").write_text("# Updated Spec Draft\n\nUpdated after chat.", encoding="utf-8")
+        (spec_iter_dir / "output.md").write_text(
+            "# Updated Spec Draft\n\nUpdated after chat.", encoding="utf-8"
+        )
         (spec_iter_dir / "questions.xml").write_text(
             """<?xml version="1.0" encoding="UTF-8"?>
 <questions>
@@ -1634,7 +2423,9 @@ def test_user_phase_need_clarification_collects_questions_and_resumes_step(tmp_p
     assert reloaded.handoff_contract.to_step == "spec"
 
 
-def test_user_phase_question_need_clarification_resumes_question_step(tmp_path: Path, capsys) -> None:
+def test_user_phase_question_need_clarification_resumes_question_step(
+    tmp_path: Path, capsys
+) -> None:
     issue_dir = tmp_path / ".cafe" / "issues" / "issue-research-clarify"
     issue_dir.mkdir(parents=True, exist_ok=True)
     question_iter_dir = issue_dir / "question" / "iteration_001"
@@ -1720,7 +2511,9 @@ def test_workflow_command_done_phase_can_restart_workflow(tmp_path: Path, monkey
     )
 
     class FakeExecutor:
-        def execute_step(self, step_name: str, step_def: dict, blackboard_state: object, **kwargs) -> StepExecutionResult:
+        def execute_step(
+            self, step_name: str, step_def: dict, blackboard_state: object, **kwargs
+        ) -> StepExecutionResult:
             executed_steps.append(step_name)
             if step_name == "pr":
                 _handoff_to_step(
@@ -1731,7 +2524,9 @@ def test_workflow_command_done_phase_can_restart_workflow(tmp_path: Path, monkey
                     status_code="confirmed",
                     intent=HandoffIntent.MANUAL_HANDOFF,
                 )
-            return _result(status_code="confirmed", step_name=step_name, step_def=step_def, artifacts={})
+            return _result(
+                status_code="confirmed", step_name=step_name, step_def=step_def, artifacts={}
+            )
 
     with (
         patch("cafe.ui.cli.GitOperations") as mock_git_cls,
@@ -1760,7 +2555,9 @@ def test_workflow_command_done_phase_can_restart_workflow(tmp_path: Path, monkey
     assert executed_steps == ["develop", "review", "pr"]
 
 
-def test_workflow_command_resumes_incomplete_iteration_before_user_phase(tmp_path: Path, monkeypatch) -> None:
+def test_workflow_command_resumes_incomplete_iteration_before_user_phase(
+    tmp_path: Path, monkeypatch
+) -> None:
     monkeypatch.chdir(tmp_path)
     executed_steps: list[str] = []
 
@@ -1795,7 +2592,9 @@ def test_workflow_command_resumes_incomplete_iteration_before_user_phase(tmp_pat
     )
 
     class FakeExecutor:
-        def execute_step(self, step_name: str, step_def: dict, blackboard_state: object, **kwargs) -> StepExecutionResult:
+        def execute_step(
+            self, step_name: str, step_def: dict, blackboard_state: object, **kwargs
+        ) -> StepExecutionResult:
             executed_steps.append(step_name)
             completed_iteration = issue_dir / "spec" / "iteration_003"
             completed_iteration.mkdir(parents=True, exist_ok=True)
@@ -1810,7 +2609,9 @@ def test_workflow_command_resumes_incomplete_iteration_before_user_phase(tmp_pat
                 ),
                 encoding="utf-8",
             )
-            return _result(status_code="ready_for_review", step_name=step_name, step_def=step_def, artifacts={})
+            return _result(
+                status_code="ready_for_review", step_name=step_name, step_def=step_def, artifacts={}
+            )
 
     with (
         patch("cafe.ui.cli.GitOperations") as mock_git_cls,
@@ -1982,7 +2783,9 @@ def test_find_external_resume_step_returns_none_when_no_github_pr(tmp_path: Path
     mock_fetch.assert_not_called()
 
 
-def test_workflow_command_resumes_pr_when_external_feedback_arrives_while_done(tmp_path: Path, monkeypatch) -> None:
+def test_workflow_command_resumes_pr_when_external_feedback_arrives_while_done(
+    tmp_path: Path, monkeypatch
+) -> None:
     monkeypatch.chdir(tmp_path)
     executed_steps: list[str] = []
 
@@ -2004,9 +2807,13 @@ def test_workflow_command_resumes_pr_when_external_feedback_arrives_while_done(t
     )
 
     class FakeExecutor:
-        def execute_step(self, step_name: str, step_def: dict, blackboard_state: object, **kwargs) -> StepExecutionResult:
+        def execute_step(
+            self, step_name: str, step_def: dict, blackboard_state: object, **kwargs
+        ) -> StepExecutionResult:
             executed_steps.append(step_name)
-            return _result(status_code="confirmed", step_name=step_name, step_def=step_def, artifacts={})
+            return _result(
+                status_code="confirmed", step_name=step_name, step_def=step_def, artifacts={}
+            )
 
     with (
         patch("cafe.ui.cli.GitOperations") as mock_git_cls,
@@ -2069,7 +2876,10 @@ steps:
         mock_git_cls.return_value = git
 
         executor = MagicMock()
-        def _execute(step_name: str, step_def: dict, blackboard_state: object, **kwargs) -> StepExecutionResult:
+
+        def _execute(
+            step_name: str, step_def: dict, blackboard_state: object, **kwargs
+        ) -> StepExecutionResult:
             executed_steps.append(step_name)
             if step_name == "spec":
                 _handoff_to_step(
@@ -2079,7 +2889,10 @@ steps:
                     to_step="develop",
                     status_code="confirmed",
                 )
-            return _result(status_code="confirmed", step_name=step_name, step_def=step_def, artifacts={})
+            return _result(
+                status_code="confirmed", step_name=step_name, step_def=step_def, artifacts={}
+            )
+
         executor.execute_step.side_effect = _execute
         mock_builder.return_value = executor
 
@@ -2124,13 +2937,24 @@ steps:
         mock_git_cls.return_value = git
         executor = MagicMock()
         executor.execute_step.side_effect = lambda step_name, step_def, blackboard_state, **kw: (
-            executed_steps.append(step_name) or _result(status_code="confirmed", step_name=step_name, step_def=step_def, artifacts={})
+            executed_steps.append(step_name)
+            or _result(
+                status_code="confirmed", step_name=step_name, step_def=step_def, artifacts={}
+            )
         )
         mock_builder.return_value = executor
 
         result = runner.invoke(
             app,
-            ["workflow", "--playbook", "single", "--execute", "--start-step", "plan", "--single-step"],
+            [
+                "workflow",
+                "--playbook",
+                "single",
+                "--execute",
+                "--start-step",
+                "plan",
+                "--single-step",
+            ],
         )
         assert result.exit_code == 0
         assert executed_steps == ["plan"]
@@ -2149,7 +2973,10 @@ def test_workflow_command_runs_hotfix_playbook(tmp_path: Path, monkeypatch) -> N
         mock_git_cls.return_value = git
         executor = MagicMock()
         executor.execute_step.side_effect = lambda step_name, step_def, blackboard_state, **kw: (
-            executed_steps.append(step_name) or _result(status_code="confirmed", step_name=step_name, step_def=step_def, artifacts={})
+            executed_steps.append(step_name)
+            or _result(
+                status_code="confirmed", step_name=step_name, step_def=step_def, artifacts={}
+            )
         )
         mock_builder.return_value = executor
 
@@ -2195,8 +3022,13 @@ steps:
         git.get_current_branch.return_value = "issue-204"
         mock_git_cls.return_value = git
         executor = MagicMock()
-        executor.execute_step.side_effect = lambda step_name, step_def, blackboard_state, **kwargs: (
-            executed_steps.append(step_name) or _result(status_code="confirmed", step_name=step_name, step_def=step_def, artifacts={})
+        executor.execute_step.side_effect = (
+            lambda step_name, step_def, blackboard_state, **kwargs: (
+                executed_steps.append(step_name)
+                or _result(
+                    status_code="confirmed", step_name=step_name, step_def=step_def, artifacts={}
+                )
+            )
         )
         mock_builder.return_value = executor
 
@@ -2227,13 +3059,17 @@ def test_workflow_execute_syncs_active_issue_on_healthy_branch(tmp_path: Path, m
         )
         mock_builder.return_value = executor
 
-        result = runner.invoke(app, ["workflow", "--playbook", "default", "--execute", "--single-step"])
+        result = runner.invoke(
+            app, ["workflow", "--playbook", "default", "--execute", "--single-step"]
+        )
 
     assert result.exit_code == 0
     assert (cafe_dir / "active_issue").read_text(encoding="utf-8").strip() == "issue-sync"
 
 
-def test_workflow_execute_recovers_from_unhealthy_git_via_marker(tmp_path: Path, monkeypatch) -> None:
+def test_workflow_execute_recovers_from_unhealthy_git_via_marker(
+    tmp_path: Path, monkeypatch
+) -> None:
     monkeypatch.chdir(tmp_path)
     cafe_dir = tmp_path / ".cafe"
     issue_dir = cafe_dir / "issues" / "saved-issue"
@@ -2255,7 +3091,9 @@ def test_workflow_execute_recovers_from_unhealthy_git_via_marker(tmp_path: Path,
         )
         mock_builder.return_value = executor
 
-        result = runner.invoke(app, ["workflow", "--playbook", "default", "--execute", "--single-step"])
+        result = runner.invoke(
+            app, ["workflow", "--playbook", "default", "--execute", "--single-step"]
+        )
 
     assert result.exit_code == 0
     assert (cafe_dir / "active_issue").read_text(encoding="utf-8").strip() == "saved-issue"

--- a/tests/unit/test_generic_workflow_step.py
+++ b/tests/unit/test_generic_workflow_step.py
@@ -8,7 +8,13 @@ from types import SimpleNamespace
 from unittest.mock import patch
 import pytest
 
-from cafe.core.blackboard import ArtifactEntry, ArtifactKind, BlackboardStore, HandoffIntent, HandoffOwner
+from cafe.core.blackboard import (
+    ArtifactEntry,
+    ArtifactKind,
+    BlackboardStore,
+    HandoffIntent,
+    HandoffOwner,
+)
 from cafe.core.hooks import HookResult
 from cafe.core.status_codes import PhaseStatusCode
 from cafe.core.types import AgentCLI, AgentConfig, TokenUsage
@@ -264,16 +270,21 @@ def test_generic_workflow_step_agent_written_baton_preserved(tmp_path: Path, mon
     def on_execute(prompt, response, streaming_output_file=None):
         # Simulate agent writing a baton targeting "plan" instead of "_done"
         baton_path = issue_dir / "next_step.txt"
-        baton_path.write_text(json.dumps({
-            "version": 1,
-            "from_step": "spec",
-            "to_owner": "agent",
-            "to_step": "plan",
-            "intent": "await_agent",
-            "status_code": "confirmed",
-            "created_at": "2026-05-14T10:00:00+08:00",
-            "source": "spec.agent",
-        }), encoding="utf-8")
+        baton_path.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "from_step": "spec",
+                    "to_owner": "agent",
+                    "to_step": "plan",
+                    "intent": "await_agent",
+                    "status_code": "confirmed",
+                    "created_at": "2026-05-14T10:00:00+08:00",
+                    "source": "spec.agent",
+                }
+            ),
+            encoding="utf-8",
+        )
 
     store = BlackboardStore(issue_dir)
     state = store.load_or_create("spec")
@@ -421,7 +432,9 @@ def test_generic_workflow_step_question_need_clarification_writes_clarification_
     assert reloaded.handoff_contract.to_step == "user"
 
 
-def test_generic_workflow_step_question_step_allows_questions_xml_edit(tmp_path: Path, monkeypatch) -> None:
+def test_generic_workflow_step_question_step_allows_questions_xml_edit(
+    tmp_path: Path, monkeypatch
+) -> None:
     monkeypatch.chdir(tmp_path)
     issue_dir = tmp_path / ".cafe" / "issues" / "issue-question-tools"
     playbook = {
@@ -453,10 +466,15 @@ def test_generic_workflow_step_question_step_allows_questions_xml_edit(tmp_path:
     executor.execute_step("question", playbook["steps"]["question"], state)
 
     allowed_tools = agent_manager.allowed_tools_calls[0] or []
-    assert "edit(./.cafe/issues/issue-question-tools/question/iteration_001/questions.xml)" in allowed_tools
+    assert (
+        "edit(./.cafe/issues/issue-question-tools/question/iteration_001/questions.xml)"
+        in allowed_tools
+    )
 
 
-def test_generic_workflow_step_auto_confirms_review_in_non_interactive(tmp_path: Path, monkeypatch) -> None:
+def test_generic_workflow_step_auto_confirms_review_in_non_interactive(
+    tmp_path: Path, monkeypatch
+) -> None:
     monkeypatch.chdir(tmp_path)
     issue_dir = tmp_path / ".cafe" / "issues" / "issue-auto-confirm"
     playbook = {
@@ -502,7 +520,9 @@ def test_generic_workflow_step_auto_confirms_review_in_non_interactive(tmp_path:
     assert reloaded.handoff_contract.to_owner == HandoffOwner.USER
 
 
-def test_generic_workflow_step_does_not_retry_for_legacy_status_tokens(tmp_path: Path, monkeypatch) -> None:
+def test_generic_workflow_step_does_not_retry_for_legacy_status_tokens(
+    tmp_path: Path, monkeypatch
+) -> None:
     monkeypatch.chdir(tmp_path)
     issue_dir = tmp_path / ".cafe" / "issues" / "issue-status-retry"
     playbook = {
@@ -537,7 +557,9 @@ def test_generic_workflow_step_does_not_retry_for_legacy_status_tokens(tmp_path:
     assert result.status_code is None
 
 
-def test_generic_workflow_step_executor_uses_iteration_specific_skill_mapping(tmp_path: Path, monkeypatch) -> None:
+def test_generic_workflow_step_executor_uses_iteration_specific_skill_mapping(
+    tmp_path: Path, monkeypatch
+) -> None:
     monkeypatch.chdir(tmp_path)
     issue_dir = tmp_path / ".cafe" / "issues" / "issue-2"
     phase_dir = issue_dir / "spec" / "iteration_001"
@@ -626,7 +648,6 @@ def test_generic_workflow_step_resolve_resume_user_input_uses_execution_config(
             )
 
     manager = ResumeAwareManager("ready_for_review")
-    state = BlackboardStore(issue_dir).load_or_create("develop")
     executor = GenericWorkflowStepExecutor(
         issue_dir=issue_dir,
         issue_name="issue-resume",
@@ -700,7 +721,9 @@ def test_generic_workflow_step_resume_user_input_rejects_different_execution_cli
     assert resolved == "workflow execute"
 
 
-def test_generic_workflow_step_executor_installs_workflow_common_and_phase_skill(tmp_path: Path, monkeypatch) -> None:
+def test_generic_workflow_step_executor_installs_workflow_common_and_phase_skill(
+    tmp_path: Path, monkeypatch
+) -> None:
     monkeypatch.chdir(tmp_path)
     issue_dir = tmp_path / ".cafe" / "issues" / "issue-review-skill"
     playbook = {
@@ -753,7 +776,9 @@ def test_generic_workflow_step_executor_installs_workflow_common_and_phase_skill
 
     allowed_tools = agent_manager.allowed_tools_calls[0] or []
     assert "edit(./.cafe/issues/issue-review-skill/review/iteration_001/output.md)" in allowed_tools
-    assert "edit(./.cafe/issues/issue-review-skill/review/iteration_001/checklist.md)" in allowed_tools
+    assert (
+        "edit(./.cafe/issues/issue-review-skill/review/iteration_001/checklist.md)" in allowed_tools
+    )
     assert "edit(./.cafe/issues/issue-review-skill/blackboard.json)" in allowed_tools
     assert "edit(./.cafe/issues/issue-review-skill/next_step.txt)" in allowed_tools
 
@@ -765,7 +790,9 @@ def test_generic_workflow_step_executor_installs_workflow_common_and_phase_skill
     assert "next_step_file=./.cafe/issues/issue-review-skill/next_step.txt" in prompt
 
 
-def test_generic_workflow_step_prompt_includes_latest_blackboard_handoff(tmp_path: Path, monkeypatch) -> None:
+def test_generic_workflow_step_prompt_includes_latest_blackboard_handoff(
+    tmp_path: Path, monkeypatch
+) -> None:
     monkeypatch.chdir(tmp_path)
     issue_dir = tmp_path / ".cafe" / "issues" / "issue-handoff"
     playbook = {
@@ -809,11 +836,15 @@ def test_generic_workflow_step_prompt_includes_latest_blackboard_handoff(tmp_pat
 
     executor.execute_step("develop", playbook["steps"]["develop"], state)
 
-    assert any("Latest workflow handoff from blackboard:" in prompt for prompt in agent_manager.prompts)
+    assert any(
+        "Latest workflow handoff from blackboard:" in prompt for prompt in agent_manager.prompts
+    )
     assert any("還要再實作 cafe skill rm" in prompt for prompt in agent_manager.prompts)
 
 
-def test_generic_workflow_step_prompt_keeps_skill_invocations_only(tmp_path: Path, monkeypatch) -> None:
+def test_generic_workflow_step_prompt_keeps_skill_invocations_only(
+    tmp_path: Path, monkeypatch
+) -> None:
     monkeypatch.chdir(tmp_path)
     issue_dir = tmp_path / ".cafe" / "issues" / "issue-pr-skill-body"
     playbook = {
@@ -862,7 +893,9 @@ def test_generic_workflow_step_prompt_keeps_skill_invocations_only(tmp_path: Pat
     assert "Write PR content to:" not in prompt
 
 
-def test_generic_workflow_step_pr_prompt_overrides_external_state_guardrail(tmp_path: Path, monkeypatch) -> None:
+def test_generic_workflow_step_pr_prompt_overrides_external_state_guardrail(
+    tmp_path: Path, monkeypatch
+) -> None:
     monkeypatch.chdir(tmp_path)
     issue_dir = tmp_path / ".cafe" / "issues" / "issue-pr-guardrail"
     playbook = {
@@ -906,10 +939,15 @@ def test_generic_workflow_step_pr_prompt_overrides_external_state_guardrail(tmp_
     prompt = agent_manager.prompts[-1]
     assert "Do not wait for, verify, or require a remote GitHub branch/PR" in prompt
     assert "Remote PR publish happens later in the host-side publish_output hook." in prompt
-    assert "Before updating the workflow baton, verify whether the requested state change has actually happened in files or external state relevant to this phase." not in prompt
+    assert (
+        "Before updating the workflow baton, verify whether the requested state change has actually happened in files or external state relevant to this phase."
+        not in prompt
+    )
 
 
-def test_generic_workflow_step_writes_pr_publish_request_contract(tmp_path: Path, monkeypatch) -> None:
+def test_generic_workflow_step_writes_pr_publish_request_contract(
+    tmp_path: Path, monkeypatch
+) -> None:
     monkeypatch.chdir(tmp_path)
     issue_dir = tmp_path / ".cafe" / "issues" / "issue-pr-contract"
     playbook = {
@@ -954,13 +992,130 @@ def test_generic_workflow_step_writes_pr_publish_request_contract(tmp_path: Path
     publish_request = json.loads(
         (issue_dir / "pr" / "iteration_001" / "publish_request.json").read_text(encoding="utf-8")
     )
+    capability_request = json.loads(
+        (issue_dir / "pr" / "iteration_001" / "capability_request.json").read_text(encoding="utf-8")
+    )
     assert publish_request["capability"] == "cafe.pr.publish"
+    assert capability_request == publish_request
     assert publish_request["args"] == {
         "output": ".cafe/issues/issue-pr-contract/pr/iteration_001/output.md",
         "base": "v02",
     }
     assert publish_request["permissions"]["network"] == ["github.com", "api.github.com"]
     assert publish_request["permissions"]["writes"] == [".git", ".cafe/issues/issue-pr-contract"]
+
+
+def test_generic_workflow_step_writes_declared_capability_request_for_non_pr_step(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    issue_dir = tmp_path / ".cafe" / "issues" / "issue-capability-contract"
+    playbook = {
+        "playbook": {"id": "default"},
+        "roles": {"developer": {"default_agent": "David"}},
+        "steps": {
+            "publish": {
+                "skill": "develop",
+                "role": "developer",
+                "output_artifact": "code",
+                "allowed_tools": ["Read"],
+                "capability_requests": ["demo.unknown"],
+                "valid_intents": ["confirmed"],
+                "on": {"await_agent": "_done"},
+            }
+        },
+    }
+    store = BlackboardStore(issue_dir)
+    state = store.load_or_create("publish")
+    spec_file = issue_dir / "spec" / "iteration_001" / "output.md"
+    plan_file = issue_dir / "plan" / "iteration_001" / "output.md"
+    spec_file.parent.mkdir(parents=True, exist_ok=True)
+    plan_file.parent.mkdir(parents=True, exist_ok=True)
+    spec_file.write_text("# Spec\n", encoding="utf-8")
+    plan_file.write_text("# Plan\n", encoding="utf-8")
+    store.set_artifact(state, "spec", str(spec_file))
+    store.set_artifact(state, "plan", str(plan_file))
+    executor = GenericWorkflowStepExecutor(
+        issue_dir=issue_dir,
+        issue_name="issue-capability-contract",
+        playbook=playbook,
+        generic_phase=_build_loader(tmp_path),
+        agent_manager=FakeAgentManager("confirmed"),
+        git_ops=FakeGitOperations(),
+        role_agent_map={"developer": "David"},
+    )
+
+    executor.execute_step("publish", playbook["steps"]["publish"], state)
+
+    capability_request = json.loads(
+        (issue_dir / "publish" / "iteration_001" / "capability_request.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert capability_request == {
+        "capability": "demo.unknown",
+        "args": {},
+        "permissions": {},
+    }
+    assert not (issue_dir / "publish" / "iteration_001" / "publish_request.json").exists()
+
+
+def test_generic_workflow_step_writes_multi_capability_request_contract(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    issue_dir = tmp_path / ".cafe" / "issues" / "issue-capability-contract"
+    playbook = {
+        "playbook": {"id": "default"},
+        "roles": {"developer": {"default_agent": "David"}},
+        "steps": {
+            "publish": {
+                "skill": "develop",
+                "role": "developer",
+                "output_artifact": "code",
+                "allowed_tools": ["Read"],
+                "capability_requests": ["demo.first", "demo.second"],
+                "valid_intents": ["confirmed"],
+                "on": {"await_agent": "_done"},
+            }
+        },
+    }
+    store = BlackboardStore(issue_dir)
+    state = store.load_or_create("publish")
+    spec_file = issue_dir / "spec" / "iteration_001" / "output.md"
+    plan_file = issue_dir / "plan" / "iteration_001" / "output.md"
+    spec_file.parent.mkdir(parents=True, exist_ok=True)
+    plan_file.parent.mkdir(parents=True, exist_ok=True)
+    spec_file.write_text("# Spec\n", encoding="utf-8")
+    plan_file.write_text("# Plan\n", encoding="utf-8")
+    store.set_artifact(state, "spec", str(spec_file))
+    store.set_artifact(state, "plan", str(plan_file))
+    executor = GenericWorkflowStepExecutor(
+        issue_dir=issue_dir,
+        issue_name="issue-capability-contract",
+        playbook=playbook,
+        generic_phase=_build_loader(tmp_path),
+        agent_manager=FakeAgentManager("confirmed"),
+        git_ops=FakeGitOperations(),
+        role_agent_map={"developer": "David"},
+    )
+
+    executor.execute_step("publish", playbook["steps"]["publish"], state)
+
+    capability_request = json.loads(
+        (issue_dir / "publish" / "iteration_001" / "capability_request.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert capability_request == {
+        "requests": [
+            {"capability": "demo.first", "args": {}, "permissions": {}},
+            {"capability": "demo.second", "args": {}, "permissions": {}},
+        ]
+    }
+    assert not (issue_dir / "publish" / "iteration_001" / "publish_request.json").exists()
 
 
 def test_generic_workflow_step_collects_clarification_before_next_agent_run(
@@ -989,7 +1144,10 @@ def test_generic_workflow_step_collects_clarification_before_next_agent_run(
     }
     store = BlackboardStore(issue_dir)
     state = store.load_or_create("spec")
-    def _write_questions_xml(*, response: str, streaming_output_file: str | None, **_: object) -> None:
+
+    def _write_questions_xml(
+        *, response: str, streaming_output_file: str | None, **_: object
+    ) -> None:
         if response != "need_clarification" or not streaming_output_file:
             return
         iteration_dir = Path(streaming_output_file).parent
@@ -1044,10 +1202,7 @@ def test_generic_workflow_step_collects_clarification_before_next_agent_run(
     assert second_result.response == "confirmed"
     # In non-interactive mode the UserInputCollector does not auto-answer
     # need_clarification — the workflow stops at user step.
-    assert any(
-        "No additional changes needed" not in prompt
-        for prompt in agent_manager.prompts
-    )
+    assert any("No additional changes needed" not in prompt for prompt in agent_manager.prompts)
 
 
 def test_initial_requirements_collection_does_not_auto_continue_clarification(
@@ -1101,7 +1256,9 @@ def test_initial_requirements_collection_does_not_auto_continue_clarification(
     assert reloaded.handoff_contract.to_step == "user"
 
 
-def test_generic_workflow_step_records_script_hook_events_to_blackboard(tmp_path: Path, monkeypatch) -> None:
+def test_generic_workflow_step_records_script_hook_events_to_blackboard(
+    tmp_path: Path, monkeypatch
+) -> None:
     monkeypatch.chdir(tmp_path)
     issue_dir = tmp_path / ".cafe" / "issues" / "issue-script-event"
     playbook = {
@@ -1177,7 +1334,9 @@ def test_generic_workflow_step_records_script_hook_events_to_blackboard(tmp_path
     assert script_event.data["status"] == "success"
 
 
-def test_generic_workflow_step_auto_continues_pause_statuses_in_interactive_mode(tmp_path: Path, monkeypatch) -> None:
+def test_generic_workflow_step_auto_continues_pause_statuses_in_interactive_mode(
+    tmp_path: Path, monkeypatch
+) -> None:
     monkeypatch.chdir(tmp_path)
     issue_dir = tmp_path / ".cafe" / "issues" / "issue-review"
     spec_dir = issue_dir / "spec" / "iteration_001"
@@ -1223,7 +1382,9 @@ def test_generic_workflow_step_auto_continues_pause_statuses_in_interactive_mode
     assert result.auto_continue is False
 
 
-def test_generic_workflow_step_keeps_missing_status_without_continue_prompt(tmp_path: Path, monkeypatch) -> None:
+def test_generic_workflow_step_keeps_missing_status_without_continue_prompt(
+    tmp_path: Path, monkeypatch
+) -> None:
     monkeypatch.chdir(tmp_path)
     issue_dir = tmp_path / ".cafe" / "issues" / "issue-no-status"
     playbook = {
@@ -1257,11 +1418,15 @@ def test_generic_workflow_step_keeps_missing_status_without_continue_prompt(tmp_
     assert "done without status" in result.response
     assert result.status_code is None
     assert len(executor.agent_manager.prompts) == 1
-    context_data = json.loads((issue_dir / "spec" / "iteration_001" / "iteration.json").read_text(encoding="utf-8"))
+    context_data = json.loads(
+        (issue_dir / "spec" / "iteration_001" / "iteration.json").read_text(encoding="utf-8")
+    )
     assert "status_code" not in context_data
 
 
-def test_generic_workflow_step_does_not_recover_from_unchanged_output(tmp_path: Path, monkeypatch) -> None:
+def test_generic_workflow_step_does_not_recover_from_unchanged_output(
+    tmp_path: Path, monkeypatch
+) -> None:
     monkeypatch.chdir(tmp_path)
     issue_dir = tmp_path / ".cafe" / "issues" / "issue-stale-output"
     playbook = {
@@ -1274,7 +1439,7 @@ def test_generic_workflow_step_does_not_recover_from_unchanged_output(tmp_path: 
                 "output_artifact": "code",
                 "allowed_tools": ["Read"],
                 "valid_intents": ["confirmed", "no_changes_needed"],
-                "on": {"await_agent": "review", "await_agent": "review"},
+                "on": {"await_agent": "review"},
             }
         },
     }
@@ -1308,7 +1473,9 @@ def test_generic_workflow_step_does_not_recover_from_unchanged_output(tmp_path: 
         executor.execute_step("develop", playbook["steps"]["develop"], state)
 
 
-def test_generic_workflow_step_restores_spec_runtime_allowed_tools(tmp_path: Path, monkeypatch) -> None:
+def test_generic_workflow_step_restores_spec_runtime_allowed_tools(
+    tmp_path: Path, monkeypatch
+) -> None:
     monkeypatch.chdir(tmp_path)
     issue_dir = tmp_path / ".cafe" / "issues" / "issue-spec-tools"
     playbook = {
@@ -1351,7 +1518,9 @@ def test_generic_workflow_step_restores_spec_runtime_allowed_tools(tmp_path: Pat
     assert "edit(./.cafe/issues/issue-spec-tools/spec/iteration_001/questions.xml)" in allowed_tools
 
 
-def test_generic_workflow_step_uses_baton_only_tools_on_baton_error(tmp_path: Path, monkeypatch) -> None:
+def test_generic_workflow_step_uses_baton_only_tools_on_baton_error(
+    tmp_path: Path, monkeypatch
+) -> None:
     monkeypatch.chdir(tmp_path)
     issue_dir = tmp_path / ".cafe" / "issues" / "issue-spec-baton-retry"
     playbook = {
@@ -1390,12 +1559,23 @@ def test_generic_workflow_step_uses_baton_only_tools_on_baton_error(tmp_path: Pa
     assert "ls" in allowed_tools
     assert "edit(./.cafe/issues/issue-spec-baton-retry/blackboard.json)" in allowed_tools
     assert "edit(./.cafe/issues/issue-spec-baton-retry/next_step.txt)" in allowed_tools
-    assert "edit(./.cafe/issues/issue-spec-baton-retry/spec/iteration_001/output.md)" not in allowed_tools
-    assert "edit(./.cafe/issues/issue-spec-baton-retry/spec/iteration_001/checklist.md)" not in allowed_tools
-    assert "edit(./.cafe/issues/issue-spec-baton-retry/spec/iteration_001/questions.xml)" not in allowed_tools
+    assert (
+        "edit(./.cafe/issues/issue-spec-baton-retry/spec/iteration_001/output.md)"
+        not in allowed_tools
+    )
+    assert (
+        "edit(./.cafe/issues/issue-spec-baton-retry/spec/iteration_001/checklist.md)"
+        not in allowed_tools
+    )
+    assert (
+        "edit(./.cafe/issues/issue-spec-baton-retry/spec/iteration_001/questions.xml)"
+        not in allowed_tools
+    )
 
 
-def test_generic_workflow_step_restores_develop_runtime_allowed_tools(tmp_path: Path, monkeypatch) -> None:
+def test_generic_workflow_step_restores_develop_runtime_allowed_tools(
+    tmp_path: Path, monkeypatch
+) -> None:
     monkeypatch.chdir(tmp_path)
     issue_dir = tmp_path / ".cafe" / "issues" / "issue-develop-tools"
     playbook = {
@@ -1406,7 +1586,16 @@ def test_generic_workflow_step_restores_develop_runtime_allowed_tools(tmp_path: 
                 "skill": "develop",
                 "role": "developer",
                 "output_artifact": "code",
-                "allowed_tools": ["Read", "Edit", "Write", "Grep", "Glob", "Bash", "WebFetch", "WebSearch"],
+                "allowed_tools": [
+                    "Read",
+                    "Edit",
+                    "Write",
+                    "Grep",
+                    "Glob",
+                    "Bash",
+                    "WebFetch",
+                    "WebSearch",
+                ],
                 "valid_intents": ["confirmed"],
                 "on": {"await_agent": "_done"},
             }
@@ -1447,7 +1636,9 @@ def test_generic_workflow_step_restores_develop_runtime_allowed_tools(tmp_path: 
     assert "web_search" in allowed_tools
 
 
-def test_generic_workflow_step_restores_review_runtime_allowed_tools(tmp_path: Path, monkeypatch) -> None:
+def test_generic_workflow_step_restores_review_runtime_allowed_tools(
+    tmp_path: Path, monkeypatch
+) -> None:
     monkeypatch.chdir(tmp_path)
     issue_dir = tmp_path / ".cafe" / "issues" / "issue-review-tools"
     playbook = {
@@ -1500,10 +1691,14 @@ def test_generic_workflow_step_restores_review_runtime_allowed_tools(tmp_path: P
     assert "bash(git show)" in allowed_tools
     assert "bash(git status)" in allowed_tools
     assert "edit(./.cafe/issues/issue-review-tools/review/iteration_001/output.md)" in allowed_tools
-    assert "edit(./.cafe/issues/issue-review-tools/review/iteration_001/checklist.md)" in allowed_tools
+    assert (
+        "edit(./.cafe/issues/issue-review-tools/review/iteration_001/checklist.md)" in allowed_tools
+    )
 
 
-def test_generic_workflow_step_restores_pr_runtime_allowed_tools(tmp_path: Path, monkeypatch) -> None:
+def test_generic_workflow_step_restores_pr_runtime_allowed_tools(
+    tmp_path: Path, monkeypatch
+) -> None:
     monkeypatch.chdir(tmp_path)
     issue_dir = tmp_path / ".cafe" / "issues" / "issue-pr-tools"
     playbook = {
@@ -1515,7 +1710,16 @@ def test_generic_workflow_step_restores_pr_runtime_allowed_tools(tmp_path: Path,
                 "role": "developer",
                 "input_artifacts": ["spec", "plan", "review_feedback"],
                 "output_artifact": "pr_result",
-                "allowed_tools": ["Read", "Edit", "Write", "Grep", "Glob", "Bash", "WebFetch", "WebSearch"],
+                "allowed_tools": [
+                    "Read",
+                    "Edit",
+                    "Write",
+                    "Grep",
+                    "Glob",
+                    "Bash",
+                    "WebFetch",
+                    "WebSearch",
+                ],
                 "valid_intents": ["confirmed"],
                 "on": {"await_agent": "_done"},
             }
@@ -1619,7 +1823,9 @@ def test_generic_workflow_step_pr_does_not_require_status_code(tmp_path: Path, m
     assert not (issue_dir / "pr" / "status.json").exists()
 
 
-def test_generic_workflow_step_pr_does_not_parse_status_from_response(tmp_path: Path, monkeypatch) -> None:
+def test_generic_workflow_step_pr_does_not_parse_status_from_response(
+    tmp_path: Path, monkeypatch
+) -> None:
     monkeypatch.chdir(tmp_path)
     issue_dir = tmp_path / ".cafe" / "issues" / "issue-pr-no-parse"
     playbook = {
@@ -1817,7 +2023,9 @@ def test_generic_workflow_step_pr_prompt_uses_baton_wording(tmp_path: Path, monk
     assert not any("Before returning a status code" in prompt for prompt in agent_manager.prompts)
 
 
-def test_generic_workflow_step_applies_phase_specific_model_per_step(tmp_path: Path, monkeypatch) -> None:
+def test_generic_workflow_step_applies_phase_specific_model_per_step(
+    tmp_path: Path, monkeypatch
+) -> None:
     monkeypatch.chdir(tmp_path)
     issue_dir = tmp_path / ".cafe" / "issues" / "issue-models"
     playbook = {
@@ -1881,7 +2089,9 @@ def test_generic_workflow_step_applies_phase_specific_model_per_step(tmp_path: P
     assert "claude-opus-4.6" in (agent_manager.preview_calls[1] or [])
 
 
-def test_generic_workflow_step_applies_phase_specific_model_from_clis_format(tmp_path: Path, monkeypatch) -> None:
+def test_generic_workflow_step_applies_phase_specific_model_from_clis_format(
+    tmp_path: Path, monkeypatch
+) -> None:
     # Regression: per-phase models declared in the new `clis:` list format must
     # reach the CLI command. Previously _resolve_step_model only understood the
     # old `role.<phase>.model` shape, so the clis list was silently ignored and
@@ -2003,6 +2213,7 @@ def test_generic_workflow_step_develop_confirmed(tmp_path: Path, monkeypatch) ->
 # ---------------------------------------------------------------------------
 # Tests for _get_allowed_directories merging (Task 3)
 # ---------------------------------------------------------------------------
+
 
 def _make_minimal_executor(tmp_path, **kwargs):
     """Build a GenericWorkflowStepExecutor with minimal config for dir-merge tests."""
@@ -2174,7 +2385,9 @@ def _write_plan_prereq_artifacts(issue_dir: Path) -> None:
     (spec_dir / "iteration.json").write_text('{"iteration": 1}', encoding="utf-8")
 
 
-def test_plan_non_interactive_ready_for_review_hands_off_to_user(tmp_path: Path, monkeypatch) -> None:
+def test_plan_non_interactive_ready_for_review_hands_off_to_user(
+    tmp_path: Path, monkeypatch
+) -> None:
     monkeypatch.chdir(tmp_path)
     issue_dir = tmp_path / ".cafe" / "issues" / "issue-plan-noninteractive-review"
     _write_plan_prereq_artifacts(issue_dir)
@@ -2201,7 +2414,9 @@ def test_plan_non_interactive_ready_for_review_hands_off_to_user(tmp_path: Path,
     assert reloaded.handoff_contract.to_step == "user"
 
 
-def test_plan_non_interactive_need_clarification_hands_off_to_user(tmp_path: Path, monkeypatch) -> None:
+def test_plan_non_interactive_need_clarification_hands_off_to_user(
+    tmp_path: Path, monkeypatch
+) -> None:
     monkeypatch.chdir(tmp_path)
     issue_dir = tmp_path / ".cafe" / "issues" / "issue-plan-noninteractive-clarify"
     _write_plan_prereq_artifacts(issue_dir)
@@ -2228,7 +2443,9 @@ def test_plan_non_interactive_need_clarification_hands_off_to_user(tmp_path: Pat
     assert reloaded.handoff_contract.intent == HandoffIntent.NEED_CLARIFICATION
 
 
-def test_develop_checklist_prefers_review_feedback_over_pr_result(tmp_path: Path, monkeypatch) -> None:
+def test_develop_checklist_prefers_review_feedback_over_pr_result(
+    tmp_path: Path, monkeypatch
+) -> None:
     """Develop correction checklist uses review_feedback when both artifacts exist."""
     monkeypatch.chdir(tmp_path)
     issue_dir = tmp_path / ".cafe" / "issues" / "issue-develop-feedback"
@@ -2306,7 +2523,11 @@ def test_update_iteration_history_preserves_model_and_stats_on_second_call(
 
     with patch.object(phase, "_append_iteration_index"):
         phase._update_iteration_history(
-            phase_specific_data={"response": "agent output", "permission_denials": [], "streaming_log": []},
+            phase_specific_data={
+                "response": "agent output",
+                "permission_denials": [],
+                "streaming_log": [],
+            },
             prompt="test prompt",
             agent_cli="claude",
             model="claude-haiku-4-5-20251001",
@@ -2339,6 +2560,7 @@ def test_update_iteration_history_preserves_model_and_stats_on_second_call(
 # ---------------------------------------------------------------------------
 # Tests for no_changes_needed playbook-driven routing (Issue #301)
 # ---------------------------------------------------------------------------
+
 
 def _develop_step_playbook_with_no_changes_target(no_changes_target: str | None) -> dict:
     """Build a minimal develop-step playbook with configurable no_changes_needed routing."""
@@ -2569,7 +2791,9 @@ def test_resolve_iteration_user_input_same_cli_session_returns_continue(tmp_path
     assert executor._resolve_iteration_user_input("spec") == "continue"
 
 
-def test_resolve_iteration_user_input_different_session_returns_full_candidate(tmp_path: Path) -> None:
+def test_resolve_iteration_user_input_different_session_returns_full_candidate(
+    tmp_path: Path,
+) -> None:
     issue_dir = tmp_path / ".cafe" / "issues" / "issue-resume-input"
     spec_dir = issue_dir / "spec"
     prev_iter = spec_dir / "iteration_001"
@@ -2603,7 +2827,9 @@ def test_resolve_iteration_user_input_loads_prewritten_user_input_file(tmp_path:
     spec_dir = issue_dir / "spec"
     current_iter = spec_dir / "iteration_002"
     current_iter.mkdir(parents=True)
-    (current_iter / "user_input.md").write_text("Answer from workflow --user-input", encoding="utf-8")
+    (current_iter / "user_input.md").write_text(
+        "Answer from workflow --user-input", encoding="utf-8"
+    )
     prev_iter = spec_dir / "iteration_001"
     prev_iter.mkdir(parents=True)
     (prev_iter / "iteration.json").write_text(
@@ -2625,10 +2851,7 @@ def test_resolve_iteration_user_input_loads_prewritten_user_input_file(tmp_path:
     executor.iteration = 2
     executor._step_agent_name = "Roger"
 
-    assert (
-        executor._resolve_iteration_user_input("spec")
-        == "Answer from workflow --user-input"
-    )
+    assert executor._resolve_iteration_user_input("spec") == "Answer from workflow --user-input"
 
 
 def test_resolve_iteration_user_input_interrupted_iteration_reuse(tmp_path: Path) -> None:

--- a/tests/unit/test_native_user_input_hook.py
+++ b/tests/unit/test_native_user_input_hook.py
@@ -4,8 +4,6 @@ import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from cafe.core.hooks.native import (
     GitHubIssueFetcher,
     GitHubPRCreator,
@@ -70,7 +68,9 @@ def _record_previous_step_status(issue_dir: Path, step_name: str, status_code: s
     )
 
 
-def test_user_input_collector_confirms_ready_for_review_without_running_agent(tmp_path: Path) -> None:
+def test_user_input_collector_confirms_ready_for_review_without_running_agent(
+    tmp_path: Path,
+) -> None:
     phase_dir = tmp_path / "spec"
     prev_iter_dir = phase_dir / "iteration_002"
     prev_iter_dir.mkdir(parents=True, exist_ok=True)
@@ -82,8 +82,10 @@ def test_user_input_collector_confirms_ready_for_review_without_running_agent(tm
     phase._process_review_decision = MagicMock()
 
     hook = UserInputCollector()
-    with patch.object(hook, "_display_previous_output") as mock_display_output, \
-         patch.object(hook, "_display_previous_iteration_delta") as mock_display_delta:
+    with (
+        patch.object(hook, "_display_previous_output") as mock_display_output,
+        patch.object(hook, "_display_previous_iteration_delta") as mock_display_delta,
+    ):
         result = hook.run(
             stage="prepare_input",
             phase=phase,
@@ -122,8 +124,10 @@ def test_user_input_collector_brief_ready_for_review_uses_delta_when_confirm_out
     phase._process_review_decision = MagicMock()
 
     hook = UserInputCollector()
-    with patch.object(hook, "_display_previous_output") as mock_display_output, \
-         patch.object(hook, "_display_previous_iteration_delta") as mock_display_delta:
+    with (
+        patch.object(hook, "_display_previous_output") as mock_display_output,
+        patch.object(hook, "_display_previous_iteration_delta") as mock_display_delta,
+    ):
         hook.run(
             stage="prepare_input",
             phase=phase,
@@ -136,7 +140,9 @@ def test_user_input_collector_brief_ready_for_review_uses_delta_when_confirm_out
     mock_display_delta.assert_called_once()
 
 
-def test_user_input_collector_plan_ready_for_review_skips_full_output_display_when_delta_available(tmp_path: Path) -> None:
+def test_user_input_collector_plan_ready_for_review_skips_full_output_display_when_delta_available(
+    tmp_path: Path,
+) -> None:
     phase_dir = tmp_path / "plan"
     prev_prev_iter_dir = phase_dir / "iteration_001"
     prev_prev_iter_dir.mkdir(parents=True, exist_ok=True)
@@ -152,8 +158,10 @@ def test_user_input_collector_plan_ready_for_review_skips_full_output_display_wh
     phase._process_review_decision = MagicMock()
 
     hook = UserInputCollector()
-    with patch.object(hook, "_display_previous_output") as mock_display_output, \
-         patch.object(hook, "_display_previous_iteration_delta") as mock_display_delta:
+    with (
+        patch.object(hook, "_display_previous_output") as mock_display_output,
+        patch.object(hook, "_display_previous_iteration_delta") as mock_display_delta,
+    ):
         result = hook.run(
             stage="prepare_input",
             phase=phase,
@@ -168,7 +176,9 @@ def test_user_input_collector_plan_ready_for_review_skips_full_output_display_wh
     mock_display_delta.assert_called_once()
 
 
-def test_user_input_collector_plan_ready_for_review_falls_back_to_full_output_without_delta(tmp_path: Path) -> None:
+def test_user_input_collector_plan_ready_for_review_falls_back_to_full_output_without_delta(
+    tmp_path: Path,
+) -> None:
     phase_dir = tmp_path / "plan"
     prev_iter_dir = phase_dir / "iteration_001"
     prev_iter_dir.mkdir(parents=True, exist_ok=True)
@@ -180,8 +190,10 @@ def test_user_input_collector_plan_ready_for_review_falls_back_to_full_output_wi
     phase._process_review_decision = MagicMock()
 
     hook = UserInputCollector()
-    with patch.object(hook, "_display_previous_output") as mock_display_output, \
-         patch.object(hook, "_display_previous_iteration_delta") as mock_display_delta:
+    with (
+        patch.object(hook, "_display_previous_output") as mock_display_output,
+        patch.object(hook, "_display_previous_iteration_delta") as mock_display_delta,
+    ):
         mock_display_delta.return_value = False
         result = hook.run(
             stage="prepare_input",
@@ -218,8 +230,12 @@ def test_user_input_collector_loads_interactive_qa_for_need_clarification(tmp_pa
     phase = _FakePhase(phase_dir=phase_dir, iteration=2)
     hook = UserInputCollector()
 
-    with patch.object(hook, "_display_previous_output") as mock_display_output, \
-         patch("cafe.core.hooks.native.interactive_qa_flow", return_value="Q1: Question?\nA1: Answer") as mock_qa:
+    with (
+        patch.object(hook, "_display_previous_output") as mock_display_output,
+        patch(
+            "cafe.core.hooks.native.interactive_qa_flow", return_value="Q1: Question?\nA1: Answer"
+        ) as mock_qa,
+    ):
         result = hook.run(
             stage="prepare_input",
             phase=phase,
@@ -229,7 +245,9 @@ def test_user_input_collector_loads_interactive_qa_for_need_clarification(tmp_pa
         )
 
     assert result.context_updates["user_input"] == "Q1: Question?\nA1: Answer"
-    assert result.events == [{"type": "user_input_collected", "step": "spec", "source": "questions_xml"}]
+    assert result.events == [
+        {"type": "user_input_collected", "step": "spec", "source": "questions_xml"}
+    ]
     assert phase.step_user_inputs["spec"] == "Q1: Question?\nA1: Answer"
     mock_display_output.assert_called_once()
     mock_qa.assert_called_once()
@@ -245,9 +263,13 @@ def test_user_input_collector_falls_back_to_prompt_when_no_questions_xml(tmp_pat
     phase = _FakePhase(phase_dir=phase_dir, iteration=2)
     hook = UserInputCollector()
 
-    with patch.object(hook, "_display_previous_output"), \
-         patch("cafe.core.hooks.native.interactive_qa_flow") as mock_qa, \
-         patch("cafe.core.hooks.native.prompt_multiline", return_value="manual clarification") as mock_prompt:
+    with (
+        patch.object(hook, "_display_previous_output"),
+        patch("cafe.core.hooks.native.interactive_qa_flow") as mock_qa,
+        patch(
+            "cafe.core.hooks.native.prompt_multiline", return_value="manual clarification"
+        ) as mock_prompt,
+    ):
         result = hook.run(
             stage="prepare_input",
             phase=phase,
@@ -262,7 +284,9 @@ def test_user_input_collector_falls_back_to_prompt_when_no_questions_xml(tmp_pat
     mock_prompt.assert_called_once()
 
 
-def test_user_input_collector_falls_back_to_prompt_when_questions_xml_invalid(tmp_path: Path) -> None:
+def test_user_input_collector_falls_back_to_prompt_when_questions_xml_invalid(
+    tmp_path: Path,
+) -> None:
     phase_dir = tmp_path / "spec"
     prev_iter_dir = phase_dir / "iteration_001"
     prev_iter_dir.mkdir(parents=True, exist_ok=True)
@@ -276,9 +300,13 @@ def test_user_input_collector_falls_back_to_prompt_when_questions_xml_invalid(tm
     phase = _FakePhase(phase_dir=phase_dir, iteration=2)
     hook = UserInputCollector()
 
-    with patch.object(hook, "_display_previous_output"), \
-         patch("cafe.core.hooks.native.interactive_qa_flow") as mock_qa, \
-         patch("cafe.core.hooks.native.prompt_multiline", return_value="fallback answer") as mock_prompt:
+    with (
+        patch.object(hook, "_display_previous_output"),
+        patch("cafe.core.hooks.native.interactive_qa_flow") as mock_qa,
+        patch(
+            "cafe.core.hooks.native.prompt_multiline", return_value="fallback answer"
+        ) as mock_prompt,
+    ):
         result = hook.run(
             stage="prepare_input",
             phase=phase,
@@ -322,7 +350,9 @@ def test_user_input_collector_noninteractive_reads_existing_user_input_file(tmp_
     assert result.events[0]["source"] == "user_input_file"
 
 
-def test_user_input_collector_reuses_existing_user_input_file_without_reasking(tmp_path: Path) -> None:
+def test_user_input_collector_reuses_existing_user_input_file_without_reasking(
+    tmp_path: Path,
+) -> None:
     phase_dir = tmp_path / "spec"
     prev_iter_dir = phase_dir / "iteration_001"
     current_iter_dir = phase_dir / "iteration_002"
@@ -351,19 +381,25 @@ def test_user_input_collector_reuses_existing_user_input_file_without_reasking(t
         )
 
     assert result.context_updates["user_input"] == "Q1: Question?\nA1: Confirmed answer"
-    assert result.events == [{"type": "user_input_collected", "step": "spec", "source": "user_input_file"}]
+    assert result.events == [
+        {"type": "user_input_collected", "step": "spec", "source": "user_input_file"}
+    ]
     assert phase.step_user_inputs["spec"] == "Q1: Question?\nA1: Confirmed answer"
     mock_display_output.assert_not_called()
     mock_qa.assert_not_called()
 
 
-def test_user_input_collector_prompts_initial_plan_user_input_on_first_iteration(tmp_path: Path) -> None:
+def test_user_input_collector_prompts_initial_plan_user_input_on_first_iteration(
+    tmp_path: Path,
+) -> None:
     phase_dir = tmp_path / "plan"
     phase_dir.mkdir(parents=True, exist_ok=True)
     phase = _FakePhase(phase_dir=phase_dir, iteration=1)
     hook = UserInputCollector()
 
-    with patch("cafe.core.hooks.native.prompt_multiline", return_value="Follow strict TDD first") as mock_prompt:
+    with patch(
+        "cafe.core.hooks.native.prompt_multiline", return_value="Follow strict TDD first"
+    ) as mock_prompt:
         result = hook.run(
             stage="prepare_input",
             phase=phase,
@@ -373,14 +409,18 @@ def test_user_input_collector_prompts_initial_plan_user_input_on_first_iteration
         )
 
     assert result.context_updates["user_input"] == "Follow strict TDD first"
-    assert result.events == [{"type": "user_input_collected", "step": "plan", "source": "initial_prompt"}]
+    assert result.events == [
+        {"type": "user_input_collected", "step": "plan", "source": "initial_prompt"}
+    ]
     assert phase.step_user_inputs["plan"] == "Follow strict TDD first"
     prompt_text = mock_prompt.call_args.args[0]
     assert "Suggested content:" in prompt_text
     assert "Technical solution/direction" in prompt_text
 
 
-def test_user_input_collector_skips_initial_plan_prompt_in_noninteractive_mode(tmp_path: Path) -> None:
+def test_user_input_collector_skips_initial_plan_prompt_in_noninteractive_mode(
+    tmp_path: Path,
+) -> None:
     phase_dir = tmp_path / "plan"
     phase_dir.mkdir(parents=True, exist_ok=True)
     phase = _FakePhase(phase_dir=phase_dir, iteration=1)
@@ -397,7 +437,9 @@ def test_user_input_collector_skips_initial_plan_prompt_in_noninteractive_mode(t
         )
 
     assert result.context_updates["user_input"] == ""
-    assert result.events == [{"type": "user_input_collected", "step": "plan", "source": "initial_prompt"}]
+    assert result.events == [
+        {"type": "user_input_collected", "step": "plan", "source": "initial_prompt"}
+    ]
     assert phase.step_user_inputs["plan"] == ""
     mock_prompt.assert_not_called()
 
@@ -421,7 +463,10 @@ def test_github_issue_fetcher_uses_context_user_input_without_prompting(tmp_path
             context={"user_input": "Build a standalone myip command."},
         )
 
-    assert output_file.read_text(encoding="utf-8") == "# Initial Requirements\n\nBuild a standalone myip command.\n"
+    assert (
+        output_file.read_text(encoding="utf-8")
+        == "# Initial Requirements\n\nBuild a standalone myip command.\n"
+    )
     assert result.context_updates["user_input"] == "Build a standalone myip command."
     assert result.events == [
         {
@@ -454,7 +499,10 @@ def test_github_issue_fetcher_uses_phase_step_user_input_without_prompting(tmp_p
             output_file=output_file,
         )
 
-    assert output_file.read_text(encoding="utf-8") == "# Initial Requirements\n\nBuild a standalone myip command.\n"
+    assert (
+        output_file.read_text(encoding="utf-8")
+        == "# Initial Requirements\n\nBuild a standalone myip command.\n"
+    )
     assert result.context_updates["user_input"] == "Build a standalone myip command."
     assert result.events == [
         {
@@ -468,7 +516,9 @@ def test_github_issue_fetcher_uses_phase_step_user_input_without_prompting(tmp_p
     mock_fetch_issue.assert_not_called()
 
 
-def test_execute_step_skips_checklist_validation_when_confirmed_without_agent_run(tmp_path: Path) -> None:
+def test_execute_step_skips_checklist_validation_when_confirmed_without_agent_run(
+    tmp_path: Path,
+) -> None:
     issue_dir = tmp_path / ".cafe" / "issues" / "demo"
     issue_dir.mkdir(parents=True, exist_ok=True)
 
@@ -511,10 +561,14 @@ def test_execute_step_skips_checklist_validation_when_confirmed_without_agent_ru
 def test_pr_link_opener_opens_current_pr_url_when_confirmed() -> None:
     hook = PRLinkOpener()
 
-    with patch("cafe.core.hooks.native.GitHubOps") as mock_github_ops, \
-         patch("cafe.core.hooks.native.webbrowser.open") as mock_open, \
-         patch("cafe.core.hooks.native.sys.stdin.isatty", return_value=True):
-        mock_github_ops.return_value.get_current_pr_url.return_value = "https://github.com/test/repo/pull/123"
+    with (
+        patch("cafe.core.hooks.native.GitHubOps") as mock_github_ops,
+        patch("cafe.core.hooks.native.webbrowser.open") as mock_open,
+        patch("cafe.core.hooks.native.sys.stdin.isatty", return_value=True),
+    ):
+        mock_github_ops.return_value.get_current_pr_url.return_value = (
+            "https://github.com/test/repo/pull/123"
+        )
 
         result = hook.run(stage="publish_output", status_code=PhaseStatusCode.CONFIRMED)
 
@@ -527,10 +581,14 @@ def test_pr_link_opener_opens_current_pr_url_when_confirmed() -> None:
 def test_pr_link_opener_skips_browser_in_non_interactive() -> None:
     hook = PRLinkOpener()
 
-    with patch("cafe.core.hooks.native.GitHubOps") as mock_github_ops, \
-         patch("cafe.core.hooks.native.webbrowser.open") as mock_open, \
-         patch("cafe.core.hooks.native.sys.stdin.isatty", return_value=False):
-        mock_github_ops.return_value.get_current_pr_url.return_value = "https://github.com/test/repo/pull/123"
+    with (
+        patch("cafe.core.hooks.native.GitHubOps") as mock_github_ops,
+        patch("cafe.core.hooks.native.webbrowser.open") as mock_open,
+        patch("cafe.core.hooks.native.sys.stdin.isatty", return_value=False),
+    ):
+        mock_github_ops.return_value.get_current_pr_url.return_value = (
+            "https://github.com/test/repo/pull/123"
+        )
 
         result = hook.run(stage="publish_output", status_code=PhaseStatusCode.CONFIRMED)
 
@@ -541,8 +599,10 @@ def test_pr_link_opener_skips_browser_in_non_interactive() -> None:
 def test_pr_link_opener_noops_when_pr_url_unavailable() -> None:
     hook = PRLinkOpener()
 
-    with patch("cafe.core.hooks.native.GitHubOps") as mock_github_ops, \
-         patch("cafe.core.hooks.native.webbrowser.open") as mock_open:
+    with (
+        patch("cafe.core.hooks.native.GitHubOps") as mock_github_ops,
+        patch("cafe.core.hooks.native.webbrowser.open") as mock_open,
+    ):
         mock_github_ops.return_value.get_current_pr_url.side_effect = Exception("no pr")
 
         result = hook.run(stage="publish_output", status_code=PhaseStatusCode.CONFIRMED)
@@ -554,10 +614,16 @@ def test_pr_link_opener_noops_when_pr_url_unavailable() -> None:
 def test_pr_link_opener_noops_when_browser_open_fails() -> None:
     hook = PRLinkOpener()
 
-    with patch("cafe.core.hooks.native.GitHubOps") as mock_github_ops, \
-         patch("cafe.core.hooks.native.webbrowser.open", side_effect=Exception("blocked")) as mock_open, \
-         patch("cafe.core.hooks.native.sys.stdin.isatty", return_value=True):
-        mock_github_ops.return_value.get_current_pr_url.return_value = "https://github.com/test/repo/pull/123"
+    with (
+        patch("cafe.core.hooks.native.GitHubOps") as mock_github_ops,
+        patch(
+            "cafe.core.hooks.native.webbrowser.open", side_effect=Exception("blocked")
+        ) as mock_open,
+        patch("cafe.core.hooks.native.sys.stdin.isatty", return_value=True),
+    ):
+        mock_github_ops.return_value.get_current_pr_url.return_value = (
+            "https://github.com/test/repo/pull/123"
+        )
 
         result = hook.run(stage="publish_output", status_code=PhaseStatusCode.CONFIRMED)
 
@@ -627,7 +693,9 @@ def test_local_pr_reviewer_writes_feedback_todo_and_requests_changes(tmp_path: P
 
     assert result.override_status_code == PhaseStatusCode.NEEDS_CHANGES
     assert "- [ ] Please fix the failing test" in output_file.read_text(encoding="utf-8")
-    assert (output_file.parent / "user_input.md").read_text(encoding="utf-8") == "Please fix the failing test"
+    assert (output_file.parent / "user_input.md").read_text(
+        encoding="utf-8"
+    ) == "Please fix the failing test"
     assert result.events[0]["type"] == "local_pr_review_changes_requested"
 
 
@@ -645,10 +713,18 @@ def test_github_pr_creator_prepare_input_loads_unresolved_comments(tmp_path: Pat
         patch("cafe.core.hooks.native.GitHubOps") as mock_github_ops,
         patch("cafe.core.hooks.native.get_processed_comment_ids_from_history", return_value=set()),
         patch("cafe.core.hooks.native.get_all_pr_comments", return_value=["raw-comments"]),
-        patch("cafe.core.hooks.native.filter_unresolved_comments", return_value=["unresolved-comment"]),
-        patch("cafe.core.hooks.native.format_comments_for_prompt", return_value="Comment #1\nPlease fix this"),
+        patch(
+            "cafe.core.hooks.native.filter_unresolved_comments", return_value=["unresolved-comment"]
+        ),
+        patch(
+            "cafe.core.hooks.native.format_comments_for_prompt",
+            return_value="Comment #1\nPlease fix this",
+        ),
     ):
-        mock_github_ops.return_value.get_pr_for_branch.return_value = {"number": 42, "url": "https://github.com/test/repo/pull/42"}
+        mock_github_ops.return_value.get_pr_for_branch.return_value = {
+            "number": 42,
+            "url": "https://github.com/test/repo/pull/42",
+        }
         result = hook.run(stage="prepare_input", phase=phase, step_name="pr")
 
     assert result.context_updates["pr_number"] == "42"
@@ -657,7 +733,9 @@ def test_github_pr_creator_prepare_input_loads_unresolved_comments(tmp_path: Pat
     assert result.events == [{"type": "pr_comments_loaded", "count": 1, "pr_number": "42"}]
 
 
-def test_github_pr_creator_prepare_input_uses_and_updates_last_seen_comments(tmp_path: Path) -> None:
+def test_github_pr_creator_prepare_input_uses_and_updates_last_seen_comments(
+    tmp_path: Path,
+) -> None:
     phase_dir = tmp_path / "pr"
     artifact_file = phase_dir / "artifacts" / "pr_last_seen_comments.json"
     artifact_file.parent.mkdir(parents=True, exist_ok=True)
@@ -678,9 +756,14 @@ def test_github_pr_creator_prepare_input_uses_and_updates_last_seen_comments(tmp
     with (
         patch("cafe.core.hooks.native.get_processed_comment_ids_from_history") as mock_processed,
         patch("cafe.core.hooks.native.GitHubOps") as mock_github_ops,
-        patch("cafe.core.hooks.native.get_all_pr_comments", return_value=[comment]) as mock_comments,
+        patch(
+            "cafe.core.hooks.native.get_all_pr_comments", return_value=[comment]
+        ) as mock_comments,
         patch("cafe.core.hooks.native.filter_unresolved_comments", return_value=[comment]),
-        patch("cafe.core.hooks.native.format_comments_for_prompt", return_value="Comment #1\nPlease fix this"),
+        patch(
+            "cafe.core.hooks.native.format_comments_for_prompt",
+            return_value="Comment #1\nPlease fix this",
+        ),
     ):
         mock_github_ops.return_value.get_pr_for_branch.return_value = {
             "number": 250,
@@ -726,8 +809,7 @@ def test_github_pr_creator_publish_output_runs_sync_pr_script(tmp_path: Path) ->
     completed = MagicMock()
     completed.returncode = 0
     completed.stdout = (
-        '{"action":"created","pr_number":"42",'
-        '"pr_url":"https://github.com/test/repo/pull/42"}\n'
+        '{"action":"created","pr_number":"42",' '"pr_url":"https://github.com/test/repo/pull/42"}\n'
     )
     completed.stderr = ""
 
@@ -761,6 +843,110 @@ def test_github_pr_creator_publish_output_runs_sync_pr_script(tmp_path: Path) ->
     assert result.events[1]["type"] == "capability_receipt"
     assert result.events[1]["capability"] == "cafe.pr.publish"
     assert result.events[1]["success"] is True
+
+
+def test_github_pr_creator_publish_output_rejects_unknown_generic_capability_without_script(
+    tmp_path: Path,
+) -> None:
+    from cafe.core.blackboard import BlackboardStore
+
+    issue_dir = tmp_path / ".cafe" / "issues" / "demo"
+    phase_dir = issue_dir / "publish"
+    output_file = phase_dir / "iteration_001" / "output.md"
+    capability_request_file = phase_dir / "iteration_001" / "capability_request.json"
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    output_file.write_text("# Publish\n", encoding="utf-8")
+    capability_request_file.write_text(
+        json.dumps({"capability": "demo.unknown", "args": {}, "permissions": {}}),
+        encoding="utf-8",
+    )
+    phase = _FakePhase(phase_dir=phase_dir, iteration=1)
+    phase.git_ops = MagicMock()
+    phase.git_ops.get_repo_root.return_value = tmp_path
+    store = BlackboardStore(issue_dir)
+    blackboard_state = store.load_or_create("publish")
+
+    hook = GitHubPRCreator()
+    with patch("cafe.core.capabilities.subprocess.run") as mock_run:
+        result = hook.run(
+            stage="publish_output",
+            phase=phase,
+            step_name="publish",
+            step_def={"capability_requests": ["demo.unknown"]},
+            output_file=output_file,
+            capability_request_file=capability_request_file,
+            blackboard_state=blackboard_state,
+            status_code=PhaseStatusCode.CONFIRMED,
+        )
+
+    mock_run.assert_not_called()
+    assert result.events == [
+        {
+            "type": "capability_receipt",
+            "capability": "demo.unknown",
+            "success": False,
+            "correlation_id": result.events[0]["correlation_id"],
+            "category": "validation_error",
+            "code": "unknown_capability",
+        }
+    ]
+    loaded = store.load_or_create("publish")
+    assert loaded.capability_receipts[-1]["capability"] == "demo.unknown"
+    assert loaded.capability_receipts[-1]["success"] is False
+
+
+def test_github_pr_creator_publish_output_records_all_multi_capability_receipts(
+    tmp_path: Path,
+) -> None:
+    from cafe.core.blackboard import BlackboardStore
+
+    issue_dir = tmp_path / ".cafe" / "issues" / "demo"
+    phase_dir = issue_dir / "publish"
+    output_file = phase_dir / "iteration_001" / "output.md"
+    capability_request_file = phase_dir / "iteration_001" / "capability_request.json"
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    output_file.write_text("# Publish\n", encoding="utf-8")
+    capability_request_file.write_text(
+        json.dumps(
+            {
+                "requests": [
+                    {"capability": "demo.first", "args": {}, "permissions": {}},
+                    {"capability": "demo.second", "args": {}, "permissions": {}},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    phase = _FakePhase(phase_dir=phase_dir, iteration=1)
+    phase.git_ops = MagicMock()
+    phase.git_ops.get_repo_root.return_value = tmp_path
+    store = BlackboardStore(issue_dir)
+    blackboard_state = store.load_or_create("publish")
+
+    hook = GitHubPRCreator()
+    with patch("cafe.core.capabilities.subprocess.run") as mock_run:
+        result = hook.run(
+            stage="publish_output",
+            phase=phase,
+            step_name="publish",
+            step_def={"capability_requests": ["demo.first", "demo.second"]},
+            output_file=output_file,
+            capability_request_file=capability_request_file,
+            blackboard_state=blackboard_state,
+            status_code=PhaseStatusCode.CONFIRMED,
+        )
+
+    mock_run.assert_not_called()
+    assert [event["capability"] for event in result.events] == ["demo.first", "demo.second"]
+    assert [event["code"] for event in result.events] == [
+        "unknown_capability",
+        "unknown_capability",
+    ]
+    loaded = store.load_or_create("publish")
+    assert [receipt["capability"] for receipt in loaded.capability_receipts[-2:]] == [
+        "demo.first",
+        "demo.second",
+    ]
 
 
 def test_github_pr_creator_publish_output_runs_from_workflow_complete_baton_without_status_code(
@@ -808,8 +994,7 @@ def test_github_pr_creator_publish_output_runs_from_workflow_complete_baton_with
     completed = MagicMock()
     completed.returncode = 0
     completed.stdout = (
-        '{"action":"created","pr_number":"42",'
-        '"pr_url":"https://github.com/test/repo/pull/42"}\n'
+        '{"action":"created","pr_number":"42",' '"pr_url":"https://github.com/test/repo/pull/42"}\n'
     )
     completed.stderr = ""
 
@@ -829,6 +1014,73 @@ def test_github_pr_creator_publish_output_runs_from_workflow_complete_baton_with
     assert result.events[0]["type"] == "pr_synced"
     assert result.events[0]["source"] == "capability"
     assert result.events[1]["type"] == "capability_receipt"
+
+
+def test_github_pr_creator_publish_output_runs_from_pr_done_await_agent_baton(
+    tmp_path: Path,
+) -> None:
+    issue_dir = tmp_path / ".cafe" / "issues" / "demo"
+    phase_dir = issue_dir / "pr"
+    output_file = phase_dir / "iteration_001" / "output.md"
+    publish_request_file = phase_dir / "iteration_001" / "publish_request.json"
+    next_step_file = issue_dir / "next_step.txt"
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    output_file.write_text("# Test PR\n\nBody\n", encoding="utf-8")
+    publish_request_file.write_text(
+        json.dumps(
+            {
+                "capability": "cafe.pr.publish",
+                "args": {
+                    "output": ".cafe/issues/demo/pr/iteration_001/output.md",
+                    "base": "develop",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    next_step_file.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "from_step": "pr",
+                "to_owner": "done",
+                "to_step": "done",
+                "intent": "await_agent",
+                "status_code": "confirmed",
+                "created_at": "2026-04-26T22:49:02.559908+08:00",
+                "source": "agent.test",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    phase = _FakePhase(phase_dir=phase_dir, iteration=1)
+    phase.git_ops = MagicMock()
+    phase.git_ops.get_repo_root.return_value = tmp_path
+
+    completed = MagicMock()
+    completed.returncode = 0
+    completed.stdout = (
+        '{"action":"updated","pr_number":"42",' '"pr_url":"https://github.com/test/repo/pull/42"}\n'
+    )
+    completed.stderr = ""
+
+    hook = GitHubPRCreator()
+    with patch("cafe.core.capabilities.subprocess.run", return_value=completed) as mock_run:
+        result = hook.run(
+            stage="publish_output",
+            phase=phase,
+            step_name="pr",
+            output_file=output_file,
+            publish_request_file=publish_request_file,
+            context={"next_step_path": str(next_step_file)},
+            status_code=None,
+        )
+
+    mock_run.assert_called_once()
+    assert result.events[0]["type"] == "pr_synced"
+    assert result.events[1]["type"] == "capability_receipt"
+    assert result.context_updates["pr_sync_action"] == "updated"
 
 
 def test_github_pr_creator_publish_output_runs_from_legacy_done_baton(
@@ -862,8 +1114,7 @@ def test_github_pr_creator_publish_output_runs_from_legacy_done_baton(
     completed = MagicMock()
     completed.returncode = 0
     completed.stdout = (
-        '{"action":"updated","pr_number":"42",'
-        '"pr_url":"https://github.com/test/repo/pull/42"}\n'
+        '{"action":"updated","pr_number":"42",' '"pr_url":"https://github.com/test/repo/pull/42"}\n'
     )
     completed.stderr = ""
 
@@ -913,7 +1164,9 @@ def test_github_pr_creator_publish_output_skips_local_pr_mode(tmp_path: Path) ->
     assert result.events == []
 
 
-def test_github_pr_creator_publish_ignores_untrusted_script_field_in_request(tmp_path: Path) -> None:
+def test_github_pr_creator_publish_ignores_untrusted_script_field_in_request(
+    tmp_path: Path,
+) -> None:
     """Registry-resolved script is used; agent-supplied script path must not change dispatch."""
     issue_dir = tmp_path / ".cafe" / "issues" / "demo"
     phase_dir = issue_dir / "pr"
@@ -942,8 +1195,7 @@ def test_github_pr_creator_publish_ignores_untrusted_script_field_in_request(tmp
     completed = MagicMock()
     completed.returncode = 0
     completed.stdout = (
-        '{"action":"created","pr_number":"42",'
-        '"pr_url":"https://github.com/test/repo/pull/42"}\n'
+        '{"action":"created","pr_number":"42",' '"pr_url":"https://github.com/test/repo/pull/42"}\n'
     )
     completed.stderr = ""
 
@@ -962,7 +1214,9 @@ def test_github_pr_creator_publish_ignores_untrusted_script_field_in_request(tmp
     assert cmd[1] == str(hook._resolve_sync_script(tmp_path))
 
 
-def test_pr_comment_poster_posts_todo_comment_only_when_confirmed_and_complete(tmp_path: Path) -> None:
+def test_pr_comment_poster_posts_todo_comment_only_when_confirmed_and_complete(
+    tmp_path: Path,
+) -> None:
     output_file = tmp_path / "output.md"
     output_file.write_text("## Todo List\n- [x] Fix comment\n", encoding="utf-8")
 
@@ -972,7 +1226,10 @@ def test_pr_comment_poster_posts_todo_comment_only_when_confirmed_and_complete(t
     hook = PRCommentPoster()
 
     with patch("cafe.core.hooks.native.GitHubOps") as mock_github_ops:
-        mock_github_ops.return_value.get_pr_for_branch.return_value = {"number": 42, "url": "https://github.com/test/repo/pull/42"}
+        mock_github_ops.return_value.get_pr_for_branch.return_value = {
+            "number": 42,
+            "url": "https://github.com/test/repo/pull/42",
+        }
         result = hook.run(
             stage="publish_output",
             phase=phase,
@@ -994,7 +1251,10 @@ def test_pr_comment_poster_skips_when_unchecked_items_exist(tmp_path: Path) -> N
     hook = PRCommentPoster()
 
     with patch("cafe.core.hooks.native.GitHubOps") as mock_github_ops:
-        mock_github_ops.return_value.get_pr_for_branch.return_value = {"number": 42, "url": "https://github.com/test/repo/pull/42"}
+        mock_github_ops.return_value.get_pr_for_branch.return_value = {
+            "number": 42,
+            "url": "https://github.com/test/repo/pull/42",
+        }
         result = hook.run(
             stage="publish_output",
             phase=phase,

--- a/tests/unit/test_native_user_input_hook.py
+++ b/tests/unit/test_native_user_input_hook.py
@@ -1010,7 +1010,9 @@ def test_github_pr_creator_publish_output_runs_from_workflow_complete_baton_with
             status_code=None,
         )
 
-    mock_run.assert_called_once()
+    assert mock_run.call_count == 2
+    assert mock_run.call_args_list[0].args[0][0] == "git"
+    assert mock_run.call_args_list[1].args[0][0] == "/bin/bash"
     assert result.events[0]["type"] == "pr_synced"
     assert result.events[0]["source"] == "capability"
     assert result.events[1]["type"] == "capability_receipt"
@@ -1077,7 +1079,9 @@ def test_github_pr_creator_publish_output_runs_from_pr_done_await_agent_baton(
             status_code=None,
         )
 
-    mock_run.assert_called_once()
+    assert mock_run.call_count == 2
+    assert mock_run.call_args_list[0].args[0][0] == "git"
+    assert mock_run.call_args_list[1].args[0][0] == "/bin/bash"
     assert result.events[0]["type"] == "pr_synced"
     assert result.events[1]["type"] == "capability_receipt"
     assert result.context_updates["pr_sync_action"] == "updated"
@@ -1130,7 +1134,9 @@ def test_github_pr_creator_publish_output_runs_from_legacy_done_baton(
             status_code=None,
         )
 
-    mock_run.assert_called_once()
+    assert mock_run.call_count == 2
+    assert mock_run.call_args_list[0].args[0][0] == "git"
+    assert mock_run.call_args_list[1].args[0][0] == "/bin/bash"
     assert result.events[0]["type"] == "pr_synced"
     assert result.events[0]["action"] == "updated"
     assert result.events[1]["type"] == "capability_receipt"

--- a/tests/unit/test_playbook_loader.py
+++ b/tests/unit/test_playbook_loader.py
@@ -199,6 +199,61 @@ steps:
     assert alignment.affected_document_categories == ["roadmap", "positioning"]
 
 
+def test_load_supports_capability_requests(tmp_path: Path) -> None:
+    builtin_root = tmp_path / "builtin"
+    _write_skill(builtin_root / "skills", "pr")
+    _write_playbook(
+        builtin_root / "playbooks",
+        "default",
+        """
+playbook:
+  id: default
+steps:
+  pr:
+    skill: pr
+    role: developer
+    capability_requests: [cafe.pr.publish]
+    on:
+      await_agent: _done
+""",
+    )
+
+    result = PlaybookLoader(
+        project_root=tmp_path / "project",
+        global_root=tmp_path / "global",
+        builtin_root=builtin_root,
+    ).load_model("default")
+
+    assert result.model.steps["pr"].capability_requests == ["cafe.pr.publish"]
+
+
+def test_load_rejects_duplicate_capability_requests(tmp_path: Path) -> None:
+    builtin_root = tmp_path / "builtin"
+    _write_skill(builtin_root / "skills", "pr")
+    _write_playbook(
+        builtin_root / "playbooks",
+        "default",
+        """
+playbook:
+  id: default
+steps:
+  pr:
+    skill: pr
+    role: developer
+    capability_requests: [cafe.pr.publish, cafe.pr.publish]
+    on:
+      await_agent: _done
+""",
+    )
+
+    with pytest.raises(ValueError, match="duplicate capability_requests"):
+        PlaybookLoader(
+            project_root=tmp_path / "project",
+            global_root=tmp_path / "global",
+            builtin_root=builtin_root,
+        ).load_model("default")
+
+
 def test_load_rejects_unknown_alignment_config_key(tmp_path: Path) -> None:
     builtin_root = tmp_path / "builtin"
     _write_skill(builtin_root / "skills", "cafe-develop")

--- a/tests/unit/test_use_cafe_workflow_skill.py
+++ b/tests/unit/test_use_cafe_workflow_skill.py
@@ -1,0 +1,18 @@
+"""Tests for bundled use-cafe-workflow skill guidance."""
+
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_use_cafe_workflow_skill_guides_alignment_checkpoint_delegation() -> None:
+    skill = (
+        PROJECT_ROOT / "src" / "cafe" / "data" / "skills" / "use-cafe-workflow" / "SKILL.md"
+    ).read_text(encoding="utf-8")
+
+    assert "## Alignment Checkpoints" in skill
+    assert "resolve the checkpoint on behalf of the user" in skill
+    assert "explicit JSON decision payload" in skill
+    assert "Plain text must not be used for alignment approval" in skill
+    assert "Do not write `strategic_documents_updated`" in skill
+    assert "stop and ask the user" in skill

--- a/tests/unit/test_workflow_runtime.py
+++ b/tests/unit/test_workflow_runtime.py
@@ -68,7 +68,9 @@ def test_runtime_blocks_pr_done_without_publish_receipt(tmp_path: Path) -> None:
     }
 
     def executor(step_name: str, step_def: dict, state: object) -> StepExecutionResult:
-        _write_baton(issue_dir, from_step="pr", to_owner="done", to_step="done", intent="workflow_complete")
+        _write_baton(
+            issue_dir, from_step="pr", to_owner="done", to_step="done", intent="workflow_complete"
+        )
         return StepExecutionResult(response="done", artifacts={"pr_result": "p1"})
 
     runtime = BlackboardWorkflowRuntime(
@@ -95,7 +97,9 @@ def test_runtime_completes_pr_when_publish_receipt_exists(tmp_path: Path) -> Non
     }
 
     def executor(step_name: str, step_def: dict, state: object) -> StepExecutionResult:
-        _write_baton(issue_dir, from_step="pr", to_owner="done", to_step="done", intent="workflow_complete")
+        _write_baton(
+            issue_dir, from_step="pr", to_owner="done", to_step="done", intent="workflow_complete"
+        )
         return StepExecutionResult(
             response="done",
             artifacts={"pr_result": "p1"},
@@ -124,7 +128,9 @@ def test_runtime_completes_pr_when_capability_receipt_success_exists(tmp_path: P
     }
 
     def executor(step_name: str, step_def: dict, state: object) -> StepExecutionResult:
-        _write_baton(issue_dir, from_step="pr", to_owner="done", to_step="done", intent="workflow_complete")
+        _write_baton(
+            issue_dir, from_step="pr", to_owner="done", to_step="done", intent="workflow_complete"
+        )
         return StepExecutionResult(
             response="done",
             artifacts={"pr_result": "p1"},
@@ -148,6 +154,97 @@ def test_runtime_completes_pr_when_capability_receipt_success_exists(tmp_path: P
     result = runtime.run(start_step="pr")
 
     assert result.completed is True
+    assert result.final_status_code == "BATON_WORKFLOW_COMPLETE"
+
+
+def test_runtime_blocks_declared_capability_step_without_receipt(tmp_path: Path) -> None:
+    issue_dir = tmp_path / ".cafe" / "issues" / "demo-capability-step"
+    playbook = {
+        "playbook": {"id": "default"},
+        "steps": {
+            "publish": {
+                "skill": "spec_first",
+                "role": "developer",
+                "capability_requests": ["demo.publish"],
+                "on": {"await_agent": "_done"},
+            },
+        },
+    }
+
+    def executor(step_name: str, step_def: dict, state: object) -> StepExecutionResult:
+        _write_baton(
+            issue_dir,
+            from_step="publish",
+            to_owner="done",
+            to_step="done",
+            intent="workflow_complete",
+        )
+        return StepExecutionResult(response="done", artifacts={"publish_result": "p1"})
+
+    runtime = BlackboardWorkflowRuntime(
+        issue_dir=issue_dir,
+        playbook=playbook,
+        executor=executor,
+    )
+    result = runtime.run(start_step="publish")
+
+    assert result.completed is False
+    assert result.final_step == "publish"
+    assert result.final_status_code == "MISSING_CAPABILITY_RECEIPT"
+    blackboard = BlackboardStore(issue_dir).load_or_create("publish")
+    assert blackboard.current_step == "publish"
+    blocked_events = [
+        event for event in blackboard.events if event.event_type == "workflow_blocked"
+    ]
+    assert blocked_events[-1].data["missing_capabilities"] == ["demo.publish"]
+
+
+def test_runtime_completes_declared_capability_step_with_receipt(tmp_path: Path) -> None:
+    issue_dir = tmp_path / ".cafe" / "issues" / "demo-capability-step-success"
+    playbook = {
+        "playbook": {"id": "default"},
+        "steps": {
+            "publish": {
+                "skill": "spec_first",
+                "role": "developer",
+                "capability_requests": ["demo.publish"],
+                "on": {"await_agent": "_done"},
+            },
+        },
+    }
+
+    def executor(step_name: str, step_def: dict, state: object) -> StepExecutionResult:
+        _write_baton(
+            issue_dir,
+            from_step="publish",
+            to_owner="done",
+            to_step="done",
+            intent="workflow_complete",
+        )
+        return StepExecutionResult(
+            response="done",
+            artifacts={"publish_result": "p1"},
+            events=[
+                {
+                    "type": "capability_receipt",
+                    "capability": "demo.publish",
+                    "success": True,
+                    "correlation_id": "generic-ok",
+                    "category": None,
+                    "code": None,
+                }
+            ],
+        )
+
+    runtime = BlackboardWorkflowRuntime(
+        issue_dir=issue_dir,
+        playbook=playbook,
+        executor=executor,
+    )
+    result = runtime.run(start_step="publish")
+
+    assert result.completed is True
+    assert result.final_step == "publish"
     assert result.final_status_code == "BATON_WORKFLOW_COMPLETE"
 
 
@@ -245,7 +342,9 @@ def test_runtime_retries_stale_invalid_baton_from_startup(tmp_path: Path) -> Non
     }
     prompts: list[str] = []
 
-    def executor(step_name: str, step_def: dict, state: object, *, extra_prompt: str | None = None) -> StepExecutionResult:
+    def executor(
+        step_name: str, step_def: dict, state: object, *, extra_prompt: str | None = None
+    ) -> StepExecutionResult:
         prompts.append(extra_prompt or "")
         _write_baton(
             issue_dir,
@@ -402,7 +501,9 @@ def test_runtime_single_step_executes_pr_without_legacy_runner(tmp_path: Path) -
     }
 
     def executor(step_name: str, step_def: dict, state: object) -> StepExecutionResult:
-        _write_baton(issue_dir, from_step="pr", to_owner="done", to_step="done", intent="workflow_complete")
+        _write_baton(
+            issue_dir, from_step="pr", to_owner="done", to_step="done", intent="workflow_complete"
+        )
         return StepExecutionResult(
             response="done",
             artifacts={"pr_result": "p1"},
@@ -493,7 +594,9 @@ def test_runtime_single_step_baton_transition_uses_single_step_labels(tmp_path: 
     }
 
     def executor(step_name: str, step_def: dict, state: object) -> StepExecutionResult:
-        _write_baton(issue_dir, from_step="pr", to_owner="agent", to_step="review", intent="await_agent")
+        _write_baton(
+            issue_dir, from_step="pr", to_owner="agent", to_step="review", intent="await_agent"
+        )
         return StepExecutionResult(response="done", artifacts={"pr_result": "p1"})
 
     runtime = BlackboardWorkflowRuntime(
@@ -657,7 +760,9 @@ def test_runtime_legacy_step_honors_review_confirmed_advance(tmp_path: Path) -> 
                 status_code="confirmed",
                 events=[{"type": "review_confirmed_advance"}],
             )
-        _write_baton(issue_dir, from_step="pr", to_owner="done", to_step="done", intent="workflow_complete")
+        _write_baton(
+            issue_dir, from_step="pr", to_owner="done", to_step="done", intent="workflow_complete"
+        )
         return StepExecutionResult(
             response="done",
             artifacts={"pr_result": "p1"},
@@ -733,7 +838,9 @@ def test_runtime_review_confirmed_routes_to_pr_without_legacy_class(tmp_path: Pa
     assert blackboard.artifacts["review_feedback"].path == "review-output.md"
 
 
-def test_runtime_review_needs_changes_routes_to_develop_without_legacy_class(tmp_path: Path) -> None:
+def test_runtime_review_needs_changes_routes_to_develop_without_legacy_class(
+    tmp_path: Path,
+) -> None:
     issue_dir = tmp_path / ".cafe" / "issues" / "review-needs-changes"
     playbook = {
         "playbook": {"id": "default"},
@@ -1275,7 +1382,9 @@ def test_runtime_pauses_brief_ready_for_review_with_confirm_output_intent(tmp_pa
     assert blackboard.handoff_contract.intent == HandoffIntent.CONFIRM_OUTPUT
 
 
-def test_runtime_ready_for_review_without_confirm_output_uses_manual_handoff(tmp_path: Path) -> None:
+def test_runtime_ready_for_review_without_confirm_output_uses_manual_handoff(
+    tmp_path: Path,
+) -> None:
     issue_dir = tmp_path / ".cafe" / "issues" / "develop-review-no-confirm"
     playbook = {
         "playbook": {"id": "default"},
@@ -1385,10 +1494,14 @@ def test_runtime_emits_expected_runtime_labels_per_path(tmp_path: Path) -> None:
     legacy_runtime.run(start_step="review")
     legacy_state = BlackboardStore(issue_dir_legacy).load_or_create("review")
     review_started = [
-        e for e in legacy_state.events if e.event_type == "step_started" and e.data.get("step") == "review"
+        e
+        for e in legacy_state.events
+        if e.event_type == "step_started" and e.data.get("step") == "review"
     ]
     review_completed = [
-        e for e in legacy_state.events if e.event_type == "step_completed" and e.data.get("step") == "review"
+        e
+        for e in legacy_state.events
+        if e.event_type == "step_completed" and e.data.get("step") == "review"
     ]
     boundary_transition = [
         e
@@ -1411,7 +1524,13 @@ def test_runtime_emits_expected_runtime_labels_per_path(tmp_path: Path) -> None:
     }
 
     def pr_executor(step_name: str, step_def: dict, state: object) -> StepExecutionResult:
-        _write_baton(issue_dir_pr, from_step="pr", to_owner="done", to_step="done", intent="workflow_complete")
+        _write_baton(
+            issue_dir_pr,
+            from_step="pr",
+            to_owner="done",
+            to_step="done",
+            intent="workflow_complete",
+        )
         return StepExecutionResult(
             response="done",
             artifacts={},
@@ -1659,7 +1778,11 @@ def test_runtime_handles_keyboard_interrupt(tmp_path: Path) -> None:
     bb = BlackboardStore(issue_dir).load_or_create("spec", playbook_id="default")
     interrupted_events = [e for e in bb.events if e.event_type == "step_interrupted"]
     assert len(interrupted_events) == 1
-    msg = json.loads(interrupted_events[0].message) if isinstance(interrupted_events[0].message, str) else interrupted_events[0].message
+    msg = (
+        json.loads(interrupted_events[0].message)
+        if isinstance(interrupted_events[0].message, str)
+        else interrupted_events[0].message
+    )
     assert msg["step"] == "spec"
 
 
@@ -1696,7 +1819,11 @@ def test_runtime_handles_agent_execution_error(tmp_path: Path) -> None:
     bb = BlackboardStore(issue_dir).load_or_create("spec", playbook_id="default")
     interrupted_events = [e for e in bb.events if e.event_type == "step_interrupted"]
     assert len(interrupted_events) == 1
-    msg = json.loads(interrupted_events[0].message) if isinstance(interrupted_events[0].message, str) else interrupted_events[0].message
+    msg = (
+        json.loads(interrupted_events[0].message)
+        if isinstance(interrupted_events[0].message, str)
+        else interrupted_events[0].message
+    )
     assert msg["step"] == "spec"
     assert msg["reason"] == "agent_rate_limit"
 
@@ -1751,12 +1878,16 @@ def test_runtime_reconciles_agent_error_after_valid_handoff(tmp_path: Path) -> N
         for e in bb.events
     )
 
-    iteration_data = json.loads((issue_dir / "spec" / "iteration_001" / "iteration.json").read_text())
+    iteration_data = json.loads(
+        (issue_dir / "spec" / "iteration_001" / "iteration.json").read_text()
+    )
     assert iteration_data["status_code"] == "confirmed"
     assert iteration_data["end_time"]
 
 
-def test_runtime_preserves_interrupted_when_reconciliation_evidence_incomplete(tmp_path: Path) -> None:
+def test_runtime_preserves_interrupted_when_reconciliation_evidence_incomplete(
+    tmp_path: Path,
+) -> None:
     """Incomplete persisted evidence should not be inferred as a completed handoff."""
     from cafe.agents.executor import AgentExecutionError
 
@@ -1847,11 +1978,15 @@ def test_runtime_resume_reconciliation_is_idempotent(tmp_path: Path) -> None:
     runtime = BlackboardWorkflowRuntime(
         issue_dir=issue_dir,
         playbook=playbook,
-        executor=lambda *_args, **_kwargs: StepExecutionResult(response="confirmed", artifacts={}, status_code="confirmed"),
+        executor=lambda *_args, **_kwargs: StepExecutionResult(
+            response="confirmed", artifacts={}, status_code="confirmed"
+        ),
     )
 
     first = runtime._try_resume_reconcile_interrupted_handoff(runtime_label="legacy_until_boundary")
-    second = runtime._try_resume_reconcile_interrupted_handoff(runtime_label="legacy_until_boundary")
+    second = runtime._try_resume_reconcile_interrupted_handoff(
+        runtime_label="legacy_until_boundary"
+    )
 
     assert first is not None
     assert second is None
@@ -1923,7 +2058,9 @@ def test_runtime_reconciles_after_consumed_handoff_start_step(tmp_path: Path) ->
     reconciled_event = next(e for e in bb.events if e.event_type == "step_reconciled")
     assert reconciled_event.data["step"] == "spec"
     assert reconciled_event.data["to_step"] == "plan"
-    iteration_data = json.loads((issue_dir / "spec" / "iteration_001" / "iteration.json").read_text())
+    iteration_data = json.loads(
+        (issue_dir / "spec" / "iteration_001" / "iteration.json").read_text()
+    )
     assert iteration_data["status_code"] == "confirmed"
     assert iteration_data["end_time"]
 
@@ -1931,6 +2068,7 @@ def test_runtime_reconciles_after_consumed_handoff_start_step(tmp_path: Path) ->
 # ---------------------------------------------------------------------------
 # extra_prompt 傳遞測試
 # ---------------------------------------------------------------------------
+
 
 def _simple_playbook(step_name: str = "spec") -> dict:
     return {
@@ -1988,20 +2126,29 @@ def test_execute_one_iteration_no_extra_prompt_defaults_to_none(tmp_path: Path) 
 # reject-and-retry 機制測試
 # ---------------------------------------------------------------------------
 
-def _make_valid_baton_text(issue_dir: Path, *, from_step: str = "spec", to_step: str = "done", intent: str = "workflow_complete") -> None:
+
+def _make_valid_baton_text(
+    issue_dir: Path,
+    *,
+    from_step: str = "spec",
+    to_step: str = "done",
+    intent: str = "workflow_complete",
+) -> None:
     """寫入合法 baton 到 next_step.txt。"""
     to_owner = "done" if to_step == "done" else ("user" if to_step == "user" else "agent")
     (issue_dir / "next_step.txt").write_text(
-        json.dumps({
-            "version": 1,
-            "from_step": from_step,
-            "to_owner": to_owner,
-            "to_step": to_step,
-            "intent": intent,
-            "status_code": "",
-            "created_at": "2026-05-14T10:00:00+08:00",
-            "source": "test",
-        }),
+        json.dumps(
+            {
+                "version": 1,
+                "from_step": from_step,
+                "to_owner": to_owner,
+                "to_step": to_step,
+                "intent": intent,
+                "status_code": "",
+                "created_at": "2026-05-14T10:00:00+08:00",
+                "source": "test",
+            }
+        ),
         encoding="utf-8",
     )
 
@@ -2009,21 +2156,25 @@ def _make_valid_baton_text(issue_dir: Path, *, from_step: str = "spec", to_step:
 def _make_invalid_baton_text(issue_dir: Path) -> None:
     """寫入 to_owner='human'（無效）的 baton。"""
     (issue_dir / "next_step.txt").write_text(
-        json.dumps({
-            "version": 1,
-            "from_step": "spec",
-            "to_owner": "human",
-            "to_step": "user",
-            "intent": "need_clarification",
-            "status_code": "",
-            "created_at": "2026-05-14T10:00:00+08:00",
-            "source": "test",
-        }),
+        json.dumps(
+            {
+                "version": 1,
+                "from_step": "spec",
+                "to_owner": "human",
+                "to_step": "user",
+                "intent": "need_clarification",
+                "status_code": "",
+                "created_at": "2026-05-14T10:00:00+08:00",
+                "source": "test",
+            }
+        ),
         encoding="utf-8",
     )
 
 
-def _make_invalid_target_baton_text(issue_dir: Path, *, from_step: str = "spec", to_step: str = "release") -> None:
+def _make_invalid_target_baton_text(
+    issue_dir: Path, *, from_step: str = "spec", to_step: str = "release"
+) -> None:
     """Write a baton whose target step does not exist in the playbook."""
     _write_baton(
         issue_dir,
@@ -2045,7 +2196,9 @@ def test_runtime_retries_once_on_baton_rejected_then_succeeds(tmp_path: Path) ->
         if call_count[0] == 1:
             _make_invalid_baton_text(issue_dir)
         else:
-            _make_valid_baton_text(issue_dir, from_step="spec", to_step="done", intent="workflow_complete")
+            _make_valid_baton_text(
+                issue_dir, from_step="spec", to_step="done", intent="workflow_complete"
+            )
         return StepExecutionResult(response="done", artifacts={}, status_code="")
 
     runtime = BlackboardWorkflowRuntime(
@@ -2072,7 +2225,9 @@ def test_runtime_retries_twice_on_baton_rejected_then_succeeds(tmp_path: Path) -
         if call_count[0] <= 2:
             _make_invalid_baton_text(issue_dir)
         else:
-            _make_valid_baton_text(issue_dir, from_step="spec", to_step="done", intent="workflow_complete")
+            _make_valid_baton_text(
+                issue_dir, from_step="spec", to_step="done", intent="workflow_complete"
+            )
         return StepExecutionResult(response="done", artifacts={}, status_code="")
 
     runtime = BlackboardWorkflowRuntime(
@@ -2101,7 +2256,9 @@ def test_runtime_retries_invalid_target_step_then_succeeds(tmp_path: Path) -> No
         if call_count[0] == 1:
             _make_invalid_target_baton_text(issue_dir, from_step="spec", to_step="release")
         else:
-            _make_valid_baton_text(issue_dir, from_step="spec", to_step="done", intent="workflow_complete")
+            _make_valid_baton_text(
+                issue_dir, from_step="spec", to_step="done", intent="workflow_complete"
+            )
         return StepExecutionResult(response="done", artifacts={}, status_code="")
 
     runtime = BlackboardWorkflowRuntime(
@@ -2134,9 +2291,13 @@ def test_runtime_retries_same_phase_baton_then_succeeds(tmp_path: Path) -> None:
         call_count[0] += 1
         captured_prompts.append(kwargs.get("extra_prompt"))
         if call_count[0] == 1:
-            _write_baton(issue_dir, from_step="spec", to_owner="agent", to_step="spec", intent="await_agent")
+            _write_baton(
+                issue_dir, from_step="spec", to_owner="agent", to_step="spec", intent="await_agent"
+            )
         else:
-            _make_valid_baton_text(issue_dir, from_step="spec", to_step="done", intent="workflow_complete")
+            _make_valid_baton_text(
+                issue_dir, from_step="spec", to_step="done", intent="workflow_complete"
+            )
         return StepExecutionResult(response="done", artifacts={}, status_code="")
 
     runtime = BlackboardWorkflowRuntime(
@@ -2175,9 +2336,13 @@ def test_runtime_retries_same_phase_baton_for_pr_then_succeeds(tmp_path: Path) -
         call_count[0] += 1
         captured_prompts.append(kwargs.get("extra_prompt"))
         if call_count[0] == 1:
-            _write_baton(issue_dir, from_step="pr", to_owner="agent", to_step="pr", intent="await_agent")
+            _write_baton(
+                issue_dir, from_step="pr", to_owner="agent", to_step="pr", intent="await_agent"
+            )
             return StepExecutionResult(response="stale", artifacts={"pr_result": "p1"})
-        _write_baton(issue_dir, from_step="pr", to_owner="done", to_step="done", intent="workflow_complete")
+        _write_baton(
+            issue_dir, from_step="pr", to_owner="done", to_step="done", intent="workflow_complete"
+        )
         return StepExecutionResult(
             response="done",
             artifacts={"pr_result": "p1"},
@@ -2231,7 +2396,9 @@ def test_runtime_baton_rejected_event_has_correct_fields(tmp_path: Path) -> None
         if call_count[0] == 1:
             _make_invalid_baton_text(issue_dir)
         else:
-            _make_valid_baton_text(issue_dir, from_step="spec", to_step="done", intent="workflow_complete")
+            _make_valid_baton_text(
+                issue_dir, from_step="spec", to_step="done", intent="workflow_complete"
+            )
         return StepExecutionResult(response="done", artifacts={}, status_code="")
 
     runtime = BlackboardWorkflowRuntime(
@@ -2264,7 +2431,9 @@ def test_runtime_retry_extra_prompt_contains_feedback(tmp_path: Path) -> None:
         if call_count[0] == 1:
             _make_invalid_baton_text(issue_dir)
         else:
-            _make_valid_baton_text(issue_dir, from_step="spec", to_step="done", intent="workflow_complete")
+            _make_valid_baton_text(
+                issue_dir, from_step="spec", to_step="done", intent="workflow_complete"
+            )
         return StepExecutionResult(response="done", artifacts={}, status_code="")
 
     runtime = BlackboardWorkflowRuntime(


### PR DESCRIPTION
## Summary

Implements issue #347 by moving PR publish side effects onto a generic capability request and receipt contract while preserving the existing trusted host-controlled PR publish behavior.

The change keeps the capability boundary strict: workflow/skill output can declare requested host actions, but execution still runs only through registry-controlled, allow-listed host capabilities. It also includes the approved alignment and positioning updates that document this trusted capability-contract direction.

This PR also hardens the PR publish path after review caught the stale-base failure mode: local-only base refs are no longer treated as valid GitHub PR bases.

## Changes

- Commits:
  - `d7552ab issue347: add generic capability contracts`
  - `e01054c issue347: harden pr publish base ref handling`
- Added `capability_requests` to playbook step definitions with validation for empty, duplicate, and non-string capability IDs.
- Declared `cafe.pr.publish` as the default PR step capability and introduced generic `capability_request.json` emission for steps that declare capabilities.
- Preserved legacy PR compatibility by continuing to write `publish_request.json` with the existing payload shape.
- Refactored native host hooks to load generic capability requests, execute them through the trusted registry path, and append runtime-parseable receipts.
- Added safe validation receipts for unknown, unsupported, malformed, and invalid capability requests before any host mutation can run.
- Generalized workflow runtime receipt gating so declared capability steps require successful capability receipts while preserving PR feedback handoff behavior.
- Updated roadmap, positioning, alignment checkpoint docs, chat/CLI surfaces, and related tests for the confirmed trusted capability-contract model.
- Changed PR publish base resolution so only remote-tracking refs under `origin/<base>` are accepted, preventing stale local-only branches from being forwarded to `gh pr create`.
- Added regression coverage for the local-only base topology that reproduced the previous publish failure.

## Test Plan

- Targeted review suite passed: `176 passed`.
- Focused capability/native-hook suite passed after the base-ref fix: `44 passed`.
- Full suite passed during review: `2209 passed, 1 skipped, 1 xfailed`.
- Full pre-commit suite passed during amend: `2209 passed, 1 skipped, 1 xfailed`.
- Review confirmed the stale-base reproducer now returns `''` for local-only `codex/alignment-policy-escalation`.
- `git diff --check develop..HEAD` reported no whitespace errors.