### PR TITLE
Reject malformed structured baton JSON

### DIFF
--- a/src/cafe/core/blackboard.py
+++ b/src/cafe/core/blackboard.py
@@ -11,7 +11,6 @@ from typing import Any, Dict, List, Optional
 
 from cafe.core.workflow_models import BatonRejected
 
-
 BLACKBOARD_FILENAME = "blackboard.json"
 BLACKBOARD_SCHEMA_VERSION = 1
 NEXT_STEP_FILENAME = "next_step.txt"
@@ -178,24 +177,52 @@ class HandoffContract:
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "HandoffContract":
+        required_fields = ["version", "from_step", "to_owner", "to_step", "intent"]
+        for field in required_fields:
+            if field not in data:
+                raise BatonRejected(field=field, invalid_value="", valid_values=[])
+
         try:
-            intent_raw = str(data["intent"])
-            if intent_raw == "chat_handoff":
-                intent_raw = HandoffIntent.MANUAL_HANDOFF.value
-            return cls(
-                version=int(data["version"]),
-                from_step=str(data["from_step"]),
-                to_owner=HandoffOwner(str(data["to_owner"])),
-                to_step=str(data["to_step"]),
-                intent=HandoffIntent(intent_raw),
-                status_code=str(data.get("status_code", "")),
-                created_at=str(data.get("created_at", _now_iso())),
-                source=str(data.get("source", "unknown")),
-            )
-        except KeyError as exc:
-            raise ValueError(f"Baton contract missing required field: {exc}") from exc
+            version = int(data["version"])
+        except (TypeError, ValueError) as exc:
+            raise BatonRejected(
+                field="version",
+                invalid_value=str(data["version"]),
+                valid_values=["integer"],
+            ) from exc
+
+        to_owner_raw = str(data["to_owner"])
+        try:
+            to_owner = HandoffOwner(to_owner_raw)
         except ValueError as exc:
