### PR TITLE
Add hook-based Slack workflow notifications

### DIFF
--- a/src/cafe/data/skills/cafe-develop/scripts/notify-slack.sh
+++ b/src/cafe/data/skills/cafe-develop/scripts/notify-slack.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Wrapper script. Shared implementation is maintained in one place:
+# src/cafe/data/skills/cafe-workflow-common/scripts/notify-slack.sh
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "${BASH_SOURCE[0]%/*}" && pwd)"
+SHARED_SCRIPT="$SCRIPT_DIR/../../cafe-workflow-common/scripts/notify-slack.sh"
+
+if [[ ! -f "$SHARED_SCRIPT" ]]; then
+  echo "Error: shared Slack notification script not found: $SHARED_SCRIPT" >&2
+  exit 1
+fi
+
+exec /bin/bash "$SHARED_SCRIPT" "$@"

--- a/src/cafe/data/skills/cafe-plan/scripts/notify-slack.sh
+++ b/src/cafe/data/skills/cafe-plan/scripts/notify-slack.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Wrapper script. Shared implementation is maintained in one place:
+# src/cafe/data/skills/cafe-workflow-common/scripts/notify-slack.sh
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "${BASH_SOURCE[0]%/*}" && pwd)"
+SHARED_SCRIPT="$SCRIPT_DIR/../../cafe-workflow-common/scripts/notify-slack.sh"
+
+if [[ ! -f "$SHARED_SCRIPT" ]]; then
+  echo "Error: shared Slack notification script not found: $SHARED_SCRIPT" >&2
+  exit 1
+fi
+
+exec /bin/bash "$SHARED_SCRIPT" "$@"

--- a/src/cafe/data/skills/cafe-pr/scripts/notify-slack.sh
+++ b/src/cafe/data/skills/cafe-pr/scripts/notify-slack.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Wrapper script. Shared implementation is maintained in one place:
+# src/cafe/data/skills/cafe-workflow-common/scripts/notify-slack.sh
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "${BASH_SOURCE[0]%/*}" && pwd)"
+SHARED_SCRIPT="$SCRIPT_DIR/../../cafe-workflow-common/scripts/notify-slack.sh"
+
+if [[ ! -f "$SHARED_SCRIPT" ]]; then
+  echo "Error: shared Slack notification script not found: $SHARED_SCRIPT" >&2
+  exit 1
+fi
+
+exec /bin/bash "$SHARED_SCRIPT" "$@"

--- a/src/cafe/data/skills/cafe-review/scripts/notify-slack.sh
+++ b/src/cafe/data/skills/cafe-review/scripts/notify-slack.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Wrapper script. Shared implementation is maintained in one place:
+# src/cafe/data/skills/cafe-workflow-common/scripts/notify-slack.sh
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "${BASH_SOURCE[0]%/*}" && pwd)"
+SHARED_SCRIPT="$SCRIPT_DIR/../../cafe-workflow-common/scripts/notify-slack.sh"
+
+if [[ ! -f "$SHARED_SCRIPT" ]]; then
+  echo "Error: shared Slack notification script not found: $SHARED_SCRIPT" >&2
+  exit 1
+fi
+
+exec /bin/bash "$SHARED_SCRIPT" "$@"

--- a/src/cafe/data/skills/cafe-spec/scripts/notify-slack.sh
+++ b/src/cafe/data/skills/cafe-spec/scripts/notify-slack.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Wrapper script. Shared implementation is maintained in one place:
+# src/cafe/data/skills/cafe-workflow-common/scripts/notify-slack.sh
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "${BASH_SOURCE[0]%/*}" && pwd)"
+SHARED_SCRIPT="$SCRIPT_DIR/../../cafe-workflow-common/scripts/notify-slack.sh"
+
+if [[ ! -f "$SHARED_SCRIPT" ]]; then
+  echo "Error: shared Slack notification script not found: $SHARED_SCRIPT" >&2
+  exit 1
+fi
+
+exec /bin/bash "$SHARED_SCRIPT" "$@"

