### PR TITLE
Issue #353: Persist agent attempt diagnostics and scoped same-CLI retry

### DIFF
--- a/src/cafe/agents/diagnostics.py
+++ b/src/cafe/agents/diagnostics.py
@@ -1,0 +1,60 @@
+"""Safe diagnostics and retry policy for agent execution attempts."""
+
+import re
+from typing import Any, Dict, Union
+
+from cafe.core.types import AgentCLI
+
+ERROR_EXCERPT_LIMIT = 400
+_TRANSIENT_CLI_UNAVAILABLE = re.compile(
+    r"(?:socket\s+)?connection\s+was\s+closed\s+unexpectedly",
+    re.IGNORECASE,
+)
+_BEARER_CREDENTIAL = re.compile(r"\bbearer\s+[^\s,;]+", re.IGNORECASE)
+_KEY_VALUE_CREDENTIAL = re.compile(
+    r"\b(api[_-]?key|token|password|secret|authorization)\s*[:=]\s*[^\s,;]+",
+    re.IGNORECASE,
+)
+_URL_CREDENTIAL = re.compile(r"(https?://)[^\s:/@]+:[^\s@/]+@", re.IGNORECASE)
+
+
+def sanitize_error_excerpt(error: BaseException) -> str:
+    """Return a bounded, single-line error summary safe for durable records."""
+    display_message = getattr(error, "display_message", None)
+    text = display_message if isinstance(display_message, str) and display_message else str(error)
+    text = " ".join(text.split())
+    text = _URL_CREDENTIAL.sub(r"\1<redacted>@", text)
+    text = _BEARER_CREDENTIAL.sub("Bearer <redacted>", text)
+    text = _KEY_VALUE_CREDENTIAL.sub(lambda match: f"{match.group(1)}=<redacted>", text)
+    if not text:
+        text = "Agent execution failed"
+    return text[:ERROR_EXCERPT_LIMIT]
+
+
+def is_transient_same_cli_error(error: BaseException) -> bool:
+    """Return whether an error merits the one permitted same-CLI retry."""
+    if getattr(error, "error_type", None) != "cli_unavailable":
+        return False
+    display_message = getattr(error, "display_message", None)
+    display_text = display_message if isinstance(display_message, str) else ""
+    text = " ".join(part for part in (str(error), display_text) if part)
+    return bool(_TRANSIENT_CLI_UNAVAILABLE.search(text))
+
+
+def build_failed_attempt(
+    *,
+    cli: Union[AgentCLI, str],
+    chain_role: str,
+    attempt: int,
+    error: BaseException,
+) -> Dict[str, Any]:
+    """Build the additive JSON-safe record for one unsuccessful CLI call."""
+    cli_name = cli.value if isinstance(cli, AgentCLI) else str(cli)
+    error_type = getattr(error, "error_type", None) or type(error).__name__
+    return {
+        "cli": cli_name,
+        "chain_role": chain_role,
+        "attempt": attempt,
+        "error_type": error_type,
+        "error_excerpt": sanitize_error_excerpt(error),
+    }

--- a/src/cafe/agents/diagnostics.py
+++ b/src/cafe/agents/diagnostics.py
@@ -10,6 +10,12 @@ _TRANSIENT_CLI_UNAVAILABLE = re.compile(
     r"(?:socket\s+)?connection\s+was\s+closed\s+unexpectedly",
     re.IGNORECASE,
 )
