### PR TITLE
Fix workflow handoff desync by contract-first runtime positioning

### DIFF
--- a/src/cafe/core/blackboard.py
+++ b/src/cafe/core/blackboard.py
@@ -542,12 +542,16 @@ class BlackboardStore:
             if not legacy_step:
                 raise ValueError(f"Baton file is empty: {self.next_step_path}")
             if "=" in legacy_step or "\n" in legacy_step:
-                return self._contract_from_legacy_key_values(legacy_step, state)
-            return HandoffContract.from_legacy_step(
-                step=legacy_step,
-                from_step=state.current_step,
-                source="legacy_text",
-            )
+                contract = self._contract_from_legacy_key_values(legacy_step, state)
+            else:
+                contract = HandoffContract.from_legacy_step(
+                    step=legacy_step,
+                    from_step=state.current_step,
+                    source="legacy_text",
+                )
+            if allowed_steps:
+                contract.validate(allowed_steps=allowed_steps)
+            return contract
 
         if not isinstance(payload, dict):
             raise BatonRejected(

--- a/src/cafe/core/workflow_runtime.py
+++ b/src/cafe/core/workflow_runtime.py
@@ -69,6 +69,12 @@ class HandoffReconciliationResult:
     validated_evidence: list[str] = field(default_factory=list)
 
 
+@dataclass
+class RuntimePositionResolution:
+    current_step: str
+    realignment_result: Optional[PlaybookRunResult] = None
+
+
 class BlackboardWorkflowRuntime:
     """Workflow runtime that prefers blackboard/baton-driven transitions."""
 
@@ -217,7 +223,7 @@ class BlackboardWorkflowRuntime:
                 f"Baton target mismatch before step '{current_step}': baton points to '{contract.to_step}'"
             )
 