--- a/src/cafe/data/skills/cafe-workflow-common/scripts/notify-slack.sh
+++ b/src/cafe/data/skills/cafe-workflow-common/scripts/notify-slack.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# notify-slack.sh - Best-effort Slack workflow notification hook.
+#
+# Intended for playbook after_execute script hooks filtered by when_intents.
+# The webhook URL is read from a local file and must not be committed.
+
+set -euo pipefail
+
+ISSUE=""
+STEP=""
+NEXT_STEP_FILE=""
+BLACKBOARD_FILE=""
+SUMMARY=""
+TRACE_FILE=""
+WEBHOOK_FILE="${CAFE_SLACK_WEBHOOK_FILE:-${HOME:-}/.slack-webhook}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --issue) ISSUE="$2"; shift 2 ;;
+    --step) STEP="$2"; shift 2 ;;
+    --next-step) NEXT_STEP_FILE="$2"; shift 2 ;;
+    --blackboard) BLACKBOARD_FILE="$2"; shift 2 ;;
+    --summary) SUMMARY="$2"; shift 2 ;;
+    --trace-file) TRACE_FILE="$2"; shift 2 ;;
+    --webhook-file) WEBHOOK_FILE="$2"; shift 2 ;;
+    --help)
+      echo "Usage: notify-slack.sh --step STEP --next-step FILE --blackboard FILE [--issue ISSUE]"
+      exit 0
+      ;;
+    *)
+      echo "Error: unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+resolve_python_bin() {
+  if command -v python3 >/dev/null 2>&1; then
+    command -v python3
+    return 0
+  fi
+  return 1
+}
+
+if ! PYTHON_BIN=$(resolve_python_bin); then
+  echo "Error: python3 is required." >&2
+  exit 1
+fi
+
+PAYLOAD_JSON=$("$PYTHON_BIN" - "$ISSUE" "$STEP" "$NEXT_STEP_FILE" "$BLACKBOARD_FILE" "$SUMMARY" "$TRACE_FILE" <<'PY'
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+import sys
+
+
+def read_json(path_value: str) -> dict:
+    if not path_value:
+        return {}
+    path = Path(path_value)
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+issue_arg, step_arg, next_step_arg, blackboard_arg, summary_arg, trace_arg = sys.argv[1:7]
+next_step_path = Path(next_step_arg) if next_step_arg else None
+blackboard_path = Path(blackboard_arg) if blackboard_arg else None
+
+contract = read_json(next_step_arg)
+blackboard = read_json(blackboard_arg)
+
+issue = issue_arg.strip()
+if not issue and blackboard_path is not None:
+    issue = blackboard_path.parent.name
+if not issue and next_step_path is not None:
+    issue = next_step_path.parent.name
+if not issue:
+    issue = "unknown"
+
+step = step_arg.strip() or str(contract.get("from_step") or "")
+intent = str(contract.get("intent") or contract.get("status_code") or "").strip()
+summary = str(blackboard.get("handoff_summary") or summary_arg or "").strip()
+
+if trace_arg:
+    trace_path = Path(trace_arg)
+else:
+    issue_dir = None
+    if blackboard_path is not None:
+        issue_dir = blackboard_path.parent
+    elif next_step_path is not None:
+        issue_dir = next_step_path.parent
+    trace_path = (issue_dir or Path.cwd()) / "artifacts" / "slack_notifications.jsonl"
+
+text = "\n".join(
+    [
+        "CAFE workflow notification",
+        f"Issue: {issue}",
+        f"Step: {step or 'unknown'}",
+        f"Intent: {intent or 'unknown'}",
+        f"Summary: {summary or '(none)'}",
+    ]
+)
+
+record = {
+    "timestamp": datetime.now(timezone.utc).isoformat(),
+    "issue": issue,
+    "step": step,
+    "intent": intent,
+    "summary": summary,
+    "trace_file": str(trace_path),
+}
+
+print(json.dumps({"text": text, "record": record}, ensure_ascii=False))
+PY
+)
+
+SLACK_TEXT=$("$PYTHON_BIN" -c 'import json,sys; print(json.dumps({"text": json.load(sys.stdin)["text"]}, ensure_ascii=False))' <<<"$PAYLOAD_JSON")
+TRACE_FILE=$("$PYTHON_BIN" -c 'import json,sys; print(json.load(sys.stdin)["record"]["trace_file"])' <<<"$PAYLOAD_JSON")
+
+write_trace() {
+  local action="$1"
+  local reason="$2"
+  "$PYTHON_BIN" - "$PAYLOAD_JSON" "$TRACE_FILE" "$action" "$reason" <<'PY'
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+payload = json.loads(sys.argv[1])
+trace_file = Path(sys.argv[2])
+action = sys.argv[3]
+reason = sys.argv[4]
+record = payload["record"]
+record["action"] = action
+if reason:
+    record["reason"] = reason
+trace_file.parent.mkdir(parents=True, exist_ok=True)
+with trace_file.open("a", encoding="utf-8") as handle:
+    handle.write(json.dumps(record, ensure_ascii=False) + "\n")
+print(json.dumps({"action": action, "reason": reason, "trace_file": str(trace_file)}, ensure_ascii=False))
+PY
+}
+
+if [[ -z "$WEBHOOK_FILE" || ! -f "$WEBHOOK_FILE" ]]; then
+  write_trace "skipped" "webhook_file_missing"
+  exit 0
+fi
+
+WEBHOOK_URL="$(tr -d '\r\n' < "$WEBHOOK_FILE")"
+if [[ -z "$WEBHOOK_URL" ]]; then
+  write_trace "skipped" "webhook_file_empty"
+  exit 0
+fi
+
+if ! command -v curl >/dev/null 2>&1; then
+  write_trace "skipped" "curl_missing"
+  exit 0
+fi
+
+if curl -fsS -X POST -H "Content-Type: application/json" --data "$SLACK_TEXT" "$WEBHOOK_URL" >/dev/null 2>&1; then
+  write_trace "posted" ""
+  exit 0
+fi
+
+write_trace "skipped" "curl_failed"
+exit 0