+_GENERIC_CLI_UNAVAILABLE_DISPLAY = re.compile(r"^\S+ CLI unavailable\.$", re.IGNORECASE)
+_NON_TRANSIENT_CLI_UNAVAILABLE = re.compile(
+    r"(?:failed\s+to\s+authenticate|authentication[_\s-]*failed|\b403\b|"
+    r"subscription|organization|org[\s-]*policy|access\s+is\s+disabled)",
+    re.IGNORECASE,
+)
 _BEARER_CREDENTIAL = re.compile(r"\bbearer\s+[^\s,;]+", re.IGNORECASE)
 _KEY_VALUE_CREDENTIAL = re.compile(
     r"\b(api[_-]?key|token|password|secret|authorization)\s*[:=]\s*[^\s,;]+",
@@ -36,8 +42,17 @@ def is_transient_same_cli_error(error: BaseException) -> bool:
     if getattr(error, "error_type", None) != "cli_unavailable":
         return False
     display_message = getattr(error, "display_message", None)
-    text = display_message if isinstance(display_message, str) and display_message else str(error)
-    return bool(_TRANSIENT_CLI_UNAVAILABLE.search(text))
+    if isinstance(display_message, str) and display_message:
+        if _TRANSIENT_CLI_UNAVAILABLE.search(display_message):
+            return True
+        if not _GENERIC_CLI_UNAVAILABLE_DISPLAY.fullmatch(display_message.strip()):
+            return False
+
+    raw_text = str(error)
+    return bool(
+        _TRANSIENT_CLI_UNAVAILABLE.search(raw_text)
+        and not _NON_TRANSIENT_CLI_UNAVAILABLE.search(raw_text)
+    )
 
 
 def build_failed_attempt(

--- a/src/cafe/agents/diagnostics.py
+++ b/src/cafe/agents/diagnostics.py
@@ -12,7 +12,8 @@ _TRANSIENT_CLI_UNAVAILABLE = re.compile(
 )
 _GENERIC_CLI_UNAVAILABLE_DISPLAY = re.compile(r"^\S+ CLI unavailable\.$", re.IGNORECASE)
 _NON_TRANSIENT_CLI_UNAVAILABLE = re.compile(
-    r"(?:failed\s+to\s+authenticate|authentication[_\s-]*failed|\b403\b|"
+    r"(?:failed\s+to\s+authenticate|authentication[_\s-]*failed|"
+    r"use\s+an\s+anthropic\s+api\s+key\s+instead|\b403\b|"
     r"subscription|organization|org[\s-]*policy|access\s+is\s+disabled)",
     re.IGNORECASE,
 )

--- a/src/cafe/agents/diagnostics.py
+++ b/src/cafe/agents/diagnostics.py
@@ -36,8 +36,7 @@ def is_transient_same_cli_error(error: BaseException) -> bool:
     if getattr(error, "error_type", None) != "cli_unavailable":
         return False
     display_message = getattr(error, "display_message", None)
-    display_text = display_message if isinstance(display_message, str) else ""
-    text = " ".join(part for part in (str(error), display_text) if part)
+    text = display_message if isinstance(display_message, str) and display_message else str(error)
     return bool(_TRANSIENT_CLI_UNAVAILABLE.search(text))
 
 

--- a/src/cafe/agents/executor.py
+++ b/src/cafe/agents/executor.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Callable, List, Optional, Tuple
 
 from cafe.agents.cli import AbstractCLI, ClaudeCLI, CodexCLI, CopilotCLI, CursorCLI, GeminiCLI
+from cafe.agents.diagnostics import sanitize_error_excerpt
 from cafe.core.types import AgentCLI, AgentConfig, AgentResponse, PermissionDenial, TokenUsage
 from cafe.utils.git_utils import get_repo_root, to_git_ignore_path, to_relative_path
 
@@ -943,6 +944,27 @@ class AgentExecutor:
             except Exception as e:
                 print(f"⚠️  Failed to open streaming output file: {e}")
 
+        def persist_safe_stream_error(error: AgentExecutionError) -> None:
+            """Replace any streamed error payload with one safe durable record."""
+            nonlocal streaming_file_handle
+            if streaming_file_handle is None:
+                return
+            try:
+                safe_record = {
+                    "type": "error",
+                    "error_type": error.error_type,
+                    "error_excerpt": sanitize_error_excerpt(error),
+                }
+                streaming_file_handle.seek(0)
+                streaming_file_handle.truncate()
+                streaming_file_handle.write(json.dumps(safe_record, ensure_ascii=False) + "\n")
+                streaming_file_handle.flush()
+            except Exception as write_error:
+                print(f"⚠️  Failed to sanitize streaming error output: {write_error}")
+            finally:
+                streaming_file_handle.close()
+                streaming_file_handle = None
+
         try:
             if process.stdout:
                 while True:
@@ -1010,6 +1032,7 @@ class AgentExecutor:
                                         display_message=display_message,
                                     )
                                     err.cli_command_args = cmd[1:]
+                                    persist_safe_stream_error(err)
                                     raise err
 
                             # Check for error field (e.g., "invalid_request" for prompt too long)
@@ -1025,6 +1048,7 @@ class AgentExecutor:
                                 err = AgentExecutionError(f"{cli_name} invalid request: {error_text}")
                                 err.error_type = "invalid_request"
                                 err.cli_command_args = cmd[1:]
+                                persist_safe_stream_error(err)
                                 raise err
 
                             # Extract session_id (from init message for Gemini, or any message for Claude)
@@ -1160,6 +1184,7 @@ class AgentExecutor:
                                     display_message=display_message,
                                 )
                                 err.cli_command_args = cmd[1:]
+                                persist_safe_stream_error(err)
                                 raise err
 
                             # Non-JSON line, just print it
@@ -1257,6 +1282,7 @@ class AgentExecutor:
                 )
                 # Attach actual CLI arguments for Phase to write to iteration history on error
                 err.cli_command_args = cmd[1:]
+                persist_safe_stream_error(err)
                 raise err
 
         # Append stderr to streaming output file (for debugging token usage parsing)

--- a/src/cafe/agents/manager.py
+++ b/src/cafe/agents/manager.py
@@ -6,6 +6,11 @@ import subprocess
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
+from cafe.agents.diagnostics import (
+    build_failed_attempt,
+    is_transient_same_cli_error,
+    sanitize_error_excerpt,
+)
 from cafe.agents.executor import AgentExecutor, AgentExecutionError
 from cafe.core.session import SessionManager
 from cafe.core.types import AgentCLI, AgentConfig, AgentResponse, CliEntry, TokenUsage
@@ -50,6 +55,7 @@ class AgentManager:
         self._last_model: Optional[str] = None  # Track latest model used
         self._last_cli: Optional[AgentCLI] = None
         self._last_session_id: Optional[str] = None
+        self._failed_attempts: List[Dict[str, object]] = []
         self.show_prompt = False  # CLI can set this to True to show prompts
         self._use_mock = os.getenv("CAFE_MOCK_AGENTS", "").lower() in ("true", "1", "yes")
 