-            raise ValueError(f"Baton contract contains invalid enum value: {exc}") from exc
+            raise BatonRejected(
+                field="to_owner",
+                invalid_value=to_owner_raw,
+                valid_values=[owner.value for owner in HandoffOwner],
+            ) from exc
+
+        intent_raw = str(data["intent"])
+        if intent_raw == "chat_handoff":
+            intent_raw = HandoffIntent.MANUAL_HANDOFF.value
+        try:
+            intent = HandoffIntent(intent_raw)
+        except ValueError as exc:
+            raise BatonRejected(
+                field="intent",
+                invalid_value=intent_raw,
+                valid_values=[intent.value for intent in HandoffIntent],
+            ) from exc
+
+        return cls(
+            version=version,
+            from_step=str(data["from_step"]),
+            to_owner=to_owner,
+            to_step=str(data["to_step"]),
+            intent=intent,
+            status_code=str(data.get("status_code", "")),
+            created_at=str(data.get("created_at", _now_iso())),
+            source=str(data.get("source", "unknown")),
+        )
 
     @classmethod
     def from_legacy_step(
@@ -461,27 +488,33 @@ class BlackboardStore:
 
         try:
             payload = json.loads(raw)
-            if not isinstance(payload, dict):
-                raise ValueError("Baton payload must be a JSON object")
-            try:
-                contract = HandoffContract.from_dict(payload)
-            except ValueError as exc:
-                if "invalid enum value" in str(exc).lower():
-                    raise self._make_baton_rejected(payload) from exc
-                raise
-        except BatonRejected:
-            raise
-        except (json.JSONDecodeError, ValueError) as exc:
+        except json.JSONDecodeError as exc:
             if not allow_legacy_text:
                 raise ValueError(f"Invalid baton contract payload: {exc}") from exc
             legacy_step = raw.strip()
             if not legacy_step:
-                raise ValueError(f"Baton file is empty: {self.next_step_path}") from exc
-            contract = HandoffContract.from_legacy_step(
+                raise ValueError(f"Baton file is empty: {self.next_step_path}")
+            return HandoffContract.from_legacy_step(
                 step=legacy_step,
                 from_step=state.current_step,
                 source="legacy_text",
             )
+
+        if not isinstance(payload, dict):
+            raise BatonRejected(
+                field="payload",
+                invalid_value=type(payload).__name__,
+                valid_values=["JSON object"],
+            )
+
+        try:
+            contract = HandoffContract.from_dict(payload)
+        except BatonRejected:
+            raise
+        except ValueError as exc:
+            if not allow_legacy_text:
+                raise ValueError(f"Invalid baton contract payload: {exc}") from exc
+            raise
 
         if allowed_steps:
             contract.validate(allowed_steps=allowed_steps)

--- a/src/cafe/core/workflow_models.py
+++ b/src/cafe/core/workflow_models.py
@@ -49,7 +49,7 @@ class StepInterrupted(Exception):
 
 
 class BatonRejected(Exception):
-    """Raised when a baton payload contains an invalid enum value.
+    """Raised when a baton payload fails recoverable contract validation.
 
     Carries enough detail for the runtime to build a feedback prompt so the
     agent can correct the baton on retry.

--- a/src/cafe/core/workflow_runtime.py
+++ b/src/cafe/core/workflow_runtime.py
@@ -175,14 +175,19 @@ class BlackboardWorkflowRuntime:
 
     @staticmethod
     def _baton_rejected_prompt(br: BatonRejected) -> str:
+        if br.invalid_value:
+            value_msg = f"invalid value '{br.invalid_value}'"
+        else:
+            value_msg = "required field missing from the payload"
         message = (
-            f"[BATON ERROR] Your baton was rejected because field '{br.field}' "
-            f"has invalid value '{br.invalid_value}'. "
+            f"[BATON ERROR] Your baton was rejected because field '{br.field}' has {value_msg}. "
             f"Valid values are: {br.valid_values}. "
-            "Please rewrite next_step.txt with a correct baton. "
+            "Please rewrite next_step.txt with a correct structured baton. "
             "Retry in baton-only mode: do not rewrite output.md, checklist.md, or questions.xml unless strictly required. "
             "If you are asking the user a question, use to_owner='user', "
-            "to_step='user', and intent='need_clarification'."
+            "to_step='user', and intent='need_clarification'. "
+            "If your step omits safe defaults, you may keep status_code and source empty; "
+            "other required keys must be present and valid."
         )
         if br.field == "to_step":
             message += (

--- a/tests/unit/test_workflow_models.py
+++ b/tests/unit/test_workflow_models.py
@@ -15,7 +15,6 @@ from cafe.core.blackboard import (
 )
 from cafe.core.workflow_models import BatonRejected
 
-
 # ---------------------------------------------------------------------------
 # BatonRejected 例外單元測試
 # ---------------------------------------------------------------------------
@@ -129,6 +128,51 @@ class TestLoadHandoffContractBatonRejected:
 
         with pytest.raises(BatonRejected):
             store.load_handoff_contract(state, allowed_steps=["develop", "review"], allow_legacy_text=True)
+
+    @pytest.mark.parametrize(
+        "missing_field",
+        ["version", "from_step", "to_owner", "to_step", "intent"],
+    )
+    def test_missing_required_field_raises_baton_rejected(
+        self,
+        tmp_path: Path,
+        missing_field: str,
+    ) -> None:
+        """缺少必要欄位時需直接拋 BatonRejected，不得走 legacy。"""
+        issue_dir = tmp_path / "issue-reject-missing"
+        issue_dir.mkdir(parents=True)
+        store = BlackboardStore(issue_dir)
+        state = store.load_or_create("develop")
+        payload = _base_payload()
+        payload.pop(missing_field)
+        _write_baton(issue_dir, payload)
+
+        with pytest.raises(BatonRejected) as exc_info:
+            store.load_handoff_contract(state, allowed_steps=["develop", "review"])
+
+        exc = exc_info.value
+        assert exc.field == missing_field
+        assert not exc.valid_values
+
+    def test_allow_legacy_text_json_scalar_raises_baton_rejected(self, tmp_path: Path) -> None:
+        """能 parse 的 JSON 非 object 時不可退回 legacy text。"""
+        issue_dir = tmp_path / "issue-reject-scalar"
+        issue_dir.mkdir(parents=True)
+        store = BlackboardStore(issue_dir)
+        state = store.load_or_create("develop")
+        (issue_dir / "next_step.txt").write_text('"review"', encoding="utf-8")
+
+        with pytest.raises(BatonRejected) as exc_info:
+            store.load_handoff_contract(
+                state,
+                allowed_steps=["develop", "review"],
+                allow_legacy_text=True,
+            )
+
+        exc = exc_info.value
+        assert exc.field == "payload"
+        assert exc.invalid_value == "str"
+        assert exc.valid_values == ["JSON object"]
 
     def test_allow_legacy_text_non_json_falls_back_to_legacy_step(self, tmp_path: Path) -> None:
         """JSON 解析失敗（非 enum 問題）且 allow_legacy_text=True 時走 legacy step 解析。"""

--- a/tests/unit/test_workflow_runtime.py
+++ b/tests/unit/test_workflow_runtime.py
@@ -2185,6 +2185,26 @@ def _make_invalid_target_baton_text(
     )
 
 
+def _make_missing_intent_baton_text(
+    issue_dir: Path, *, from_step: str = "spec", to_step: str = "done"
+) -> None:
+    """Write JSON baton payload missing `intent`. """
+    (issue_dir / "next_step.txt").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "from_step": from_step,
+                "to_owner": "done" if to_step == "done" else "agent",
+                "to_step": to_step,
+                "status_code": "",
+                "created_at": "2026-05-14T10:00:00+08:00",
+                "source": "test",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
 def test_runtime_retries_once_on_baton_rejected_then_succeeds(tmp_path: Path) -> None:
     """第 1 次寫出無效 baton，第 2 次（retry 1）寫出合法 baton → workflow 正常繼續，blackboard 有 1 筆 baton_rejected 事件。"""
     issue_dir = tmp_path / ".cafe" / "issues" / "retry-1"
@@ -2278,6 +2298,89 @@ def test_runtime_retries_invalid_target_step_then_succeeds(tmp_path: Path) -> No
     assert len(rejected_events) == 1
     assert rejected_events[0].data["field"] == "to_step"
     assert rejected_events[0].data["invalid_value"] == "release"
+
+
+def test_runtime_retries_missing_required_field_then_succeeds(tmp_path: Path) -> None:
+    """若 structured JSON 缺欄位，runtime 應要求修正而非 fallback 到 legacy。"""
+    issue_dir = tmp_path / ".cafe" / "issues" / "retry-missing-field"
+    issue_dir.mkdir(parents=True)
+    captured_prompts: list[str | None] = []
+    call_count = [0]
+
+    def executor(step_name: str, step_def: dict, state: object, **kwargs) -> StepExecutionResult:
+        call_count[0] += 1
+        captured_prompts.append(kwargs.get("extra_prompt"))
+        if call_count[0] == 1:
+            _make_missing_intent_baton_text(issue_dir, from_step="spec", to_step="done")
+        else:
+            _make_valid_baton_text(
+                issue_dir, from_step="spec", to_step="done", intent="workflow_complete"
+            )
+        return StepExecutionResult(response="done", artifacts={}, status_code="")
+
+    runtime = BlackboardWorkflowRuntime(
+        issue_dir=issue_dir,
+        playbook=_simple_playbook(),
+        executor=executor,
+    )
+    result = runtime.run(start_step="spec", max_transitions=5)
+
+    assert result.completed is True
+    assert len(captured_prompts) == 2
+    assert captured_prompts[0] is None
+    assert "field 'intent'" in (captured_prompts[1] or "")
+    assert "missing" in (captured_prompts[1] or "").lower()
+    bb = BlackboardStore(issue_dir).load_or_create("spec")
+    rejected_events = [e for e in bb.events if e.event_type == "baton_rejected"]
+    assert len(rejected_events) == 1
+    assert rejected_events[0].data["field"] == "intent"
+
+
+def test_runtime_rejects_no_status_legacy_text_as_status_transition(tmp_path: Path) -> None:
+    """Legacy plain-text next_step 在 legacy 相容邊界仍應被接受。"""
+    issue_dir = tmp_path / ".cafe" / "issues" / "legacy-status-text"
+    playbook = {
+        "playbook": {"id": "default"},
+        "steps": {
+            "spec": {
+                "skill": "spec_first",
+                "role": "pm",
+                "valid_intents": ["confirmed"],
+                "on": {"confirmed": "plan"},
+            },
+            "plan": {
+                "skill": "spec_first",
+                "role": "developer",
+                "valid_intents": ["confirmed"],
+                "on": {"confirmed": "_done"},
+            },
+        },
+    }
+
+    visited_steps: list[str] = []
+
+    def executor(step_name: str, step_def: dict, state: object) -> StepExecutionResult:
+        visited_steps.append(step_name)
+        if step_name == "spec":
+            (issue_dir / "next_step.txt").write_text("plan", encoding="utf-8")
+            return StepExecutionResult(response="", artifacts={}, status_code="")
+        _make_valid_baton_text(
+            issue_dir, from_step="plan", to_step="done", intent="workflow_complete"
+        )
+        return StepExecutionResult(response="", artifacts={}, status_code="")
+
+    runtime = BlackboardWorkflowRuntime(
+        issue_dir=issue_dir,
+        playbook=playbook,
+        executor=executor,
+    )
+    result = runtime.run(start_step="spec", max_transitions=5)
+
+    assert result.completed is True
+    assert result.final_step == "plan"
+    assert visited_steps == ["spec", "plan"]
+    blackboard = BlackboardStore(issue_dir).load_or_create("plan")
+    assert blackboard.current_step == "done"
 
 
 def test_runtime_retries_same_phase_baton_then_succeeds(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Fixes issue #357 by making structured baton JSON authoritative: JSON payloads that parse successfully but are missing required handoff fields are rejected as malformed structured output instead of being reinterpreted as legacy plain text. Legacy compatibility remains available for genuine plain-text step-name batons.

## Changes

- Commit `2a2c4f8 issue357: reject malformed structured batons`.
- Added required-field and recoverable validation in `HandoffContract.from_dict` so missing required baton fields, invalid owners, invalid intents, and invalid versions produce explicit rejection behavior.
- Updated `BlackboardStore.load_handoff_contract` so legacy text fallback is limited to non-JSON payloads while structured JSON objects and JSON scalar payloads stay on the structured validation path.
- Improved baton retry guidance to distinguish missing fields from invalid values and explain which optional metadata may use safe defaults.
- Added regression coverage for missing required fields, structured-vs-legacy discrimination, runtime retry recovery, JSON scalar rejection, and legitimate legacy plain-text handoff compatibility.

## Test Plan

- Passed: `PYTHONPATH=src uv run --extra dev python -m pytest tests/unit/test_workflow_models.py tests/unit/test_workflow_runtime.py`.
- Passed: `PYTHONPATH=src uv run --extra dev python -m pytest tests/unit/test_cli_workflow_command.py`.
- Passed: `PYTHONPATH=src uv run --extra dev python -m ruff check --select I src/cafe/core/blackboard.py src/cafe/core/workflow_runtime.py src/cafe/core/workflow_models.py tests/unit/test_workflow_models.py tests/unit/test_workflow_runtime.py`.
- Passed: `git diff --check develop...HEAD`.