--- a/src/cafe/phases/generic_phase.py
+++ b/src/cafe/phases/generic_phase.py
@@ -2,21 +2,21 @@
 
 from __future__ import annotations
 
+import json
 import re
 import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
+from cafe.core.blackboard import HandoffIntent
 from cafe.core.hooks import BUILTIN_HOOKS, HookResult
 from cafe.core.hooks.script_schema import validate_script_args_schema
 from cafe.core.questions_schema import validate_questions_xml
 from cafe.core.status_codes import PhaseStatusCode, StatusCodeParser
-from cafe.core.blackboard import HandoffIntent
+from cafe.core.types import AgentCLI
 from cafe.skills.loader import SkillLoader, canonical_skill_name
 from cafe.skills.native_bridge import NativeSkillBridge
-from cafe.core.types import AgentCLI
-
 
 AgentExecutor = Callable[[str], str]
 
@@ -397,7 +397,12 @@ class GenericPhase:
         )
 
         if when_intents:
-            detected_status = self._detect_status_code(response=response or "", step_def=step_def)
+            detected_status = self._detect_status_code(
+                response=response or "",
+                step_def=step_def,
+                context=context,
+                step_name=hook_kwargs.get("step_name"),
+            )
             if detected_status not in when_intents:
                 return HookResult(
                     events=[
@@ -656,11 +661,63 @@ class GenericPhase:
         return cmd
 
     @staticmethod
-    def _detect_status_code(*, response: str, step_def: Dict[str, Any]) -> Optional[str]:
+    def _read_baton_intent(
+        *, next_step_path: Optional[str], step_name: Optional[str]
+    ) -> Optional[str]:
+        if not next_step_path:
+            return None
+
+        try:
+            raw = Path(next_step_path).read_text(encoding="utf-8").strip()
+        except OSError:
+            return None
+
+        if not raw:
+            return None
+
+        try:
+            payload = json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            return None
+
+        if not isinstance(payload, dict):
+            return None
+
+        if (
+            step_name
+            and payload.get("from_step")
+            and str(payload.get("from_step", "")) != str(step_name)
+        ):
+            return None
+
+        intent = payload.get("intent")
+        if not isinstance(intent, str):
+            return None
+        return intent.strip() or None
+
+    @staticmethod
+    def _detect_status_code(
+        *,
+        response: str,
+        step_def: Dict[str, Any],
+        context: Optional[Dict[str, Any]] = None,
+        step_name: Optional[str] = None,
+    ) -> Optional[str]:
         valid = [
             PhaseStatusCode(code)
             for code in step_def.get("valid_intents", [])
             if code in {item.value for item in PhaseStatusCode}
         ]
+
+        context = context or {}
+        valid_values = {status.value for status in (valid or list(PhaseStatusCode))}
+
+        next_step_intent = GenericPhase._read_baton_intent(
+            next_step_path=context.get("next_step_path"),
+            step_name=step_name,
+        )
+        if next_step_intent in valid_values:
+            return next_step_intent
+
         status_code = StatusCodeParser.extract(response, valid_codes=valid or list(PhaseStatusCode))
         return status_code.value if status_code is not None else None

--- a/src/cafe/phases/generic_phase.py
+++ b/src/cafe/phases/generic_phase.py
@@ -684,6 +684,15 @@ class GenericPhase:
             return None
 
         if (
+            payload.get("source") == "workflow.start_step_override"
+            and (
+                not step_name
+                or str(payload.get("to_step", payload.get("from_step", ""))) == str(step_name)
+            )
+        ):
+            return None
+
+        if (
             step_name
             and payload.get("from_step")
             and str(payload.get("from_step", "")) != str(step_name)

--- a/tests/unit/test_generic_phase.py
+++ b/tests/unit/test_generic_phase.py
@@ -931,6 +931,90 @@ def test_execute_script_hook_filters_notification_intent_from_baton_file(
     )
 
 
+def test_execute_script_hook_ignores_start_step_override_baton_intent(
+    tmp_path: Path,
+) -> None:
+    loader = _setup_loader(tmp_path)
+    calls_file = tmp_path / "calls.txt"
+    next_step = tmp_path / "next_step.txt"
+    next_step.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "from_step": "plan",
+                "to_owner": "agent",
+                "to_step": "plan",
+                "intent": "await_agent",
+                "status_code": "",
+                "created_at": "2026-07-06T00:00:01Z",
+                "source": "workflow.start_step_override",
+            }
+        ),
+        encoding="utf-8",
+    )
+    _write_skill_script(
+        loader,
+        skill_name="cafe-plan",
+        script_name="notify-slack.sh",
+        body=(
+            "#!/usr/bin/env bash\n"
+            "set -euo pipefail\n"
+            "GROUP=\"\"\n"
+            "while [[ $# -gt 0 ]]; do\n"
+            "  case \"$1\" in\n"
+            "    --group) GROUP=\"$2\"; shift 2 ;;\n"
+            "    *) shift ;;\n"
+            "  esac\n"
+            "done\n"
+            f"echo \"$GROUP\" >> {str(calls_file)!r}\n"
+            "echo '{\"action\":\"posted\"}'\n"
+        ),
+    )
+    phase = GenericPhase(loader)
+
+    result = phase.execute(
+        skill_name="cafe-plan",
+        skill_invocation="/plan",
+        shared_skill_invocations=["/cafe-workflow-common"],
+        context={"next_step_path": str(next_step)},
+        step_def={
+            "hooks": {
+                "after_execute": [
+                    {
+                        "script": "notify-slack.sh",
+                        "args": {"group": "user"},
+                        "when_intents": ["need_clarification", "need_permission"],
+                    },
+                    {
+                        "script": "notify-slack.sh",
+                        "args": {"group": "milestone"},
+                        "when_intents": ["await_agent", "workflow_complete"],
+                    },
+                ]
+            },
+            "valid_intents": [
+                "await_agent",
+                "workflow_complete",
+                "need_clarification",
+                "need_permission",
+            ],
+        },
+        hook_context={"step_name": "plan"},
+        agent_executor=lambda prompt: "need_permission\nNeed permission to proceed.",
+    )
+
+    assert result.status_code is None
+    assert calls_file.read_text(encoding="utf-8").strip() == "user"
+    events = [item for item in result.events if item.get("type") == "script_hook"]
+    assert any(item["status"] == "success" and item["stdout"] for item in events)
+    assert any(
+        item["status"] == "skipped"
+        and item["reason"] == "intent_mismatch"
+        and item["when_intents"] == ["await_agent", "workflow_complete"]
+        for item in events
+    )
+
+
 def test_execute_script_hook_passes_timeout_to_subprocess(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     loader = _setup_loader(tmp_path)
     _write_skill_script(

--- a/tests/unit/test_generic_phase.py
+++ b/tests/unit/test_generic_phase.py
@@ -1,5 +1,6 @@
 """Tests for GenericPhase."""
 
+import json
 import subprocess
 from pathlib import Path
 
@@ -842,6 +843,90 @@ def test_execute_script_hook_filters_notification_intent_groups(
         item["status"] == "skipped"
         and item["reason"] == "intent_mismatch"
         and item["when_intents"] == skipped_intents
+        for item in events
+    )
+
+
+def test_execute_script_hook_filters_notification_intent_from_baton_file(
+    tmp_path: Path,
+) -> None:
+    loader = _setup_loader(tmp_path)
+    calls_file = tmp_path / "calls.txt"
+    next_step = tmp_path / "next_step.txt"
+    next_step.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "from_step": "plan",
+                "to_owner": "agent",
+                "to_step": "review",
+                "intent": "workflow_complete",
+                "status_code": "",
+                "created_at": "2026-07-06T00:00:00Z",
+                "source": "test",
+            }
+        ),
+        encoding="utf-8",
+    )
+    _write_skill_script(
+        loader,
+        skill_name="cafe-plan",
+        script_name="notify-slack.sh",
+        body=(
+            "#!/usr/bin/env bash\n"
+            "set -euo pipefail\n"
+            "GROUP=\"\"\n"
+            "while [[ $# -gt 0 ]]; do\n"
+            "  case \"$1\" in\n"
+            "    --group) GROUP=\"$2\"; shift 2 ;;\n"
+            "    *) shift ;;\n"
+            "  esac\n"
+            "done\n"
+            f"echo \"$GROUP\" >> {str(calls_file)!r}\n"
+            "echo '{\"action\":\"posted\"}'\n"
+        ),
+    )
+    phase = GenericPhase(loader)
+
+    result = phase.execute(
+        skill_name="cafe-plan",
+        skill_invocation="/plan",
+        shared_skill_invocations=["/cafe-workflow-common"],
+        context={"next_step_path": str(next_step)},
+        step_def={
+            "hooks": {
+                "after_execute": [
+                    {
+                        "script": "notify-slack.sh",
+                        "args": {"group": "user"},
+                        "when_intents": ["need_clarification", "need_permission"],
+                    },
+                    {
+                        "script": "notify-slack.sh",
+                        "args": {"group": "milestone"},
+                        "when_intents": ["await_agent", "workflow_complete"],
+                    },
+                ]
+            },
+            "valid_intents": [
+                "await_agent",
+                "workflow_complete",
+                "need_clarification",
+                "need_permission",
+            ],
+        },
+        hook_context={"step_name": "plan"},
+        agent_executor=lambda prompt: "Done. Wrote baton.",
+    )
+
+    assert result.status_code is None
+    assert calls_file.read_text(encoding="utf-8").strip() == "milestone"
+    events = [item for item in result.events if item.get("type") == "script_hook"]
+    assert any(item["status"] == "success" and item["stdout"] for item in events)
+    assert any(
+        item["status"] == "skipped"
+        and item["reason"] == "intent_mismatch"
+        and item["when_intents"] == ["need_clarification", "need_permission"]
         for item in events
     )
 