@@ -383,6 +389,7 @@ class AgentManager:
             AgentNotFoundError: If agent not found
             AgentExecutionError: If all agents (primary + backups) fail
         """
+        self._failed_attempts = []
         base_executor = self.get_agent(agent_name)
 
         try:
@@ -407,6 +414,8 @@ class AgentManager:
         # Track if we've already retried for session conflict
         retried = False
         read_only_budget_retried = False
+        transient_retry_done = False
+        primary_attempt = 1
         attempt_prompt = prompt
         read_only_command_limit = (
             self.DEVELOP_READ_ONLY_COMMAND_LIMIT if phase_name == "develop" else None
@@ -431,6 +440,12 @@ class AgentManager:
                 )
                 break  # Success, exit loop
             except AgentExecutionError as e:
+                self._record_failed_attempt(
+                    cli=executor.config.cli,
+                    chain_role="primary",
+                    attempt=primary_attempt,
+                    error=e,
+                )
                 # Handle session conflict (only retry once)
                 if (
                     getattr(e, "error_type", None) == "read_only_budget_exceeded"
@@ -442,13 +457,22 @@ class AgentManager:
                     print(
                         "⚠️  Resuming the develop session once with an immediate-edit instruction..."
                     )
+                    primary_attempt += 1
                 elif hasattr(e, 'error_type') and e.error_type == "SESSION_CONFLICT" and not retried:
                     retried = True
                     # Clear session ID to force creation of new session on next execution
                     print(f"⚠️  Session conflict detected, will create new session on retry...")
                     executor.config.session_id = None
+                    primary_attempt += 1
 
                     # Loop will retry (with no session ID, a new one will be created)
+                elif is_transient_same_cli_error(e) and not transient_retry_done:
+                    transient_retry_done = True
+                    primary_attempt += 1
+                    print(
+                        f"⚠️  {executor.config.cli.value} connection closed unexpectedly, "
+                        "retrying once..."
+                    )
                 elif hasattr(e, 'error_type') and e.error_type in self.FALLBACKABLE_ERROR_TYPES:
                     # Try backup agents
                     agent_response = self._try_backup_agents(
@@ -597,7 +621,9 @@ class AgentManager:
 
         # Track tried CLIs to avoid duplicates
         tried_clis = {config.cli}
-        failed_agents: List[str] = [f"{primary_cli_name} ({primary_error})"]
+        failed_agents: List[str] = [
+            f"{primary_cli_name} ({sanitize_error_excerpt(primary_error)})"
+        ]
 
         for entry in fallback_entries:
             if entry.cli in tried_clis:
@@ -621,34 +647,55 @@ class AgentManager:
             )
             backup_executor = AgentExecutor(backup_config)
 
-            try:
-                execute_kwargs = {}
-                if phase_name == "develop":
-                    execute_kwargs["max_read_only_commands"] = (
-                        self.DEVELOP_READ_ONLY_COMMAND_LIMIT
+            backup_attempt = 1
+            transient_retry_done = False
+            while True:
+                try:
+                    execute_kwargs = {}
+                    if phase_name == "develop":
+                        execute_kwargs["max_read_only_commands"] = (
+                            self.DEVELOP_READ_ONLY_COMMAND_LIMIT
+                        )
+                    agent_response = backup_executor.execute(
+                        prompt,
+                        allowed_tools,
+                        allowed_directories,
+                        streaming_output_file,
+                        **execute_kwargs,
                     )
-                agent_response = backup_executor.execute(
-                    prompt,
-                    allowed_tools,
-                    allowed_directories,
-                    streaming_output_file,
-                    **execute_kwargs,
-                )
-                if agent_response.cli is None:
-                    agent_response.cli = entry.cli
-                if agent_response.session_id is None:
-                    agent_response.session_id = backup_executor.config.session_id
-                if agent_response.model is None:
-                    agent_response.model = backup_model
-                print(f"✅ Successfully completed with {entry.cli.value}")
-                return agent_response
-            except AgentExecutionError as backup_error:
-                if hasattr(backup_error, 'error_type') and backup_error.error_type in self.FALLBACKABLE_ERROR_TYPES:
-                    failed_agents.append(f"{entry.cli.value} ({backup_error})")
-                    print(f"❌ {entry.cli.value} failed ({self._fallback_reason(backup_error)}), trying next agent...")
-                    self._print_fallback_error_detail(backup_error)
-                    continue
-                else:
+                    if agent_response.cli is None:
+                        agent_response.cli = entry.cli
+                    if agent_response.session_id is None:
+                        agent_response.session_id = backup_executor.config.session_id
+                    if agent_response.model is None:
+                        agent_response.model = backup_model
+                    print(f"✅ Successfully completed with {entry.cli.value}")
+                    return agent_response
+                except AgentExecutionError as backup_error:
+                    self._record_failed_attempt(
+                        cli=entry.cli,
+                        chain_role="fallback",
+                        attempt=backup_attempt,
+                        error=backup_error,
+                    )
+                    if is_transient_same_cli_error(backup_error) and not transient_retry_done:
+                        transient_retry_done = True
+                        backup_attempt += 1
+                        print(
+                            f"⚠️  {entry.cli.value} connection closed unexpectedly, "
+                            "retrying once..."
+                        )
+                        continue
+                    if (
+                        hasattr(backup_error, 'error_type')
+                        and backup_error.error_type in self.FALLBACKABLE_ERROR_TYPES
+                    ):
+                        failed_agents.append(
+                            f"{entry.cli.value} ({sanitize_error_excerpt(backup_error)})"
+                        )
+                        print(f"❌ {entry.cli.value} failed ({self._fallback_reason(backup_error)}), trying next agent...")
+                        self._print_fallback_error_detail(backup_error)
+                        break
                     raise
 
         # All agents (primary + all fallbacks) failed, compose error message
@@ -657,7 +704,33 @@ class AgentManager:
             f"All agents failed. Tried: {tried_list}. "
             f"Please wait for transient failures to clear or add more backup agents.",
             error_type=getattr(primary_error, "error_type", None) or "agent_unavailable",
+            display_message=(
+                f"All agents failed. Tried: {tried_list}. "
+                "Please wait for transient failures to clear or add more backup agents."
+            ),
         )
+
+    def _record_failed_attempt(
+        self,
+        *,
+        cli: AgentCLI,
+        chain_role: str,
+        attempt: int,
+        error: AgentExecutionError,
+    ) -> None:
+        """Append one safe diagnostic record for the current execute call."""
+        self._failed_attempts.append(
+            build_failed_attempt(
+                cli=cli,
+                chain_role=chain_role,
+                attempt=attempt,
+                error=error,
+            )
+        )
+
+    def get_failed_attempts(self) -> List[Dict[str, object]]:
+        """Return a defensive copy of this execution's failed CLI attempts."""
+        return [dict(attempt) for attempt in self._failed_attempts]
 
     @staticmethod
     def _fallback_reason(error: AgentExecutionError) -> str:

