### PR TITLE
Enforce phase-scoped CLI preflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,8 +233,26 @@ developer:
       develop: sonnet
     - cli: codex             # First fallback
       model: o4-mini
-    - cli: cursor-agent      # Second fallback
+  - cli: cursor-agent      # Second fallback
 ```
+
+### Phase Configuration
+
+Project-level phase overrides live in `.cafe/phases.yaml` with the step name as the top-level key.
+
+```yaml
+build:
+  name: Build step
+  role: developer
+  clis:
+    - cli: claude
+      model: gpt-5
+    - cli: gemini
+```
+
+The highest precedence source is worktree-local `.cafe/phases.yaml` in the active
+worktree, then repository `.cafe/phases.yaml`. Missing or malformed entries are rejected with
+field-level validation errors.
 
 ### Project Settings
 

--- a/src/cafe/agents/executor.py
+++ b/src/cafe/agents/executor.py
@@ -153,7 +153,9 @@ class AgentExecutor:
         prompt: str,
         allowed_tools: Optional[List[str]] = None,
         allowed_directories: Optional[List[str]] = None,
-        streaming_output_file: Optional[str] = None
+        streaming_output_file: Optional[str] = None,
+        max_read_only_commands: Optional[int] = None,
+        max_initial_read_only_commands: Optional[int] = None,
     ) -> AgentResponse:
         """Execute the agent with given prompt.
 
@@ -162,6 +164,8 @@ class AgentExecutor:
             allowed_tools: List of allowed tools (using Claude naming convention)
             allowed_directories: List of allowed directories (e.g., [".cafe", "src"])
             streaming_output_file: Optional file path to write streaming output line-by-line
+            max_read_only_commands: Optional command budget between mutations
+            max_initial_read_only_commands: Optional stricter budget before the first mutation
 
         Returns:
             AgentResponse with response text, token usage, and permission denials
@@ -252,6 +256,8 @@ class AgentExecutor:
                     json_content_extractor=json_content_extractor,
                     streaming_output_file=streaming_output_file,
                     env=env,
+                    max_read_only_commands=max_read_only_commands,
+                    max_initial_read_only_commands=max_initial_read_only_commands,
                 )
             else:
                 # Only use response parser for stream-json formats
@@ -277,6 +283,8 @@ class AgentExecutor:
                     json_content_extractor=json_content_extractor,
                     streaming_output_file=streaming_output_file,
                     env=env,
+                    max_read_only_commands=max_read_only_commands,
+                    max_initial_read_only_commands=max_initial_read_only_commands,
                 )
 
             # Extract session ID if needed
@@ -757,6 +765,57 @@ class AgentExecutor:
 
         return permission_denials
 
+    @staticmethod
+    def _classify_stream_activity(data: dict) -> Optional[str]:
+        """Classify Codex stream events for the no-progress guard."""
+        if data.get("type") != "item.completed":
+            return None
+        item = data.get("item")
+        if not isinstance(item, dict):
+            return None
+
+        item_type = str(item.get("type", ""))
+        if item_type in {"file_change", "file_write", "edit", "write"}:
+            return "mutation"
+        if item_type != "command_execution":
+            return None
+
+        lowered = str(item.get("command", "")).lower()
+        mutation_patterns = (
+            r"\bapply_patch\b",
+            r"\bsed\b[^\n]*\s-i(?:\s|$)",
+            r"\bperl\b[^\n]*\s-pi(?:\s|$)",
+            r"\b(?:touch|mkdir|rm|mv|cp|tee)\b",
+            r"\bgit\s+(?:add|commit|mv|rm|apply)\b",
+        )
+        if any(re.search(pattern, lowered) for pattern in mutation_patterns):
+            return "mutation"
+
+        # Codex may report shell-based writes only as command_execution events
+        # instead of emitting a separate file_change event. Detect output
+        # redirection to workspace paths while ignoring diagnostic redirects.
+        first_line = lowered.splitlines()[0] if lowered else ""
+        redirection_targets = re.findall(
+            r"(?:^|[\s;&|])(?:\d*)>>?\s*[\"']?([^\s;|\"']+)",
+            first_line,
+        )
+        for target in redirection_targets:
+            if target in {"&1", "&2"} or target.isdigit():
+                continue
+            if target.startswith(("/dev/", "/tmp/")):
+                continue
+            return "mutation"
+
+        test_patterns = (
+            r"\bpytest\b",
+            r"\bpython(?:3)?\s+-m\s+(?:pytest|unittest)\b",
+            r"\b(?:tox|nox|jest|vitest)\b",
+            r"\b(?:npm|pnpm|yarn|bun)\s+(?:run\s+)?test\b",
+        )
+        if any(re.search(pattern, lowered) for pattern in test_patterns):
+            return None
+        return "read_only"
+
     def _execute_with_streaming(
         self,
         cmd: List[str],
@@ -766,6 +825,8 @@ class AgentExecutor:
         parse_stream_json: bool = False,
         json_content_extractor: Optional[Callable[[dict], Optional[str]]] = None,
         streaming_output_file: Optional[str] = None,
+        max_read_only_commands: Optional[int] = None,
+        max_initial_read_only_commands: Optional[int] = None,
     ) -> AgentResponse:
         """Execute command with streaming output.
 
@@ -777,6 +838,8 @@ class AgentExecutor:
             json_content_extractor: Optional function to extract content from parsed JSON.
                                    If None and parse_stream_json=True, uses default Claude extractor.
             streaming_output_file: Optional file path to write streaming output line-by-line
+            max_read_only_commands: Optional command budget between mutations
+            max_initial_read_only_commands: Optional stricter budget before the first mutation
 
         Returns:
             AgentResponse with response text, token usage, and permission denials
@@ -857,6 +920,8 @@ class AgentExecutor:
         session_id = None
         model: Optional[str] = None
         permission_denials: List[PermissionDenial] = []
+        read_only_command_count = 0
+        mutation_seen = False
 
         # Add idle timeout to prevent hanging when process stops outputting
         import select
@@ -971,6 +1036,46 @@ class AgentExecutor:
                                 and not session_id
                             ):
                                 session_id = data["thread_id"]
+
+                            if max_read_only_commands is not None:
+                                activity = self._classify_stream_activity(data)
+                                if activity == "mutation":
+                                    mutation_seen = True
+                                    read_only_command_count = 0
+                                elif activity == "read_only":
+                                    read_only_command_count += 1
+                                    active_limit = max_read_only_commands
+                                    if (
+                                        not mutation_seen
+                                        and max_initial_read_only_commands is not None
+                                    ):
+                                        active_limit = max_initial_read_only_commands
+                                    if read_only_command_count >= active_limit:
+                                        if session_id:
+                                            self.config.session_id = session_id
+                                        print(
+                                            "\n⚠️  Read-only progress budget exhausted "
+                                            f"({read_only_command_count}/{active_limit}); "
+                                            "terminating this agent attempt before it can loop."
+                                        )
+                                        process.terminate()
+                                        try:
+                                            process.wait(timeout=2)
+                                        except subprocess.TimeoutExpired:
+                                            process.kill()
+                                            process.wait(timeout=2)
+                                        if streaming_file_handle:
+                                            streaming_file_handle.close()
+                                        err = AgentExecutionError(
+                                            "Read-only progress budget exhausted without a file edit.",
+                                            error_type="read_only_budget_exceeded",
+                                            display_message=(
+                                                "Develop agent exhausted its read-only progress budget "
+                                                "without making the next file edit."
+                                            ),
+                                        )
+                                        err.cli_command_args = cmd[1:]
+                                        raise err
 
                             # Extract token usage (usually in final message)
                             if "usage" in data:

--- a/src/cafe/agents/manager.py
+++ b/src/cafe/agents/manager.py
@@ -24,6 +24,16 @@ class AgentManager:
     CAFE_DIR = ".cafe"
     AGENTS_DIR = "agents"
     FALLBACKABLE_ERROR_TYPES = ("rate_limit", "cli_not_found", "cli_unavailable", "model_not_found")
+    DEVELOP_READ_ONLY_COMMAND_LIMIT = 20
+    DEVELOP_READ_ONLY_RETRY_LIMIT = 3
+    DEVELOP_READ_ONLY_RETRY_PROMPT = (
+        "The runtime stopped your previous attempt because it exhausted the read-only "
+        "progress budget without making the next file edit. Do not restart discovery or reread "
+        "the spec, plan, skills, or unchanged source files. Your FIRST tool action must be "
+        "a file edit that adds the first relevant failing test (or the first implementation "
+        "edit only when the approved plan requires no new test). Use the context already in "
+        "this session."
+    )
 
     def __init__(self, session_manager: Optional[SessionManager] = None, issue_name: Optional[str] = None) -> None:
         """Initialize agent manager.
@@ -199,9 +209,19 @@ class AgentManager:
         reordered.insert(0, preferred_entry)
         return self._normalize_chain(reordered)
 
-    def _session_id_for_cli(self, agent_name: str, cli: AgentCLI) -> Optional[str]:
+    def _session_id_for_cli(
+        self,
+        agent_name: str,
+        cli: AgentCLI,
+        phase_name: Optional[str] = None,
+    ) -> Optional[str]:
         """Load a persisted session ID for agent+CLI, if available."""
-        saved = self.session_manager.load_session(agent_name, cli, self.issue_name)
+        saved = self.session_manager.load_session(
+            agent_name,
+            cli,
+            self.issue_name,
+            phase_name,
+        )
         if not saved:
             return None
 
@@ -210,6 +230,7 @@ class AgentManager:
     def get_last_successful_cli_and_session(
         self,
         agent_name: str,
+        phase_name: Optional[str] = None,
     ) -> tuple[Optional[AgentCLI], Optional[str]]:
         """Return last successful CLI and its session for this agent, if available."""
         try:
@@ -226,7 +247,7 @@ class AgentManager:
         if active_cli not in configured:
             return None, None
 
-        return active_cli, self._session_id_for_cli(agent_name, active_cli)
+        return active_cli, self._session_id_for_cli(agent_name, active_cli, phase_name)
 
     def get_execution_config(
         self,
@@ -240,7 +261,11 @@ class AgentManager:
             return base
 
         primary = chain[0]
-        primary_session_id = self._session_id_for_cli(agent_name, primary.cli)
+        primary_session_id = self._session_id_for_cli(
+            agent_name,
+            primary.cli,
+            phase_name,
+        )
         primary_model = primary.resolve_model(phase_name)
         if primary_model is None:
             primary_model = primary.model
@@ -354,19 +379,43 @@ class AgentManager:
 
         # Track if we've already retried for session conflict
         retried = False
+        read_only_budget_retried = False
+        attempt_prompt = prompt
+        read_only_command_limit = (
+            self.DEVELOP_READ_ONLY_COMMAND_LIMIT if phase_name == "develop" else None
+        )
+        initial_read_only_command_limit = None
 
         while True:
             try:
+                execute_kwargs = {}
+                if read_only_command_limit is not None:
+                    execute_kwargs["max_read_only_commands"] = read_only_command_limit
+                if initial_read_only_command_limit is not None:
+                    execute_kwargs["max_initial_read_only_commands"] = (
+                        initial_read_only_command_limit
+                    )
                 agent_response = executor.execute(
-                    prompt,
+                    attempt_prompt,
                     allowed_tools,
                     allowed_directories,
                     streaming_output_file,
+                    **execute_kwargs,
                 )
                 break  # Success, exit loop
             except AgentExecutionError as e:
                 # Handle session conflict (only retry once)
-                if hasattr(e, 'error_type') and e.error_type == "SESSION_CONFLICT" and not retried:
+                if (
+                    getattr(e, "error_type", None) == "read_only_budget_exceeded"
+                    and not read_only_budget_retried
+                ):
+                    read_only_budget_retried = True
+                    attempt_prompt = self.DEVELOP_READ_ONLY_RETRY_PROMPT
+                    initial_read_only_command_limit = self.DEVELOP_READ_ONLY_RETRY_LIMIT
+                    print(
+                        "⚠️  Resuming the develop session once with an immediate-edit instruction..."
+                    )
+                elif hasattr(e, 'error_type') and e.error_type == "SESSION_CONFLICT" and not retried:
                     retried = True
                     # Clear session ID to force creation of new session on next execution
                     print(f"⚠️  Session conflict detected, will create new session on retry...")
@@ -407,7 +456,11 @@ class AgentManager:
         # Save session ID if it was created during execution
         if actual_session_id:
             self.session_manager.save_session(
-                agent_name, actual_cli, actual_session_id, self.issue_name
+                agent_name,
+                actual_cli,
+                actual_session_id,
+                self.issue_name,
+                phase_name,
             )
 
         # Accumulate token usage
@@ -528,7 +581,11 @@ class AgentManager:
             print(f"Trying {entry.cli.value}...")
 
             # Create a new executor for the fallback CLI, reusing its session if one exists.
-            fallback_session_id = self._session_id_for_cli(config.name, entry.cli)
+            fallback_session_id = self._session_id_for_cli(
+                config.name,
+                entry.cli,
+                phase_name,
+            )
             backup_config = AgentConfig(
                 name=config.name,
                 cli=entry.cli,
@@ -538,11 +595,17 @@ class AgentManager:
             backup_executor = AgentExecutor(backup_config)
 
             try:
+                execute_kwargs = {}
+                if phase_name == "develop":
+                    execute_kwargs["max_read_only_commands"] = (
+                        self.DEVELOP_READ_ONLY_COMMAND_LIMIT
+                    )
                 agent_response = backup_executor.execute(
                     prompt,
                     allowed_tools,
                     allowed_directories,
                     streaming_output_file,
+                    **execute_kwargs,
                 )
                 if agent_response.cli is None:
                     agent_response.cli = entry.cli

--- a/src/cafe/agents/manager.py
+++ b/src/cafe/agents/manager.py
@@ -92,7 +92,10 @@ class AgentManager:
         executor = AgentExecutor(config_with_session)
         self.agents[config.name] = executor
 
-    def _load_active_cli_from_file(self, agent_name: str) -> Optional[tuple[AgentCLI, Optional[str], Optional[str]]]:
+    def _load_active_cli_from_file(
+        self,
+        agent_name: str,
+    ) -> Optional[tuple[AgentCLI, Optional[str], Optional[AgentCLI], Optional[tuple[str, ...]]]]:
         """Load the last successful CLI for this agent from active_clis.json."""
         if self.issue_name is None:
             return None
@@ -130,7 +133,24 @@ class AgentManager:
                 configured_primary = AgentCLI(raw_primary)
             except ValueError:
                 configured_primary = None
-        return cli, model_value, configured_primary
+
+        raw_chain = record.get("chain")
+        chain: Optional[tuple[str, ...]] = None
+        if isinstance(raw_chain, list):
+            chain_entries: list[str] = []
+            for item in raw_chain:
+                if isinstance(item, str) and item:
+                    chain_entries.append(item)
+                elif isinstance(item, dict):
+                    cli_name = item.get("cli")
+                    if not isinstance(cli_name, str) or not cli_name:
+                        continue
+                    model_value = item.get("model")
+                    model_text = str(model_value).strip() if isinstance(model_value, str) else ""
+                    chain_entries.append(f"{cli_name}:{model_text}")
+            chain = tuple(chain_entries) if chain_entries else None
+
+        return cli, (model if isinstance(model, str) else None), configured_primary, chain
 
     def _configured_chain_for_agent(self, config: AgentConfig) -> list[CliEntry]:
         """Return configured CLI chain entries for this agent, with legacy fallback support."""
@@ -177,16 +197,23 @@ class AgentManager:
     def _resolve_execution_chain(
         self,
         config: AgentConfig,
+        phase_name: Optional[str] = None,
     ) -> list[CliEntry]:
         """Build execution chain with fallback preference from last successful CLI."""
         chain = self._normalize_chain(self._configured_chain_for_agent(config))
+
+        configured_chain = tuple(
+            f"{entry.cli.value}:{entry.resolve_model(phase_name) or ''}" for entry in chain
+        )
 
         last_success = self._load_active_cli_from_file(config.name)
         if not last_success:
             return chain
 
-        preferred_cli = last_success[0]
-        recorded_primary = last_success[2]
+        preferred_cli, _, recorded_primary, recorded_chain = last_success
+        if recorded_chain is not None and recorded_chain != configured_chain:
+            return chain
+
         # Sticky reorder is a within-config fallback preference: keep using the
         # CLI that last succeeded so we don't thrash mid-issue. But an explicit
         # crew.yaml edit that changes the configured primary must win. If the
@@ -242,7 +269,7 @@ class AgentManager:
         if not active_info:
             return None, None
 
-        active_cli, _active_model, _ = active_info
+        active_cli = active_info[0]
         configured = [entry.cli for entry in self._normalize_chain(self._configured_chain_for_agent(config))]
         if active_cli not in configured:
             return None, None
@@ -256,7 +283,7 @@ class AgentManager:
     ) -> AgentConfig:
         """Return an AgentConfig adjusted for the effective CLI continuation target."""
         base = self.get_agent(agent_name).config
-        chain = self._resolve_execution_chain(base)
+        chain = self._resolve_execution_chain(base, phase_name=phase_name)
         if not chain:
             return base
 

--- a/src/cafe/agents/mock_executor.py
+++ b/src/cafe/agents/mock_executor.py
@@ -49,6 +49,8 @@ class MockAgentExecutor:
         tools: Optional[List[str]] = None,
         json_content_extractor: Optional[Callable] = None,
         streaming_output_file: Optional[str] = None,
+        max_read_only_commands: Optional[int] = None,
+        max_initial_read_only_commands: Optional[int] = None,
     ) -> AgentResponse:
         """Execute with predefined response.
 
@@ -57,6 +59,8 @@ class MockAgentExecutor:
             tools: Tool names (saved but not used)
             json_content_extractor: JSON extractor (not used)
             streaming_output_file: Streaming output file (not used in mock)
+            max_read_only_commands: Between-edit progress limit (not used in mock)
+            max_initial_read_only_commands: Initial discovery limit (not used in mock)
 
         Returns:
             AgentResponse with response, token_usage, and permission_denials

--- a/src/cafe/core/phase.py
+++ b/src/cafe/core/phase.py
@@ -8,7 +8,7 @@ import inspect
 from abc import ABC, abstractmethod
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -347,6 +347,7 @@ class Phase(PhaseStateMixin, PhaseSandboxMixin, PhaseReviewMixin, PhaseChecklist
         agent_name: str,
         agent_cli: Optional[str],
         model: Optional[str],
+        execution_chain: Optional[Iterable[Any]] = None,
         phase_specific_data: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Remember the last successful CLI for handoff resolution."""
@@ -366,12 +367,59 @@ class Phase(PhaseStateMixin, PhaseSandboxMixin, PhaseReviewMixin, PhaseChecklist
 
             extra = phase_specific_data or {}
             configured_primary = self._configured_primary_cli_value(agent_name)
+            execution_chain_snapshot = []
+            if execution_chain is not None:
+                for entry in execution_chain:
+                    if isinstance(entry, str):
+                        entry_text = entry.strip()
+                        if not entry_text:
+                            continue
+                        cli_text, _, model_text = entry_text.partition(":")
+                        if not cli_text:
+                            continue
+                        normalized_model = model_text if model_text else None
+                        execution_chain_snapshot.append(
+                            {
+                                "cli": cli_text,
+                                "model": normalized_model or None,
+                            }
+                        )
+                        continue
+                    if isinstance(entry, AgentCLI):
+                        cli_name = entry.value
+                        execution_chain_snapshot.append({"cli": cli_name, "model": None})
+                        continue
+                    if isinstance(entry, dict):
+                        cli_name = entry.get("cli")
+                        model_value = entry.get("model")
+                        if isinstance(cli_name, str):
+                            execution_chain_snapshot.append(
+                                {
+                                    "cli": cli_name,
+                                    "model": str(model_value).strip() if isinstance(model_value, str) else None,
+                                }
+                            )
+                        continue
+                    cli_name = getattr(entry, "cli", None)
+                    if cli_name is None or not hasattr(cli_name, "value"):
+                        continue
+                    model_value = getattr(entry, "model", None)
+                    resolved_phase = getattr(entry, "resolve_model", None)
+                    if callable(resolved_phase):
+                        model_value = resolved_phase(phase_specific_data.get("step_name")) if hasattr(phase_specific_data, "get") else None
+                    execution_chain_snapshot.append(
+                        {
+                            "cli": str(cli_name.value),
+                            "model": str(model_value).strip() if isinstance(model_value, str) else None,
+                        }
+                    )
             data[agent_name] = {
                 "cli": agent_cli,
                 "model": model,
                 # Crew primary at record time, so a later crew.yaml primary change
                 # invalidates this sticky record instead of being overridden by it.
                 "configured_primary": configured_primary,
+                "chain": execution_chain_snapshot,
                 "step_name": extra.get("step_name"),
                 "updated_at": datetime.now().astimezone().isoformat(),
             }
@@ -779,6 +827,7 @@ class Phase(PhaseStateMixin, PhaseSandboxMixin, PhaseReviewMixin, PhaseChecklist
                 agent_name=agent_name,
                 agent_cli=agent_cli,
                 model=model,
+                execution_chain=getattr(execution_config, "clis", None),
                 phase_specific_data=phase_specific_data,
             )
 

--- a/src/cafe/core/session.py
+++ b/src/cafe/core/session.py
@@ -24,7 +24,11 @@ class SessionManager:
         self.sessions_dir.mkdir(parents=True, exist_ok=True)
 
     def get_session_file(
-        self, agent_name: str, cli: AgentCLI, issue_name: Optional[str] = None
+        self,
+        agent_name: str,
+        cli: AgentCLI,
+        issue_name: Optional[str] = None,
+        phase_name: Optional[str] = None,
     ) -> Path:
         """Get the session file path for an agent.
 
@@ -44,13 +48,18 @@ class SessionManager:
             # Issue-specific sessions go under .cafe/issues/{issue_name}/sessions/
             issue_sessions_dir = Path(".cafe/issues") / issue_name / "sessions"
             issue_sessions_dir.mkdir(parents=True, exist_ok=True)
-            return issue_sessions_dir / f"{agent_name}_{cli.value}.json"
+            phase_suffix = f"_{phase_name}" if phase_name else ""
+            return issue_sessions_dir / f"{agent_name}_{cli.value}{phase_suffix}.json"
 
         # Global sessions (no issue) go under .cafe/sessions/
         return self.sessions_dir / f"{agent_name}_{cli.value}.json"
 
     def load_session(
-        self, agent_name: str, cli: AgentCLI, issue_name: Optional[str] = None
+        self,
+        agent_name: str,
+        cli: AgentCLI,
+        issue_name: Optional[str] = None,
+        phase_name: Optional[str] = None,
     ) -> Optional[SessionData]:
         """Load existing session data for an agent.
 
@@ -62,7 +71,7 @@ class SessionManager:
         Returns:
             SessionData if exists, None otherwise
         """
-        session_file = self.get_session_file(agent_name, cli, issue_name)
+        session_file = self.get_session_file(agent_name, cli, issue_name, phase_name)
         if not session_file.exists():
             return None
 
@@ -80,6 +89,7 @@ class SessionManager:
         cli: AgentCLI,
         session_id: str,
         issue_name: Optional[str] = None,
+        phase_name: Optional[str] = None,
     ) -> None:
         """Save session data for an agent.
 
@@ -89,10 +99,10 @@ class SessionManager:
             session_id: Session ID to save
             issue_name: Name of the issue (for issue-specific sessions)
         """
-        session_file = self.get_session_file(agent_name, cli, issue_name)
+        session_file = self.get_session_file(agent_name, cli, issue_name, phase_name)
 
         # Load existing session to preserve created_at, or create new
-        existing = self.load_session(agent_name, cli, issue_name)
+        existing = self.load_session(agent_name, cli, issue_name, phase_name)
         now = datetime.now()
 
         session_data = SessionData(
@@ -101,13 +111,18 @@ class SessionManager:
             session_id=session_id,
             created_at=existing.created_at if existing else now,
             last_used_at=now,
+            phase_name=phase_name,
         )
 
         with open(session_file, "w") as f:
             json.dump(session_data.model_dump(mode="json"), f, indent=2, default=str)
 
     def delete_session(
-        self, agent_name: str, cli: AgentCLI, issue_name: Optional[str] = None
+        self,
+        agent_name: str,
+        cli: AgentCLI,
+        issue_name: Optional[str] = None,
+        phase_name: Optional[str] = None,
     ) -> None:
         """Delete session for an agent.
 
@@ -116,7 +131,7 @@ class SessionManager:
             cli: CLI type
             issue_name: Name of the issue (for issue-specific sessions)
         """
-        session_file = self.get_session_file(agent_name, cli, issue_name)
+        session_file = self.get_session_file(agent_name, cli, issue_name, phase_name)
         if session_file.exists():
             session_file.unlink()
 

--- a/src/cafe/core/types.py
+++ b/src/cafe/core/types.py
@@ -228,6 +228,7 @@ class SessionData(BaseModel):
     session_id: str
     created_at: datetime
     last_used_at: datetime
+    phase_name: Optional[str] = None
 
 
 class SessionConfig(BaseModel):

--- a/src/cafe/data/skills/cafe-develop/SKILL.md
+++ b/src/cafe/data/skills/cafe-develop/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cafe-develop
 description: "依計畫進行程式開發與測試"
-version: 1.0.0
+version: 1.3.0
 ---
 
 # Develop
@@ -16,12 +16,19 @@ Read your agent file: {agent_file}
 ## Instructions
 - 依計畫逐項完成
 - 先補測試再改程式
+- 第一次探索只做一輪：讀一次 spec、plan，再針對 Test List 與預計修改點搜尋程式碼；未出現新證據時不得重讀同一檔案或重跑相同的搜尋、`git status`、`git diff`
+- 在第一次實質修改前，以及任兩次實質修改之間，唯讀工具呼叫（read/search/list/status/diff 等）上限皆為 **20 次**；每次實質修改會重設計數，測試執行不會重設此上限
+- runtime 會硬性中止超過唯讀上限的 attempt，並只允許在同一 session 續跑一次；續跑時必須在 3 次唯讀呼叫內完成下一個相關檔案修改，不得重新開始探索
+- 到達上限前必須寫入第一個相關的 failing test；若依計畫不需新增測試，則寫入第一個實作修改。若仍無法安全修改，立即提出具體 clarification 並交棒給 user，不得繼續探索
 - 新增或修改的測試必須對應計畫 **Test List** 項目（範圍變更時先更新計畫）
 - 斷言以 invariant 為主：避免綁定 UI copy、CSS class、DOM 結構、內部 state shape；允許 a11y role/label、`data-testid`、以及規格明訂的文案（見 `cafe-plan/references/test_invariants_policy.md`）
 - 每輪完成後更新 checklist
 - 維持既有 commit 風格與程式碼註解語言
 - 優先重用現有模式與工具
 - 與 reviewer 往返、blackboard/baton 更新、以及 user 仲裁等跨 phase 規則：請依 shared skill「cafe-workflow-common」的 **Develop and review disagreement protocol** 與 **Shared Rules**；本 skill 不重複敘述。
+
+## Output
+Write development summary to: {output_file}
 
 ## Handoff
 - 依照本輪結果更新 blackboard 與 next-step baton。

--- a/src/cafe/data/skills/cafe-workflow-common/SKILL.md
+++ b/src/cafe/data/skills/cafe-workflow-common/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cafe-workflow-common
-description: Use this skill at the start of any CAFE workflow phase to load the latest workflow handoff from blackboard, identify the current baton state, and ground the phase in the shared workflow context before reading phase-specific artifacts.
-version: 1.2.0
+description: Use this skill at the start of any CAFE workflow phase to load the bounded workflow digest, identify the current baton state, and ground the phase in shared context before reading phase-specific artifacts.
+version: 1.3.0
 ---
 
 # Workflow Common
@@ -11,9 +11,11 @@ version: 1.2.0
 - Treat the blackboard as the primary handoff surface between user turns, chat turns, and workflow phases.
 
 ## First Steps
-1. Read the latest shared workflow blackboard from the runtime-provided path.
-2. Identify the latest handoff summary, relevant recent events, and current workflow step.
-3. Only after grounding yourself in the blackboard, continue into phase-specific artifacts and instructions.
+1. Read the runtime-provided **Bounded blackboard digest** and latest handoff summary.
+2. Identify the current workflow step, baton, artifact pointers, and recent event summaries from that digest.
+3. Continue into phase-specific artifacts and instructions after this bounded grounding pass.
+
+The full `blackboard.json` is an unbounded audit history. Do **not** read or print the whole file during normal phase startup. If a concrete conflict requires older history, query only the exact field or matching event summaries needed. Read a full event payload only when the bounded summary is insufficient to resolve a specific disagreement.
 
 ## How workflow transitions work
 
@@ -129,7 +131,8 @@ If you write an invalid `to_owner` or `intent` value, the runtime will **reject*
 ## What Not To Do
 - Do not re-explain the shared workflow model in every phase artifact.
 - Do not invent a new handoff format outside the baton mechanism.
-- Do not skip the blackboard read just because the phase prompt also includes artifact paths.
+- Do not read the full `blackboard.json` as an initial discovery step; use the runtime-provided bounded digest.
+- Do not repeat the same blackboard query when neither the baton nor relevant files have changed.
 - Do not write `blackboard.json` — only write `next_step.txt`. The runtime updates the blackboard based on your baton.
 - Do not use status codes in your response text as the primary transition mechanism — write the baton instead.
 - Do not invoke high-level workflow-driving skills (for example `use-cafe-workflow`) inside a running phase. Follow only the shared skills and phase skill already listed by the runtime prompt.
@@ -152,9 +155,9 @@ If you write an invalid `to_owner` or `intent` value, the runtime will **reject*
 
 Follow these in addition to **Shared Rules** whenever you are in **develop** or **review**.
 
-- The runtime prompt includes concrete paths to the blackboard and baton; read them before writing your baton.
+- The runtime prompt includes the bounded digest plus concrete paths to the blackboard and baton. Use the digest and read the small baton file before writing a new baton; keep the full blackboard path for selective diagnostics only.
 - **Reasonable feedback:** if the other role's request is technically sound, implement or accept it and write a baton targeting the next step (e.g. develop → review, review → pr).
-- **Disagreement:** if you reject the other role's position, first read their full `output.md` and the dispute summary in blackboard `events` before deciding; then write technical reasoning in this iteration's `output.md`. Write a baton routing back to the other engineering step.
+- **Disagreement:** if you reject the other role's position, first read their full `output.md` and selectively query the matching dispute event summaries before deciding. Read a matching event's full payload only if its summary lacks the necessary technical detail. Then write technical reasoning in this iteration's `output.md` and a baton routing back to the other engineering step.
 - **First pushback from develop:** write a baton with `to_owner: "agent"`, `to_step: "review"`, `intent: "manual_handoff"`.
 - **Round limit:** the same disagreement may go back and forth at most **three** times between develop and review. If the blackboard already shows three rounds without convergence, do **not** write a baton targeting the other engineering step again.
 - **User arbitration:** if you still disagree after the limit (or the issue is product-level), capture both sides in `questions.xml` and write a baton with `to_owner: "user"`, `intent: "need_clarification"`.

--- a/src/cafe/data/skills/use-cafe-workflow/SKILL.md
+++ b/src/cafe/data/skills/use-cafe-workflow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: use-cafe-workflow
 description: Use this skill when you need to develop an issue by driving CAFE from the terminal with non-interactive commands instead of manually performing each phase.
-version: 1.4.0
+version: 1.4.1
 ---
 
 # Use CAFE Workflow
@@ -35,8 +35,9 @@ Do not split this into `mandate.yaml` or other parallel config files.
 ### Kickoff (required before first `cafe make`)
 
 1. Inventory existing docs; co-create any that are `missing`.
-2. Confirm with the user: active playbook, **preset** (`issue-scoped` | `product-led` | `technical-led` | `full-stack` | `custom`), **axes** for that playbook (examples only—user may rename/add), **level** per axis (`agent` | `propose` | `escalate`), **confirmation_contract**, and **out_of_mandate** (billing, legal, production access, …).
-3. Write repo-wide `documents` and `mandate` updates to `.cafe/strategic_context.yaml`. Do **not** create, edit, or delete `issues.<issue-name>` unless the user explicitly asks for an issue-specific strategic override.
+2. Before preparing the issue, confirm with the user: active playbook, **preset** (`issue-scoped` | `product-led` | `technical-led` | `full-stack` | `custom`), **axes** for that playbook (examples only—user may rename/add), **level** per axis (`agent` | `propose` | `escalate`), **confirmation_contract**, **out_of_mandate** (billing, legal, production access, …), and whether to create a Git worktree.
+3. Recommend creating a worktree by default at `.cafe/worktrees/<issue-name>`. Include this recommendation in the kickoff confirmation; if the user confirms the recommended kickoff without changing the worktree choice, treat worktree creation as approved. If the user declines, prepare on a feature branch in the current checkout.
+4. Write repo-wide `documents` and `mandate` updates to `.cafe/strategic_context.yaml`. Do **not** create, edit, or delete `issues.<issue-name>` unless the user explicitly asks for an issue-specific strategic override.
 
 ### Issue overrides are opt-in only
 
@@ -130,16 +131,19 @@ Re-read `.cafe/strategic_context.yaml` and linked documents before answering que
 ## Initial Setup
 1. Check the repo state with `git status --short --branch`.
 2. If CAFE is not initialized, run `cafe init --preset <preset>` instead of interactive `cafe init`.
-3. Prepare the issue non-interactively:
+3. Complete the kickoff confirmation, including the worktree choice, before running `cafe prepare`.
+4. Prepare the issue non-interactively. Worktree mode is the default:
    ```bash