--- a/tests/unit/test_generic_phase.py
+++ b/tests/unit/test_generic_phase.py
@@ -765,6 +765,87 @@ def test_execute_script_hook_can_skip_when_status_mismatch(tmp_path: Path) -> No
     assert event["reason"] == "intent_mismatch"
 
 
+@pytest.mark.parametrize(
+    "agent_response,expected_group,skipped_group",
+    [
+        ("need_permission", "user", "milestone"),
+        ("await_agent", "milestone", "user"),
+        ("workflow_complete", "milestone", "user"),
+    ],
+)
+def test_execute_script_hook_filters_notification_intent_groups(
+    tmp_path: Path,
+    agent_response: str,
+    expected_group: str,
+    skipped_group: str,
+) -> None:
+    loader = _setup_loader(tmp_path)
+    calls_file = tmp_path / "calls.txt"
+    _write_skill_script(
+        loader,
+        skill_name="cafe-plan",
+        script_name="notify-slack.sh",
+        body=(
+            "#!/usr/bin/env bash\n"
+            "set -euo pipefail\n"
+            "GROUP=\"\"\n"
+            "while [[ $# -gt 0 ]]; do\n"
+            "  case \"$1\" in\n"
+            "    --group) GROUP=\"$2\"; shift 2 ;;\n"
+            "    *) shift ;;\n"
+            "  esac\n"
+            "done\n"
+            f"echo \"$GROUP\" >> {str(calls_file)!r}\n"
+            "echo '{\"action\":\"posted\"}'\n"
+        ),
+    )
+    phase = GenericPhase(loader)
+
+    result = phase.execute(
+        skill_name="cafe-plan",
+        skill_invocation="/plan",
+        shared_skill_invocations=["/cafe-workflow-common"],
+        step_def={
+            "hooks": {
+                "after_execute": [
+                    {
+                        "script": "notify-slack.sh",
+                        "args": {"group": "user"},
+                        "when_intents": ["need_clarification", "need_permission"],
+                    },
+                    {
+                        "script": "notify-slack.sh",
+                        "args": {"group": "milestone"},
+                        "when_intents": ["await_agent", "workflow_complete"],
+                    },
+                ]
+            },
+            "valid_intents": [
+                "await_agent",
+                "workflow_complete",
+                "need_clarification",
+                "need_permission",
+            ],
+        },
+        agent_executor=lambda prompt: agent_response,
+    )
+
+    assert calls_file.read_text(encoding="utf-8").strip() == expected_group
+    events = [item for item in result.events if item.get("type") == "script_hook"]
+    skipped_intents = (
+        ["await_agent", "workflow_complete"]
+        if skipped_group == "milestone"
+        else ["need_clarification", "need_permission"]
+    )
+    assert any(item["status"] == "success" and item["stdout"] for item in events)
+    assert any(
+        item["status"] == "skipped"
+        and item["reason"] == "intent_mismatch"
+        and item["when_intents"] == skipped_intents
+        for item in events
+    )
+
+
 def test_execute_script_hook_passes_timeout_to_subprocess(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     loader = _setup_loader(tmp_path)
     _write_skill_script(

--- a/tests/unit/test_skill_notify_slack_script.py
+++ b/tests/unit/test_skill_notify_slack_script.py
@@ -1,0 +1,155 @@
+import json
+import os
+import subprocess
+from pathlib import Path
+
+
+def _write_workflow_files(tmp_path: Path, *, intent: str = "await_agent") -> tuple[Path, Path]:
+    issue_dir = tmp_path / ".cafe" / "issues" / "demo-issue"
+    issue_dir.mkdir(parents=True)
+    next_step = issue_dir / "next_step.txt"
+    next_step.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "from_step": "build",
+                "to_owner": "agent",
+                "to_step": "review",
+                "intent": intent,
+                "status_code": "",
+                "created_at": "2026-07-06T00:00:00Z",
+                "source": "test",
+            }
+        ),
+        encoding="utf-8",
+    )
+    blackboard = issue_dir / "blackboard.json"
+    blackboard.write_text(
+        json.dumps({"handoff_summary": "Build finished and is ready for review."}),
+        encoding="utf-8",
+    )
+    return next_step, blackboard
+
+
+def _script_path() -> Path:
+    project_root = Path(__file__).resolve().parents[2]
+    return project_root / "src/cafe/data/skills/cafe-workflow-common/scripts/notify-slack.sh"
+
+
+def test_notify_slack_skips_missing_webhook_and_writes_trace(tmp_path: Path) -> None:
+    next_step, blackboard = _write_workflow_files(tmp_path, intent="need_permission")
+    trace_file = tmp_path / "trace" / "slack.jsonl"
+
+    result = subprocess.run(
+        [
+            "/bin/bash",
+            str(_script_path()),
+            "--step",
+            "build",
+            "--next-step",
+            str(next_step),
+            "--blackboard",
+            str(blackboard),
+            "--trace-file",
+            str(trace_file),
+        ],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "HOME": str(tmp_path / "home")},
+        check=False,
+    )
+
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert payload["action"] == "skipped"
+    assert payload["reason"] == "webhook_file_missing"
+
+    trace = json.loads(trace_file.read_text(encoding="utf-8").strip())
+    assert trace["action"] == "skipped"
+    assert trace["reason"] == "webhook_file_missing"
+    assert trace["issue"] == "demo-issue"
+    assert trace["step"] == "build"
+    assert trace["intent"] == "need_permission"
+    assert trace["summary"] == "Build finished and is ready for review."
+    assert trace["timestamp"]
+
+
+def test_notify_slack_posts_payload_with_workflow_context(tmp_path: Path) -> None:
+    next_step, blackboard = _write_workflow_files(tmp_path, intent="workflow_complete")
+    trace_file = tmp_path / "trace" / "slack.jsonl"
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".slack-webhook").write_text("https://hooks.slack.test/demo\n", encoding="utf-8")
+
+    curl_log = tmp_path / "curl.json"
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    fake_curl = bin_dir / "curl"
+    fake_curl.write_text(
+        "#!/usr/bin/env bash\n"
+        "python3 - \"$@\" <<'PY'\n"
+        "import json, sys\n"
+        "args = sys.argv[1:]\n"
+        "payload = args[args.index('--data') + 1]\n"
+        "url = args[-1]\n"
+        f"open({str(curl_log)!r}, 'w', encoding='utf-8').write(json.dumps({{'payload': payload, 'url': url}}))\n"
+        "PY\n",
+        encoding="utf-8",
+    )
+    fake_curl.chmod(0o755)
+
+    env = {
+        **os.environ,
+        "HOME": str(home),
+        "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+    }
+    result = subprocess.run(
+        [
+            "/bin/bash",
+            str(_script_path()),
+            "--step",
+            "build",
+            "--next-step",
+            str(next_step),
+            "--blackboard",
+            str(blackboard),
+            "--trace-file",
+            str(trace_file),
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert payload["action"] == "posted"
+
+    curl_call = json.loads(curl_log.read_text(encoding="utf-8"))
+    slack_payload = json.loads(curl_call["payload"])
+    assert curl_call["url"] == "https://hooks.slack.test/demo"
+    assert "Issue: demo-issue" in slack_payload["text"]
+    assert "Step: build" in slack_payload["text"]
+    assert "Intent: workflow_complete" in slack_payload["text"]
+    assert "Build finished and is ready for review." in slack_payload["text"]
+
+    trace = json.loads(trace_file.read_text(encoding="utf-8").strip())
+    assert trace["action"] == "posted"
+    assert trace["intent"] == "workflow_complete"
+
+
+def test_standard_phase_notify_slack_wrappers_delegate_to_shared_script() -> None:
+    project_root = Path(__file__).resolve().parents[2]
+    wrappers = [
+        project_root / "src/cafe/data/skills/cafe-spec/scripts/notify-slack.sh",
+        project_root / "src/cafe/data/skills/cafe-plan/scripts/notify-slack.sh",
+        project_root / "src/cafe/data/skills/cafe-develop/scripts/notify-slack.sh",
+        project_root / "src/cafe/data/skills/cafe-review/scripts/notify-slack.sh",
+        project_root / "src/cafe/data/skills/cafe-pr/scripts/notify-slack.sh",
+    ]
+
+    for wrapper in wrappers:
+        content = wrapper.read_text(encoding="utf-8")
+        assert "../../cafe-workflow-common/scripts/notify-slack.sh" in content
+        assert "exec /bin/bash" in content


### PR DESCRIPTION
## Summary

Implements GitHub issue #356 by adding opt-in, hook-based Slack notifications for workflow milestone and user-intervention intents without introducing product-level notification settings or trusted host capability expansion.

## Changes

- Added a shared `notify-slack.sh` script under `cafe-workflow-common` that reads baton and blackboard context, builds traceable Slack payloads, and records posted/skipped notification traces.
- Added phase-local `notify-slack.sh` wrappers for spec, plan, develop, review, and pr skills so playbooks can opt in with existing `after_execute` script hooks.
- Extended script hook intent filtering to read agent-written baton intents from `next_step.txt`, while ignoring runtime `workflow.start_step_override` placeholder batons.
- Added unit coverage for notification intent groups, baton-first intent detection, runtime placeholder baton fallback behavior, missing-webhook skips, payload content, fake posted notifications, and wrapper delegation.

Commits:
- `27ea75a` issue356: add slack notification hook script
- `01baca0` issue356: detect script hook intents from baton
- `0a9f00d` issue356: ignore start_step_override baton when filtering hook intent

## Test Plan

- `PYTHONPATH=src uv run --extra dev python -m pytest tests/unit/test_skill_notify_slack_script.py`
- `PYTHONPATH=src uv run --extra dev python -m pytest tests/unit/test_generic_phase.py -k 'script_hook'`
- `PYTHONPATH=src uv run --extra dev python -m pytest tests/unit/test_skill_sync_github_script.py tests/unit/test_playbook_loader.py -q`
- Reviewer verification: `PYTHONPATH=src uv run --extra dev python -m pytest tests/unit/test_generic_phase.py -k 'script_hook_ignores_start_step_override_baton_intent or script_hook_filters_notification_intent_from_baton_file or script_hook_filters_notification_intent_groups' -q` (5 passed).