--- a/src/cafe/core/phase.py
+++ b/src/cafe/core/phase.py
@@ -782,6 +782,20 @@ class Phase(PhaseStateMixin, PhaseSandboxMixin, PhaseReviewMixin, PhaseChecklist
 
         # Track model separately (use latest value, don't accumulate)
         model: Optional[str] = None
+        failed_attempts: List[Dict[str, Any]] = []
+
+        def get_failed_attempts() -> List[Dict[str, Any]]:
+            """Read optional manager diagnostics without breaking legacy test doubles."""
+            getter = getattr(self.agent_manager, "get_failed_attempts", None)
+            if not callable(getter):
+                return []
+            try:
+                attempts = getter()
+            except Exception:
+                return []
+            if not isinstance(attempts, list):
+                return []
+            return [dict(attempt) for attempt in attempts if isinstance(attempt, dict)]
 
         try:
             execute_kwargs = {
@@ -804,6 +818,7 @@ class Phase(PhaseStateMixin, PhaseSandboxMixin, PhaseReviewMixin, PhaseChecklist
                 prompt,
                 **execute_kwargs,
             )
+            failed_attempts = get_failed_attempts()
 
             actual_agent_cli = getattr(self.agent_manager, "get_last_cli", lambda: None)()
             if (
@@ -839,7 +854,10 @@ class Phase(PhaseStateMixin, PhaseSandboxMixin, PhaseReviewMixin, PhaseChecklist
             from cafe.agents.executor import AgentExecutionError
             from cafe.core.types import CriticalPhaseError
 
-            display_error = getattr(e, "display_message", None) or str(e)
+            from cafe.agents.diagnostics import sanitize_error_excerpt
+
+            failed_attempts = get_failed_attempts()
+            display_error = sanitize_error_excerpt(e)
             print(f"⚠️  Agent execution failed: {display_error}")
 
             # 4a. Check if it's a critical error - fail immediately without recovery
@@ -862,13 +880,26 @@ class Phase(PhaseStateMixin, PhaseSandboxMixin, PhaseReviewMixin, PhaseChecklist
                         context_data["status_code"] = None
                     else:
                         context_data.pop("status_code", None)
-                    context_data["error"] = str(e)
+                    context_data["error"] = display_error
                     context_data["display_error"] = display_error
                     context_data["error_type"] = e.error_type
                     context_data["is_critical"] = True
+                    if failed_attempts:
+                        context_data["failed_attempts"] = failed_attempts
 
                     with open(context_file, "w", encoding="utf-8") as f:
                         json.dump(context_data, f, ensure_ascii=False, indent=2)
+
+                error_file = iteration_dir / "error.json"
+                error_data = {
+                    "error": display_error,
+                    "error_type": e.error_type,
+                    "is_critical": True,
+                    "timestamp": datetime.now().astimezone().isoformat(),
+                    "failed_attempts": failed_attempts,
+                }
+                with open(error_file, "w", encoding="utf-8") as f:
+                    json.dump(error_data, f, ensure_ascii=False, indent=2)
 
                 # Create a CriticalError wrapper to signal this should stop the workflow
                 raise CriticalPhaseError(
@@ -895,14 +926,15 @@ class Phase(PhaseStateMixin, PhaseSandboxMixin, PhaseReviewMixin, PhaseChecklist
             iteration_dir.mkdir(parents=True, exist_ok=True)
             error_file = iteration_dir / "error.json"
             error_data = {
-                "error": str(e),
-                "error_type": type(e).__name__,
+                "error": display_error,
+                "error_type": getattr(e, "error_type", None) or type(e).__name__,
                 "is_critical": isinstance(e, CriticalPhaseError),
                 "timestamp": datetime.now().astimezone().isoformat(),
                 "written_files": [str(f) for f in written_files],
                 "changed_written_files": [str(f) for f in changed_written_files],
                 "recovered_response": bool(recovered_response),
                 "recovered_status": recovered_status_code.value if recovered_status_code else None,
+                "failed_attempts": failed_attempts,
             }
             with open(error_file, "w", encoding="utf-8") as f:
                 json.dump(error_data, f, ensure_ascii=False, indent=2)
@@ -922,7 +954,9 @@ class Phase(PhaseStateMixin, PhaseSandboxMixin, PhaseReviewMixin, PhaseChecklist
                 phase_specific_data["response"] = response
                 phase_specific_data["permission_denials"] = []
                 phase_specific_data["recovered_from_error"] = True
-                phase_specific_data["original_error"] = str(e)
+                phase_specific_data["original_error"] = display_error
+                if failed_attempts:
+                    phase_specific_data["failed_attempts"] = failed_attempts
 
                 # Update history（Including recovered response and status）
                 # Record actual CLI arguments if possible (if error object has them)
@@ -963,7 +997,9 @@ class Phase(PhaseStateMixin, PhaseSandboxMixin, PhaseReviewMixin, PhaseChecklist
                         history_data["status_code"] = None
                     else:
                         history_data.pop("status_code", None)
-                    history_data["error"] = str(e)
+                    history_data["error"] = display_error
+                    if failed_attempts:
+                        history_data["failed_attempts"] = failed_attempts
 
                     # Record error type (if any)
                     if isinstance(e, AgentExecutionError) and hasattr(e, "error_type"):
@@ -987,12 +1023,15 @@ class Phase(PhaseStateMixin, PhaseSandboxMixin, PhaseReviewMixin, PhaseChecklist
         if no_response_status:
             # Agent returned empty response - save and return NO_RESPONSE
             # Note: streaming.jsonl is already written in real-time by executor
+            history_data = {
+                "response": response,
+                "permission_denials": [denial.model_dump() for denial in permission_denials],
+                "streaming_log": streaming_log,
+            }
+            if failed_attempts:
+                history_data["failed_attempts"] = failed_attempts
             self._update_iteration_history(
-                phase_specific_data={
-                    "response": response,
-                    "permission_denials": [denial.model_dump() for denial in permission_denials],
-                    "streaming_log": streaming_log
-                },
+                phase_specific_data=history_data,
                 prompt=prompt,
                 agent_cli=agent_cli,
                 agent_session_id=agent_session_id,
@@ -1007,12 +1046,15 @@ class Phase(PhaseStateMixin, PhaseSandboxMixin, PhaseReviewMixin, PhaseChecklist
             return response, no_response_status
 
         if not require_status_code:
+            history_data = {
+                "response": response,
+                "permission_denials": [denial.model_dump() for denial in permission_denials],
+                "streaming_log": streaming_log,
+            }
+            if failed_attempts:
+                history_data["failed_attempts"] = failed_attempts
             self._update_iteration_history(
-                phase_specific_data={
-                    "response": response,
-                    "permission_denials": [denial.model_dump() for denial in permission_denials],
-                    "streaming_log": streaming_log,
-                },
+                phase_specific_data=history_data,
                 prompt=prompt,
                 agent_cli=agent_cli,
                 agent_session_id=agent_session_id,
@@ -1067,6 +1109,8 @@ class Phase(PhaseStateMixin, PhaseSandboxMixin, PhaseReviewMixin, PhaseChecklist
             "permission_denials": [denial.model_dump() for denial in permission_denials],
             "streaming_log": streaming_log
         }
+        if failed_attempts:
+            phase_data["failed_attempts"] = failed_attempts
 
         # Note: streaming.jsonl is already written in real-time by executor
         self._update_iteration_history(

--- a/tests/integration/test_agent_attempt_diagnostics.py
+++ b/tests/integration/test_agent_attempt_diagnostics.py
@@ -96,6 +96,14 @@ def _stream_error_process(line: str) -> MagicMock:
     return process
 
 
+def _stream_success_process(text: str) -> MagicMock:
+    process = MagicMock()
+    process.stdout.readline.side_effect = [json.dumps({"content": text}) + "\n", ""]
+    process.stderr.read.return_value = ""
+    process.wait.return_value = 0
+    return process
+
+
 def _success(text: str) -> AgentResponse:
     return AgentResponse(response=text, token_usage=TokenUsage())
 
@@ -205,3 +213,29 @@ def test_real_stream_error_path_redacts_durable_streaming_log(tmp_path: Path) ->
     assert "raw-primary-secret" not in streaming_text
     assert "raw-fallback-secret" not in streaming_text
     assert "error_excerpt" in streaming_text
+
+
+def test_real_stream_socket_close_retries_primary_before_fallback(tmp_path: Path) -> None:
+    """A pure classified disconnect retries Claude instead of consuming Gemini."""
+    executor = _build_executor(tmp_path, _manager())
+    disconnected_process = _stream_error_process(
+        '{"type":"assistant","error":"socket connection was closed unexpectedly",'
+        '"message":{"content":[{"type":"text",'
+        '"text":"socket connection was closed unexpectedly"}]}}\n'
+    )
+    retry_process = _stream_success_process("retry output")
+
+    with patch(
+        "subprocess.Popen",
+        side_effect=[disconnected_process, retry_process],
+    ) as popen, patch("sys.platform", "win32"):
+        _run_iteration(executor)
+
+    iteration_path = executor.phase_dir / "iteration_001" / "iteration.json"
+    record = json.loads(iteration_path.read_text(encoding="utf-8"))
+    assert popen.call_count == 2
+    assert record["response"] == "retry output"
+    assert record["cli"] == "claude"
+    assert [(item["cli"], item["attempt"]) for item in record["failed_attempts"]] == [
+        ("claude", 1),
+    ]

--- a/tests/integration/test_agent_attempt_diagnostics.py
+++ b/tests/integration/test_agent_attempt_diagnostics.py
@@ -87,6 +87,15 @@ def _manager() -> AgentManager:
     return manager
 
 
+def _stream_error_process(line: str) -> MagicMock:
+    process = MagicMock()
+    process.stdout.readline.side_effect = [line, ""]
+    process.stderr.read.return_value = ""
+    process.wait.return_value = 1
+    process.terminate.return_value = None
+    return process
+
+
 def _success(text: str) -> AgentResponse:
     return AgentResponse(response=text, token_usage=TokenUsage())
 
@@ -161,3 +170,38 @@ def test_all_failed_journey_persists_sanitized_history_without_raw_secrets(tmp_p
     )
     assert "raw-primary-secret" not in persisted_text
     assert "raw-fallback-secret" not in persisted_text
+
+
+def test_real_stream_error_path_redacts_durable_streaming_log(tmp_path: Path) -> None:
+    """CLI process error events never leave their raw credentials in streaming.jsonl."""
+    manager = AgentManager()
+    manager.register_agent(
+        AgentConfig(
+            name="David",
+            cli=AgentCLI.CLAUDE,
+            clis=[CliEntry(cli=AgentCLI.CLAUDE), CliEntry(cli=AgentCLI.CODEX)],
+        )
+    )
+    executor = _build_executor(tmp_path, manager)
+    primary_process = _stream_error_process(
+        '{"type":"assistant","error":"Failed to authenticate: HTTP 403; '
+        'socket connection was closed unexpectedly; token=raw-primary-secret",'
+        '"message":{"content":[{"type":"text",'
+        '"text":"Failed to authenticate: HTTP 403; socket connection was closed unexpectedly; '
+        'token=raw-primary-secret"}]}}\n'
+    )
+    fallback_process = _stream_error_process(
+        '{"type":"error","message":"rate limit; token=raw-fallback-secret"}\n'
+    )
+
+    with patch(
+        "subprocess.Popen",
+        side_effect=[primary_process, fallback_process],
+    ), patch("sys.platform", "win32"), pytest.raises(CriticalPhaseError):
+        _run_iteration(executor)
+
+    streaming_path = executor.phase_dir / "iteration_001" / "streaming.jsonl"
+    streaming_text = streaming_path.read_text(encoding="utf-8")
+    assert "raw-primary-secret" not in streaming_text
+    assert "raw-fallback-secret" not in streaming_text
+    assert "error_excerpt" in streaming_text

--- a/tests/integration/test_agent_attempt_diagnostics.py
+++ b/tests/integration/test_agent_attempt_diagnostics.py
@@ -1,0 +1,163 @@
+"""Journey tests for durable CLI-attempt diagnostics."""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cafe.agents.executor import AgentExecutionError
+from cafe.agents.manager import AgentManager
+from cafe.core.types import (
+    AgentCLI,
+    AgentConfig,
+    AgentResponse,
+    CliEntry,
+    CriticalPhaseError,
+    TokenUsage,
+)
+from cafe.phases.generic_phase import GenericPhase
+from cafe.phases.generic_workflow_step import GenericWorkflowStepExecutor
+from cafe.skills.loader import SkillLoader
+from cafe.skills.native_bridge import NativeSkillBridge
+
+
+def _build_loader(tmp_path: Path) -> GenericPhase:
+    skill_root = tmp_path / "builtin" / "skills" / "develop"
+    skill_root.mkdir(parents=True)
+    (skill_root / "SKILL.md").write_text(
+        "---\nname: develop\ndescription: desc\n---\n\nWrite output to: {output_file}\n",
+        encoding="utf-8",
+    )
+    loader = SkillLoader(
+        project_root=tmp_path,
+        global_root=tmp_path / "global",
+        builtin_root=tmp_path / "builtin",
+    )
+    loader.discover()
+    return GenericPhase(
+        loader,
+        skill_bridge=NativeSkillBridge(
+            loader,
+            project_root=tmp_path,
+            home_dir=tmp_path / "home",
+        ),
+    )
+
+
+def _build_executor(tmp_path: Path, manager: AgentManager) -> GenericWorkflowStepExecutor:
+    issue_dir = tmp_path / ".cafe" / "issues" / "attempt-diagnostics"
+    phase_dir = issue_dir / "develop"
+    spec_file = issue_dir / "spec" / "iteration_001" / "output.md"
+    spec_file.parent.mkdir(parents=True, exist_ok=True)
+    spec_file.write_text("# Initial Requirements\n", encoding="utf-8")
+    git_ops = MagicMock()
+    git_ops.get_current_branch.return_value = "attempt-diagnostics"
+    git_ops.get_main_branch.return_value = "main"
+    git_ops.get_default_base_branch.return_value = "main"
+    git_ops.get_commits_between.return_value = ""
+    executor = GenericWorkflowStepExecutor(
+        issue_dir=issue_dir,
+        issue_name="attempt-diagnostics",
+        playbook={
+            "playbook": {"id": "default"},
+            "roles": {"developer": {"default_agent": "David"}},
+            "steps": {"develop": {"skill": "develop", "role": "developer"}},
+        },
+        generic_phase=_build_loader(tmp_path),
+        agent_manager=manager,
+        git_ops=git_ops,
+        role_agent_map={"developer": "David"},
+        interactive=False,
+    )
+    executor.phase_dir = phase_dir
+    executor.iteration = 1
+    return executor
+
+
+def _manager() -> AgentManager:
+    manager = AgentManager()
+    manager.register_agent(
+        AgentConfig(
+            name="David",
+            cli=AgentCLI.CLAUDE,
+            clis=[CliEntry(cli=AgentCLI.CLAUDE), CliEntry(cli=AgentCLI.GEMINI)],
+        )
+    )
+    return manager
+
+
+def _success(text: str) -> AgentResponse:
+    return AgentResponse(response=text, token_usage=TokenUsage())
+
+
+def _run_iteration(executor: GenericWorkflowStepExecutor) -> None:
+    executor._execute_agent_iteration(
+        agent_name="David",
+        prompt="perform the workflow step",
+        user_input="",
+        valid_intents=[],
+        require_status_code=False,
+        allowed_tools=[],
+        phase_specific_data={"step_name": "develop"},
+    )
+
+
+def test_fallback_success_preserves_primary_attempts_in_iteration_record(tmp_path: Path) -> None:
+    """A successful fallback does not erase retried primary failure history."""
+    executor = _build_executor(tmp_path, _manager())
+    transient = AgentExecutionError(
+        "socket connection was closed unexpectedly; token=raw-primary-secret",
+        error_type="cli_unavailable",
+    )
+
+    with patch(
+        "cafe.agents.executor.AgentExecutor.execute",
+        side_effect=[transient, transient, _success("fallback output")],
+    ):
+        _run_iteration(executor)
+
+    iteration_path = executor.phase_dir / "iteration_001" / "iteration.json"
+    record = json.loads(iteration_path.read_text(encoding="utf-8"))
+    assert record["response"] == "fallback output"
+    assert record["cli"] == "gemini"
+    assert [(item["cli"], item["attempt"]) for item in record["failed_attempts"]] == [
+        ("claude", 1),
+        ("claude", 2),
+    ]
+    assert "raw-primary-secret" not in iteration_path.read_text(encoding="utf-8")
+
+
+def test_all_failed_journey_persists_sanitized_history_without_raw_secrets(tmp_path: Path) -> None:
+    """Terminal failures leave a complete, redacted durable attempt history."""
+    executor = _build_executor(tmp_path, _manager())
+    primary_error = AgentExecutionError(
+        "socket connection was closed unexpectedly; bearer raw-primary-secret",
+        error_type="cli_unavailable",
+    )
+    fallback_error = AgentExecutionError(
+        "rate limit; password=raw-fallback-secret",
+        error_type="rate_limit",
+    )
+
+    with patch(
+        "cafe.agents.executor.AgentExecutor.execute",
+        side_effect=[primary_error, primary_error, fallback_error],
+    ), pytest.raises(CriticalPhaseError):
+        _run_iteration(executor)
+
+    iteration_path = executor.phase_dir / "iteration_001" / "iteration.json"
+    error_path = executor.phase_dir / "iteration_001" / "error.json"
+    iteration_record = json.loads(iteration_path.read_text(encoding="utf-8"))
+    assert [(item["cli"], item["attempt"]) for item in iteration_record["failed_attempts"]] == [
+        ("claude", 1),
+        ("claude", 2),
+        ("gemini", 1),
+    ]
+    assert error_path.exists()
+    persisted_text = (
+        iteration_path.read_text(encoding="utf-8")
+        + error_path.read_text(encoding="utf-8")
+    )
+    assert "raw-primary-secret" not in persisted_text
+    assert "raw-fallback-secret" not in persisted_text

--- a/tests/unit/test_agent_diagnostics.py
+++ b/tests/unit/test_agent_diagnostics.py
@@ -1,5 +1,7 @@
 """Tests for safe, durable agent-attempt diagnostics."""
 
+import pytest
+
 from cafe.agents.diagnostics import (
     ERROR_EXCERPT_LIMIT,
     build_failed_attempt,
@@ -84,3 +86,26 @@ def test_generic_unavailable_display_keeps_pure_socket_close_retryable() -> None
     )
 
     assert is_transient_same_cli_error(error)
+
+
+@pytest.mark.parametrize(
+    "unavailable_signal",
+    [
+        "disabled Claude subscription access",
+        "use an Anthropic API key instead",
+        "failed to authenticate",
+        "authentication_failed",
+        "API Error: 403",
+    ],
+)
+def test_generic_unavailable_display_never_retries_account_signals(
+    unavailable_signal: str,
+) -> None:
+    """Account and policy failures remain non-transient despite socket noise."""
+    error = AgentExecutionError(
+        f"{unavailable_signal}; socket connection was closed unexpectedly",
+        error_type="cli_unavailable",
+        display_message="Claude CLI unavailable.",
+    )
+
+    assert not is_transient_same_cli_error(error)

--- a/tests/unit/test_agent_diagnostics.py
+++ b/tests/unit/test_agent_diagnostics.py
@@ -73,3 +73,14 @@ def test_classified_auth_error_is_not_retried_for_raw_socket_text() -> None:
     )
 
     assert not is_transient_same_cli_error(error)
+
+
+def test_generic_unavailable_display_keeps_pure_socket_close_retryable() -> None:
+    """A generic classified unavailable message must not hide a pure disconnect."""
+    error = AgentExecutionError(
+        "socket connection was closed unexpectedly",
+        error_type="cli_unavailable",
+        display_message="Claude CLI unavailable.",
+    )
+
+    assert is_transient_same_cli_error(error)

--- a/tests/unit/test_agent_diagnostics.py
+++ b/tests/unit/test_agent_diagnostics.py
@@ -3,6 +3,7 @@
 from cafe.agents.diagnostics import (
     ERROR_EXCERPT_LIMIT,
     build_failed_attempt,
+    is_transient_same_cli_error,
     sanitize_error_excerpt,
 )
 from cafe.agents.executor import AgentExecutionError
@@ -61,3 +62,14 @@ def test_sanitized_excerpt_handles_empty_and_overlong_error_text() -> None:
     excerpt = sanitize_error_excerpt(AgentExecutionError("x" * (ERROR_EXCERPT_LIMIT + 50)))
 
     assert len(excerpt) == ERROR_EXCERPT_LIMIT
+
+
+def test_classified_auth_error_is_not_retried_for_raw_socket_text() -> None:
+    """Retry policy follows the classified display message over noisy raw stderr."""
+    error = AgentExecutionError(
+        "authentication failed: HTTP 403; socket connection was closed unexpectedly",
+        error_type="cli_unavailable",
+        display_message="Claude authentication failed. Check your credentials.",
+    )
+
+    assert not is_transient_same_cli_error(error)

--- a/tests/unit/test_agent_diagnostics.py
+++ b/tests/unit/test_agent_diagnostics.py
@@ -1,0 +1,63 @@
+"""Tests for safe, durable agent-attempt diagnostics."""
+
+from cafe.agents.diagnostics import (
+    ERROR_EXCERPT_LIMIT,
+    build_failed_attempt,
+    sanitize_error_excerpt,
+)
+from cafe.agents.executor import AgentExecutionError
+from cafe.core.types import AgentCLI
+
+
+def test_sanitized_excerpt_preserves_reason_without_sensitive_values() -> None:
+    """Durable excerpts normalize useful context while redacting credentials."""
+    error = AgentExecutionError(
+        "connection closed unexpectedly\n"
+        "Authorization: Bearer super-secret-token-value\n"
+        "api_key=sk-secret-value password=hunter2\n"
+        "https://alice:hunter2@example.test/run?token=opaque-secret",
+        error_type="cli_unavailable",
+    )
+
+    excerpt = sanitize_error_excerpt(error)
+
+    assert "connection closed unexpectedly" in excerpt
+    assert "\n" not in excerpt
+    assert "super-secret-token-value" not in excerpt
+    assert "sk-secret-value" not in excerpt
+    assert "hunter2" not in excerpt
+    assert "opaque-secret" not in excerpt
+    assert len(excerpt) <= ERROR_EXCERPT_LIMIT
+
+
+def test_display_message_is_preferred_and_failed_attempt_is_serializable() -> None:
+    """A classified display message is the durable diagnostic when available."""
+    error = AgentExecutionError(
+        "raw stderr includes token=secret-token",
+        error_type="cli_unavailable",
+        display_message="Claude CLI unavailable: connection closed unexpectedly.",
+    )
+
+    record = build_failed_attempt(
+        cli=AgentCLI.CLAUDE,
+        chain_role="primary",
+        attempt=1,
+        error=error,
+    )
+
+    assert record == {
+        "cli": "claude",
+        "chain_role": "primary",
+        "attempt": 1,
+        "error_type": "cli_unavailable",
+        "error_excerpt": "Claude CLI unavailable: connection closed unexpectedly.",
+    }
+
+
+def test_sanitized_excerpt_handles_empty_and_overlong_error_text() -> None:
+    """Fallback diagnostics remain useful and bounded for malformed CLI errors."""
+    assert sanitize_error_excerpt(AgentExecutionError(""))
+
+    excerpt = sanitize_error_excerpt(AgentExecutionError("x" * (ERROR_EXCERPT_LIMIT + 50)))
+
+    assert len(excerpt) == ERROR_EXCERPT_LIMIT

--- a/tests/unit/test_clis_chain_fallback.py
+++ b/tests/unit/test_clis_chain_fallback.py
@@ -26,6 +26,13 @@ def _cli_unavailable() -> AgentExecutionError:
     return AgentExecutionError("subscription disabled", error_type="cli_unavailable")
 
 
+def _transient_cli_unavailable() -> AgentExecutionError:
+    return AgentExecutionError(
+        "socket connection was closed unexpectedly",
+        error_type="cli_unavailable",
+    )
+
+
 def _model_not_found() -> AgentExecutionError:
     return AgentExecutionError("bad model", error_type="model_not_found")
 
@@ -177,6 +184,126 @@ class TestClisChainFallbackBasic:
 
         assert response == "codex ok"
         assert call_count == 2
+
+    def test_primary_transient_error_retries_once_before_fallback(self) -> None:
+        """A known transient primary error gets one same-CLI retry before fallback."""
+        manager = _make_manager([
+            CliEntry(cli=AgentCLI.CLAUDE),
+            CliEntry(cli=AgentCLI.GEMINI),
+        ])
+        errors = [_transient_cli_unavailable(), _transient_cli_unavailable()]
+
+        def side_effect(*args, **kwargs):
+            if errors:
+                raise errors.pop(0)
+            return _ok("gemini response")
+
+        with patch(
+            "cafe.agents.executor.AgentExecutor.execute",
+            side_effect=side_effect,
+        ) as execute:
+            response, *_ = manager.execute("David", "unchanged prompt")
+
+        assert response == "gemini response"
+        assert execute.call_count == 3
+        assert manager.get_failed_attempts() == [
+            {
+                "cli": "claude",
+                "chain_role": "primary",
+                "attempt": 1,
+                "error_type": "cli_unavailable",
+                "error_excerpt": "socket connection was closed unexpectedly",
+            },
+            {
+                "cli": "claude",
+                "chain_role": "primary",
+                "attempt": 2,
+                "error_type": "cli_unavailable",
+                "error_excerpt": "socket connection was closed unexpectedly",
+            },
+        ]
+
+    def test_fallback_transient_error_retries_once_without_reordering_chain(self) -> None:
+        """Each fallback gets one bounded retry before the next configured CLI."""
+        manager = _make_manager([
+            CliEntry(cli=AgentCLI.CLAUDE),
+            CliEntry(cli=AgentCLI.GEMINI),
+            CliEntry(cli=AgentCLI.COPILOT),
+        ])
+        errors = [_rate_limit(), _transient_cli_unavailable(), _transient_cli_unavailable()]
+
+        def side_effect(*args, **kwargs):
+            if errors:
+                raise errors.pop(0)
+            return _ok("copilot response")
+
+        with patch(
+            "cafe.agents.executor.AgentExecutor.execute",
+            side_effect=side_effect,
+        ) as execute:
+            response, *_ = manager.execute("David", "unchanged prompt")
+
+        assert response == "copilot response"
+        assert execute.call_count == 4
+        assert [record["cli"] for record in manager.get_failed_attempts()] == [
+            "claude",
+            "gemini",
+            "gemini",
+        ]
+        assert [record["attempt"] for record in manager.get_failed_attempts()] == [1, 1, 2]
+
+    @pytest.mark.parametrize(
+        ("error", "expected_type"),
+        [
+            (_rate_limit(), "rate_limit"),
+            (_cli_not_found(), "cli_not_found"),
+            (_model_not_found(), "model_not_found"),
+            (_cli_unavailable(), "cli_unavailable"),
+            (AgentExecutionError("HTTP 403", error_type="cli_unavailable"), "cli_unavailable"),
+        ],
+    )
+    def test_non_transient_errors_do_not_receive_same_cli_retry(
+        self,
+        error: AgentExecutionError,
+        expected_type: str,
+    ) -> None:
+        """Fallbackable, non-transient errors preserve the existing one-call behavior."""
+        manager = _make_manager([
+            CliEntry(cli=AgentCLI.CLAUDE),
+            CliEntry(cli=AgentCLI.GEMINI),
+        ])
+
+        with patch(
+            "cafe.agents.executor.AgentExecutor.execute",
+            side_effect=[error, _ok("fallback response")],
+        ) as execute:
+            response, *_ = manager.execute("David", "prompt")
+
+        assert response == "fallback response"
+        assert execute.call_count == 2
+        assert manager.get_failed_attempts()[0]["error_type"] == expected_type
+
+    def test_failed_attempt_diagnostics_reset_for_each_execute(self) -> None:
+        """A later execution cannot inherit diagnostics from an earlier failure."""
+        manager = _make_manager([CliEntry(cli=AgentCLI.CLAUDE)])
+
+        with patch(
+            "cafe.agents.executor.AgentExecutor.execute",
+            side_effect=[_transient_cli_unavailable(), _ok("retried")],
+        ):
+            response, *_ = manager.execute("David", "prompt")
+
+        assert response == "retried"
+        assert len(manager.get_failed_attempts()) == 1
+
+        with patch(
+            "cafe.agents.executor.AgentExecutor.execute",
+            return_value=_ok("clean execution"),
+        ):
+            response, *_ = manager.execute("David", "another prompt")
+
+        assert response == "clean execution"
+        assert manager.get_failed_attempts() == []
 
     def test_model_not_found_also_triggers_fallback(self) -> None:
         """Bad model configuration on one CLI should try the next configured CLI."""


### PR DESCRIPTION
## Summary
- Implemented Issue #353 scope from `spec/iteration_002` to persist durable failure diagnostics and narrow same-CLI retry behavior without changing fallback ordering, CLI config, rate-limit policy, or crew resolution.
- Added redacted, bounded, per-attempt metadata for both primary and fallback CLI failures, including `error_type`, `error_excerpt`, and ordered attempts (`attempt`) to aid post-run tracing.
- Preserved compatibility and existing behavior for successful fallback paths while making recovery/error persistence safer and more auditable.

## Changes
- Added shared diagnostics policy in `src/cafe/agents/diagnostics.py` to:
  - classify only narrow transient `cli_unavailable` signals (socket-close condition) as retryable,
  - redact and normalize error excerpts,
  - cap excerpt length for durability safety.
- Updated `src/cafe/agents/manager.py` to:
  - reset and collect per-execution failed attempt records,
  - attempt one bounded same-CLI retry only for retryable transients,
  - keep effective execution chain ordering and sticky-fallback behavior.
- Updated `src/cafe/core/phase.py` durable persistence to:
  - store `failed_attempts` on success and error paths,
  - use sanitized excerpts instead of raw failure text in iteration/error aggregates.
- Updated streaming persistence in `src/cafe/agents/executor.py` to avoid persisting raw failed stream payloads containing credentials or tokens.
- Added/updated tests:
  - `tests/unit/test_agent_diagnostics.py`
  - `tests/unit/test_clis_chain_fallback.py`
  - `tests/integration/test_agent_attempt_diagnostics.py`
- Reviewed commits included in this PR:
  - `0fc5fcc agents: persist failed attempt diagnostics`
  - `2f5a93f agents: sanitize failed stream diagnostics`
  - `9a84620 agents: preserve transient retry classification`
  - `9439550 agents: exclude api key authentication retries`

## Test Plan
- Ran focused unit/integration regressions after implementation:
  - `136 passed` (initial focused diagnostic suite),
  - `138 passed` (follow-up),
  - `143 passed` (final focused suite),
  - `3 passed` for workflow skill guardrails,
  - `2,357` and then `2,362` pre-commit fast suite checks.
- Executed review/verification scenarios for:
  - same-CLI retry ordering,
  - transient vs non-transient classification boundaries,
  - successful fallback with preserved primary failed attempt history,
  - terminal failure persistence with redacted sensitive content.

Closes #353