### PR TITLE
issue366: re-ground resumed workflow steps

### DIFF
--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -114,6 +114,10 @@ When a design touches trusted capabilities, host execution, GitHub mutation, bro
 - An agent-authored script is not automatically a trusted host-side script.
 - External mutations should be auditable, limitable, deniable, and explainable to the user.
 
+Runtime prompt assembly and resume-context fixes that only re-ground an agent on
+the current workflow artifacts do not by themselves change this capability
+contract positioning.
+
 This positioning lets CAFE evolve toward stronger automation while preventing capability contracts from becoming a privilege-escalation mechanism.
 
 ## Decision Principles

--- a/src/cafe/core/hooks/alignment.py
+++ b/src/cafe/core/hooks/alignment.py
@@ -28,11 +28,12 @@ class AlignmentCheckpointGate(NoOpHook):
             return HookResult()
 
         step_def = kwargs.get("step_def") or {}
-        # Alignment runs by default; the playbook `alignment:` block only tunes
-        # thresholds/categories or opts out explicitly.
+        # Alignment is opt-in: a step runs the gate only when it declares an
+        # `alignment:` block. Omitting the block disables the gate; a playbook
+        # that wants gating must add `alignment:` (and may tune it further).
         raw_alignment = step_def.get("alignment")
         if not isinstance(raw_alignment, dict):
-            raw_alignment = {}
+            return HookResult()
         if raw_alignment.get("enabled", True) is False:
             return HookResult()
         if raw_alignment.get("trigger_policy", "policy") == "disabled":
@@ -56,8 +57,8 @@ class AlignmentCheckpointGate(NoOpHook):
             output_file=kwargs.get("output_file"),
         )
         strategic_context = load_strategic_context(Path.cwd(), issue_name=getattr(phase, "issue_name", None))
-        # Unset categories default to every configured document category so the
-        # default-on gate has signal even without playbook tuning.
+        # Unset categories default to every configured document category so an
+        # opted-in gate has signal even without further category tuning.
         default_categories = tuple(strategic_context.documents.keys())
         config = AlignmentPolicyConfig(
             pause_threshold=int(raw_alignment.get("pause_threshold", 5)),

--- a/src/cafe/phases/generic_phase.py
+++ b/src/cafe/phases/generic_phase.py
@@ -339,8 +339,9 @@ class GenericPhase:
         )
 
     # Hooks that run on every step regardless of playbook declaration.
-    # Alignment is a policy decision, not a playbook opt-in; steps opt out
-    # explicitly via `alignment: {enabled: false}` instead of omitting the hook.
+    # The alignment gate is registered on every step, but it is opt-in: it only
+    # fires when the step declares an `alignment:` block (omitting the block, or
+    # `alignment: {enabled: false}`, disables it).
     DEFAULT_STAGE_HOOKS: Dict[str, tuple] = {"prepare_input": ("AlignmentCheckpointGate",)}
 
     def _run_hook_stage(

--- a/src/cafe/phases/generic_phase.py
+++ b/src/cafe/phases/generic_phase.py
@@ -144,6 +144,10 @@ class GenericPhase:
                         "Remote PR publish happens later in the host-side publish_output hook.",
                     ]
                 )
+        if context and context.get("resume_input_artifacts"):
+            runtime_context.extend(
+                ["Current step input artifacts:", context["resume_input_artifacts"]]
+            )
         if context and context.get("user_input"):
             runtime_context.extend(["Current user input for this iteration:", context["user_input"]])
 

--- a/src/cafe/phases/generic_workflow_step.py
+++ b/src/cafe/phases/generic_workflow_step.py
@@ -475,6 +475,23 @@ class GenericWorkflowStepExecutor(Phase):
             updated["user_input"] = resolved
         else:
             updated.pop("user_input", None)
+
+        # On resume, surface current input artifact paths so the agent
+        # re-grounds on the current scope instead of inferring from prior work.
+        previous_data = self._load_previous_iteration_data()
+        current_data = self._load_current_iteration_data()
+        if is_resume_iteration(
+            iteration=self.iteration,
+            previous_iteration_data=previous_data,
+            current_iteration_data=current_data,
+        ):
+            artifact_lines = []
+            for key in ("develop_file", "spec_file", "plan_file", "feedback_file"):
+                if updated.get(key):
+                    artifact_lines.append(f"- {key}: {updated[key]}")
+            if artifact_lines:
+                updated["resume_input_artifacts"] = "\n".join(artifact_lines)
+
         return updated
 
     def _detect_written_output_files(self) -> List[Path]:

