### PR TITLE
issue360: add skill-sourced basic principles checklists

### DIFF
--- a/src/cafe/data/skills/write-cafe-skill/SKILL.md
+++ b/src/cafe/data/skills/write-cafe-skill/SKILL.md
@@ -65,6 +65,7 @@ version: 2.0.0
 - Add `references/` only for details that would otherwise bloat `SKILL.md`.
 - Each reference file should be focused and named by topic.
 - In `SKILL.md`, say exactly when to open each reference.
+- Put always-on workflow rules in `references/basic_principles.md` when they should become a checklist gate for every mode of that skill; keep mode-specific procedures in `references/execution_steps_*.md`.
 
 ## When To Add Scripts
 - Add `scripts/` when the same command or transformation would otherwise be rewritten repeatedly.

--- a/src/cafe/data/skills/write-cafe-skill/references/skill-spec.md
+++ b/src/cafe/data/skills/write-cafe-skill/references/skill-spec.md
@@ -157,6 +157,17 @@ Placeholder 是 activate 時的**純文字替換**（`{key}` → 值），不支
 **references/**
 - 只放「條件才需要讀」的細節，避免撐大 SKILL.md；一層深、依主題命名。
 - SKILL.md 內必須明說「何時」打開哪個 reference。
+- `references/execution_steps_*.md` 放程序性步驟：有順序，且可依 normal/correction、iteration 或其他模式拆分。
+- `references/basic_principles.md` 放常備規則：repo 慣例、風格、不變式、反覆出現的檢核點。內容使用 `- ` bullet list；runtime 會以 opt-in 方式轉成 checklist 的 `## Basic Principles` 段，且不分 normal/correction 模式一律附掛。沒有這個檔案時不阻塞，也不改變既有 checklist。
+- agent 檔 guidelines 放個人風格與角色偏好：跟 agent 走、跨 phase 生效，不應取代 workflow skill 的常備規則。
+
+三個管道的分工：
+
+| 管道 | 語意 | 模式 |
+| --- | --- | --- |
+| `references/execution_steps_*.md` | 程序：有順序、分 normal/correction 或 iteration | 分模式 |
+| `references/basic_principles.md` | 常備規則：repo 慣例、風格、不變式 | 不分模式、一律附掛 |
+| agent 檔 guidelines | 個人風格，跟 agent 走 | 跨 phase |
 
 **scripts/**
 - 用於重複執行的固定命令，或需要外網、憑證、GitHub/API mutation 的操作。
@@ -201,4 +212,5 @@ skill 文件內不要假設只有某一條 playbook 會用它。
 - [ ] 沒有重述 baton schema、chat handoff 格式或其他 shared 規則；引用句式符合 §7
 - [ ] `## Handoff` 為固定一行
 - [ ] references / scripts 有明確觸發條件；對外 mutation 走 host-side hook
+- [ ] 常備規則放 `references/basic_principles.md`，不要散落在多個 `execution_steps_*` 變體中重複維護
 - [ ] 若是共用規則，已更新 `cafe-workflow-common` 的 Where policies live 索引

--- a/src/cafe/phases/generic_workflow_step.py
+++ b/src/cafe/phases/generic_workflow_step.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from cafe.agents.manager import AgentManager
-from cafe.core.capabilities import CAPABILITY_PR_PUBLISH_ID
 from cafe.core.blackboard import (
     ArtifactEntry,
     ArtifactKind,
@@ -16,8 +15,15 @@ from cafe.core.blackboard import (
     HandoffIntent,
     HandoffOwner,
 )
+from cafe.core.capabilities import CAPABILITY_PR_PUBLISH_ID
 from cafe.core.git import GitOperations
 from cafe.core.phase import Phase
+from cafe.core.resume_user_input import (
+    is_resume_iteration,
+    load_prior_run_context,
+    prior_cli_and_session,
+    resolve_resume_user_input,
+)
 from cafe.core.status_codes import (
     PhaseStatusCode,
     StatusCodeParser,
@@ -26,13 +32,7 @@ from cafe.core.status_codes import (
 )
 from cafe.core.workflow_models import StepExecutionResult
 from cafe.phases.generic_phase import GenericPhase
-from cafe.core.resume_user_input import (
-    is_resume_iteration,
-    load_prior_run_context,
-    prior_cli_and_session,
-    resolve_resume_user_input,
-)
-from cafe.skills.loader import canonical_skill_name
+from cafe.skills.bridge import try_load_skill_reference
 from cafe.skills.checklist_composer import (
     generate_develop_checklist,
     generate_plan_checklist,
@@ -40,6 +40,7 @@ from cafe.skills.checklist_composer import (
     generate_review_checklist,
     generate_spec_checklist,
 )
+from cafe.skills.loader import canonical_skill_name
 from cafe.utils.git_utils import to_cwd_relative_path
 
 
@@ -727,6 +728,10 @@ class GenericWorkflowStepExecutor(Phase):
         ) or self._artifact_path(blackboard_state, "pr_result")
 
         skill_name = canonical_skill_name(skill_name)
+        skill_basic_principles = try_load_skill_reference(
+            skill_name,
+            "basic_principles.md",
+        )
         if skill_name == "cafe-spec":
             prev_spec = None
             if self.iteration > 1:
@@ -741,6 +746,7 @@ class GenericWorkflowStepExecutor(Phase):
                 prev_spec_file=prev_spec,
                 checklist_file_path=checklist_file,
                 questions_xml_file=questions_display,
+                basic_principles=skill_basic_principles,
             )
             return
 
@@ -761,6 +767,7 @@ class GenericWorkflowStepExecutor(Phase):
                 iteration=self.iteration,
                 prev_plan_file=prev_plan,
                 questions_xml_file=questions_display,
+                basic_principles=skill_basic_principles,
             )
             return
 
@@ -777,6 +784,7 @@ class GenericWorkflowStepExecutor(Phase):
                 feedback_file_path=review_feedback,
                 output_file=output_display,
                 questions_xml_file=questions_display,
+                basic_principles=skill_basic_principles,
             )
             return
 
@@ -791,6 +799,7 @@ class GenericWorkflowStepExecutor(Phase):
                 review_file_path=output_display,
                 base_branch=str(base_branch or self.git_ops.get_default_base_branch()),
                 checklist_file_path=checklist_file,
+                basic_principles=skill_basic_principles,
             )
             return
 
@@ -811,6 +820,7 @@ class GenericWorkflowStepExecutor(Phase):
                 checklist_file_path=checklist_file,
                 iteration=self.iteration,
                 prev_pr_file=prev_pr,
+                basic_principles=skill_basic_principles,
             )
             return
 

--- a/src/cafe/skills/checklist_composer.py
+++ b/src/cafe/skills/checklist_composer.py
@@ -262,6 +262,7 @@ def generate_review_checklist(
     pr_feedback_file_path: Optional[str] = None,
     plan_file_path: Optional[str] = None,
     pr_todo_list_file_path: Optional[str] = None,
+    basic_principles: Optional[str] = None,
 ) -> None:
     """Generate checklist file for review phase."""
     agent_file = AgentManager.get_agent_file_path(agent_name, "reviewer")
@@ -276,8 +277,18 @@ def generate_review_checklist(
 [ ] Check that ALL todo items are marked as completed [x]. If any unchecked items [ ] remain, return needs_changes
 """
 
+    basic_principles_checklist = ""
+    if basic_principles:
+        basic_principles_checklist = convert_to_checklist(
+            basic_principles,
+            "Basic Principles",
+        )
+
     agent_guidelines = extract_agent_guidelines_checklist(agent_file)
-    checklist_content = f"{execution_steps}\n{pr_todo_list_section}{agent_guidelines}"
+    checklist_content = f"{execution_steps}\n"
+    if basic_principles_checklist:
+        checklist_content += f"{basic_principles_checklist}\n"
+    checklist_content += f"{pr_todo_list_section}{agent_guidelines}"
 
     placeholders = {
         "agent_file": agent_file,

--- a/tests/fixtures/checklists/manifest.json
+++ b/tests/fixtures/checklists/manifest.json
@@ -4,6 +4,8 @@
   "spec_iter4",
   "plan_iter1",
   "plan_iter2",
+  "spec_iter1_with_basic_principles",
+  "plan_iter1_with_basic_principles",
   "develop_normal",
   "develop_correction",
   "review",

--- a/tests/fixtures/checklists/plan_iter1_with_basic_principles.md
+++ b/tests/fixtures/checklists/plan_iter1_with_basic_principles.md
@@ -1,0 +1,65 @@
+## Checklist
+
+[ ] Read src/cafe/data/agents/developer/Nick.md to understand your role and native language
+[ ] Read the development guide in .cafe/issues/test/plan/iteration_001/output.md
+[ ] Read the requirements document .cafe/issues/test/spec/iteration_001/output.md
+[ ] Plan implementation steps (planning, not implementation)
+[ ] Fill required sections **Negative space**, **Layering map**, and **Dependency ADR** (explicit "none" / "no new dependencies" if applicable — empty placeholders are incomplete)
+[ ] If `.cafe/strategic_context.yaml` has `documents.principles.path` with `status: exists`, read that file and ground Negative space and Dependency ADR; otherwise leave principles cross-refs blank
+[ ] For any new major in Dependency ADR, note if released within the last 30 days and justify or pick a stable alternative
+[ ] Complete **`## Test List`** in the plan output (`Unit tests (N)` and `Integration tests (M)` with labels mapping to invariants or user journeys; if N or M is 0, explain why)
+[ ] Read `src/cafe/data/skills/cafe-plan/references/test_invariants_policy.md` when writing Test List items and assertion guidance
+[ ] Confirm: Integration test entries describe **user journeys** and **invariant outcomes**, not UI components
+[ ] Confirm: Test List items avoid brittle bindings (UI copy, CSS classes, DOM structure, internal state shape) unless the spec explicitly requires them
+[ ] Append plan after "## Development Guide" section
+[ ] Keep "## Development Guide" section unchanged
+[ ] Confirm: Only wrote plans and steps, NO actual code
+[ ] Confirm: No code was modified
+[ ] Update blackboard and next-step baton to hand off to the next workflow target
+
+## Interactive Q&A Questions
+
+[ ] If user clarification is needed: write questions to .cafe/issues/test/plan/iteration_001/questions.xml in the following XML format and hand off to `user` with need_clarification:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<questions>
+  <question id="1">
+    <title>Your question text here?</title>
+    <options>
+      <option>Suggested answer 1</option>
+      <option>Suggested answer 2</option>
+      <option>Suggested answer 3</option>
+    </options>
+  </question>
+  <question id="2">
+    <title>Another question?</title>
+    <options>
+      <option>Option A</option>
+      <option>Option B</option>
+    </options>
+  </question>
+</questions>
+```
+
+Rules:
+- Write all questions and options in your native language (not English unless that is your native language)
+- Root element must be `<questions>`
+- Each question must have a unique `id` attribute, a `<title>`, and `<options>` with at least one `<option>`
+- Provide 2-4 suggested options per question
+- Options should be concise and distinct
+- For multi-select questions (user can pick multiple options), you MUST add `type="checkbox"` attribute to the `<question>` element (e.g., `<question id="1" type="checkbox">`). This includes DoD questions.
+
+
+## Basic Principles
+
+[ ] Keep checklist output stable
+[ ] Keep user impact explicit
+
+## Agent Guidelines Checklist
+
+[ ] Adhere to the project's coding standards.
+[ ] Write comments in the project's customary natural language.
+[ ] Follow the project's commit message style.
+[ ] Break down tasks using the TDD approach: for each task, write the corresponding test cases before implementation. Ensure all unit tests pass upon the completion of each task.
+[ ] Write robust, non-fragile tests: mock only at boundaries (external APIs, I/O), assert on behavior/outcomes not implementation details, avoid exact string matching on error messages.

--- a/tests/fixtures/checklists/spec_iter1_with_basic_principles.md
+++ b/tests/fixtures/checklists/spec_iter1_with_basic_principles.md
@@ -1,0 +1,69 @@
+## Checklist
+
+[ ] Read src/cafe/data/agents/pm/Roger.md to understand your role and native language
+[ ] Read .cafe/issues/test/spec/iteration_001/output.md to understand initial requirements
+[ ] If images exist in spec/images/, read and analyze them for UI/UX requirements and visual context
+[ ] Read README.md for project context
+[ ] Search codebase using Read/Grep tools to find answers before asking users
+[ ] Identify unclear areas that need clarification
+[ ] Preserve original requirements content - Keep the "Initial Requirements" section and "Issue Title" (if present) unchanged, only add your analysis below
+[ ] Write analysis results to .cafe/issues/test/spec/iteration_001/output.md (NOT in your response)
+[ ] Update blackboard and next-step baton to hand off to the next workflow target
+[ ] Confirm: No technical details were included (no implementation, architecture, languages, frameworks, databases)
+[ ] Confirm: Only provided 2-3 high-level approach options if any, without prescribing specific technical solutions
+[ ] Confirm: No code was modified
+[ ] Keep the response brief; workflow transitions are controlled by the baton
+
+## Interactive Q&A Questions
+
+[ ] If user clarification is needed: write questions to .cafe/issues/test/spec/iteration_001/questions.xml in the following XML format and hand off to `user` with `intent=need_clarification`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<questions>
+  <question id="1">
+    <title>Your question text here?</title>
+    <options>
+      <option>Suggested answer 1</option>
+      <option>Suggested answer 2</option>
+      <option>Suggested answer 3</option>
+    </options>
+  </question>
+  <question id="2">
+    <title>Another question?</title>
+    <options>
+      <option>Option A</option>
+      <option>Option B</option>
+    </options>
+  </question>
+</questions>
+```
+
+Rules:
+- Write all questions and options in your native language (not English unless that is your native language)
+- Root element must be `<questions>`
+- Each question must have a unique `id` attribute, a `<title>`, and `<options>` with at least one `<option>`
+- Provide 2-4 suggested options per question
+- Options should be concise and distinct
+- For multi-select questions (user can pick multiple options), you MUST add `type="checkbox"` attribute to the `<question>` element (e.g., `<question id="1" type="checkbox">`). This includes DoD questions.
+
+
+## Basic Principles
+
+[ ] Keep implementation minimal
+[ ] Prefer existing utilities
+
+
+## Definition of Done (DoD) -- MANDATORY
+
+[ ] You MUST include DoD questions in questions.xml and request clarification (even if requirements are already clear -- send DoD questions alone)
+[ ] DoD questions focus on functional requirements only (e.g., all major features working, error handling working, edge cases tested)
+[ ] Do NOT add "Other" or custom input options to checkbox questions -- the system automatically adds an "Other" option to every checkbox question
+[ ] NEVER mark the spec as ready for review without first confirming DoD with the user
+[ ] After receiving user's DoD answers, integrate selected items into the Acceptance Criteria section with "✅ **DoD:**" prefix
+
+## Agent Guidelines Checklist
+
+[ ] Focus on the Requirement: Do not jump into discussions about technical implementation.
+[ ] User Perspective: Think about functions and scenarios from the user's point of view.
+[ ] Clear Communication: Ask questions in a simple and direct manner.

--- a/tests/unit/test_generic_workflow_step.py
+++ b/tests/unit/test_generic_workflow_step.py
@@ -1,13 +1,14 @@
 """Tests for direct workflow step execution."""
 
-from collections.abc import Iterator
 import json
+from collections.abc import Iterator
 from pathlib import Path
-from types import MethodType
-from types import SimpleNamespace
+from types import MethodType, SimpleNamespace
 from unittest.mock import patch
+
 import pytest
 
+from cafe.agents.executor import AgentExecutionError
 from cafe.core.blackboard import (
     ArtifactEntry,
     ArtifactKind,
@@ -18,12 +19,10 @@ from cafe.core.blackboard import (
 from cafe.core.hooks import HookResult
 from cafe.core.status_codes import PhaseStatusCode
 from cafe.core.types import AgentCLI, AgentConfig, TokenUsage
-from cafe.phases.generic_phase import GenericPhaseExecution
-from cafe.phases.generic_phase import GenericPhase
+from cafe.phases.generic_phase import GenericPhase, GenericPhaseExecution
 from cafe.phases.generic_workflow_step import GenericWorkflowStepExecutor
 from cafe.skills.loader import SkillLoader
 from cafe.skills.native_bridge import NativeSkillBridge
-from cafe.agents.executor import AgentExecutionError
 
 
 class FakeAgentManager:
@@ -2494,6 +2493,135 @@ def test_develop_checklist_prefers_review_feedback_over_pr_result(
     assert call_kwargs["correction_mode"] is True
     assert "review" in call_kwargs["feedback_file_path"]
     assert "pr" not in call_kwargs["feedback_file_path"]
+
+
+def _write_skill_with_basic_principles(
+    tmp_path: Path,
+    *,
+    skill_name: str,
+    basic_principles: str,
+) -> None:
+    skill_dir = tmp_path / ".cafe" / "skills" / skill_name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {skill_name}\ndescription: test skill\n---\n",
+        encoding="utf-8",
+    )
+    references = skill_dir / "references"
+    references.mkdir(parents=True, exist_ok=True)
+    (references / "basic_principles.md").write_text(
+        basic_principles,
+        encoding="utf-8",
+    )
+
+
+def test_spec_checklist_loads_custom_basic_principles_reference(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    issue_dir = tmp_path / ".cafe" / "issues" / "issue-spec-basic-principles"
+    playbook = {
+        "playbook": {"id": "default"},
+        "roles": {"developer": {"default_agent": "David"}},
+        "steps": {
+            "spec": {
+                "skill": "spec",
+                "role": "developer",
+                "output_artifact": "spec",
+                "allowed_tools": ["Read"],
+                "valid_intents": ["confirmed"],
+                "on": {"await_agent": "_done"},
+            }
+        },
+    }
+
+    _write_skill_with_basic_principles(
+        tmp_path,
+        skill_name="cafe-spec",
+        basic_principles="- Stay scoped\n- Keep behavior stable",
+    )
+    executor = GenericWorkflowStepExecutor(
+        issue_dir=issue_dir,
+        issue_name="issue-spec-basic-principles",
+        playbook=playbook,
+        generic_phase=_build_loader(tmp_path),
+        agent_manager=FakeAgentManager("confirmed"),
+        git_ops=FakeGitOperations(),
+        role_agent_map={"developer": "David"},
+    )
+    executor.phase_dir = issue_dir / "spec"
+    executor.iteration = 1
+    output_file = issue_dir / "output.md"
+    checklist_file = issue_dir / "checklist.md"
+    questions_xml_file = issue_dir / "questions.xml"
+
+    state = BlackboardStore(issue_dir).load_or_create("spec")
+    with patch("cafe.phases.generic_workflow_step.generate_spec_checklist") as mock_gen:
+        executor._generate_checklist(
+            step_name="spec",
+            skill_name="spec",
+            agent_name="David",
+            step_def={"skill": "spec"},
+            blackboard_state=state,
+            checklist_file=checklist_file,
+            output_file=output_file,
+            questions_xml_file=questions_xml_file,
+        )
+
+    mock_gen.assert_called_once()
+    assert mock_gen.call_args.kwargs["basic_principles"] == "- Stay scoped\n- Keep behavior stable"
+
+
+def test_spec_checklist_omits_missing_basic_principles_reference(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    issue_dir = tmp_path / ".cafe" / "issues" / "issue-spec-no-basic-principles"
+    playbook = {
+        "playbook": {"id": "default"},
+        "roles": {"developer": {"default_agent": "David"}},
+        "steps": {
+            "spec": {
+                "skill": "spec",
+                "role": "developer",
+                "output_artifact": "spec",
+                "allowed_tools": ["Read"],
+                "valid_intents": ["confirmed"],
+                "on": {"await_agent": "_done"},
+            }
+        },
+    }
+
+    executor = GenericWorkflowStepExecutor(
+        issue_dir=issue_dir,
+        issue_name="issue-spec-no-basic-principles",
+        playbook=playbook,
+        generic_phase=_build_loader(tmp_path),
+        agent_manager=FakeAgentManager("confirmed"),
+        git_ops=FakeGitOperations(),
+        role_agent_map={"developer": "David"},
+    )
+    executor.phase_dir = issue_dir / "spec"
+    executor.iteration = 1
+    output_file = issue_dir / "output.md"
+    checklist_file = issue_dir / "checklist.md"
+    questions_xml_file = issue_dir / "questions.xml"
+    state = BlackboardStore(issue_dir).load_or_create("spec")
+
+    with patch("cafe.phases.generic_workflow_step.generate_spec_checklist") as mock_gen:
+        executor._generate_checklist(
+            step_name="spec",
+            skill_name="spec",
+            agent_name="David",
+            step_def={"skill": "spec"},
+            blackboard_state=state,
+            checklist_file=checklist_file,
+            output_file=output_file,
+            questions_xml_file=questions_xml_file,
+        )
+
+    mock_gen.assert_called_once()
+    assert mock_gen.call_args.kwargs["basic_principles"] == ""
 
 
 def test_update_iteration_history_preserves_model_and_stats_on_second_call(

--- a/tests/unit/test_skill_checklist_composer.py
+++ b/tests/unit/test_skill_checklist_composer.py
@@ -89,6 +89,26 @@ GOLDEN_RUNNERS = {
         prev_plan_file=".cafe/issues/test/plan/iteration_001/output.md",
         template_mode="manual",
     ),
+    "spec_iter1_with_basic_principles": lambda path: generate_spec_checklist(
+        iteration=1,
+        agent_name="Roger",
+        current_spec_file=".cafe/issues/test/spec/iteration_001/output.md",
+        prev_spec_file=None,
+        checklist_file_path=path,
+        basic_principles="- Keep implementation minimal\n- Prefer existing utilities",
+        questions_xml_file=".cafe/issues/test/spec/iteration_001/questions.xml",
+        template_mode="manual",
+    ),
+    "plan_iter1_with_basic_principles": lambda path: generate_plan_checklist(
+        agent_name="Nick",
+        plan_file_path=".cafe/issues/test/plan/iteration_001/output.md",
+        spec_file_path=".cafe/issues/test/spec/iteration_001/output.md",
+        checklist_file_path=path,
+        iteration=1,
+        template_mode="manual",
+        basic_principles="- Keep checklist output stable\n- Keep user impact explicit",
+        questions_xml_file=".cafe/issues/test/plan/iteration_001/questions.xml",
+    ),
     "develop_normal": lambda path: generate_develop_checklist(
         agent_name="Nick",
         spec_file_path=".cafe/issues/test/spec/iteration_001/output.md",
@@ -238,3 +258,91 @@ def test_spec_and_develop_xml_question_instruction_requires_need_clarification()
     develop_instruction = load_skill_reference("cafe-develop", "xml_questions_instruction.md")
     assert "intent=need_clarification" in spec_instruction
     assert "intent=need_clarification" in develop_instruction
+
+
+def test_generate_checklist_with_basic_principles_includes_checklist_section(tmp_path: Path) -> None:
+    checklist_path = tmp_path / "checklist.md"
+    generate_plan_checklist(
+        agent_name="David",
+        plan_file_path=".cafe/issues/test/plan/iteration_001/output.md",
+        spec_file_path=".cafe/issues/test/spec/iteration_001/output.md",
+        checklist_file_path=checklist_path,
+        iteration=1,
+        template_mode="manual",
+        basic_principles="- Keep scope\n- Follow existing conventions",
+    )
+    content = checklist_path.read_text(encoding="utf-8")
+
+    assert "## Basic Principles" in content
+    assert "[ ] Keep scope" in content
+    assert "[ ] Follow existing conventions" in content
+
+
+def test_review_and_pr_checklists_include_basic_principles(tmp_path: Path) -> None:
+    review_path = tmp_path / "review_checklist.md"
+    pr_path = tmp_path / "pr_checklist.md"
+
+    generate_review_checklist(
+        agent_name="Alice",
+        spec_file_path=".cafe/issues/test/spec/iteration_001/output.md",
+        review_file_path=".cafe/issues/test/review/iteration_001/output.md",
+        base_branch="develop",
+        checklist_file_path=review_path,
+        plan_file_path=".cafe/issues/test/plan/iteration_001/output.md",
+        basic_principles="- Review with repository scope",
+    )
+    generate_pr_checklist(
+        agent_name="Nick",
+        spec_file_path=".cafe/issues/test/spec/iteration_001/output.md",
+        plan_file_path=".cafe/issues/test/plan/iteration_001/output.md",
+        pr_file=".cafe/issues/test/pr/iteration_001/output.md",
+        checklist_file_path=pr_path,
+        basic_principles="- Keep PR description factual",
+    )
+
+    review_content = review_path.read_text(encoding="utf-8")
+    pr_content = pr_path.read_text(encoding="utf-8")
+
+    assert "## Basic Principles" in review_content
+    assert "[ ] Review with repository scope" in review_content
+    assert "## Basic Principles" in pr_content
+    assert "[ ] Keep PR description factual" in pr_content
+
+
+def test_generate_checklist_ignores_non_bullet_basic_principles_lines(tmp_path: Path) -> None:
+    checklist_path = tmp_path / "checklist.md"
+    generate_develop_checklist(
+        agent_name="David",
+        spec_file_path=".cafe/issues/test/spec/iteration_001/output.md",
+        plan_file_path=".cafe/issues/test/plan/iteration_001/output.md",
+        develop_file=None,
+        checklist_file_path=checklist_path,
+        correction_mode=False,
+        output_file=".cafe/issues/test/develop/iteration_001/output.md",
+        basic_principles=(
+            "- Valid list item\n"
+            "Not a list item\n"
+            "* wrong bullet marker\n"
+            "- Another valid list item"
+        ),
+    )
+
+    content = checklist_path.read_text(encoding="utf-8")
+
+    assert "Not a list item" not in content
+    assert "wrong bullet marker" not in content
+    assert "[ ] Valid list item" in content
+    assert "[ ] Another valid list item" in content
+
+
+def test_write_cafe_skill_spec_documents_basic_principles_reference() -> None:
+    spec = Path("src/cafe/data/skills/write-cafe-skill/references/skill-spec.md").read_text(
+        encoding="utf-8"
+    )
+    skill = Path("src/cafe/data/skills/write-cafe-skill/SKILL.md").read_text(encoding="utf-8")
+
+    assert "references/basic_principles.md" in spec
+    assert "## Basic Principles" in spec
+    assert "references/execution_steps_*.md" in spec
+    assert "agent 檔 guidelines" in spec
+    assert "references/basic_principles.md" in skill


### PR DESCRIPTION
# issue360: add skill-sourced basic principles checklists

## Summary

Implements GitHub issue #360 by adding an opt-in `references/basic_principles.md` path for CAFE workflow checklist generation. When a skill provides the reference, workflow checklists append it through the existing `convert_to_checklist(..., "Basic Principles")` behavior; when absent, checklist generation remains backward-compatible.

## Changes

- Added optional `basic_principles` propagation from `GenericWorkflowStepExecutor._generate_checklist()` into spec, plan, develop, review, and PR checklist generators.
- Reused the existing skill reference bridge and checklist conversion behavior so missing references fall back to empty content and malformed non-bullet lines stay ignored.
- Extended review checklist generation to accept and render `basic_principles`, matching the existing generator contract used by other phases.
- Added golden fixtures and focused unit coverage for present, missing, malformed, review/PR, and custom skill-reference behavior.
- Updated `write-cafe-skill` documentation to describe when to use `references/basic_principles.md`, its bullet-list format, and its non-blocking optional behavior.

Commit:

- `69bac96 issue360: add skill basic principles checklists`

## Test Plan

- `PYTHONPATH=src uv run --extra dev python -m pytest tests/unit/test_skill_checklist_composer.py tests/unit/test_generic_workflow_step.py -q`
- `PYTHONPATH=src uv run --extra dev python -m ruff check --select I src/cafe/skills/checklist_composer.py src/cafe/phases/generic_workflow_step.py tests/unit/test_skill_checklist_composer.py tests/unit/test_generic_workflow_step.py`
- `git diff --check develop..HEAD`
- Pre-commit fast suite passed as recorded in the develop artifact: `2233 passed, 1 skipped, 1 xfailed`
