### PR TITLE
Avoid routine alignment checkpoint false positives

### DIFF
--- a/src/cafe/core/alignment.py
+++ b/src/cafe/core/alignment.py
@@ -217,6 +217,71 @@ TRUSTED_CAPABILITY_BOUNDARY_KEYWORDS: tuple[str, ...] = (
     "信任邊界",
 )
 
+_STRATEGIC_CHANGE_ACTION_RE = re.compile(
+    r"""
+    \b(?:
+        chang(?:e|es|ed|ing)
+        |expand(?:s|ed|ing)?
+        |broaden(?:s|ed|ing)?
+        |shift(?:s|ed|ing)?
+        |redefin(?:e|es|ed|ing)
+        |revis(?:e|es|ed|ing)
+        |updat(?:e|es|ed|ing)
+        |modif(?:y|ies|ied|ying)
+        |alter(?:s|ed|ing)?
+        |decid(?:e|es|ed|ing)
+        |clarif(?:y|ies|ied|ying)
+        |defin(?:e|es|ed|ing)
+        |draft(?:s|ed|ing)?
+        |introduc(?:e|es|ed|ing)
+        |add(?:s|ed|ing)?
+        |remov(?:e|es|ed|ing)
+    )\b
+    |改變|變更|擴大|擴張|拓展|重新定義|修訂|更新|修改|調整|決定|釐清|定義|草擬|新增|移除
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+_STRATEGIC_TARGET_RES: tuple[re.Pattern[str], ...] = (
+    re.compile(r"\broadmap(?:\s+scope)?\b", re.IGNORECASE),
+    re.compile(
+        r"\bproduct(?:\s+[\w-]+){0,4}\s+(?:direction|strategy|scope)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\b(?:positioning|governance|principles?|business model|user trust|north star)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(r"路線圖|產品.{0,24}(?:方向|策略|範圍)|定位|治理|原則|商業模式|使用者信任|北極星"),
+)
+
+_NEGATED_ACTION_PREFIX_RE = re.compile(
+    r"""
+    (?:
+        \b(?:do|does|did|will|would|should|must|can)\s+not\s+
+        |\b(?:don't|doesn't|didn't|won't|wouldn't|shouldn't|mustn't|can't)\s+
+        |\bwithout\s+
+        |\bno\s+
+        |\bnot\s+
+        |不(?:會|再|要|應|得|需)?
+        |無需
+        |毋須
+        |避免
+    )$
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+_NON_SCOPE_LINE_MARKERS: tuple[str, ...] = (
+    "out of scope",
+    "non-goal",
+    "non-goals",
+    "範圍外",
+    "非目標",
+    "本次不做",
+    "不包含",
+)
+
 
 def evaluate_alignment_policy(
     input_data: AlignmentPolicyInput,
@@ -246,7 +311,7 @@ def evaluate_alignment_policy(
     for axis_name, axis in strategic_context.axes.items():
         if axis.level != "escalate":
             continue
-        if _matches_keywords(text, AXIS_KEYWORDS.get(axis_name, (axis_name,))):
+        if _matches_axis_escalation(text, axis_name):
             triggered.append(
                 TriggeredRule(
                     f"mandate_escalation:{axis_name}",
@@ -417,6 +482,42 @@ def _matches_keywords(text: str, keywords: Sequence[str]) -> bool:
     return any(keyword.lower() in text for keyword in keywords)
 
 
+def _matches_axis_escalation(text: str, axis_name: str) -> bool:
+    """Return whether the request has actionable impact on an escalated axis.
+
+    Product artifacts routinely mention headings such as "scope" and
+    "principles", including explicit statements that positioning is unchanged.
+    Those mentions are context, not a product-direction decision. Require a
+    non-negated change/decision action near a strategic product target before
+    forcing a product-scope checkpoint.
+    """
+    if axis_name == "product_scope":
+        return _matches_strategic_change_intent(text)
+    return _matches_keywords(text, AXIS_KEYWORDS.get(axis_name, (axis_name,)))
+
+
+def _matches_strategic_change_intent(text: str) -> bool:
+    for action in _STRATEGIC_CHANGE_ACTION_RE.finditer(text):
+        line_start = text.rfind("\n", 0, action.start()) + 1
+        line_end = text.find("\n", action.end())
+        if line_end == -1:
+            line_end = len(text)
+        line = text[line_start:line_end]
+        line_prefix = text[line_start : action.start()].rstrip()
+        nearby_prefix = line_prefix[-32:]
+        if any(marker in line.lower() for marker in _NON_SCOPE_LINE_MARKERS):
+            continue
+        if _NEGATED_ACTION_PREFIX_RE.search(nearby_prefix):
+            continue
+
+        window_start = max(line_start, action.start() - 120)
+        window_end = min(line_end, action.end() + 120)
+        window = text[window_start:window_end]
+        if any(pattern.search(window) for pattern in _STRATEGIC_TARGET_RES):
+            return True
+    return False
+
+
 def _detect_document_categories(text: str) -> list[str]:
     categories: list[str] = []
     for category, keywords in DOCUMENT_KEYWORDS.items():
@@ -461,7 +562,9 @@ def _score_signals(
     strategic_context: StrategicContext,
 ) -> list[TriggeredRule]:
     rules: list[TriggeredRule] = []
-    if _matches_keywords(text, TRUSTED_CAPABILITY_BOUNDARY_KEYWORDS):
+    trusted_boundary = _matches_keywords(text, TRUSTED_CAPABILITY_BOUNDARY_KEYWORDS)
+    strategic_change = _matches_strategic_change_intent(text)
+    if trusted_boundary:
         rules.append(
             TriggeredRule(
                 "trusted_capability_boundary",
@@ -470,21 +573,7 @@ def _score_signals(
                 5,
             )
         )
-    if _matches_keywords(
-        text,
-        (
-            "product",
-            "roadmap",
-            "governance",
-            "positioning",
-            "principles",
-            "產品",
-            "路線圖",
-            "治理",
-            "定位",
-            "原則",
-        ),
-    ):
+    if strategic_change:
         rules.append(
             TriggeredRule(
                 "product_or_governance_impact",
@@ -513,17 +602,18 @@ def _score_signals(
                 "architecture_scope_risk", "Architecture scope risk detected.", "medium", 2
             )
         )
-    for category in affected_categories:
-        doc = strategic_context.document(category)
-        if doc.status in {"missing", "draft"}:
-            rules.append(
-                TriggeredRule(
-                    f"strategic_document_{doc.status}:{category}",
-                    f"Relevant strategic document '{category}' is {doc.status}.",
-                    "medium",
-                    3,
+    if strategic_change or trusted_boundary or _explicit_alignment_requested(text):
+        for category in affected_categories:
+            doc = strategic_context.document(category)
+            if doc.status in {"missing", "draft"}:
+                rules.append(
+                    TriggeredRule(
+                        f"strategic_document_{doc.status}:{category}",
+                        f"Relevant strategic document '{category}' is {doc.status}.",
+                        "medium",
+                        3,
+                    )
                 )
-            )
     return rules
 
 

--- a/tests/unit/test_alignment_policy.py
+++ b/tests/unit/test_alignment_policy.py
@@ -211,6 +211,61 @@ def test_routine_low_risk_work_does_not_pause(tmp_path: Path) -> None:
     assert result.payload is None
 
 
+def test_routine_scope_wording_does_not_trigger_product_alignment(tmp_path: Path) -> None:
+    result = evaluate_alignment_policy(
+        AlignmentPolicyInput(
+            step_name="spec",
+            user_input=(
+                "Implement the remaining operational scope, preserve existing fallback "
+                "behavior, and cover it with regression tests."
+            ),
+        ),
+        strategic_context=_context(tmp_path),
+    )
+
+    assert result.level == AlignmentDecisionLevel.NO_ALIGNMENT
+    assert result.payload is None
+
+
+def test_spec_boilerplate_and_negated_positioning_change_do_not_pause(
+    tmp_path: Path,
+) -> None:
+    result = evaluate_alignment_policy(
+        AlignmentPolicyInput(
+            step_name="spec",
+            user_input=("四項全選：保存安全摘要、同一 CLI 重試一次、保持相容，並加入回歸測試。"),
+            artifacts={
+                "current_output": """
+## 範圍與紅線
+
+- 本次不做產品方向擴張。
+- 不改變產品定位、治理原則或受信任權限邊界。
+
+## Principles 對應
+
+這是既有 workflow reliability 行為的修正。
+"""
+            },
+        ),
+        strategic_context=_context(tmp_path),
+    )
+
+    assert result.level == AlignmentDecisionLevel.NO_ALIGNMENT
+    assert result.payload is None
+
+
+def test_chinese_product_direction_change_still_forces_checkpoint(tmp_path: Path) -> None:
+    result = evaluate_alignment_policy(
+        AlignmentPolicyInput(step_name="spec", user_input="這次需要調整產品方向與路線圖。"),
+        strategic_context=_context(tmp_path),
+    )
+
+    assert result.level == AlignmentDecisionLevel.MUST_ALIGN
+    assert any(
+        rule.rule_id == "mandate_escalation:product_scope" for rule in result.triggered_rules
+    )
+
+
 def test_configured_document_categories_do_not_trigger_by_themselves(tmp_path: Path) -> None:
     result = evaluate_alignment_policy(
         AlignmentPolicyInput(step_name="develop", user_input="Fix a typo in a unit test helper."),


### PR DESCRIPTION
## Summary
- Require actionable, non-negated strategic change intent before `product_scope` escalation
- Prevent routine spec headings and “no positioning change” language from re-triggering checkpoints
- Keep explicit alignment, roadmap direction changes, out-of-mandate work, and trusted capability boundaries gated

## Root cause
Alignment policy treated bare words such as `scope`, `feature`, and `principles` in the current spec output as hard product-scope escalation. Since normal spec artifacts contain those words, clarification resumes could repeatedly pause.

## Validation
- Exact #353 resume input + current spec evaluates to `no_alignment`, score 0
- Relevant unit suite: 154 passed
- Full suite: 2337 passed, 1 skipped, 1 xfailed
- Ruff check/format and `git diff --check` passed