--- a/tests/integration/test_gemini_session_integration.py
+++ b/tests/integration/test_gemini_session_integration.py
@@ -172,7 +172,7 @@ class TestGeminiSessionIntegration:
         assert response1 == "Fallback response"
 
         (issue_dir / "active_clis.json").write_text(
-            '{"PM_Agent": {"cli": "gemini", "model": "gemini-pro", "updated_at": "2026-06-13T00:00:00+08:00"}}',
+            '{"PM_Agent": {"cli": "gemini", "model": "gemini-pro", "configured_primary": "claude", "updated_at": "2026-06-13T00:00:00+08:00"}}',
             encoding="utf-8",
         )
 

--- a/tests/unit/test_generic_phase.py
+++ b/tests/unit/test_generic_phase.py
@@ -145,6 +145,46 @@ def test_build_prompt_includes_user_input_when_set(tmp_path: Path) -> None:
     assert "Please prioritize the auth module." in prompt
 
 
+def test_build_prompt_includes_resume_input_artifacts_when_set(tmp_path: Path) -> None:
+    phase = GenericPhase(_setup_loader(tmp_path))
+    prompt = phase.build_prompt(
+        skill_name="cafe-develop",
+        skill_invocation="/develop",
+        shared_skill_invocations=["/cafe-workflow-common"],
+        context={
+            "blackboard_path": ".cafe/issues/demo/blackboard.json",
+            "next_step_path": ".cafe/issues/demo/next_step.txt",
+            "resume_input_artifacts": "- develop_file: .cafe/issues/demo/develop/output.md",
+        },
+        output_file=Path("out.md"),
+        checklist_file=Path("checklist.md"),
+    )
+
+    assert "Current step input artifacts:" in prompt
+    assert "- develop_file: .cafe/issues/demo/develop/output.md" in prompt
+
+
+def test_build_prompt_omits_resume_input_artifacts_when_unset(tmp_path: Path) -> None:
+    phase = GenericPhase(_setup_loader(tmp_path))
+    prompt = phase.build_prompt(
+        skill_name="cafe-develop",
+        skill_invocation="/develop",
+        shared_skill_invocations=["/cafe-workflow-common"],
+        context={
+            "blackboard_path": ".cafe/issues/demo/blackboard.json",
+            "next_step_path": ".cafe/issues/demo/next_step.txt",
+            "handoff_summary": "Resume implementation.",
+            "user_input": "continue",
+        },
+        output_file=Path("out.md"),
+        checklist_file=Path("checklist.md"),
+    )
+
+    assert "Current step input artifacts:" not in prompt
+    assert "Latest workflow handoff from blackboard:" in prompt
+    assert "Current user input for this iteration:" in prompt
+
+
 def test_build_prompt_pr_phase_appends_publish_ordering_when_handoff_present(tmp_path: Path) -> None:
     phase = GenericPhase(_setup_loader(tmp_path))
     prompt = phase.build_prompt(

--- a/tests/unit/test_generic_workflow_step.py
+++ b/tests/unit/test_generic_workflow_step.py
@@ -3044,6 +3044,94 @@ def test_apply_resume_to_runtime_context_keeps_real_input(tmp_path: Path) -> Non
     )
 
 
