### PR TITLE
Ignore preserved capability boundaries during alignment

### DIFF
--- a/src/cafe/core/alignment.py
+++ b/src/cafe/core/alignment.py
@@ -234,10 +234,11 @@ _STRATEGIC_CHANGE_ACTION_RE = re.compile(
         |defin(?:e|es|ed|ing)
         |draft(?:s|ed|ing)?
         |introduc(?:e|es|ed|ing)
+        |replac(?:e|es|ed|ing)
         |add(?:s|ed|ing)?
         |remov(?:e|es|ed|ing)
     )\b
-    |改變|變更|擴大|擴張|拓展|重新定義|修訂|更新|修改|調整|決定|釐清|定義|草擬|新增|移除
+    |改變|變更|擴大|擴張|拓展|重新定義|修訂|更新|修改|調整|決定|釐清|定義|草擬|導入|替換|取代|新增|移除
     """,
     re.IGNORECASE | re.VERBOSE,
 )
@@ -253,6 +254,11 @@ _STRATEGIC_TARGET_RES: tuple[re.Pattern[str], ...] = (
         re.IGNORECASE,
     ),
     re.compile(r"路線圖|產品.{0,24}(?:方向|策略|範圍)|定位|治理|原則|商業模式|使用者信任|北極星"),
+)
+
+_TRUSTED_CAPABILITY_TARGET_RES: tuple[re.Pattern[str], ...] = tuple(
+    re.compile(re.escape(keyword), re.IGNORECASE)
+    for keyword in TRUSTED_CAPABILITY_BOUNDARY_KEYWORDS
 )
 
 _NEGATED_ACTION_PREFIX_RE = re.compile(
@@ -497,6 +503,18 @@ def _matches_axis_escalation(text: str, axis_name: str) -> bool:
 
 
 def _matches_strategic_change_intent(text: str) -> bool:
+    return _matches_actionable_change_intent(text, _STRATEGIC_TARGET_RES)
+
+
+def _matches_trusted_capability_change_intent(text: str) -> bool:
+    """Return whether trusted host authority or execution boundaries would change."""
+    return _matches_actionable_change_intent(text, _TRUSTED_CAPABILITY_TARGET_RES)
+
+
+def _matches_actionable_change_intent(
+    text: str,
+    target_patterns: Sequence[re.Pattern[str]],
+) -> bool:
     for action in _STRATEGIC_CHANGE_ACTION_RE.finditer(text):
         line_start = text.rfind("\n", 0, action.start()) + 1
         line_end = text.find("\n", action.end())
@@ -513,7 +531,7 @@ def _matches_strategic_change_intent(text: str) -> bool:
         window_start = max(line_start, action.start() - 120)
         window_end = min(line_end, action.end() + 120)
         window = text[window_start:window_end]
-        if any(pattern.search(window) for pattern in _STRATEGIC_TARGET_RES):
+        if any(pattern.search(window) for pattern in target_patterns):
             return True
     return False
 
@@ -562,7 +580,7 @@ def _score_signals(
     strategic_context: StrategicContext,
 ) -> list[TriggeredRule]:
     rules: list[TriggeredRule] = []
-    trusted_boundary = _matches_keywords(text, TRUSTED_CAPABILITY_BOUNDARY_KEYWORDS)
+    trusted_boundary = _matches_trusted_capability_change_intent(text)
     strategic_change = _matches_strategic_change_intent(text)
     if trusted_boundary:
         rules.append(
@@ -627,7 +645,7 @@ def _should_include_configured_documents(
         return True
     if any(rule.risk_level == "high" for rule in triggered_rules):
         return True
-    if _matches_keywords(text, TRUSTED_CAPABILITY_BOUNDARY_KEYWORDS):
+    if _matches_trusted_capability_change_intent(text):
         return True
     return _matches_keywords(
         text,

--- a/tests/unit/test_alignment_policy.py
+++ b/tests/unit/test_alignment_policy.py
@@ -254,6 +254,34 @@ def test_spec_boilerplate_and_negated_positioning_change_do_not_pause(
     assert result.payload is None
 
 
+def test_plan_confirmation_and_preserved_trust_boundary_do_not_pause(
+    tmp_path: Path,
+) -> None:
+    result = evaluate_alignment_policy(
+        AlignmentPolicyInput(
+            step_name="plan",
+            user_input=(
+                "計畫已確認。此計畫符合既有 roadmap 與產品定位；"
+                "依已授權的 driver confirmation 繼續進入 develop。"
+            ),
+            artifacts={
+                "current_output": """
+這符合 roadmap 的 repo-first 與可復原 execution state，
+並且不擴張 trusted host capability boundary。
+""",
+                "spec": """
+- 不新增外部系統操作、權限或可信任能力。
+- 不改變人員判斷、外部操作或受信任權限邊界。
+""",
+            },
+        ),
+        strategic_context=_context(tmp_path),
+    )
+
+    assert result.level == AlignmentDecisionLevel.NO_ALIGNMENT
+    assert result.payload is None
+
+
 def test_chinese_product_direction_change_still_forces_checkpoint(tmp_path: Path) -> None:
     result = evaluate_alignment_policy(
         AlignmentPolicyInput(step_name="spec", user_input="這次需要調整產品方向與路線圖。"),
@@ -377,7 +405,7 @@ def test_trusted_capability_uses_mapped_roadmap_docs_without_missing_false_posit
     assert docs["positioning"].status == "missing"
 
 
-def test_confirmed_strategy_signal_does_not_force_document_update_requirement(
+def test_confirmed_capability_boundary_scope_does_not_pause(
     tmp_path: Path,
 ) -> None:
     spec_text = """
@@ -407,12 +435,8 @@ def test_confirmed_strategy_signal_does_not_force_document_update_requirement(
         ),
     )
 
-    assert result.level == AlignmentDecisionLevel.MUST_ALIGN
-    rule_ids = {rule.rule_id for rule in result.triggered_rules}
-    assert "trusted_capability_boundary" in rule_ids
-    assert "strategic_document_update_required" not in rule_ids
-    assert result.payload is not None
-    assert result.payload.strategic_document_update_requirements == ()
+    assert result.level == AlignmentDecisionLevel.ALIGNMENT_NOTE
+    assert not any(rule.rule_id == "trusted_capability_boundary" for rule in result.triggered_rules)
 
 
 def test_medium_risk_records_note_only(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Require an actionable, non-negated change near a trusted capability target before pausing
- Keep true capability-contract replacements and trust-boundary changes gated
- Stop confirmed plans and non-scope statements from re-triggering alignment

## Root cause
The policy treated any mention of a trusted capability boundary as a high-risk change. Normal plans such as “do not expand the trusted host capability boundary” therefore paused again during confirmation.

## Validation
- Exact #353 confirmation + complete plan/spec evaluates to `no_alignment`, score 0
- True capability-contract replacement cases still evaluate to `must_align`
- Full suite: 2338 passed, 1 skipped, 1 xfailed
- Ruff and `git diff --check` passed