-    def _resolve_runtime_position_from_handoff(self) -> str:
+    def _resolve_runtime_position_from_handoff(self) -> RuntimePositionResolution:
         """Use the structured baton as the runtime position source.
 
         ``blackboard.current_step`` remains persisted context for observability,
@@ -230,7 +236,7 @@ class BlackboardWorkflowRuntime:
                 allowed_steps=list(self.steps.keys()),
             )
         except BatonRejected:
-            return self.blackboard.current_step
+            return RuntimePositionResolution(current_step=self.blackboard.current_step)
         previous = self.blackboard.current_step
         if contract.to_owner == HandoffOwner.AGENT:
             resolved = contract.to_step
@@ -242,7 +248,7 @@ class BlackboardWorkflowRuntime:
         if previous != resolved:
             self.blackboard_store.record_event(
                 self.blackboard,
-                "runtime_position_resolved",
+                "runtime_position_realigned",
                 {
                     "previous_current_step": previous,
                     "from_step": contract.from_step,
@@ -253,7 +259,16 @@ class BlackboardWorkflowRuntime:
                 },
             )
             self.blackboard_store.set_current_step(self.blackboard, resolved)
-        return resolved
+            if contract.to_owner == HandoffOwner.AGENT:
+                return RuntimePositionResolution(
+                    current_step=resolved,
+                    realignment_result=PlaybookRunResult(
+                        final_step=previous,
+                        final_status_code="BATON_POSITION_REALIGNED",
+                        completed=False,
+                    ),
+                )
+        return RuntimePositionResolution(current_step=resolved)
 
     def _result_from_terminal_position(self, current_step: str) -> Optional[PlaybookRunResult]:
         if current_step not in {"user", "done"}:
@@ -1840,7 +1855,14 @@ class BlackboardWorkflowRuntime:
         single_step: bool = False,
     ) -> PlaybookRunResult:
         if single_step:
-            current_step = start_step or self._resolve_runtime_position_from_handoff()
+            resolution = (
+                RuntimePositionResolution(current_step=start_step)
+                if start_step is not None
+                else self._resolve_runtime_position_from_handoff()
+            )
+            if resolution.realignment_result is not None:
+                return resolution.realignment_result
+            current_step = resolution.current_step
             terminal_result = self._result_from_terminal_position(current_step)
             if terminal_result is not None:
                 return terminal_result
@@ -1865,7 +1887,14 @@ class BlackboardWorkflowRuntime:
             if reconciled is not None and self.blackboard.current_step not in self.steps:
                 return reconciled
 
-        current_step = start_step or self._resolve_runtime_position_from_handoff()
+        resolution = (
+            RuntimePositionResolution(current_step=start_step)
+            if start_step is not None
+            else self._resolve_runtime_position_from_handoff()
+        )
+        if resolution.realignment_result is not None:
+            return resolution.realignment_result
+        current_step = resolution.current_step
         terminal_result = self._result_from_terminal_position(current_step)
         if terminal_result is not None:
             return terminal_result

--- a/src/cafe/core/workflow_runtime.py
+++ b/src/cafe/core/workflow_runtime.py
@@ -217,6 +217,64 @@ class BlackboardWorkflowRuntime:
                 f"Baton target mismatch before step '{current_step}': baton points to '{contract.to_step}'"
             )
 
+    def _resolve_runtime_position_from_handoff(self) -> str:
+        """Use the structured baton as the runtime position source.
+
+        ``blackboard.current_step`` remains persisted context for observability,
+        but an already-valid handoff contract is the authoritative routing
+        signal at resume time.
+        """
+        try:
+            contract = self.blackboard_store.load_handoff_contract(
+                self.blackboard,
+                allowed_steps=list(self.steps.keys()),
+            )
+        except BatonRejected:
+            return self.blackboard.current_step
+        previous = self.blackboard.current_step
+        if contract.to_owner == HandoffOwner.AGENT:
+            resolved = contract.to_step
+        elif contract.to_owner == HandoffOwner.USER:
+            resolved = "user"
+        else:
+            resolved = "done"
+
+        if previous != resolved:
+            self.blackboard_store.record_event(
+                self.blackboard,
+                "runtime_position_resolved",
+                {
+                    "previous_current_step": previous,
+                    "from_step": contract.from_step,
+                    "to_owner": contract.to_owner.value,
+                    "to_step": contract.to_step,
+                    "resolved_step": resolved,
+                    "source": contract.source,
+                },
+            )
+            self.blackboard_store.set_current_step(self.blackboard, resolved)
+        return resolved
+
+    def _result_from_terminal_position(self, current_step: str) -> Optional[PlaybookRunResult]:
+        if current_step not in {"user", "done"}:
+            return None
+        contract = self.blackboard_store.load_handoff_contract(
+            self.blackboard,
+            allowed_steps=list(self.steps.keys()),
+        )
+        status_code = (
+            contract.status_code
+            or f"BATON_{contract.intent.value.upper()}"
+        )
+        if current_step == "done":
+            cafe_dir = self.issue_dir.parent.parent
+            clear_marker_if_matches(cafe_dir, self.issue_dir.name)
+        return PlaybookRunResult(
+            final_step=contract.from_step,
+            final_status_code=status_code,
+            completed=current_step == "done",
+        )
+
     def _resolve_next_step(
         self,
         *,
@@ -1782,7 +1840,10 @@ class BlackboardWorkflowRuntime:
         single_step: bool = False,
     ) -> PlaybookRunResult:
         if single_step:
-            current_step = start_step or self.blackboard.current_step
+            current_step = start_step or self._resolve_runtime_position_from_handoff()
+            terminal_result = self._result_from_terminal_position(current_step)
+            if terminal_result is not None:
+                return terminal_result
             if current_step not in self.steps:
                 raise ValueError(f"Unknown playbook step '{current_step}'")
             if start_step is not None:
@@ -1804,7 +1865,10 @@ class BlackboardWorkflowRuntime:
             if reconciled is not None and self.blackboard.current_step not in self.steps:
                 return reconciled
 
-        current_step = start_step or self.blackboard.current_step
+        current_step = start_step or self._resolve_runtime_position_from_handoff()
+        terminal_result = self._result_from_terminal_position(current_step)
+        if terminal_result is not None:
+            return terminal_result
         if current_step not in self.steps:
             raise ValueError(f"Unknown playbook step '{current_step}'")
 

--- a/src/cafe/ui/commands/workflow.py
+++ b/src/cafe/ui/commands/workflow.py
@@ -898,13 +898,14 @@ def workflow(
                 playbook=playbook_data,
                 executor=wrapped_executor,
             )
-            result = runner.run(start_step=effective_start_step, single_step=single_step)
+            result = runner.run(start_step=pending_start_step, single_step=single_step)
             latest_blackboard = BlackboardStore(issue_dir).load_or_create(
                 str(playbook_data.get("entry_point") or next(iter(playbook_data["steps"].keys()))),
                 playbook_id=str(playbook_data["playbook"]["id"]),
             )
             if (
                 not single_step
+                and result.final_status_code != "BATON_POSITION_REALIGNED"
                 and latest_blackboard.current_step == "pr"
                 and effective_start_step != "pr"
             ):

--- a/tests/integration/test_workflow_e2e.py
+++ b/tests/integration/test_workflow_e2e.py
@@ -84,6 +84,8 @@ def _run_until_settled(
         )
         if last_result.completed:
             return last_result
+        if last_result.final_status_code == "BATON_POSITION_REALIGNED":
+            return last_result
         if latest.current_step in {"user", "done"}:
             return last_result
         # Continue from blackboard's current_step (boundary handoff).
@@ -378,6 +380,159 @@ class TestUserHandoff:
         assert blackboard.current_step == "user"
         pause_events = [e for e in blackboard.events if e.event_type == "workflow_paused"]
         assert pause_events, "workflow_paused event should be recorded"
+
+    def test_contract_mismatch_realigns_before_resuming_agent_step(
+        self, tmp_path: Path
+    ) -> None:
+        """A valid baton/current_step mismatch pauses once before the target step runs."""
+        issue_dir = tmp_path / ".cafe" / "issues" / "issue-contract-mismatch"
+        playbook = {
+            "playbook": {"id": "default"},
+            "steps": {
+                "spec": {
+                    "skill": "spec_first",
+                    "role": "pm",
+                    "on": {"await_agent": "plan"},
+                },
+                "plan": {
+                    "skill": "plan",
+                    "role": "developer",
+                    "on": {"await_agent": "_done"},
+                },
+            },
+        }
+        store = BlackboardStore(issue_dir)
+        blackboard = store.load_or_create("spec")
+        store.update_handoff_contract(
+            blackboard,
+            from_step="spec",
+            to_owner=HandoffOwner.AGENT,
+            to_step="plan",
+            intent=HandoffIntent.AWAIT_AGENT,
+            status_code="confirmed",
+            source="test.desync",
+        )
+        executed_steps: list[str] = []
+
+        def executor(
+            step_name: str, step_def: dict, state: BlackboardState
+        ) -> StepExecutionResult:
+            executed_steps.append(step_name)
+            return StepExecutionResult(
+                response="confirmed",
+                artifacts={str(step_def.get("output_artifact", step_name)): "output.md"},
+                status_code="confirmed",
+            )
+
+        first = BlackboardWorkflowRuntime(
+            issue_dir=issue_dir,
+            playbook=playbook,
+            executor=executor,
+        ).run(max_transitions=10)
+
+        assert first.completed is False
+        assert first.final_status_code == "BATON_POSITION_REALIGNED"
+        assert executed_steps == []
+        blackboard = BlackboardStore(issue_dir).load_or_create("spec")
+        assert blackboard.current_step == "plan"
+        assert any(
+            e.event_type == "runtime_position_realigned" for e in blackboard.events
+        )
+
+        second = BlackboardWorkflowRuntime(
+            issue_dir=issue_dir,
+            playbook=playbook,
+            executor=executor,
+        ).run(max_transitions=10)
+
+        assert second.completed is True
+        assert second.final_step == "plan"
+        assert executed_steps == ["plan"]
+
+    def test_contract_owner_user_and_done_are_terminal_positions(
+        self, tmp_path: Path
+    ) -> None:
+        """Contract owner states should not execute an agent step while resuming."""
+        playbook = {
+            "playbook": {"id": "default"},
+            "steps": {
+                "develop": {
+                    "skill": "develop",
+                    "role": "developer",
+                    "on": {"await_agent": "review"},
+                },
+                "review": {
+                    "skill": "review",
+                    "role": "reviewer",
+                    "on": {"await_agent": "_done"},
+                },
+            },
+        }
+        executed_steps: list[str] = []
+
+        def executor(
+            step_name: str, step_def: dict, state: BlackboardState
+        ) -> StepExecutionResult:
+            executed_steps.append(step_name)
+            return StepExecutionResult(
+                response="confirmed",
+                artifacts={},
+                status_code="confirmed",
+            )
+
+        user_issue_dir = tmp_path / ".cafe" / "issues" / "issue-contract-user"
+        user_store = BlackboardStore(user_issue_dir)
+        user_blackboard = user_store.load_or_create("develop")
+        user_store.update_handoff_contract(
+            user_blackboard,
+            from_step="develop",
+            to_owner=HandoffOwner.USER,
+            to_step="user",
+            intent=HandoffIntent.NEED_CLARIFICATION,
+            status_code="need_clarification",
+            source="test.user",
+        )
+
+        user_result = BlackboardWorkflowRuntime(
+            issue_dir=user_issue_dir,
+            playbook=playbook,
+            executor=executor,
+        ).run(max_transitions=10)
+
+        assert user_result.completed is False
+        assert user_result.final_step == "develop"
+        assert user_result.final_status_code == "need_clarification"
+        assert (
+            BlackboardStore(user_issue_dir).load_or_create("develop").current_step
+            == "user"
+        )
+
+        done_issue_dir = tmp_path / ".cafe" / "issues" / "issue-contract-done"
+        done_store = BlackboardStore(done_issue_dir)
+        done_blackboard = done_store.load_or_create("review")
+        done_store.update_handoff_contract(
+            done_blackboard,
+            from_step="review",
+            to_owner=HandoffOwner.DONE,
+            to_step="done",
+            intent=HandoffIntent.WORKFLOW_COMPLETE,
+            status_code="confirmed",
+            source="test.done",
+        )
+
+        done_result = BlackboardWorkflowRuntime(
+            issue_dir=done_issue_dir,
+            playbook=playbook,
+            executor=executor,
+        ).run(max_transitions=10)
+
+        assert done_result.completed is True
+        assert done_result.final_step == "review"
+        assert (
+            BlackboardStore(done_issue_dir).load_or_create("develop").current_step
+            == "done"
+        )
+        assert executed_steps == []
 
     def test_user_handoff_auto_continue_resumes_in_same_run(self, tmp_path: Path) -> None:
         """spec 先 need_clarification（auto_continue=True），再 confirmed → 不暫停，直接流向 plan。"""

--- a/tests/unit/test_workflow_models.py
+++ b/tests/unit/test_workflow_models.py
@@ -484,6 +484,20 @@ class TestLegacyKeyValueBaton:
         assert contract.to_step == "review"
         assert contract.source == "legacy_text"
 
+    def test_unknown_single_step_name_is_rejected_by_allowed_steps(self, tmp_path: Path) -> None:
+        issue_dir, store, state = self._store_and_state(tmp_path)
+        (issue_dir / "next_step.txt").write_text("no_such_step\n", encoding="utf-8")
+
+        with pytest.raises(BatonRejected) as exc_info:
+            store.load_handoff_contract(
+                state,
+                allowed_steps=["build", "review"],
+                allow_legacy_text=True,
+            )
+
+        assert exc_info.value.field == "to_step"
+        assert exc_info.value.invalid_value == "no_such_step"
+
     def test_invalid_intent_value_falls_back_to_step_derived_intent(self, tmp_path: Path) -> None:
         issue_dir, store, state = self._store_and_state(tmp_path)
         (issue_dir / "next_step.txt").write_text(

--- a/tests/unit/test_workflow_runtime.py
+++ b/tests/unit/test_workflow_runtime.py
@@ -1008,7 +1008,7 @@ def test_runtime_resumes_from_blackboard_current_step(tmp_path: Path) -> None:
     assert executed_steps == ["plan"]
 
 
-def test_runtime_resumes_from_handoff_contract_when_current_step_is_stale(
+def test_runtime_pauses_after_realigning_stale_current_step_from_handoff_contract(
     tmp_path: Path,
 ) -> None:
     issue_dir = tmp_path / ".cafe" / "issues" / "demo-stale-current-step"
@@ -1060,15 +1060,28 @@ def test_runtime_resumes_from_handoff_contract_when_current_step_is_stale(
 
     result = runtime.run(max_transitions=5)
 
-    assert result.completed is True
-    assert result.final_step == "plan"
-    assert executed_steps == ["plan"]
+    assert result.completed is False
+    assert result.final_step == "spec"
+    assert result.final_status_code == "BATON_POSITION_REALIGNED"
+    assert executed_steps == []
     blackboard = BlackboardStore(issue_dir).load_or_create("spec")
-    resolved_events = [
-        event for event in blackboard.events if event.event_type == "runtime_position_resolved"
+    assert blackboard.current_step == "plan"
+    realigned_events = [
+        event for event in blackboard.events if event.event_type == "runtime_position_realigned"
     ]
-    assert resolved_events[-1].data["previous_current_step"] == "spec"
-    assert resolved_events[-1].data["resolved_step"] == "plan"
+    assert realigned_events[-1].data["previous_current_step"] == "spec"
+    assert realigned_events[-1].data["resolved_step"] == "plan"
+
+    next_runtime = BlackboardWorkflowRuntime(
+        issue_dir=issue_dir,
+        playbook=playbook,
+        executor=executor,
+    )
+    resumed = next_runtime.run(max_transitions=5)
+
+    assert resumed.completed is True
+    assert resumed.final_step == "plan"
+    assert executed_steps == ["plan"]
 
 
 def test_runtime_resumes_to_user_wait_from_handoff_contract(tmp_path: Path) -> None:

--- a/tests/unit/test_workflow_runtime.py
+++ b/tests/unit/test_workflow_runtime.py
@@ -1008,6 +1008,170 @@ def test_runtime_resumes_from_blackboard_current_step(tmp_path: Path) -> None:
     assert executed_steps == ["plan"]
 
 
+def test_runtime_resumes_from_handoff_contract_when_current_step_is_stale(
+    tmp_path: Path,
+) -> None:
+    issue_dir = tmp_path / ".cafe" / "issues" / "demo-stale-current-step"
+    issue_dir.mkdir(parents=True)
+    playbook = {
+        "playbook": {"id": "default"},
+        "steps": {
+            "spec": {"skill": "spec_first", "role": "pm", "on": {"await_agent": "plan"}},
+            "plan": {
+                "skill": "spec_first",
+                "role": "developer",
+                "valid_intents": ["confirmed"],
+                "on": {"await_agent": "_done"},
+            },
+        },
+    }
+    (issue_dir / "blackboard.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "current_step": "spec",
+                "playbook_id": "default",
+                "artifacts": {},
+                "events": [],
+                "decisions": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    _write_baton(
+        issue_dir,
+        from_step="spec",
+        to_owner="agent",
+        to_step="plan",
+        intent="await_agent",
+        status_code="confirmed",
+    )
+    executed_steps: list[str] = []
+
+    def executor(step_name: str, step_def: dict, state: object) -> StepExecutionResult:
+        executed_steps.append(step_name)
+        return StepExecutionResult(response="confirmed", artifacts={}, status_code="confirmed")
+
+    runtime = BlackboardWorkflowRuntime(
+        issue_dir=issue_dir,
+        playbook=playbook,
+        executor=executor,
+    )
+
+    result = runtime.run(max_transitions=5)
+
+    assert result.completed is True
+    assert result.final_step == "plan"
+    assert executed_steps == ["plan"]
+    blackboard = BlackboardStore(issue_dir).load_or_create("spec")
+    resolved_events = [
+        event for event in blackboard.events if event.event_type == "runtime_position_resolved"
+    ]
+    assert resolved_events[-1].data["previous_current_step"] == "spec"
+    assert resolved_events[-1].data["resolved_step"] == "plan"
+
+
+def test_runtime_resumes_to_user_wait_from_handoff_contract(tmp_path: Path) -> None:
+    issue_dir = tmp_path / ".cafe" / "issues" / "demo-user-wait-contract"
+    issue_dir.mkdir(parents=True)
+    playbook = {
+        "playbook": {"id": "default"},
+        "steps": {
+            "develop": {"skill": "develop", "role": "developer", "on": {"await_agent": "review"}},
+            "review": {"skill": "review", "role": "reviewer", "on": {"await_agent": "_done"}},
+        },
+    }
+    (issue_dir / "blackboard.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "current_step": "develop",
+                "playbook_id": "default",
+                "artifacts": {},
+                "events": [],
+                "decisions": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    _write_baton(
+        issue_dir,
+        from_step="develop",
+        to_owner="user",
+        to_step="user",
+        intent="need_clarification",
+        status_code="need_clarification",
+    )
+
+    def executor(step_name: str, step_def: dict, state: object) -> StepExecutionResult:
+        raise AssertionError("user-owned baton should not execute an agent step")
+
+    runtime = BlackboardWorkflowRuntime(
+        issue_dir=issue_dir,
+        playbook=playbook,
+        executor=executor,
+    )
+
+    result = runtime.run(max_transitions=5)
+
+    assert result.completed is False
+    assert result.final_step == "develop"
+    assert result.final_status_code == "need_clarification"
+    blackboard = BlackboardStore(issue_dir).load_or_create("develop")
+    assert blackboard.current_step == "user"
+
+
+def test_runtime_resumes_to_done_from_handoff_contract(tmp_path: Path) -> None:
+    cafe_dir = tmp_path / ".cafe"
+    issue_dir = cafe_dir / "issues" / "demo-done-contract"
+    issue_dir.mkdir(parents=True)
+    (cafe_dir / "active_issue").write_text("demo-done-contract\n", encoding="utf-8")
+    playbook = {
+        "playbook": {"id": "default"},
+        "steps": {
+            "pr": {"skill": "pr", "role": "developer", "on": {"await_agent": "_done"}},
+        },
+    }
+    (issue_dir / "blackboard.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "current_step": "pr",
+                "playbook_id": "default",
+                "artifacts": {},
+                "events": [],
+                "decisions": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    _write_baton(
+        issue_dir,
+        from_step="pr",
+        to_owner="done",
+        to_step="done",
+        intent="workflow_complete",
+    )
+
+    def executor(step_name: str, step_def: dict, state: object) -> StepExecutionResult:
+        raise AssertionError("done-owned baton should not execute an agent step")
+
+    runtime = BlackboardWorkflowRuntime(
+        issue_dir=issue_dir,
+        playbook=playbook,
+        executor=executor,
+    )
+
+    result = runtime.run(max_transitions=5)
+
+    assert result.completed is True
+    assert result.final_step == "pr"
+    assert result.final_status_code == "BATON_WORKFLOW_COMPLETE"
+    blackboard = BlackboardStore(issue_dir).load_or_create("pr")
+    assert blackboard.current_step == "done"
+    assert not (cafe_dir / "active_issue").exists()
+
+
 def test_runtime_records_done_handoff_for_non_pr_terminal_transition(tmp_path: Path) -> None:
     issue_dir = tmp_path / ".cafe" / "issues" / "done-transition"
     playbook = {


### PR DESCRIPTION
## Summary

Address issue #362 by making workflow execution position and transitions driven by the structured `next_step` handoff contract (`to_owner` + `to_step`), preventing `blackboard.current_step` from silently overriding valid handoff signals.

This PR preserves behavior within existing workflow/runtimes and resolves a desync class where resume flow could loop or advance incorrectly when `current_step` and contract targets diverged.

## Changes

- `src/cafe/core/workflow_runtime.py`
  - Add contract-first runtime position resolver with explicit handling for `to_owner=agent/user/done`.
  - Realign stale runtime entry points to contract-derived positions before step execution.
  - Emit reconciliation event when position mismatch is detected (`runtime_position_realigned`).
  - Avoid implicit continuation when contract state indicates terminal/user wait branches.
- `src/cafe/core/blackboard.py`
  - Keep strict structured contract validation and explicit compatibility behavior for legacy input only.
  - Prevent unknown/invalid legacy values from bypassing structured contract checks.
- Tests and behavior coverage:
  - `tests/unit/test_workflow_runtime.py`
  - `tests/unit/test_workflow_models.py`
  - `tests/integration/test_workflow_e2e.py`
- Commits:
  - `da4f2fe3dc118afcae6d4ac293f1abcdf54eb540` (derive resume position from structured handoff contract)
  - `445956b63c1aa8ebf22f1d3bdf5e6be767eff0de` (runtime baton: pause after position realignment)

## Test Plan

- `pytest tests/unit/test_workflow_runtime.py tests/unit/test_workflow_models.py tests/integration/test_workflow_e2e.py -q`
- Result from review evidence: 110 tests passed.

Closes #362