-   cafe prepare <issue-name> --no-interactive --input-method=manual --rigor=medium --spec-template=auto --plan-template=default
+   cafe prepare <issue-name> --no-interactive --input-method=manual --rigor=medium --spec-template=auto --plan-template=default --worktree .cafe/worktrees/<issue-name>
    ```
-4. For a GitHub-backed issue, use:
+5. For a GitHub-backed issue, use:
    ```bash
-   cafe prepare <issue-name> --no-interactive --input-method=github --issue-id=<number> --rigor=medium --spec-template=auto --plan-template=default --auto-create-pr
+   cafe prepare <issue-name> --no-interactive --input-method=github --issue-id=<number> --rigor=medium --spec-template=auto --plan-template=default --auto-create-pr --worktree .cafe/worktrees/<issue-name>
    ```
-5. If the prepare command creates or reports a worktree, `cd` into that worktree before running workflow commands.
-6. **Strategic Context:** inventory, co-create missing documents, confirm mandate and confirmation contract with user, write repo-wide `.cafe/strategic_context.yaml` updates, and leave `issues:` untouched unless the user explicitly requested an issue-specific override. Then run the first `cafe make`.
+6. If the user declined worktree mode, omit `--worktree`; otherwise do not silently fall back to the main checkout when worktree creation fails.
+7. If the prepare command creates or reports a worktree, `cd` into that worktree before running workflow commands.
+8. If the issue was accidentally prepared without the confirmed worktree before its first `cafe make`, recreate or repair the preparation so `issue.yaml` records `worktree_path`, then continue from the worktree without discarding issue configuration.
+9. **Strategic Context:** inventory, co-create missing documents, confirm mandate and confirmation contract with user, write repo-wide `.cafe/strategic_context.yaml` updates, and leave `issues:` untouched unless the user explicitly requested an issue-specific override. Then run the first `cafe make`.
 
 ## Running Work
 1. Start the workflow with the user's requirement. Point agents at the single config when useful:

--- a/src/cafe/phases/generic_phase.py
+++ b/src/cafe/phases/generic_phase.py
@@ -53,14 +53,26 @@ class GenericPhase:
         if hook_registry:
             self.hook_registry.update(hook_registry)
 
-    def prepare_skill(self, *, skill_name: str, agent_cli: AgentCLI) -> str:
+    def prepare_skill(
+        self,
+        *,
+        skill_name: str,
+        agent_cli: AgentCLI,
+        context: Optional[Dict[str, str]] = None,
+    ) -> str:
         """Install one skill for the target CLI and return its invocation syntax."""
-        self.skill_bridge.install_skill(skill_name, agent_cli)
+        self.skill_bridge.install_skill(skill_name, agent_cli, context=context)
         return self.skill_bridge.get_invocation(skill_name, agent_cli)
 
-    def prepare_skills(self, *, skill_names: list[str], agent_cli: AgentCLI) -> list[str]:
+    def prepare_skills(
+        self,
+        *,
+        skill_names: list[str],
+        agent_cli: AgentCLI,
+        context: Optional[Dict[str, str]] = None,
+    ) -> list[str]:
         """Install a list of skills for the target CLI and return invocation syntax."""
-        self.skill_bridge.install_skills(skill_names, agent_cli)
+        self.skill_bridge.install_skills(skill_names, agent_cli, context=context)
         return [self.skill_bridge.get_invocation(name, agent_cli) for name in skill_names]
 
     def build_prompt(
@@ -125,6 +137,16 @@ class GenericPhase:
         runtime_context.append(
             "- stay within this prompt's listed shared skills + phase skill; do not invoke external workflow-driving skills (e.g. use-cafe-workflow)"
         )
+
+        if context and context.get("blackboard_digest"):
+            runtime_context.extend(
+                [
+                    "Bounded blackboard digest:",
+                    context["blackboard_digest"],
+                    "Use this digest for initial workflow grounding. Do not read the full blackboard file; it is an unbounded audit history and may exceed the agent context window.",
+                    "If a concrete conflict requires older history, query only the specific field or event needed, and do not print event data payloads wholesale.",
+                ]
+            )
 
         if context and context.get("handoff_summary"):
             runtime_context.extend(

--- a/src/cafe/phases/generic_workflow_step.py
+++ b/src/cafe/phases/generic_workflow_step.py
@@ -43,7 +43,8 @@ from cafe.skills.checklist_composer import (
     generate_spec_checklist,
 )
 from cafe.skills.loader import canonical_skill_name
-from cafe.utils.git_utils import to_cwd_relative_path
+from cafe.utils.git_utils import get_repo_root, to_cwd_relative_path, get_git_toplevel
+from cafe.utils.phase_config import load_phase_step_model
 
 
 def align_pr_baton_after_execution(
@@ -182,7 +183,7 @@ class GenericWorkflowStepExecutor(Phase):
 
         skill_name = self._resolve_skill_name(step_def, self.iteration)
         valid_intents = self._resolve_valid_intents(step_def)
-        agent_name = self._resolve_agent_name(step_def)
+        agent_name = self._resolve_agent_name(step_name, step_def)
         self._step_agent_name = agent_name
         self._apply_step_agent_model(step_name=step_name, step_def=step_def, agent_name=agent_name)
         agent_cli = self.agent_manager.get_agent(agent_name).config.cli
@@ -505,8 +506,42 @@ class GenericWorkflowStepExecutor(Phase):
                 return str(numbered[0][1])
         raise ValueError("Step is missing skill configuration")
 
-    def _resolve_agent_name(self, step_def: Dict[str, Any]) -> str:
+    def _resolve_phase_config_paths(self) -> tuple[Optional[Path], Optional[Path]]:
+        local_path = None
+        repo_path = None
+        try:
+            repo_root = get_repo_root()
+            worktree_root = get_git_toplevel()
+            repo_path = repo_root / ".cafe" / "phases.yaml"
+            if self.issue_name:
+                local_path = worktree_root / ".cafe" / "phases.yaml"
+        except Exception:
+            pass
+        return local_path, repo_path
+
+    def _resolve_step_phase_config(self, step_name: str):
+        local_path, repo_path = self._resolve_phase_config_paths()
+        return load_phase_step_model(
+            step_name=step_name,
+            local_path=local_path,
+            repo_path=repo_path,
+        )
+
+    def _resolve_agent_name(self, step_name: str, step_def: Dict[str, Any]) -> str:
         role = str(step_def.get("role", "developer"))
+        try:
+            phase_resolution = self._resolve_step_phase_config(step_name)
+            if phase_resolution.role and phase_resolution.role != role:
+                raise ValueError(
+                    f"phase config role mismatch for '{step_name}': expected '{role}', got '{phase_resolution.role}'"
+                )
+            if phase_resolution.name:
+                return phase_resolution.name
+        except ValueError as exc:
+            raise ValueError(
+                f"invalid phase config for '{step_name}' in '{step_name}': {exc}"
+            ) from exc
+
         agent_name = self.role_agent_map.get(role)
         if agent_name:
             return agent_name
@@ -524,6 +559,21 @@ class GenericWorkflowStepExecutor(Phase):
         self.agent_manager.get_agent(agent_name).config.model = model
 
     def _resolve_step_model(self, *, step_name: str, step_def: Dict[str, Any]) -> Optional[str]:
+        # Phase-level config (worktree/repo/local) is authoritative for a step.
+        try:
+            phase_resolution = self._resolve_step_phase_config(step_name)
+            expected_role = str(step_def.get("role", "developer"))
+            if phase_resolution.role and phase_resolution.role != expected_role:
+                raise ValueError(
+                    f"phase config role mismatch for '{step_name}': expected '{expected_role}', got '{phase_resolution.role}'"
+                )
+            if phase_resolution.model:
+                return phase_resolution.model
+        except ValueError as exc:
+            raise ValueError(
+                f"invalid phase config for '{step_name}' in '{step_name}': {exc}"
+            )
+
         role = str(step_def.get("role", "developer"))
         config = self.role_configs.get(role, {})
         if not isinstance(config, dict):

--- a/src/cafe/phases/generic_workflow_step.py
+++ b/src/cafe/phases/generic_workflow_step.py
@@ -93,6 +93,9 @@ class GenericWorkflowStepExecutor(Phase):
     """Execute one playbook step without shelling out to legacy CLI commands."""
 
     SHARED_WORKFLOW_SKILLS = ["cafe-workflow-common", "cafe-github_sync"]
+    BLACKBOARD_DIGEST_EVENT_LIMIT = 5
+    BLACKBOARD_DIGEST_ARTIFACT_LIMIT = 20
+    BLACKBOARD_DIGEST_TEXT_LIMIT = 240
 
     def __init__(
         self,
@@ -183,19 +186,22 @@ class GenericWorkflowStepExecutor(Phase):
         self._step_agent_name = agent_name
         self._apply_step_agent_model(step_name=step_name, step_def=step_def, agent_name=agent_name)
         agent_cli = self.agent_manager.get_agent(agent_name).config.cli
-        shared_skill_invocations = self.generic_phase.prepare_skills(
-            skill_names=self.SHARED_WORKFLOW_SKILLS,
-            agent_cli=agent_cli,
-        )
-        skill_invocation = self.generic_phase.prepare_skill(
-            skill_name=skill_name, agent_cli=agent_cli
-        )
         context = self._build_context(
             step_name=step_name,
             step_def=step_def,
             blackboard_state=blackboard_state,
             agent_name=agent_name,
             output_file=output_file,
+        )
+        shared_skill_invocations = self.generic_phase.prepare_skills(
+            skill_names=self.SHARED_WORKFLOW_SKILLS,
+            agent_cli=agent_cli,
+            context=context,
+        )
+        skill_invocation = self.generic_phase.prepare_skill(
+            skill_name=skill_name,
+            agent_cli=agent_cli,
+            context=context,
         )
         self._generate_checklist(
             step_name=step_name,
@@ -662,6 +668,7 @@ class GenericWorkflowStepExecutor(Phase):
         context = {
             "agent_file": AgentManager.get_agent_file_path(agent_name, role_dir),
             "handoff_summary": getattr(blackboard_state, "handoff_summary", ""),
+            "blackboard_digest": self._build_blackboard_digest(blackboard_state),
             "blackboard_path": self._display_path(self.issue_dir / "blackboard.json"),
             "next_step_path": self._display_path(self.issue_dir / "next_step.txt"),
             "output_file": self._display_path(output_file),
@@ -708,6 +715,50 @@ class GenericWorkflowStepExecutor(Phase):
             )
 
         return context
+
+    @classmethod
+    def _build_blackboard_digest(cls, state: BlackboardState) -> str:
+        """Serialize a small execution projection without unbounded event payloads."""
+
+        def bounded(value: Any) -> str:
+            text = str(value)
+            if len(text) <= cls.BLACKBOARD_DIGEST_TEXT_LIMIT:
+                return text
+            return f"{text[: cls.BLACKBOARD_DIGEST_TEXT_LIMIT]}…"
+
+        artifact_items = sorted(state.artifacts.items())
+        selected_artifacts = artifact_items[-cls.BLACKBOARD_DIGEST_ARTIFACT_LIMIT :]
+        artifacts = {
+            name: {
+                "version": entry.version,
+                "updated_by": entry.updated_by,
+                "path": bounded(entry.path),
+            }
+            for name, entry in selected_artifacts
+        }
+        recent_events = [
+            {
+                "timestamp": event.timestamp,
+                "step": event.step,
+                "event_type": event.event_type,
+                "message": bounded(event.message),
+            }
+            for event in state.events[-cls.BLACKBOARD_DIGEST_EVENT_LIMIT :]
+        ]
+        digest = {
+            "current_step": state.current_step,
+            "playbook_id": state.playbook_id,
+            "handoff_contract": (
+                state.handoff_contract.to_dict()
+                if state.handoff_contract is not None
+                else None
+            ),
+            "artifacts": artifacts,
+            "omitted_artifact_count": max(0, len(artifact_items) - len(selected_artifacts)),
+            "recent_events": recent_events,
+            "omitted_event_count": max(0, len(state.events) - len(recent_events)),
+        }
+        return json.dumps(digest, ensure_ascii=False, indent=2)
 
     def _generate_checklist(
         self,

--- a/src/cafe/skills/native_bridge.py
+++ b/src/cafe/skills/native_bridge.py
@@ -77,7 +77,12 @@ class NativeSkillBridge:
         except (SkillDiscoveryError, FileNotFoundError):
             return name
 
-    def install_skill(self, name: str, cli: AgentCLI) -> Path:
+    def install_skill(
+        self,
+        name: str,
+        cli: AgentCLI,
+        context: dict[str, str] | None = None,
+    ) -> Path:
         """Install one resolved skill into the project-local CLI-native directory.
 
         Using the worktree-local skill directory avoids cross-process races when
@@ -98,6 +103,12 @@ class NativeSkillBridge:
         if target_dir.exists():
             shutil.rmtree(target_dir)
         shutil.copytree(source_dir, target_dir)
+        if context:
+            skill_file = target_dir / "SKILL.md"
+            rendered = skill_file.read_text(encoding="utf-8")
+            for key, value in context.items():
+                rendered = rendered.replace(f"{{{key}}}", str(value))
+            skill_file.write_text(rendered, encoding="utf-8")
         return target_dir
 
     def _ensure_cli_dir_git_excluded(self, cli: AgentCLI) -> None:
@@ -135,7 +146,12 @@ class NativeSkillBridge:
         except Exception:
             return
 
-    def install_skills(self, names: list[str], cli: AgentCLI) -> list[Path]:
+    def install_skills(
+        self,
+        names: list[str],
+        cli: AgentCLI,
+        context: dict[str, str] | None = None,
+    ) -> list[Path]:
         """Install a list of skills for one CLI."""
         installed: list[Path] = []
         seen: set[str] = set()
@@ -143,7 +159,7 @@ class NativeSkillBridge:
             if name in seen:
                 continue
             seen.add(name)
-            installed.append(self.install_skill(name, cli))
+            installed.append(self.install_skill(name, cli, context=context))
         return installed
 
     def get_invocation(self, name: str, cli: AgentCLI) -> str:

--- a/src/cafe/ui/chat.py
+++ b/src/cafe/ui/chat.py
@@ -66,11 +66,12 @@ def _load_chat_role_config(
 ) -> Optional[dict]:
     """Load role config from crew.yaml first, then config.yaml."""
     try:
-        cafe_dir = Path(getattr(config_manager, "config_dir"))
-        crew_data = CrewManager(cafe_dir=cafe_dir).load()
-        role_config = crew_data.get(role)
-        if isinstance(role_config, dict):
-            return role_config
+        config_dir = getattr(config_manager, "config_dir", None)
+        if isinstance(config_dir, (str, Path)):
+            crew_data = CrewManager(cafe_dir=Path(config_dir)).load()
+            role_config = crew_data.get(role)
+            if isinstance(role_config, dict):
+                return role_config
     except Exception:
         pass
 
@@ -186,6 +187,20 @@ def _load_active_chat_cli(
             cli,
             step_name if isinstance(step_name, str) else None,
         )
+
+    recorded_chain = record.get("chain")
+    if isinstance(recorded_chain, list):
+        # Accept legacy stored chains as list of dicts or list of strings
+        def _extract_cli_value(item):
+            if isinstance(item, dict):
+                return item.get("cli")
+            return item
+
+        recorded_chain_values = [_extract_cli_value(i) for i in recorded_chain]
+        current_chain = [entry.cli.value for entry in normalize_role_config(role_config)]
+        if recorded_chain_values != current_chain:
+            return None
+
     return cli, model if isinstance(model, str) else None
 
 

--- a/src/cafe/ui/cli.py
+++ b/src/cafe/ui/cli.py
@@ -366,12 +366,14 @@ def _setup_agents(
     config_manager: ConfigManager,
     issue_name: Optional[str] = None,
     phase_name: Optional[str] = None,
+    cafe_dir: Optional[Path] = None,
 ) -> AgentManager:
     """Setup agent manager with default agents."""
     return _shared_setup_agents(
         config_manager=config_manager,
         issue_name=issue_name,
         phase_name=phase_name,
+        cafe_dir=cafe_dir,
     )
 
 

--- a/src/cafe/ui/cli_shared.py
+++ b/src/cafe/ui/cli_shared.py
@@ -31,6 +31,8 @@ from cafe.services.delta_display import DeltaDisplay
 from cafe.skills.loader import SkillLoader
 from cafe.utils.config import ConfigError, ConfigManager
 from cafe.utils.crew import CrewManager, normalize_role_config
+from cafe.utils.phase_config import load_phase_step_model
+from cafe.utils.git_utils import get_repo_root, get_git_toplevel
 
 VALID_CONTENT_TYPES = [
     "context",
@@ -106,26 +108,49 @@ def _get_github_helpers():
 def check_agent_clis_available(config_manager: ConfigManager) -> List[str]:
     """Check if all configured agent CLIs are installed."""
     try:
-        crew_data = CrewManager(cafe_dir=Path(config_manager.config_dir)).load()
+        config_dir = getattr(config_manager, "config_dir", None)
+        crew_data = (
+            CrewManager(cafe_dir=Path(config_dir)).load()
+            if isinstance(config_dir, (str, Path))
+            else {}
+        )
     except (AttributeError, TypeError):
         crew_data = {}
 
-    def _role_cli(role: str, default_cli: str) -> str:
+    def _role_config(role: str, default_cli: str) -> dict:
         if crew_data and role in crew_data and isinstance(crew_data[role], dict):
-            return crew_data[role].get("cli", default_cli)
+            return crew_data[role]
         val = config_manager.get(f"agents.{role}", {})
-        return val.get("cli", default_cli) if isinstance(val, dict) else default_cli
+        return val if isinstance(val, dict) else {"cli": default_cli}
 
-    pm_config = {"cli": _role_cli("pm", "copilot")}
-    dev_config = {"cli": _role_cli("developer", "copilot")}
-    reviewer_config = {"cli": _role_cli("reviewer", "copilot")}
+    role_configs = [
+        _role_config("pm", "copilot"),
+        _role_config("developer", "copilot"),
+        _role_config("reviewer", "copilot"),
+    ]
 
-    required_clis = [pm_config["cli"], dev_config["cli"], reviewer_config["cli"]]
+    def _configured_chain(config: dict) -> list[str]:
+        chain = [entry.cli.value for entry in normalize_role_config(config)]
+        if chain:
+            return chain
+        cli = config.get("cli")
+        return [cli] if isinstance(cli, str) and cli else ["copilot"]
 
     missing_clis = []
-    for cli in required_clis:
-        if shutil.which(cli) is None and cli not in missing_clis:
-            missing_clis.append(cli)
+    for role_config in role_configs:
+        chain = _configured_chain(role_config)
+        available = [cli for cli in chain if shutil.which(cli) is not None]
+        if available:
+            missing_in_chain = [cli for cli in chain if cli not in available]
+            if missing_in_chain:
+                console.print(
+                    "[yellow]Warning:[/yellow] Some configured fallback CLIs are not installed: "
+                    + ", ".join(dict.fromkeys(missing_in_chain))
+                )
+            continue
+        for cli in chain:
+            if cli not in missing_clis:
+                missing_clis.append(cli)
 
     return missing_clis
 
@@ -165,31 +190,137 @@ def setup_agents(
             return crew_data[role]
         return config_manager.get(f"agents.{role}", {"name": default_name, "cli": "copilot"})
 
+    def _resolve_phase_config_paths() -> tuple[Optional[Path], Optional[Path]]:
+        local_path = None
+        repo_path = None
+        try:
+            repo_root = get_repo_root()
+            worktree_root = get_git_toplevel()
+            local_path = worktree_root / ".cafe" / "phases.yaml"
+            repo_path = repo_root / ".cafe" / "phases.yaml"
+        except Exception:
+            fallback_cafe_dir = Path(cafe_dir) if cafe_dir else Path(config_manager.config_dir)
+            local_path = fallback_cafe_dir / "phases.yaml"
+        return local_path, repo_path
+
+    def _resolve_phase_overrides() -> tuple[Optional[str], Optional[list[dict[str, str]]], Optional[str]]:
+        if not issue_name or not phase_name:
+            return None, None, None
+        try:
+            local_path, repo_path = _resolve_phase_config_paths()
+            resolved = load_phase_step_model(
+                step_name=phase_name,
+                local_path=local_path,
+                repo_path=repo_path,
+            )
+        except ValueError as exc:
+            raise ValueError(
+                f"invalid phase config for step '{phase_name}': {exc}"
+            ) from exc
+        if not resolved.clis:
+            return resolved.name, None, resolved.role
+
+        clis_payload = []
+        for cli_name, model in resolved.clis:
+            entry = {"cli": cli_name}
+            if model is not None:
+                entry["model"] = model
+            clis_payload.append(entry)
+        return resolved.name, clis_payload, resolved.role
+
+    phase_name_override, phase_clis, phase_role = _resolve_phase_overrides()
+
+    def _resolve_phase_target_role() -> Optional[str]:
+        if phase_role is not None:
+            return phase_role
+        if not phase_name:
+            return None
+        try:
+            playbook_name = config_manager.get("settings.playbook", None)
+            if not playbook_name:
+                playbook_name = config_manager.get("playbook", "default")
+            playbook = PlaybookLoader(project_root=get_git_toplevel()).load(str(playbook_name))
+            step_def = playbook.get("steps", {}).get(phase_name, {})
+            if isinstance(step_def, dict):
+                role = step_def.get("role")
+                if isinstance(role, str) and role.strip():
+                    return role.strip()
+        except Exception:
+            pass
+        return {
+            "spec": "pm",
+            "plan": "developer",
+            "develop": "developer",
+            "review": "reviewer",
+            "pr": "developer",
+        }.get(phase_name)
+
+    phase_target_role = _resolve_phase_target_role()
+
+    def _resolve_phase_model() -> Optional[str]:
+        if not phase_name or not issue_name:
+            return None
+
+        try:
+            local_path, repo_path = _resolve_phase_config_paths()
+            resolution = load_phase_step_model(
+                step_name=phase_name,
+                local_path=local_path,
+                repo_path=repo_path,
+            )
+        except ValueError as exc:
+            raise ValueError(
+                f"invalid phase config for step '{phase_name}': {exc}"
+            ) from exc
+        return resolution.model
+
     pm_config = _role_config("pm", "Roger")
     dev_config = _role_config("developer", "David")
     reviewer_config = _role_config("reviewer", "Richard")
 
-    def _build_agent_config(role_config: dict, default_name: str) -> AgentConfig:
-        chain = normalize_role_config(role_config)
-
-        # Seed models_config from raw models: dict for backward compat
-        # (manager._try_backup_agents reads it; callers may also inspect it)
-        raw_models = role_config.get("models", {}) or {}
+    def _build_models_config(config: dict) -> Dict[str, Dict[str, str]]:
+        raw_models = config.get("models", {}) or {}
         models_config: Dict[str, Dict[str, str]] = {}
         if isinstance(raw_models, dict):
             for cli_name, phase_map in raw_models.items():
                 if isinstance(phase_map, dict):
                     models_config[cli_name] = {k: str(v) for k, v in phase_map.items()}
+        return models_config
 
-        if chain:
-            primary = chain[0]
+    def _build_agent_config(role_config: dict, role: str, default_name: str) -> AgentConfig:
+        active_chain = normalize_role_config(role_config)
+        agent_name = role_config.get("name", default_name)
+        phase_model = _resolve_phase_model() if phase_name else None
+
+        phase_applies_to_role = phase_target_role == role
+
+        if phase_target_role is not None and not phase_applies_to_role:
+            active_chain = normalize_role_config(role_config)
+            agent_name = str(role_config.get("name", default_name))
+        elif phase_applies_to_role and (phase_clis is not None or phase_name_override is not None):
+            merged_config = dict(role_config)
+            if phase_clis is not None:
+                merged_config["clis"] = phase_clis
+            if phase_name_override is not None:
+                merged_config["name"] = phase_name_override
+            agent_name = str(merged_config.get("name", default_name))
+            active_chain = normalize_role_config(merged_config)
+
+        models_config = _build_models_config(role_config)
+
+        if active_chain:
+            primary = active_chain[0]
             cli = primary.cli
-            model = primary.resolve_model(phase_name)
-            backup_clis = [e.cli for e in chain[1:]]
-            # Merge chain entries into models_config (chain takes priority)
-            for entry in chain:
+            if phase_clis is not None and phase_model is not None and phase_applies_to_role:
+                model = phase_model
+            else:
+                model = primary.resolve_model(phase_name)
+            backup_clis = [e.cli for e in active_chain[1:]]
+            for entry in active_chain:
                 if entry.phase_models:
                     models_config[entry.cli.value] = dict(entry.phase_models)
+            if model is None and phase_model is not None and phase_applies_to_role:
+                model = phase_model
         else:
             # No valid CLI in role config; fall back to copilot with no model
             cli = AgentCLI.COPILOT
@@ -197,17 +328,17 @@ def setup_agents(
             backup_clis = []
 
         return AgentConfig(
-            name=role_config.get("name", default_name),
+            name=agent_name,
             cli=cli,
             model=model,
-            clis=chain,
+            clis=active_chain,
             backup_clis=backup_clis,
             models_config=models_config,
         )
 
-    agent_manager.register_agent(_build_agent_config(pm_config, "Roger"))
-    agent_manager.register_agent(_build_agent_config(dev_config, "David"))
-    agent_manager.register_agent(_build_agent_config(reviewer_config, "Richard"))
+    agent_manager.register_agent(_build_agent_config(pm_config, "pm", "Roger"))
+    agent_manager.register_agent(_build_agent_config(dev_config, "developer", "David"))
+    agent_manager.register_agent(_build_agent_config(reviewer_config, "reviewer", "Richard"))
 
     return agent_manager
 

--- a/src/cafe/ui/cli_shared.py
+++ b/src/cafe/ui/cli_shared.py
@@ -105,7 +105,14 @@ def _get_github_helpers():
     return get_all_pr_comments, filter_unresolved_comments
 
 
-def check_agent_clis_available(config_manager: ConfigManager) -> List[str]:
+def check_agent_clis_available(
+    config_manager: ConfigManager,
+    *,
+    active_step: Optional[str] = None,
+    active_role: Optional[str] = None,
+    phase_config_local_path: Optional[Path] = None,
+    phase_config_repo_path: Optional[Path] = None,
+) -> List[str]:
     """Check if all configured agent CLIs are installed."""
     try:
         config_dir = getattr(config_manager, "config_dir", None)
@@ -123,12 +130,6 @@ def check_agent_clis_available(config_manager: ConfigManager) -> List[str]:
         val = config_manager.get(f"agents.{role}", {})
         return val if isinstance(val, dict) else {"cli": default_cli}
 
-    role_configs = [
-        _role_config("pm", "copilot"),
-        _role_config("developer", "copilot"),
-        _role_config("reviewer", "copilot"),
-    ]
-
     def _configured_chain(config: dict) -> list[str]:
         chain = [entry.cli.value for entry in normalize_role_config(config)]
         if chain:
@@ -136,19 +137,81 @@ def check_agent_clis_available(config_manager: ConfigManager) -> List[str]:
         cli = config.get("cli")
         return [cli] if isinstance(cli, str) and cli else ["copilot"]
 
-    missing_clis = []
-    for role_config in role_configs:
-        chain = _configured_chain(role_config)
+    def _check_chain(chain: list[str], *, context: Optional[str] = None) -> List[str]:
         available = [cli for cli in chain if shutil.which(cli) is not None]
         if available:
             missing_in_chain = [cli for cli in chain if cli not in available]
             if missing_in_chain:
-                console.print(
-                    "[yellow]Warning:[/yellow] Some configured fallback CLIs are not installed: "
-                    + ", ".join(dict.fromkeys(missing_in_chain))
-                )
-            continue
+                warning = "[yellow]Warning:[/yellow] Some configured fallback CLIs are not installed: "
+                if context is not None:
+                    warning = f"[yellow]Warning:[/yellow] Some configured CLIs are not installed ({context}): "
+                console.print(warning + ", ".join(dict.fromkeys(missing_in_chain)))
+            return []
+
+        missing_clis = []
         for cli in chain:
+            if cli not in missing_clis:
+                missing_clis.append(cli)
+        return missing_clis
+
+    def _resolve_phase_config_paths() -> tuple[Optional[Path], Optional[Path]]:
+        if phase_config_local_path is not None or phase_config_repo_path is not None:
+            return phase_config_local_path, phase_config_repo_path
+        try:
+            repo_root = get_repo_root()
+            worktree_root = get_git_toplevel()
+            return worktree_root / ".cafe" / "phases.yaml", repo_root / ".cafe" / "phases.yaml"
+        except Exception:
+            if isinstance(config_dir, (str, Path)):
+                return Path(config_dir) / "phases.yaml", None
+        return None, None
+
+    if active_step is not None and active_step not in {"user", "done"}:
+        local_path, repo_path = _resolve_phase_config_paths()
+        phase_resolution = load_phase_step_model(
+            step_name=active_step,
+            local_path=local_path,
+            repo_path=repo_path,
+        )
+        if phase_resolution.clis:
+            source_paths = {
+                "worktree": local_path.as_posix() if local_path is not None else None,
+                "repo": repo_path.as_posix() if repo_path is not None else None,
+            }
+            phase_config_file = (
+                source_paths.get(phase_resolution.clis_source or "")
+                or phase_resolution.clis_source
+                or phase_resolution.source
+                or "phase-config"
+            )
+            return _check_chain(
+                [cli for cli, _model in phase_resolution.clis],
+                context=f"file={phase_config_file} step={active_step} field=clis",
+            )
+
+        target_role = active_role or phase_resolution.role or {
+            "spec": "pm",
+            "plan": "developer",
+            "develop": "developer",
+            "review": "reviewer",
+            "pr": "developer",
+        }.get(active_step)
+        if target_role:
+            return _check_chain(
+                _configured_chain(_role_config(target_role, "copilot")),
+                context=f"step={active_step} field=clis",
+            )
+
+    role_configs = [
+        _role_config("pm", "copilot"),
+        _role_config("developer", "copilot"),
+        _role_config("reviewer", "copilot"),
+    ]
+
+    missing_clis = []
+    for role_config in role_configs:
+        chain = _configured_chain(role_config)
+        for cli in _check_chain(chain):
             if cli not in missing_clis:
                 missing_clis.append(cli)
 

--- a/src/cafe/ui/commands/workflow.py
+++ b/src/cafe/ui/commands/workflow.py
@@ -710,6 +710,19 @@ def workflow(
             console.print(f"[dim]Executing[/dim] step={step_name} iteration={iteration:03d}")
             if dry_run:
                 return dry_executor(step_name, step_def, blackboard_state, extra_prompt=extra_prompt)
+            step_role = step_def.get("role") if isinstance(step_def, dict) else None
+            missing_clis = _check_agent_clis_available(
+                config_manager,
+                active_step=step_name,
+                active_role=step_role if isinstance(step_role, str) else None,
+            )
+            if missing_clis:
+                console.print(
+                    f"[red]Error: No executable CLI candidates for step={step_name} field=clis[/red]"
+                )
+                for cli in missing_clis:
+                    console.print(f"  [red]✗[/red] {cli}")
+                raise typer.Exit(1)
             step_executor = _executor_holder["executor"]
             assert step_executor is not None
             try:

--- a/src/cafe/ui/commands/workflow.py
+++ b/src/cafe/ui/commands/workflow.py
@@ -764,10 +764,17 @@ def workflow(
                     active_step=active_step,
                 )
             if not dry_run and active_step in {"user", "done"}:
-                incomplete_step = _find_incomplete_workflow_step(
-                    issue_dir=issue_dir,
-                    playbook_data=playbook_data,
+                handoff_contract = getattr(blackboard, "handoff_contract", None)
+                waiting_for_alignment = (
+                    handoff_contract is not None
+                    and handoff_contract.intent == HandoffIntent.ALIGNMENT_CHECKPOINT
                 )
+                incomplete_step = None
+                if not waiting_for_alignment:
+                    incomplete_step = _find_incomplete_workflow_step(
+                        issue_dir=issue_dir,
+                        playbook_data=playbook_data,
+                    )
                 if incomplete_step is not None:
                     pending_start_step = incomplete_step
                     store = BlackboardStore(issue_dir)
@@ -784,11 +791,13 @@ def workflow(
                         f"[yellow]Resuming unfinished iteration[/yellow] step={incomplete_step}"
                     )
                     continue
-                external_step = _find_external_resume_step(
-                    issue_dir=issue_dir,
-                    playbook_data=playbook_data,
-                    git_ops=git,
-                )
+                external_step = None
+                if not waiting_for_alignment:
+                    external_step = _find_external_resume_step(
+                        issue_dir=issue_dir,
+                        playbook_data=playbook_data,
+                        git_ops=git,
+                    )
                 if external_step is not None:
                     pending_start_step = external_step
                     store = BlackboardStore(issue_dir)

--- a/src/cafe/utils/phase_config.py
+++ b/src/cafe/utils/phase_config.py
@@ -1,0 +1,280 @@
+"""Utilities for loading and validating phase-level execution config."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping, Optional
+
+import yaml
+
+
+SOURCE_WORKTREE = "worktree"
+SOURCE_REPO = "repo"
+
+SUPPORTED_CLI_VALUES = {"claude", "gemini", "cursor-agent", "codex", "copilot"}
+
+
+@dataclass(frozen=True)
+class PhaseStepModelResolution:
+    """Resolved phase config fields for one workflow step."""
+
+    name: Optional[str]
+    role: Optional[str]
+    clis: tuple[tuple[str, Optional[str]], ...]
+    model: Optional[str]
+    source: Optional[str]
+    chain: tuple[str, ...]
+
+
+def _as_stripped_scalar(value: object, *, field: str, step: str, source: str) -> Optional[str]:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError(
+            f"invalid phase config for step '{step}' in '{source}': field='{field}': expected non-empty string"
+        )
+
+    model_value = value.strip()
+    if not model_value:
+        raise ValueError(
+            f"invalid phase config for step '{step}' in '{source}': field='{field}': expected non-empty string"
+        )
+    return model_value
+
+
+def _load_yaml_file(path: Path) -> Mapping:
+    """Load YAML from `path` and validate top-level mapping shape."""
+    try:
+        payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except Exception as exc:  # pragma: no cover - defensive parse guard
+        raise ValueError(f"invalid phase config in '{path}': failed to parse YAML: {exc}") from exc
+
+    if payload is None:
+        return {}
+    if not isinstance(payload, Mapping):
+        raise ValueError(f"invalid phase config in '{path}': expected top-level mapping")
+    return payload
+
+
+def _validate_phase_doc(payload: Mapping, source: str) -> None:
+    """Validate the whole YAML document, including inactive step keys."""
+    for step_key, step_config in payload.items():
+        if not isinstance(step_key, str):
+            raise ValueError(f"invalid phase config in '{source}': top-level keys must be strings")
+        step_name = step_key.strip()
+        if not step_name:
+            raise ValueError(f"invalid phase config in '{source}': field='step': step name cannot be empty")
+
+        if not isinstance(step_config, Mapping):
+            raise ValueError(
+                f"invalid phase config for step '{step_name}' in '{source}': expected mapping"
+            )
+
+        if not step_config:
+            continue
+
+        invalid_fields = set(step_config.keys()) - {"name", "role", "clis"}
+        if invalid_fields:
+            field = next(iter(sorted(invalid_fields)))
+            raise ValueError(
+                f"invalid phase config for step '{step_name}' in '{source}': field='{step_name}.{field}': unknown field"
+            )
+
+        raw_name = step_config.get("name")
+        if raw_name is not None:
+            _as_stripped_scalar(raw_name, field=f"{step_name}.name", step=step_name, source=source)
+
+        raw_role = step_config.get("role")
+        if raw_role is not None:
+            _as_stripped_scalar(raw_role, field=f"{step_name}.role", step=step_name, source=source)
+
+        clis = step_config.get("clis")
+        if clis is not None:
+            if not isinstance(clis, list):
+                raise ValueError(
+                    f"invalid phase config for step '{step_name}' in '{source}': field='{step_name}.clis': expected non-empty list"
+                )
+            if not clis:
+                raise ValueError(
+                    f"invalid phase config for step '{step_name}' in '{source}': field='{step_name}.clis': expected non-empty list"
+                )
+
+            seen: set[str] = set()
+            for index, entry in enumerate(clis):
+                if not isinstance(entry, Mapping):
+                    raise ValueError(
+                        f"invalid phase config for step '{step_name}' in '{source}': field='{step_name}.clis[{index}]': expected map"
+                    )
+                unknown = set(entry.keys()) - {"cli", "model"}
+                if unknown:
+                    extra = next(iter(sorted(unknown)))
+                    raise ValueError(
+                        f"invalid phase config for step '{step_name}' in '{source}': field='{step_name}.clis[{index}].{extra}': unknown key '{extra}'"
+                    )
+
+                cli = _as_stripped_scalar(
+                    entry.get("cli"),
+                    field=f"{step_name}.clis[{index}].cli",
+                    step=step_name,
+                    source=source,
+                )
+                if cli is None:
+                    raise ValueError(
+                        f"invalid phase config for step '{step_name}' in '{source}': field='{step_name}.clis[{index}].cli': expected non-empty string"
+                    )
+                if cli not in SUPPORTED_CLI_VALUES:
+                    raise ValueError(
+                        f"invalid phase config for step '{step_name}' in '{source}': field='{step_name}.clis[{index}].cli': unsupported cli '{cli}'"
+                    )
+                if cli in seen:
+                    raise ValueError(
+                        f"invalid phase config for step '{step_name}' in '{source}': field='{step_name}.clis': duplicate cli '{cli}'"
+                    )
+                seen.add(cli)
+
+                _as_stripped_scalar(
+                    entry.get("model"),
+                    field=f"{step_name}.clis[{index}].model",
+                    step=step_name,
+                    source=source,
+                )
+
+
+def _resolved_step_payload(
+    *,
+    payload: Mapping,
+    step_name: str,
+    source: str,
+) -> tuple[Optional[str], Optional[str], Optional[tuple[tuple[str, Optional[str]], ...]], Optional[str]]:
+    if not step_name:
+        return None, None, None, None
+
+    step_config = payload.get(step_name)
+    if not isinstance(step_config, Mapping):
+        return None, None, None, None
+
+    name = _as_stripped_scalar(
+        step_config.get("name"),
+        field=f"{step_name}.name",
+        step=step_name,
+        source=source,
+    )
+    role = _as_stripped_scalar(
+        step_config.get("role"),
+        field=f"{step_name}.role",
+        step=step_name,
+        source=source,
+    )
+
+    clis = None
+    raw_clis = step_config.get("clis")
+    if raw_clis:
+        parsed: list[tuple[str, Optional[str]]] = []
+        for index, entry in enumerate(raw_clis):
+            if not isinstance(entry, Mapping):
+                raise ValueError(
+                    f"invalid phase config for step '{step_name}' in '{source}': field='{step_name}.clis[{index}]': expected map"
+                )
+            cli = _as_stripped_scalar(
+                entry.get("cli"),
+                field=f"{step_name}.clis[{index}].cli",
+                step=step_name,
+                source=source,
+            )
+            if cli is None:
+                raise ValueError(
+                    f"invalid phase config for step '{step_name}' in '{source}': field='{step_name}.clis[{index}].cli': expected non-empty string"
+                )
+            model = _as_stripped_scalar(
+                entry.get("model"),
+                field=f"{step_name}.clis[{index}].model",
+                step=step_name,
+                source=source,
+            )
+            parsed.append((cli, model))
+        clis = tuple(parsed)
+
+    return name, role, clis, model_from_cli_clis(clis)
+
+
+def model_from_cli_clis(clis: Optional[tuple[tuple[str, Optional[str]], ...]]) -> Optional[str]:
+    if not clis:
+        return None
+    return clis[0][1]
+
+
+def load_phase_step_model(
+    *,
+    step_name: str,
+    local_path: Optional[Path],
+    repo_path: Optional[Path] = None,
+    worktree_path: Optional[Path] = None,
+) -> PhaseStepModelResolution:
+    """Resolve model + metadata across phase config source chain.
+
+    Resolution order (high -> low):
+    1. local worktree override (`local_path`)
+    2. repo fallback (`repo_path`)
+    """
+    if not isinstance(step_name, str) or not step_name.strip():
+        raise ValueError("invalid phase config step_name: expected non-empty string")
+
+    active_step = step_name.strip()
+    chain: list[str] = []
+    payloads: dict[str, Mapping] = {}
+
+    for source_label, path in (
+        (SOURCE_WORKTREE, local_path),
+        (SOURCE_REPO, repo_path),
+    ):
+        if path is None or not path.exists():
+            continue
+
+        payload = _load_yaml_file(path)
+        _validate_phase_doc(payload, source=path.as_posix())
+        chain.append(source_label)
+        payloads[source_label] = payload
+
+    # Backward-compatible legacy local fallback is intentionally not in the active
+    # precedence chain; old behavior is not authoritative in the new contract.
+    if not chain and worktree_path is not None and worktree_path.exists():
+        payload = _load_yaml_file(worktree_path)
+        _validate_phase_doc(payload, source=worktree_path.as_posix())
+        chain.append("legacy")
+        payloads["legacy"] = payload
+
+    resolved_name: Optional[str] = None
+    resolved_role: Optional[str] = None
+    resolved_clis: Optional[tuple[tuple[str, Optional[str]], ...]] = None
+    resolved_model: Optional[str] = None
+    resolved_source: Optional[str] = None
+
+    for source_label in chain:
+        payload = payloads[source_label]
+        name, role, clis, model = _resolved_step_payload(
+            payload=payload,
+            step_name=active_step,
+            source=source_label,
+        )
+        if resolved_name is None and name is not None:
+            resolved_name = name
+            resolved_source = source_label
+        if resolved_role is None and role is not None:
+            resolved_role = role
+            if resolved_source is None:
+                resolved_source = source_label
+        if resolved_clis is None and clis is not None:
+            resolved_clis = clis
+            resolved_model = model
+            if resolved_source is None:
+                resolved_source = source_label
+
+    return PhaseStepModelResolution(
+        name=resolved_name,
+        role=resolved_role,
+        clis=resolved_clis or (),
+        model=resolved_model,
+        source=resolved_source,
+        chain=tuple(chain),
+    )

--- a/src/cafe/utils/phase_config.py
+++ b/src/cafe/utils/phase_config.py
@@ -25,6 +25,9 @@ class PhaseStepModelResolution:
     model: Optional[str]
     source: Optional[str]
     chain: tuple[str, ...]
+    name_source: Optional[str] = None
+    role_source: Optional[str] = None
+    clis_source: Optional[str] = None
 
 
 def _as_stripped_scalar(value: object, *, field: str, step: str, source: str) -> Optional[str]:
@@ -43,17 +46,33 @@ def _as_stripped_scalar(value: object, *, field: str, step: str, source: str) ->
     return model_value
 
 
+def _validation_error(source: str, *, step: str, field: str, detail: str) -> ValueError:
+    return ValueError(
+        f"invalid phase config in '{source}': step='{step}': field='{field}': {detail}"
+    )
+
+
 def _load_yaml_file(path: Path) -> Mapping:
     """Load YAML from `path` and validate top-level mapping shape."""
     try:
         payload = yaml.safe_load(path.read_text(encoding="utf-8"))
     except Exception as exc:  # pragma: no cover - defensive parse guard
-        raise ValueError(f"invalid phase config in '{path}': failed to parse YAML: {exc}") from exc
+        raise _validation_error(
+            path.as_posix(),
+            step="unknown",
+            field="document",
+            detail=f"failed to parse YAML: {exc}",
+        ) from exc
 
     if payload is None:
         return {}
     if not isinstance(payload, Mapping):
-        raise ValueError(f"invalid phase config in '{path}': expected top-level mapping")
+        raise _validation_error(
+            path.as_posix(),
+            step="unknown",
+            field="root",
+            detail="expected top-level mapping",
+        )
     return payload
 
 
@@ -61,14 +80,24 @@ def _validate_phase_doc(payload: Mapping, source: str) -> None:
     """Validate the whole YAML document, including inactive step keys."""
     for step_key, step_config in payload.items():
         if not isinstance(step_key, str):
-            raise ValueError(f"invalid phase config in '{source}': top-level keys must be strings")
+            raise _validation_error(
+                source,
+                step="unknown",
+                field="step",
+                detail="top-level keys must be strings",
+            )
         step_name = step_key.strip()
         if not step_name:
-            raise ValueError(f"invalid phase config in '{source}': field='step': step name cannot be empty")
+            raise _validation_error(
+                source,
+                step="unknown",
+                field="step",
+                detail="step name cannot be empty",
+            )
 
         if not isinstance(step_config, Mapping):
             raise ValueError(
-                f"invalid phase config for step '{step_name}' in '{source}': expected mapping"
+                f"invalid phase config for step '{step_name}' in '{source}': field='{step_name}': expected mapping"
             )
 
         if not step_config:
@@ -249,6 +278,9 @@ def load_phase_step_model(
     resolved_clis: Optional[tuple[tuple[str, Optional[str]], ...]] = None
     resolved_model: Optional[str] = None
     resolved_source: Optional[str] = None
+    resolved_name_source: Optional[str] = None
+    resolved_role_source: Optional[str] = None
+    resolved_clis_source: Optional[str] = None
 
     for source_label in chain:
         payload = payloads[source_label]
@@ -259,14 +291,17 @@ def load_phase_step_model(
         )
         if resolved_name is None and name is not None:
             resolved_name = name
+            resolved_name_source = source_label
             resolved_source = source_label
         if resolved_role is None and role is not None:
             resolved_role = role
+            resolved_role_source = source_label
             if resolved_source is None:
                 resolved_source = source_label
         if resolved_clis is None and clis is not None:
             resolved_clis = clis
             resolved_model = model
+            resolved_clis_source = source_label
             if resolved_source is None:
                 resolved_source = source_label
 
@@ -277,4 +312,7 @@ def load_phase_step_model(
         model=resolved_model,
         source=resolved_source,
         chain=tuple(chain),
+        name_source=resolved_name_source,
+        role_source=resolved_role_source,
+        clis_source=resolved_clis_source,
     )

--- a/tests/integration/test_gemini_session_integration.py
+++ b/tests/integration/test_gemini_session_integration.py
@@ -90,7 +90,9 @@ class TestGeminiSessionIntegration:
             mock_process_1.wait.return_value = 0
             mock_popen.return_value = mock_process_1
 
-            response1, _, _, _, _, _ = agent_manager.execute("PM_Agent", "First prompt")
+            response1, _, _, _, _, _ = agent_manager.execute(
+                "PM_Agent", "First prompt", phase_name="spec"
+            )
             assert response1 == "First response"
 
             # Verify session_id was saved
@@ -109,7 +111,9 @@ class TestGeminiSessionIntegration:
             mock_process_2.wait.return_value = 0
             mock_popen.return_value = mock_process_2
 
-            response2, _, _, _, _, _ = agent_manager.execute("PM_Agent", "What did I say?")
+            response2, _, _, _, _, _ = agent_manager.execute(
+                "PM_Agent", "What did I say?", phase_name="spec"
+            )
             assert "First prompt" in response2 or "You said" in response2
 
             # Verify second call included --resume parameter
@@ -167,12 +171,14 @@ class TestGeminiSessionIntegration:
 
         with patch("subprocess.Popen", side_effect=first_run_side_effect), \
              patch("sys.platform", "win32"):
-            response1, _, _, _, _, _ = agent_manager.execute("PM_Agent", "First prompt")
+            response1, _, _, _, _, _ = agent_manager.execute(
+                "PM_Agent", "First prompt", phase_name="spec"
+            )
 
         assert response1 == "Fallback response"
 
         (issue_dir / "active_clis.json").write_text(
-            '{"PM_Agent": {"cli": "gemini", "model": "gemini-pro", "updated_at": "2026-06-13T00:00:00+08:00"}}',
+            '{"PM_Agent": {"cli": "gemini", "model": "gemini-pro", "configured_primary": "claude", "step_name": "spec", "updated_at": "2026-06-13T00:00:00+08:00"}}',
             encoding="utf-8",
         )
 
@@ -191,7 +197,9 @@ class TestGeminiSessionIntegration:
 
         with patch("subprocess.Popen", side_effect=second_run_side_effect), \
              patch("sys.platform", "win32"):
-            response2, _, _, _, _, _ = agent_manager.execute("PM_Agent", "Second prompt")
+            response2, _, _, _, _, _ = agent_manager.execute(
+                "PM_Agent", "Second prompt", phase_name="spec"
+            )
 
         assert response2 == "Second response"
         assert len(second_call_commands) == 1

--- a/tests/integration/test_phase_config_worktree.py
+++ b/tests/integration/test_phase_config_worktree.py
@@ -1,0 +1,70 @@
+from pathlib import Path
+
+import yaml
+
+import pytest
+
+from cafe.utils.phase_config import load_phase_step_model
+
+
+def _write_yaml(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(payload), encoding="utf-8")
+
+
+def test_load_phase_step_model_prefers_worktree_then_repo(tmp_path: Path) -> None:
+    local_phase_config = tmp_path / "worktree" / ".cafe" / "phases.yaml"
+    repo_phase_config = tmp_path / ".cafe" / "phases.yaml"
+
+    _write_yaml(repo_phase_config, {"build": {"name": "RepoName", "clis": [{"cli": "claude", "model": "repo"}]}})
+    _write_yaml(local_phase_config, {"build": {"clis": [{"cli": "gemini", "model": "local-gemini"}]}})
+
+    result = load_phase_step_model(
+        step_name="build",
+        local_path=local_phase_config,
+        repo_path=repo_phase_config,
+    )
+
+    assert result.name == "RepoName"
+    assert result.clis == (("gemini", "local-gemini"),)
+    assert result.model == "local-gemini"
+    assert result.chain == ("worktree", "repo")
+
+
+def test_load_phase_step_model_rejects_invalid_payload_shape(tmp_path: Path) -> None:
+    phase_config = tmp_path / ".cafe" / "phases.yaml"
+    _write_yaml(phase_config, {"build": {"unsupported": "value"}})
+    with pytest.raises(ValueError, match="unknown field"):
+        load_phase_step_model(step_name="build", local_path=phase_config)
+
+
+def test_load_phase_step_model_rejects_duplicate_cli_entries(tmp_path: Path) -> None:
+    phase_config = tmp_path / ".cafe" / "phases.yaml"
+    _write_yaml(
+        phase_config,
+        {"build": {"clis": [{"cli": "claude", "model": "opus"}, {"cli": "claude", "model": "sonnet"}]}},
+    )
+    with pytest.raises(ValueError, match="duplicate cli"):
+        load_phase_step_model(step_name="build", local_path=phase_config)
+
+
+def test_load_phase_step_model_rejects_unknown_cli(tmp_path: Path) -> None:
+    phase_config = tmp_path / ".cafe" / "phases.yaml"
+    _write_yaml(
+        phase_config,
+        {"build": {"clis": [{"cli": "not-a-cli", "model": "bad"}]}},
+    )
+    with pytest.raises(ValueError, match="unsupported cli"):
+        load_phase_step_model(step_name="build", local_path=phase_config)
+
+
+def test_load_phase_step_model_field_by_field_fallback(tmp_path: Path) -> None:
+    local = tmp_path / "worktree" / ".cafe" / "phases.yaml"
+    repo = tmp_path / ".cafe" / "phases.yaml"
+    _write_yaml(local, {"build": {"clis": [{"cli": "codex", "model": "local-codex"}]}})
+    _write_yaml(repo, {"build": {"name": "RepoName", "role": "developer", "clis": [{"cli": "claude", "model": "repo-claude"}]}})
+
+    result = load_phase_step_model(step_name="build", local_path=local, repo_path=repo)
+    assert result.name == "RepoName"
+    assert result.role == "developer"
+    assert result.model == "local-codex"

--- a/tests/unit/test_agent_executor.py
+++ b/tests/unit/test_agent_executor.py
@@ -757,6 +757,126 @@ class TestStreamingExecution:
         assert "Hello" in captured.out
         assert "world" in captured.out
 
+    def test_streaming_stops_when_develop_read_only_budget_is_exhausted(self) -> None:
+        config = AgentConfig(name="David", cli=AgentCLI.CODEX)
+        executor = AgentExecutor(config)
+        mock_process = MagicMock()
+        mock_process.stdout.readline.side_effect = [
+            '{"type":"thread.started","thread_id":"thread-budget"}\n',
+            *[
+                '{"type":"item.completed","item":{"type":"command_execution","command":"rg -n test src"}}\n'
+                for _ in range(3)
+            ],
+            "",
+        ]
+        mock_process.stderr.read.return_value = ""
+        mock_process.wait.return_value = 0
+
+        with patch("subprocess.Popen", return_value=mock_process), patch(
+            "sys.platform", "win32"
+        ):
+            with pytest.raises(AgentExecutionError) as exc_info:
+                executor._execute_with_streaming(
+                    cmd=["codex", "exec", "prompt"],
+                    cli_name="Codex",
+                    parse_stream_json=True,
+                    max_read_only_commands=3,
+                )
+
+        assert exc_info.value.error_type == "read_only_budget_exceeded"
+        assert executor.config.session_id == "thread-budget"
+        mock_process.terminate.assert_called_once()
+
+    def test_streaming_read_only_budget_resets_after_each_file_change(self) -> None:
+        config = AgentConfig(name="David", cli=AgentCLI.CODEX)
+        executor = AgentExecutor(config)
+        mock_process = MagicMock()
+        mock_process.stdout.readline.side_effect = [
+            '{"type":"thread.started","thread_id":"thread-edit"}\n',
+            '{"type":"item.completed","item":{"type":"command_execution","command":"cat plan.md"}}\n',
+            '{"type":"item.completed","item":{"type":"file_change","changes":[{"path":"tests/test_phase.py"}]}}\n',
+            '{"type":"item.completed","item":{"type":"command_execution","command":"rg -n test src"}}\n',
+            '{"type":"item.completed","item":{"type":"file_change","changes":[{"path":"src/cafe/phase.py"}]}}\n',
+            '{"type":"item.completed","item":{"type":"command_execution","command":"git diff --check"}}\n',
+            "",
+        ]
+        mock_process.stderr.read.return_value = ""
+        mock_process.wait.return_value = 0
+
+        with patch("subprocess.Popen", return_value=mock_process), patch(
+            "sys.platform", "win32"
+        ):
+            executor._execute_with_streaming(
+                cmd=["codex", "exec", "prompt"],
+                cli_name="Codex",
+                parse_stream_json=True,
+                max_read_only_commands=2,
+            )
+
+        mock_process.terminate.assert_not_called()
+
+    def test_streaming_stops_after_post_edit_read_only_budget(self) -> None:
+        config = AgentConfig(name="David", cli=AgentCLI.CODEX)
+        executor = AgentExecutor(config)
+        mock_process = MagicMock()
+        mock_process.stdout.readline.side_effect = [
+            '{"type":"thread.started","thread_id":"thread-post-edit"}\n',
+            '{"type":"item.completed","item":{"type":"file_change","changes":[{"path":"tests/test_phase.py"}]}}\n',
+            *[
+                '{"type":"item.completed","item":{"type":"command_execution","command":"rg -n test src"}}\n'
+                for _ in range(2)
+            ],
+            "",
+        ]
+        mock_process.stderr.read.return_value = ""
+        mock_process.wait.return_value = 0
+
+        with patch("subprocess.Popen", return_value=mock_process), patch(
+            "sys.platform", "win32"
+        ):
+            with pytest.raises(AgentExecutionError) as exc_info:
+                executor._execute_with_streaming(
+                    cmd=["codex", "exec", "prompt"],
+                    cli_name="Codex",
+                    parse_stream_json=True,
+                    max_read_only_commands=2,
+                )
+
+        assert exc_info.value.error_type == "read_only_budget_exceeded"
+        mock_process.terminate.assert_called_once()
+
+    def test_streaming_read_only_budget_detects_shell_redirection_edit(self) -> None:
+        config = AgentConfig(name="David", cli=AgentCLI.CODEX)
+        executor = AgentExecutor(config)
+        mock_process = MagicMock()
+        mock_process.stdout.readline.side_effect = [
+            '{"type":"thread.started","thread_id":"thread-shell-edit"}\n',
+            (
+                '{"type":"item.completed","item":{"type":"command_execution",'
+                '"command":"/bin/zsh -lc \\"cat > tests/test_phase.py\\""}}\n'
+            ),
+            *[
+                '{"type":"item.completed","item":{"type":"command_execution","command":"rg -n test src"}}\n'
+                for _ in range(5)
+            ],
+            "",
+        ]
+        mock_process.stderr.read.return_value = ""
+        mock_process.wait.return_value = 0
+
+        with patch("subprocess.Popen", return_value=mock_process), patch(
+            "sys.platform", "win32"
+        ):
+            executor._execute_with_streaming(
+                cmd=["codex", "exec", "prompt"],
+                cli_name="Codex",
+                parse_stream_json=True,
+                max_read_only_commands=10,
+                max_initial_read_only_commands=1,
+            )
+
+        mock_process.terminate.assert_not_called()
+
     def test_execute_with_streaming_handles_error(self) -> None:
         """測試 streaming 執行失敗時拋出錯誤"""
         config = AgentConfig(name="Roger", cli=AgentCLI.CLAUDE)

--- a/tests/unit/test_agent_manager.py
+++ b/tests/unit/test_agent_manager.py
@@ -4,7 +4,7 @@ import pytest
 from unittest.mock import MagicMock, patch
 
 from cafe.agents.manager import AgentManager, AgentNotFoundError
-from cafe.agents.executor import AgentExecutor
+from cafe.agents.executor import AgentExecutionError, AgentExecutor
 from cafe.core.types import AgentConfig, AgentCLI
 from cafe.core.session import SessionManager
 
@@ -190,6 +190,44 @@ class TestAgentExecution:
         with pytest.raises(AgentNotFoundError, match="No current agent selected"):
             manager.execute_current("Test prompt")
 
+    def test_develop_read_only_budget_resumes_once_with_immediate_edit_prompt(self) -> None:
+        from cafe.core.types import AgentResponse, TokenUsage
+
+        manager = AgentManager()
+        manager.register_agent(AgentConfig(name="David", cli=AgentCLI.CODEX))
+        calls = []
+
+        def execute_side_effect(
+            prompt,
+            allowed_tools=None,
+            allowed_directories=None,
+            streaming_output_file=None,
+            max_read_only_commands=None,
+            max_initial_read_only_commands=None,
+        ):
+            calls.append(
+                (prompt, max_read_only_commands, max_initial_read_only_commands)
+            )
+            if len(calls) == 1:
+                raise AgentExecutionError(
+                    "read-only discovery budget exhausted",
+                    error_type="read_only_budget_exceeded",
+                )
+            return AgentResponse(response="done", token_usage=TokenUsage())
+
+        with patch.object(AgentExecutor, "execute", side_effect=execute_side_effect):
+            response, *_ = manager.execute(
+                "David",
+                "original phase prompt",
+                phase_name="develop",
+            )
+
+        assert response == "done"
+        assert calls[0] == ("original phase prompt", 20, None)
+        assert calls[1][1:] == (20, 3)
+        assert "FIRST tool action must be a file edit" in calls[1][0]
+        assert "Do not restart discovery" in calls[1][0]
+
 
 class TestSessionManagement:
     """Test session management through AgentManager."""
@@ -218,6 +256,56 @@ class TestSessionManagement:
 
         assert executor.config.session_id == "existing-session-456"
         session_mgr.load_session.assert_called_once_with("David", AgentCLI.CLAUDE, None)
+
+    def test_execution_config_reuses_only_same_phase_session(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        session_mgr = SessionManager(str(tmp_path / "sessions"))
+        session_mgr.save_session(
+            "David", AgentCLI.CODEX, "plan-session", "issue365", "plan"
+        )
+        session_mgr.save_session(
+            "David", AgentCLI.CODEX, "develop-session", "issue365", "develop"
+        )
+        manager = AgentManager(session_manager=session_mgr, issue_name="issue365")
+        manager.register_agent(AgentConfig(name="David", cli=AgentCLI.CODEX))
+
+        plan_config = manager.get_execution_config("David", phase_name="plan")
+        develop_config = manager.get_execution_config("David", phase_name="develop")
+        review_config = manager.get_execution_config("David", phase_name="review")
+
+        assert plan_config.session_id == "plan-session"
+        assert develop_config.session_id == "develop-session"
+        assert review_config.session_id is None
+
+    def test_execute_persists_session_under_current_phase(self) -> None:
+        from cafe.core.types import AgentResponse, TokenUsage
+
+        session_mgr = MagicMock(spec=SessionManager)
+        session_mgr.load_session.return_value = None
+        manager = AgentManager(session_manager=session_mgr, issue_name="issue365")
+        manager.register_agent(AgentConfig(name="David", cli=AgentCLI.CODEX))
+
+        with patch.object(
+            AgentExecutor,
+            "execute",
+            return_value=AgentResponse(
+                response="done",
+                token_usage=TokenUsage(),
+                cli=AgentCLI.CODEX,
+                session_id="develop-session",
+            ),
+        ):
+            manager.execute("David", "prompt", phase_name="develop")
+
+        session_mgr.save_session.assert_called_once_with(
+            "David",
+            AgentCLI.CODEX,
+            "develop-session",
+            "issue365",
+            "develop",
+        )
 
     def test_session_lazy_creation(self) -> None:
         """Test that session creation is deferred until first execution."""

--- a/tests/unit/test_chat.py
+++ b/tests/unit/test_chat.py
@@ -129,7 +129,19 @@ class TestLaunchChatSession:
         issue_dir.mkdir(parents=True)
         # configured_primary still claude → codex was a legit fallback, stay sticky.
         (issue_dir / "active_clis.json").write_text(
-            json.dumps({"David": {"cli": "codex", "model": "gpt-5.3-codex", "configured_primary": "claude"}}),
+            json.dumps(
+                {
+                    "David": {
+                        "cli": "codex",
+                        "model": "gpt-5.3-codex",
+                        "configured_primary": "claude",
+                        "chain": [
+                            {"cli": "claude", "model": "sonnet"},
+                            {"cli": "codex", "model": "gpt-5.3-codex"},
+                        ],
+                    }
+                }
+            ),
             encoding="utf-8",
         )
 

--- a/tests/unit/test_cli_make.py
+++ b/tests/unit/test_cli_make.py
@@ -65,6 +65,29 @@ class TestCheckAgentCLIsAvailable:
             assert "claude" in missing_clis
             assert "gemini" in missing_clis
 
+    def test_available_fallback_chain_does_not_fail_preflight(self) -> None:
+        """測試 fallback chain 有可用 CLI 時不阻擋 workflow."""
+        config_manager = MagicMock(spec=ConfigManager)
+        config_manager.get.side_effect = lambda key, default: {
+            "agents.pm": {"name": "Roger", "cli": "copilot"},
+            "agents.developer": {
+                "name": "David",
+                "clis": [{"cli": "claude"}, {"cli": "codex"}],
+            },
+            "agents.reviewer": {"name": "Richard", "cli": "copilot"},
+        }.get(key, default)
+
+        from cafe.ui.cli import _check_agent_clis_available
+
+        with patch("shutil.which") as mock_which:
+            mock_which.side_effect = lambda cli: (
+                f"/usr/local/bin/{cli}" if cli in {"copilot", "codex"} else None
+            )
+
+            missing_clis = _check_agent_clis_available(config_manager)
+
+            assert missing_clis == []
+
     def test_reads_correct_config_keys(self) -> None:
         """測試從 `.cafe/config.yaml` 正確讀取所有 agent  CLI 配置."""
         # Setup

--- a/tests/unit/test_cli_make.py
+++ b/tests/unit/test_cli_make.py
@@ -88,6 +88,53 @@ class TestCheckAgentCLIsAvailable:
 
             assert missing_clis == []
 
+    def test_active_step_phase_chain_drives_transition_preflight(self, tmp_path: Path) -> None:
+        """active step 有 explicit phase chain 時，只用該 chain 做 transition preflight."""
+        phase_config = tmp_path / ".cafe" / "phases.yaml"
+        phase_config.parent.mkdir()
+        phase_config.write_text(
+            """
+develop:
+  clis:
+    - cli: claude
+    - cli: codex
+""",
+            encoding="utf-8",
+        )
+
+        config_manager = MagicMock(spec=ConfigManager)
+        config_manager.config_dir = str(phase_config.parent)
+        config_manager.get.side_effect = lambda key, default: {
+            "agents.pm": {"name": "Roger", "cli": "gemini"},
+            "agents.developer": {"name": "David", "cli": "copilot"},
+            "agents.reviewer": {"name": "Richard", "cli": "cursor-agent"},
+        }.get(key, default)
+
+        from cafe.ui.cli import _check_agent_clis_available
+
+        checked_clis: list[str] = []
+
+        def which_side_effect(cli: str) -> str | None:
+            checked_clis.append(cli)
+            return f"/usr/local/bin/{cli}" if cli == "codex" else None
+
+        with (
+            patch("shutil.which", side_effect=which_side_effect),
+            patch("cafe.ui.cli_shared.console.print") as mock_print,
+        ):
+            missing_clis = _check_agent_clis_available(
+                config_manager,
+                active_step="develop",
+                phase_config_local_path=phase_config,
+            )
+
+        assert missing_clis == []
+        assert checked_clis == ["claude", "codex"]
+        warning_text = " ".join(str(call.args[0]) for call in mock_print.call_args_list)
+        assert phase_config.as_posix() in warning_text
+        assert "step=develop" in warning_text
+        assert "field=clis" in warning_text
+
     def test_reads_correct_config_keys(self) -> None:
         """測試從 `.cafe/config.yaml` 正確讀取所有 agent  CLI 配置."""
         # Setup

--- a/tests/unit/test_cli_setup_agents.py
+++ b/tests/unit/test_cli_setup_agents.py
@@ -111,6 +111,48 @@ class TestSetupAgentsPhaseAware:
         agent_manager = _setup_agents(config_manager)
         assert agent_manager.agents["David"].config.model == "claude-3-sonnet-20240229"
 
+    def test_setup_agents_uses_phase_config_model_if_available(
+        self,
+        tmp_path: Path,
+        monkeypatch,
+    ) -> None:
+        """Phase config in `.cafe/phases.yaml` overrides role model during setup."""
+        monkeypatch.chdir(tmp_path)
+        config_file = tmp_path / "config.yaml"
+        config_manager = ConfigManager(str(config_file))
+
+        custom_config = {
+            "agents": {
+                "developer": {
+                    "name": "David",
+                    "cli": "copilot",
+                    "model": "claude-3-sonnet-20240229",
+                },
+                "pm": {"name": "Roger", "cli": "copilot"},
+                "reviewer": {"name": "Richard", "cli": "copilot"},
+            }
+        }
+        config_manager.save_config(custom_config)
+        (tmp_path / ".cafe").mkdir(exist_ok=True)
+        (tmp_path / ".cafe" / "phases.yaml").write_text(
+            """
+spec:
+  clis:
+    - cli: copilot
+      model: claude-3-haiku-20240307
+""",
+            encoding="utf-8",
+        )
+
+        agent_manager = _setup_agents(
+            config_manager,
+            issue_name="issue-365",
+            phase_name="spec",
+            cafe_dir=tmp_path / ".cafe",
+        )
+        assert agent_manager.agents["Roger"].config.model == "claude-3-haiku-20240307"
+        assert agent_manager.agents["David"].config.model == "claude-3-sonnet-20240229"
+
 
 class TestSetupAgentsClisChain:
     """Test that setup_agents populates clis chain via normalize_role_config."""

--- a/tests/unit/test_cli_workflow_command.py
+++ b/tests/unit/test_cli_workflow_command.py
@@ -2635,6 +2635,90 @@ def test_workflow_command_resumes_incomplete_iteration_before_user_phase(
     assert executed_steps == ["spec"]
 
 
+def test_workflow_alignment_decision_precedes_incomplete_iteration_resume(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    executed_steps: list[str] = []
+
+    issue_dir = tmp_path / ".cafe" / "issues" / "issue-align-incomplete"
+    develop_iteration = issue_dir / "develop" / "iteration_002"
+    develop_iteration.mkdir(parents=True, exist_ok=True)
+    (develop_iteration / "iteration.json").write_text(
+        json.dumps(
+            {
+                "iteration": 2,
+                "step_name": "develop",
+                "timestamp": "2026-07-15T11:00:00+08:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (develop_iteration / "alignment_request.json").write_text(
+        json.dumps(
+            {
+                "fingerprint": "fp-incomplete",
+                "from_step": "develop",
+                "recommended_resume_target": "develop",
+                "strategic_document_update_requirements": [],
+                "allowed_decisions": ["approve"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    store = BlackboardStore(issue_dir)
+    blackboard = store.load_or_create("user", playbook_id="default")
+    store.set_current_step(blackboard, "user")
+    store.update_handoff_contract(
+        blackboard,
+        from_step="develop",
+        to_owner=HandoffOwner.USER,
+        to_step="user",
+        intent=HandoffIntent.ALIGNMENT_CHECKPOINT,
+        status_code="alignment_checkpoint",
+        source="test",
+    )
+
+    class FakeExecutor:
+        def execute_step(
+            self, step_name: str, step_def: dict, blackboard_state: object, **kwargs
+        ) -> StepExecutionResult:
+            executed_steps.append(step_name)
+            return _result(
+                status_code="ready_for_review",
+                step_name=step_name,
+                step_def=step_def,
+            )
+
+    with (
+        patch("cafe.ui.cli.GitOperations") as mock_git_cls,
+        patch("cafe.ui.cli._build_workflow_step_executor", return_value=FakeExecutor()),
+        patch("cafe.ui.cli._find_incomplete_workflow_step") as mock_find_incomplete,
+    ):
+        git = MagicMock()
+        git.get_current_branch.return_value = "issue-align-incomplete"
+        mock_git_cls.return_value = git
+
+        result = runner.invoke(
+            app,
+            [
+                "workflow",
+                "--playbook",
+                "default",
+                "--execute",
+                "--single-step",
+                "--user-input",
+                '{"decision":"approve"}',
+            ],
+        )
+
+    assert result.exit_code == 0
+    assert "Alignment decision recorded approve -> develop" in result.stdout
+    assert "Resuming unfinished iteration" not in result.stdout
+    assert executed_steps == ["develop"]
+    mock_find_incomplete.assert_not_called()
+
+
 def test_find_external_resume_step_returns_pr_when_new_pr_comments_exist(tmp_path: Path) -> None:
     issue_dir = tmp_path / ".cafe" / "issues" / "issue-238"
     (issue_dir / "pr").mkdir(parents=True, exist_ok=True)

--- a/tests/unit/test_clis_chain_fallback.py
+++ b/tests/unit/test_clis_chain_fallback.py
@@ -432,8 +432,12 @@ class TestClisChainFallbackBasic:
         manager_issue_1.register_agent(config)
         manager_issue_2.register_agent(config)
 
-        manager_issue_1.session_manager.save_session("David", AgentCLI.GEMINI, "session-issue-1", "issue-1")
-        manager_issue_2.session_manager.save_session("David", AgentCLI.GEMINI, "session-issue-2", "issue-2")
+        manager_issue_1.session_manager.save_session(
+            "David", AgentCLI.GEMINI, "session-issue-1", "issue-1", "develop"
+        )
+        manager_issue_2.session_manager.save_session(
+            "David", AgentCLI.GEMINI, "session-issue-2", "issue-2", "develop"
+        )
 
         issue_1_dir = Path(".cafe/issues/issue-1")
         issue_2_dir = Path(".cafe/issues/issue-2")

--- a/tests/unit/test_clis_chain_fallback.py
+++ b/tests/unit/test_clis_chain_fallback.py
@@ -349,6 +349,82 @@ class TestClisChainFallbackBasic:
         execution = manager.get_execution_config("David", phase_name="build")
         assert execution.cli == AgentCLI.CODEX
 
+    def test_stale_chain_signature_is_ignored(self, tmp_path, monkeypatch) -> None:
+        """A stale chain fingerprint does not promote a non-configured sticky CLI."""
+        monkeypatch.chdir(tmp_path)
+        manager = AgentManager(issue_name="issue-1")
+        manager.register_agent(
+            AgentConfig(
+                name="David",
+                cli=AgentCLI.CODEX,
+                model="gpt-5.5",
+                clis=[
+                    CliEntry(cli=AgentCLI.CODEX, model="gpt-5.5"),
+                    CliEntry(cli=AgentCLI.GEMINI),
+                ],
+            )
+        )
+        active_file = Path(".cafe/issues/issue-1/active_clis.json")
+        active_file.parent.mkdir(parents=True, exist_ok=True)
+        active_file.write_text(
+            json.dumps(
+                {
+                    "David": {
+                        "cli": "gemini",
+                        "model": None,
+                        "configured_primary": "codex",
+                        "chain": ["copilot", "gemini"],
+                        "updated_at": "2026-06-13T00:00:00+08:00",
+                    }
+                },
+            ),
+            encoding="utf-8",
+        )
+
+        execution = manager.get_execution_config("David", phase_name="develop")
+        assert execution.cli == AgentCLI.CODEX
+        assert execution.model == "gpt-5.5"
+
+    def test_chain_signature_includes_models_for_sticky_invalidation(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """A model change in the effective chain resets sticky CLI promotion."""
+        monkeypatch.chdir(tmp_path)
+        manager = AgentManager(issue_name="issue-1")
+        manager.register_agent(
+            AgentConfig(
+                name="David",
+                cli=AgentCLI.CODEX,
+                model="old-codex",
+                clis=[
+                    CliEntry(cli=AgentCLI.CODEX, model="old-codex"),
+                    CliEntry(cli=AgentCLI.GEMINI, model=None),
+                ],
+            )
+        )
+        active_file = Path(".cafe/issues/issue-1/active_clis.json")
+        active_file.parent.mkdir(parents=True, exist_ok=True)
+        active_file.write_text(
+            json.dumps(
+                {
+                    "David": {
+                        "cli": "gemini",
+                        "model": None,
+                        "configured_primary": "codex",
+                        "chain": [
+                            {"cli": "codex", "model": "legacy-codex"},
+                            {"cli": "gemini", "model": None},
+                        ],
+                        "updated_at": "2026-06-13T00:00:00+08:00",
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        execution = manager.get_execution_config("David", phase_name="develop")
+        assert execution.cli == AgentCLI.CODEX
+
     def test_legacy_record_without_configured_primary_does_not_override_primary(self, tmp_path, monkeypatch) -> None:
         """Pre-fix records (no configured_primary) no longer demote the crew primary."""
         monkeypatch.chdir(tmp_path)

--- a/tests/unit/test_generic_phase.py
+++ b/tests/unit/test_generic_phase.py
@@ -60,6 +60,7 @@ def test_build_prompt_includes_files_and_checklist_guard(tmp_path: Path) -> None
         context={
             "who": "team",
             "blackboard_path": ".cafe/issues/demo/blackboard.json",
+            "blackboard_digest": '{"current_step":"plan","recent_events":[]}',
             "handoff_summary": "Implement cafe skill rm with interactive multi-select and confirmation.",
             "next_step_path": ".cafe/issues/demo/next_step.txt",
         },
@@ -86,7 +87,10 @@ def test_build_prompt_includes_files_and_checklist_guard(tmp_path: Path) -> None
     assert "Implement cafe skill rm" in prompt
     assert "verify whether the requested state change has actually happened" in prompt
     assert "do not treat an old artifact or a closed external object as completion" in prompt
-    assert "Blackboard digest:" not in prompt
+    assert "Bounded blackboard digest:" in prompt
+    assert '{"current_step":"plan","recent_events":[]}' in prompt
+    assert "Do not read the full blackboard file" in prompt
+    assert "query only the specific field or event" in prompt
 
 
 def test_build_prompt_uses_baton_wording_when_status_code_not_required(tmp_path: Path) -> None:
@@ -432,6 +436,36 @@ def test_prepare_skill_installs_skill_and_returns_cli_invocation(tmp_path: Path)
 
     assert invocation == "$cafe-plan"
     assert (project_root / ".codex" / "skills" / "cafe-plan" / "SKILL.md").exists()
+
+
+def test_prepare_skill_renders_iteration_context_without_mutating_source(
+    tmp_path: Path,
+) -> None:
+    loader = _setup_loader(tmp_path)
+    source_file = loader.get_skill_dir("cafe-plan") / "SKILL.md"
+    source_before = source_file.read_text(encoding="utf-8")
+    project_root = tmp_path / "project"
+    project_root.mkdir(parents=True, exist_ok=True)
+    phase = GenericPhase(
+        loader,
+        skill_bridge=NativeSkillBridge(
+            loader,
+            project_root=project_root,
+            home_dir=tmp_path / "home",
+        ),
+    )
+
+    phase.prepare_skill(
+        skill_name="cafe-plan",
+        agent_cli=AgentCLI.CODEX,
+        context={"who": "David"},
+    )
+
+    installed_file = project_root / ".codex" / "skills" / "cafe-plan" / "SKILL.md"
+    installed = installed_file.read_text(encoding="utf-8")
+    assert "Hello David" in installed
+    assert "{who}" not in installed
+    assert source_file.read_text(encoding="utf-8") == source_before
 
 
 def test_prepare_skills_installs_shared_and_phase_skills(tmp_path: Path) -> None:

--- a/tests/unit/test_generic_workflow_step.py
+++ b/tests/unit/test_generic_workflow_step.py
@@ -258,6 +258,40 @@ def test_generic_workflow_step_executor_writes_iteration_files(tmp_path: Path, m
     assert reloaded.handoff_contract.source == "workflow.status_transition_adapter"
 
 
+def test_resolve_agent_name_uses_phase_config_name(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".cafe").mkdir(exist_ok=True)
+    (tmp_path / ".cafe" / "phases.yaml").write_text(
+        """
+develop:
+  name: PhaseDavid
+  role: developer
+""",
+        encoding="utf-8",
+    )
+    issue_dir = tmp_path / ".cafe" / "issues" / "issue-1"
+    playbook = {
+        "playbook": {"id": "default"},
+        "roles": {"developer": {"default_agent": "David"}},
+        "steps": {"develop": {"skill": "develop", "role": "developer"}},
+    }
+    executor = GenericWorkflowStepExecutor(
+        issue_dir=issue_dir,
+        issue_name="issue-1",
+        playbook=playbook,
+        generic_phase=_build_loader(tmp_path),
+        agent_manager=FakeAgentManager("await_agent"),
+        git_ops=FakeGitOperations(),
+        role_agent_map={"developer": "David"},
+    )
+
+    with (
+        patch("cafe.phases.generic_workflow_step.get_repo_root", return_value=tmp_path),
+        patch("cafe.phases.generic_workflow_step.get_git_toplevel", return_value=tmp_path),
+    ):
+        assert executor._resolve_agent_name("develop", playbook["steps"]["develop"]) == "PhaseDavid"
+
+
 def test_generic_workflow_step_agent_written_baton_preserved(tmp_path: Path, monkeypatch) -> None:
     """When the agent writes a baton directly, the status-driven write is skipped."""
     monkeypatch.chdir(tmp_path)

--- a/tests/unit/test_generic_workflow_step.py
+++ b/tests/unit/test_generic_workflow_step.py
@@ -875,6 +875,14 @@ def test_generic_workflow_step_prompt_includes_latest_blackboard_handoff(
         state,
         "還要再實作 cafe skill rm，支援批次刪除、interactive 多選與 confirm。",
     )
+    hidden_payload = "SHOULD_NOT_APPEAR_IN_BOUNDED_DIGEST" * 10_000
+    store.log_event(
+        state,
+        "plan",
+        "plan_confirmed",
+        "Plan confirmed; continue to development.",
+        {"full_prompt": hidden_payload},
+    )
     agent_manager = FakeAgentManager("confirmed")
     executor = GenericWorkflowStepExecutor(
         issue_dir=issue_dir,
@@ -892,6 +900,17 @@ def test_generic_workflow_step_prompt_includes_latest_blackboard_handoff(
         "Latest workflow handoff from blackboard:" in prompt for prompt in agent_manager.prompts
     )
     assert any("還要再實作 cafe skill rm" in prompt for prompt in agent_manager.prompts)
+    prompt = agent_manager.prompts[-1]
+    assert "Bounded blackboard digest:" in prompt
+    assert '"event_type": "plan_confirmed"' in prompt
+    assert hidden_payload not in prompt
+    assert len(prompt) < 20_000
+    installed_skill = (
+        tmp_path / ".codex" / "skills" / "cafe-plan" / "SKILL.md"
+    ).read_text(encoding="utf-8")
+    expected_output = "./.cafe/issues/issue-handoff/develop/iteration_001/output.md"
+    assert f"Write plan to: {expected_output}" in installed_skill
+    assert "{output_file}" not in installed_skill
 
 
 def test_generic_workflow_step_prompt_keeps_skill_invocations_only(

--- a/tests/unit/test_phase_config_contract.py
+++ b/tests/unit/test_phase_config_contract.py
@@ -1,0 +1,106 @@
+import pytest
+
+from cafe.utils.phase_config import load_phase_step_model
+from cafe.utils.phase_config import model_from_cli_clis
+
+
+def test_load_phase_step_model_with_direct_root_shape(tmp_path):
+    config = tmp_path / "phases.yaml"
+    config.write_text(
+        """
+build:
+  name: Build step
+  role: developer
+  clis:
+    - cli: claude
+      model: gpt-5
+    - cli: gemini
+""",
+        encoding="utf-8",
+    )
+
+    result = load_phase_step_model(step_name="build", local_path=config)
+
+    assert result.name == "Build step"
+    assert result.role == "developer"
+    assert result.clis == (("claude", "gpt-5"), ("gemini", None))
+    assert result.model == "gpt-5"
+
+
+def test_load_phase_step_model_rejects_unknown_top_level_fields(tmp_path):
+    config = tmp_path / "phases.yaml"
+    config.write_text(
+        """
+build:
+  unknown: invalid
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError):
+        load_phase_step_model(step_name="build", local_path=config)
+
+
+def test_model_from_cli_clis_prefers_first_model_entry():
+    assert model_from_cli_clis((("claude", "opus"), ("gemini", "sonnet"))) == "opus"
+
+
+def test_load_phase_step_model_accepts_empty_phase_entry_as_fallback_only(tmp_path):
+    config = tmp_path / "phases.yaml"
+    config.write_text("build: {}\n", encoding="utf-8")
+
+    result = load_phase_step_model(step_name="build", local_path=config)
+
+    assert result.name is None
+    assert result.role is None
+    assert result.clis == ()
+    assert result.model is None
+
+
+def test_load_phase_step_model_resolves_missing_fields_field_by_field(tmp_path):
+    repo = tmp_path / "repo_phases.yaml"
+    worktree = tmp_path / "worktree_phases.yaml"
+    repo.write_text(
+        """
+build:
+  name: RepoName
+  role: developer
+  clis:
+    - cli: claude
+""",
+        encoding="utf-8",
+    )
+    worktree.write_text(
+        """
+build:
+  clis:
+    - cli: gemini
+      model: gpt-gemini
+""",
+        encoding="utf-8",
+    )
+
+    result = load_phase_step_model(step_name="build", local_path=worktree, repo_path=repo)
+    assert result.name == "RepoName"
+    assert result.role == "developer"
+    assert result.clis == (("gemini", "gpt-gemini"),)
+    assert result.model == "gpt-gemini"
+
+
+def test_phase_config_rejects_non_string_top_level_keys(tmp_path):
+    config_path = tmp_path / "phases.yaml"
+    config_path.write_text(
+        """
+123:
+  clis:
+    - cli: codex
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="top-level keys must be strings"):
+        load_phase_step_model(
+            step_name="123",
+            local_path=config_path,
+            repo_path=None,
+        )

--- a/tests/unit/test_phase_config_contract.py
+++ b/tests/unit/test_phase_config_contract.py
@@ -41,6 +41,32 @@ build:
         load_phase_step_model(step_name="build", local_path=config)
 
 
+def test_phase_config_malformed_yaml_error_has_validation_context(tmp_path):
+    config = tmp_path / "phases.yaml"
+    config.write_text("build:\n  clis:\n    - cli: [codex\n", encoding="utf-8")
+
+    with pytest.raises(ValueError) as exc_info:
+        load_phase_step_model(step_name="build", local_path=config)
+
+    message = str(exc_info.value)
+    assert config.as_posix() in message
+    assert "step='unknown'" in message
+    assert "field='document'" in message
+
+
+def test_phase_config_root_type_error_has_validation_context(tmp_path):
+    config = tmp_path / "phases.yaml"
+    config.write_text("- spec\n", encoding="utf-8")
+
+    with pytest.raises(ValueError) as exc_info:
+        load_phase_step_model(step_name="build", local_path=config)
+
+    message = str(exc_info.value)
+    assert config.as_posix() in message
+    assert "step='unknown'" in message
+    assert "field='root'" in message
+
+
 def test_model_from_cli_clis_prefers_first_model_entry():
     assert model_from_cli_clis((("claude", "opus"), ("gemini", "sonnet"))) == "opus"
 
@@ -98,9 +124,14 @@ def test_phase_config_rejects_non_string_top_level_keys(tmp_path):
         encoding="utf-8",
     )
 
-    with pytest.raises(ValueError, match="top-level keys must be strings"):
+    with pytest.raises(ValueError, match="top-level keys must be strings") as exc_info:
         load_phase_step_model(
             step_name="123",
             local_path=config_path,
             repo_path=None,
         )
+
+    message = str(exc_info.value)
+    assert config_path.as_posix() in message
+    assert "step='unknown'" in message
+    assert "field='step'" in message

--- a/tests/unit/test_phase_config_runtime_mutation.py
+++ b/tests/unit/test_phase_config_runtime_mutation.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+import pytest
+
+from cafe.utils.phase_config import load_phase_step_model
+
+
+def test_load_phase_step_model_reports_step_field_for_invalid_clis(tmp_path: Path) -> None:
+    invalid_yaml = """
+spec:
+  clis:
+    - cli: codex
+      model: gpt
+    - cli: codex
+      model: sonnet
+"""
+    config_path = tmp_path / "phases.yaml"
+    config_path.write_text(invalid_yaml, encoding="utf-8")
+
+    with pytest.raises(ValueError, match=r"field=['\"]spec\.clis"):
+        load_phase_step_model(step_name="spec", local_path=config_path)

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -39,6 +39,22 @@ class TestSessionManager:
         expected_path = Path(".cafe/issues") / "myip" / "sessions" / "David_claude.json"
         assert session_file == expected_path
 
+    def test_get_session_file_with_issue_and_phase_name(self, tmp_path: Path) -> None:
+        """Workflow sessions are isolated by phase within the same issue."""
+        manager = SessionManager(str(tmp_path / "sessions"))
+
+        session_file = manager.get_session_file(
+            "David", AgentCLI.CODEX, "issue365", "develop"
+        )
+
+        expected = (
+            Path(".cafe/issues")
+            / "issue365"
+            / "sessions"
+            / "David_codex_develop.json"
+        )
+        assert session_file == expected
+
     def test_load_session_returns_none_when_file_not_exists(self, tmp_path: Path) -> None:
         """測試當 session 檔案不存在時, load_session 回傳 None"""
         manager = SessionManager(str(tmp_path / "sessions"))
@@ -149,6 +165,30 @@ class TestSessionManager:
         assert issue2_session is not None
         assert issue1_session.session_id == "session-issue1"
         assert issue2_session.session_id == "session-issue2"
+
+    def test_issue_sessions_are_isolated_by_phase(self, tmp_path: Path) -> None:
+        manager = SessionManager(str(tmp_path / "sessions"))
+
+        manager.save_session(
+            "David", AgentCLI.CODEX, "plan-session", "issue365", "plan"
+        )
+        manager.save_session(
+            "David", AgentCLI.CODEX, "develop-session", "issue365", "develop"
+        )
+
+        plan_session = manager.load_session(
+            "David", AgentCLI.CODEX, "issue365", "plan"
+        )
+        develop_session = manager.load_session(
+            "David", AgentCLI.CODEX, "issue365", "develop"
+        )
+
+        assert plan_session is not None
+        assert develop_session is not None
+        assert plan_session.session_id == "plan-session"
+        assert plan_session.phase_name == "plan"
+        assert develop_session.session_id == "develop-session"
+        assert develop_session.phase_name == "develop"
 
     def test_load_session_handles_invalid_json(self, tmp_path: Path) -> None:
         """測試載入無效 JSON 檔案時回傳 None"""

--- a/tests/unit/test_workflow_skill_guardrails.py
+++ b/tests/unit/test_workflow_skill_guardrails.py
@@ -1,0 +1,40 @@
+"""Regression tests for bounded workflow discovery instructions."""
+
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _skill_text(root: Path, name: str) -> str:
+    return (root / name / "SKILL.md").read_text(encoding="utf-8")
+
+
+def test_packaged_workflow_common_uses_bounded_digest() -> None:
+    builtin_root = PROJECT_ROOT / "src" / "cafe" / "data" / "skills"
+    text = _skill_text(builtin_root, "cafe-workflow-common")
+
+    assert "version: 1.3.0" in text
+    assert "Bounded blackboard digest" in text
+    assert "Do **not** read or print the whole file" in text
+    assert "Do not skip the blackboard read" not in text
+
+
+def test_packaged_develop_skill_has_read_only_budget() -> None:
+    builtin_root = PROJECT_ROOT / "src" / "cafe" / "data" / "skills"
+    text = _skill_text(builtin_root, "cafe-develop")
+
+    assert "version: 1.3.0" in text
+    assert "唯讀工具呼叫" in text
+    assert "20 次" in text
+    assert "failing test" in text
+    assert "不得繼續探索" in text
+    assert "任兩次實質修改之間" in text
+    assert "3 次唯讀呼叫內" in text
+
+
+def test_project_skill_mirrors_match_packaged_sources() -> None:
+    builtin_root = PROJECT_ROOT / "src" / "cafe" / "data" / "skills"
+    project_root = PROJECT_ROOT / ".codex" / "skills"
+
+    for name in ("cafe-workflow-common", "cafe-develop"):
+        assert _skill_text(project_root, name) == _skill_text(builtin_root, name)


### PR DESCRIPTION
## Summary
Implements GitHub issue #365's `.cafe/phases.yaml` execution contract for phase-scoped CLI/model configuration, strict validation, worktree fallback, crew compatibility, deterministic runtime fallback, and documentation/test coverage.

## Changes
- Added phase config parsing and resolution for arbitrary step keys with strict `name`, `role`, and `clis` validation, duplicate CLI rejection, and file/step/field error context.
- Resolved phase `name`, `role`, and `clis` independently across worktree, repo-root, crew, playbook defaults, and built-ins while preserving explicit phase chains as authoritative.
- Registered resolved personas against the complete effective CLI chain before workflow execution and constrained `active_clis` replay to the same issue step with an unchanged chain fingerprint.
- Added active-step transition preflight so workflow execution checks the effective phase chain on each non-dry-run step, warns on mixed availability, and fails only when no executable candidate remains.
- Updated README behavior docs and expanded unit/integration coverage for validation context, custom steps, worktree fallback, crew-only compatibility, runtime fallback, preflight, and chain mutation rules.
- Commits included:
  - `40eea03` workflow: complete phase config review fixes
  - `ba192b9` workflow: fix phase config review blockers
  - `2e06971` Merge branch 'develop' into issue365
  - `ab460b5` workflow: default issue setup to worktrees

## Test Plan
- `uv run pytest tests/unit/test_phase_config_contract.py tests/unit/test_cli_make.py::TestCheckAgentCLIsAvailable tests/integration/test_phase_config_worktree.py tests/unit/test_cli_setup_agents.py tests/unit/test_phase_config_runtime_mutation.py tests/unit/test_clis_chain_fallback.py --no-cov -q` (49 passed)
- `uv run pytest --no-cov -q` (2301 passed, 1 skipped, 1 xfailed)
- `git diff --check`