### PR TITLE
Supersede stale handoff summaries on explicit workflow start

### DIFF
--- a/src/cafe/ui/commands/workflow.py
+++ b/src/cafe/ui/commands/workflow.py
@@ -495,6 +495,13 @@ def _reset_baton_for_explicit_start_step(
     """Make an explicit --start-step runnable even when the persisted baton is stale."""
     store = BlackboardStore(issue_dir)
     store.set_current_step(blackboard, active_step)
+    store.set_handoff_summary(
+        blackboard,
+        (
+            f"Explicit workflow start requested for {active_step}; "
+            "the prior handoff is superseded."
+        ),
+    )
     store.update_handoff_contract(
         blackboard,
         from_step=active_step,
@@ -750,8 +757,9 @@ def workflow(
             return result
 
         pending_start_step = start_step
+        explicit_start_step_pending = start_step is not None
         while True:
-            has_explicit_start_step = pending_start_step is not None
+            has_explicit_start_step = explicit_start_step_pending
             if dry_run:
                 pending_start_step = pending_start_step or str(
                     playbook_data.get("entry_point") or next(iter(playbook_data["steps"].keys()))
@@ -775,12 +783,14 @@ def workflow(
             )
 
             active_step = pending_start_step or blackboard.current_step
-            if not dry_run and has_explicit_start_step and active_step not in {"user", "done"}:
-                _reset_baton_for_explicit_start_step(
-                    issue_dir=issue_dir,
-                    blackboard=blackboard,
-                    active_step=active_step,
-                )
+            if not dry_run and has_explicit_start_step:
+                if active_step not in {"user", "done"}:
+                    _reset_baton_for_explicit_start_step(
+                        issue_dir=issue_dir,
+                        blackboard=blackboard,
+                        active_step=active_step,
+                    )
+                explicit_start_step_pending = False
             if not dry_run and active_step in {"user", "done"}:
                 handoff_contract = getattr(blackboard, "handoff_contract", None)
                 waiting_for_alignment = (

--- a/tests/unit/test_cli_workflow_command.py
+++ b/tests/unit/test_cli_workflow_command.py
@@ -21,6 +21,7 @@ from cafe.ui.cli_shared import (
     _build_workflow_step_executor,
     apply_alignment_decision_from_payload,
 )
+from cafe.ui.commands.workflow import _reset_baton_for_explicit_start_step
 from cafe.utils.config import ConfigManager
 
 runner = CliRunner()
@@ -1662,6 +1663,37 @@ def test_workflow_command_start_step_rebuilds_stale_text_baton(tmp_path: Path, m
     blackboard = BlackboardStore(issue_dir).load_or_create("spec")
     assert blackboard.handoff_contract is not None
     assert blackboard.handoff_contract.from_step == "spec"
+
+
+def test_explicit_start_step_supersedes_stale_handoff_summary(tmp_path: Path) -> None:
+    issue_dir = tmp_path / ".cafe" / "issues" / "issue-stale-summary"
+    store = BlackboardStore(issue_dir)
+    blackboard = store.load_or_create("user", playbook_id="default")
+    store.set_current_step(blackboard, "user")
+    store.set_handoff_summary(blackboard, "Alignment checkpoint required before spec")
+    store.update_handoff_contract(
+        blackboard,
+        from_step="spec",
+        to_owner=HandoffOwner.USER,
+        to_step="user",
+        intent=HandoffIntent.ALIGNMENT_CHECKPOINT,
+        source="test",
+    )
+
+    _reset_baton_for_explicit_start_step(
+        issue_dir=issue_dir,
+        blackboard=blackboard,
+        active_step="spec",
+    )
+
+    reloaded = store.load_or_create("spec", playbook_id="default")
+    assert reloaded.current_step == "spec"
+    assert reloaded.handoff_contract is not None
+    assert reloaded.handoff_contract.intent == HandoffIntent.AWAIT_AGENT
+    assert reloaded.handoff_contract.to_step == "spec"
+    assert reloaded.handoff_summary == (
+        "Explicit workflow start requested for spec; the prior handoff is superseded."
+    )
 
 
 def test_workflow_command_prints_guidance_for_invalid_runtime_baton(


### PR DESCRIPTION
## Summary
- replace stale handoff summaries when a user explicitly restarts a workflow step
- distinguish the original `--start-step` request from internal resume steps
- preserve normal `--user-input` resume summaries

## Verification
- `pytest -q tests/unit/test_cli_workflow_command.py` (66 passed)
- `pytest -q` (2362 passed, 1 skipped, 1 xfailed)
- pre-commit and pre-push full suites passed