+def test_apply_resume_to_runtime_context_adds_resume_input_artifacts(tmp_path: Path) -> None:
+    issue_dir = tmp_path / ".cafe" / "issues" / "issue-resume-input"
+    spec_dir = issue_dir / "spec"
+    prev_iter = spec_dir / "iteration_001"
+    prev_iter.mkdir(parents=True)
+    (prev_iter / "iteration.json").write_text(
+        json.dumps(
+            {
+                "cli": "codex",
+                "session_id": "session-1",
+                "end_time": "2026-05-23T00:00:00+08:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    executor = _minimal_spec_executor(tmp_path, agent_manager=FakeAgentManager("confirmed"))
+    executor.phase_dir = spec_dir
+    executor.iteration = 2
+    executor._step_agent_name = "Roger"
+
+    updated = executor._apply_resume_to_runtime_context(
+        {"develop_file": ".cafe/issues/demo/develop/output.md"},
+        "spec",
+    )
+
+    assert (
+        updated["resume_input_artifacts"]
+        == "- develop_file: .cafe/issues/demo/develop/output.md"
+    )
+
+
+def test_apply_resume_to_runtime_context_omits_artifacts_on_fresh_run(tmp_path: Path) -> None:
+    executor = _minimal_spec_executor(tmp_path, agent_manager=FakeAgentManager("confirmed"))
+    executor.phase_dir = tmp_path / ".cafe" / "issues" / "issue-resume-input" / "spec"
+    executor.phase_dir.mkdir(parents=True)
+    executor.iteration = 1
+    executor._step_agent_name = "Roger"
+
+    updated = executor._apply_resume_to_runtime_context(
+        {"develop_file": ".cafe/issues/demo/develop/output.md"},
+        "spec",
+    )
+
+    assert "resume_input_artifacts" not in updated
+
+
+def test_apply_resume_to_runtime_context_lists_all_present_artifacts(tmp_path: Path) -> None:
+    issue_dir = tmp_path / ".cafe" / "issues" / "issue-resume-input"
+    spec_dir = issue_dir / "spec"
+    prev_iter = spec_dir / "iteration_001"
+    prev_iter.mkdir(parents=True)
+    (prev_iter / "iteration.json").write_text(
+        json.dumps(
+            {
+                "cli": "codex",
+                "session_id": "session-1",
+                "end_time": "2026-05-23T00:00:00+08:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    executor = _minimal_spec_executor(tmp_path, agent_manager=FakeAgentManager("confirmed"))
+    executor.phase_dir = spec_dir
+    executor.iteration = 2
+    executor._step_agent_name = "Roger"
+
+    updated = executor._apply_resume_to_runtime_context(
+        {
+            "feedback_file": "review.md",
+            "plan_file": "plan.md",
+            "develop_file": "develop.md",
+            "spec_file": "spec.md",
+        },
+        "spec",
+    )
+
+    assert updated["resume_input_artifacts"] == "\n".join(
+        [
+            "- develop_file: develop.md",
+            "- spec_file: spec.md",
+            "- plan_file: plan.md",
+            "- feedback_file: review.md",
+        ]
+    )
+
+
 def test_execute_step_same_session_resume_keeps_real_input_in_prompt_and_user_input_md(
     tmp_path: Path,
     monkeypatch,
@@ -3107,6 +3195,81 @@ def test_execute_step_same_session_resume_keeps_real_input_in_prompt_and_user_in
     assert (
         user_input_file.read_text(encoding="utf-8")
         == "Long clarification that should appear in prompt"
+    )
+
+
+def test_execute_step_resume_includes_current_input_artifacts_in_prompt(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    issue_dir = tmp_path / ".cafe" / "issues" / "issue-resume-artifacts"
+    develop_dir = issue_dir / "develop"
+    prev_iter = develop_dir / "iteration_001"
+    prev_iter.mkdir(parents=True)
+    (prev_iter / "iteration.json").write_text(
+        json.dumps(
+            {
+                "cli": "codex",
+                "session_id": "session-1",
+                "end_time": "2026-05-23T00:00:00+08:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    code_file = issue_dir / "develop" / "iteration_001" / "output.md"
+    code_file.write_text("Batch 2 scoped work", encoding="utf-8")
+    spec_file = issue_dir / "spec" / "iteration_001" / "output.md"
+    plan_file = issue_dir / "plan" / "iteration_001" / "output.md"
+    spec_file.parent.mkdir(parents=True, exist_ok=True)
+    plan_file.parent.mkdir(parents=True, exist_ok=True)
+    spec_file.write_text("# Spec\n", encoding="utf-8")
+    plan_file.write_text("# Plan\n", encoding="utf-8")
+    store = BlackboardStore(issue_dir)
+    state = store.load_or_create("develop")
+    store.set_artifact(state, "spec", str(spec_file))
+    store.set_artifact(state, "plan", str(plan_file))
+    store.set_artifact(state, "code", str(code_file))
+
+    playbook = {
+        "playbook": {"id": "default"},
+        "roles": {"developer": {"default_agent": "David"}},
+        "steps": {
+            "develop": {
+                "skill": "cafe-develop",
+                "role": "developer",
+                "input_artifacts": ["code"],
+                "output_artifact": "code",
+                "allowed_tools": ["Read"],
+                "valid_intents": ["confirmed"],
+                "alignment": {"enabled": False},
+                "on": {"await_agent": "_done"},
+            }
+        },
+    }
+    manager = FakeAgentManager("confirmed")
+    manager.agent.config.session_id = "session-1"
+
+    executor = GenericWorkflowStepExecutor(
+        issue_dir=issue_dir,
+        issue_name="issue-resume-artifacts",
+        playbook=playbook,
+        generic_phase=_build_loader(tmp_path),
+        agent_manager=manager,
+        git_ops=FakeGitOperations(),
+        role_agent_map={"developer": "David"},
+    )
+    executor.iteration = 2
+
+    executor.execute_step("develop", playbook["steps"]["develop"], state)
+
+    assert manager.prompts
+    prompt = manager.prompts[0]
+    assert "Current step input artifacts:" in prompt
+    assert (
+        "- develop_file: ./.cafe/issues/issue-resume-artifacts/develop/iteration_001/output.md"
+        in prompt
     )
 
 

--- a/tests/unit/test_generic_workflow_step.py
+++ b/tests/unit/test_generic_workflow_step.py
@@ -28,9 +28,9 @@ from cafe.skills.native_bridge import NativeSkillBridge
 
 @pytest.fixture(autouse=True)
 def _default_strategic_context(tmp_path: Path):
-    """Alignment now runs by default on every step; give tests a configured
-    strategic context so benign steps stay quiet. Tests that exercise the
-    missing-context behavior delete this file explicitly."""
+    """Give tests a configured strategic context so steps that opt into the
+    alignment gate stay quiet unless a test sets up a real trigger. Tests that
+    exercise the missing-context behavior delete this file explicitly."""
     config = tmp_path / ".cafe" / "strategic_context.yaml"
     config.parent.mkdir(parents=True, exist_ok=True)
     config.write_text("version: 1\n", encoding="utf-8")
@@ -3346,8 +3346,10 @@ def _make_alignment_executor(tmp_path: Path, issue_name: str, step_def: dict, us
     return issue_dir, playbook, state, agent_manager, executor
 
 
-def test_alignment_gate_runs_by_default_without_playbook_config(tmp_path: Path, monkeypatch) -> None:
-    """No `alignment:` block and no declared hook: the gate still pauses on policy triggers."""
+def test_alignment_gate_skipped_without_alignment_block(tmp_path: Path, monkeypatch) -> None:
+    """Opt-in gate: a step with no `alignment:` block does not pause, even when
+    policy triggers (e.g. roadmap-scope changes) would otherwise fire — the agent
+    runs normally instead."""
     monkeypatch.chdir(tmp_path)
     (tmp_path / ".cafe" / "strategic_context.yaml").write_text(
         """
@@ -3368,14 +3370,14 @@ mandate:
         "on": {"await_agent": "_done", "alignment_checkpoint": "develop"},
     }
     issue_dir, playbook, state, agent_manager, executor = _make_alignment_executor(
-        tmp_path, "issue-align-default-on", step_def, "This changes roadmap scope."
+        tmp_path, "issue-align-optin-skip", step_def, "This changes roadmap scope."
     )
 
     result = executor.execute_step("develop", step_def, state)
 
-    assert result.status_code == "alignment_checkpoint"
-    assert agent_manager.prompts == []
-    assert (issue_dir / "develop" / "iteration_001" / "alignment_request.json").exists()
+    assert result.status_code != "alignment_checkpoint"
+    assert agent_manager.prompts != []
+    assert not (issue_dir / "develop" / "iteration_001" / "alignment_request.json").exists()
 
 
 def test_alignment_gate_requires_missing_strategic_context_once(tmp_path: Path, monkeypatch) -> None:
@@ -3388,6 +3390,7 @@ def test_alignment_gate_requires_missing_strategic_context_once(tmp_path: Path, 
         "role": "developer",
         "output_artifact": "code",
         "allowed_tools": ["Read"],
+        "alignment": {},  # opt into the gate (empty block = enabled with defaults)
         "on": {"await_agent": "_done", "alignment_checkpoint": "develop"},
     }
     issue_dir, playbook, state, agent_manager, executor = _make_alignment_executor(


### PR DESCRIPTION
## Summary
- Add current input artifact paths to resumed workflow prompts so agents re-ground on the active step scope instead of stale handoff context
- Persist stricter workflow baton metadata used to resume from the current handoff contract
- Make alignment checkpoints opt-in so steps without an `alignment:` block do not get stuck behind strategy gates
- Add/adjust CAFE skill authoring guidance for phase/playbook workflow specs

## Tests
- pytest tests/unit/test_resume_user_input.py tests/unit/test_generic_phase.py tests/unit/test_generic_workflow_step.py -q
- pytest tests/unit/test_generic_phase.py tests/unit/test_generic_workflow_step.py tests/unit/test_workflow_runtime.py tests/unit/test_workflow_models.py tests/unit/test_skill_loader.py tests/unit/test_skill_checklist_composer.py tests/unit/test_write_cafe_playbook_skill.py tests/unit/test_cli_workflow_command.py -q

## CAFE
- Ran cafe prepare/spec/plan for issue366.
- The original run exposed an alignment checkpoint loop; this branch now makes checkpoint gating opt-in for steps that declare alignment.