### PR TITLE
Make workflow step contracts declarative

### DIFF
--- a/docs/prepare_fields.md
+++ b/docs/prepare_fields.md
@@ -11,7 +11,7 @@ Each prepare question is declared as one field object:
 | `id` | yes | Stable identifier (for example `input_method`, `quick_rigor`) |
 | `type` | yes | `enum`, `boolean`, `template`, `text`, or `setup_mode` |
 | `label` | yes | User-facing label |
-| `write` | yes* | Issue config target (`spec.rigor`, `plan.template`, `pr.auto_create`, …) |
+| `write` | yes* | Issue config target (`spec.rigor`, `plan.template`, `pr.auto_create`, or `<step>.template`) |
 | `help` | no | Optional help text |
 | `default` | no | Default value when applicable |
 | `choices` | yes for `enum` / `setup_mode` | `{ value, label, description? }` entries |
@@ -23,6 +23,7 @@ Allowed `write` targets:
 - `spec.rigor`, `spec.template`, `spec.sync_github`, `spec.input_method`, `spec.issue_id`
 - `plan.template`, `plan.sync_github`
 - `pr.auto_create`, `pr.post_todo_list`
+- `<step>.template` for a playbook step whose selected skill declares an `output_templates` catalog
 
 `setup_mode` fields describe the setup-mode chooser and must not declare `write`.
 
@@ -126,3 +127,25 @@ That asset fully describes the current default prepare flow, including setup mod
 - `PrepareProfile.resolved_prepare_fields()` (read-only contract access; does not drive UI)
 
 Omitting both `fields` and `fields_ref` preserves backward-compatible behavior.
+
+## Custom step template fields
+
+A custom output catalog belongs to its skill. A playbook may expose the selected
+template during prepare by writing to that step's own issue-config block:
+
+```yaml
+commands:
+  prepare:
+    fields:
+      - id: synthesis_template
+        type: template
+        label: Synthesis template
+        write: synthesis.template
+        default: auto
+```
+
+`cafe playbook validate` rejects this field unless the `synthesis` step's skill
+declares an output-template catalog. The selected value is persisted as
+`synthesis.template` in `issue.yaml`; runtime resolves it through that skill's
+bundled catalog, with local and global template overrides retaining normal
+precedence. `auto` exposes the catalog without forcing a particular file.

--- a/src/cafe/core/playbook.py
+++ b/src/cafe/core/playbook.py
@@ -18,7 +18,7 @@ from cafe.core.prepare_fields import (
 )
 from cafe.core.status_codes import PLAYBOOK_INTENT_KEYS, PhaseStatusCode
 from cafe.skills.exceptions import SkillDiscoveryError
-from cafe.skills.loader import SkillLoader
+from cafe.skills.loader import SkillLoader, canonical_skill_name
 from cafe.templates.manager import TemplateManager
 
 DONE_TARGET = "_done"
@@ -113,6 +113,7 @@ class StepConfig(BaseModel):
     assignee_type: Literal["agent", "human", "auto"] = "agent"
     input_artifacts: List[str] = Field(default_factory=list)
     output_artifact: Optional[str] = None
+    template: Optional[str] = None
     allowed_tools: List[str] = Field(default_factory=list)
     capability_requests: List[str] = Field(default_factory=list)
     valid_intents: List[str] = Field(default_factory=list)
@@ -460,7 +461,11 @@ def validate_playbook(
                 f"Step '{step_name}': assignee_type={step.assignee_type} (reserved for v0.3)"
             )
 
-    _validate_prepare_metadata(model, skill_loader=skill_loader, playbook_path=path)
+    _validate_prepare_metadata(
+        model,
+        skill_loader=skill_loader,
+        playbook_path=path,
+    )
 
     if warnings and strict:
         raise ValueError("\n".join(warnings))
@@ -477,6 +482,7 @@ def _validate_prepare_metadata(
     prepare = resolve_prepare_config(model)
     spec_manager = TemplateManager(template_type="spec")
     plan_manager = TemplateManager(template_type="plan")
+    template_managers = _declared_template_managers(model, skill_loader)
 
     _validate_prepare_template(
         spec_manager,
@@ -529,11 +535,46 @@ def _validate_prepare_metadata(
         prepare,
         spec_manager=spec_manager,
         plan_manager=plan_manager,
+        template_managers=template_managers,
         enforce_legacy_setup_modes=has_explicit_legacy_prepare_metadata,
     )
 
     if has_explicit_legacy_prepare_metadata:
         assert_prepare_semantics_match(model.commands.prepare, parsed_fields)
+
+
+def _declared_template_managers(
+    model: PlaybookDefinition,
+    skill_loader: SkillLoader,
+) -> Dict[str, TemplateManager]:
+    """Resolve template catalogs from each step's selected skill contract."""
+    managers: Dict[str, TemplateManager] = {}
+    for step_name, step in model.steps.items():
+        selectors = [step.skill] if isinstance(step.skill, str) else list(step.skill.values())
+        contracts = [skill_loader.get_workflow_contract(skill) for skill in selectors]
+        catalogs = {
+            contract.output_templates.catalog
+            for contract in contracts
+            if contract.output_templates is not None
+        }
+        if len(catalogs) > 1:
+            raise ValueError(
+                f"Step {step_name!r} selects skills with incompatible template catalogs"
+            )
+        if not catalogs:
+            if step.template is not None:
+                raise ValueError(f"Step {step_name!r} declares a template without a skill template catalog")
+            continue
+        skill_name = canonical_skill_name(str(selectors[0]))
+        manager = TemplateManager(
+            template_type=next(iter(catalogs)),
+            skill_name=skill_name,
+            skill_loader=skill_loader,
+        )
+        if step.template is not None:
+            _validate_prepare_template(manager, step.template, f"steps.{step_name}.template")
+        managers[step_name] = manager
+    return managers
 
 
 def _validate_prepare_template(

--- a/src/cafe/core/playbook.py
+++ b/src/cafe/core/playbook.py
@@ -452,6 +452,7 @@ def validate_playbook(
         _validate_step_role(step_name, step, model.roles)
         _validate_step_chat_role(step_name, step, model.roles)
         _validate_step_skills(step_name, step, skill_loader)
+        _validate_step_required_prompt_inputs(step_name, step, skill_loader)
         _validate_script_hook_stages(step_name, step.hooks)
         _validate_targets(step_name, step.allowed_goto, steps, "allowed_goto")
         _validate_transition_targets(step_name, step.on, steps)
@@ -482,7 +483,7 @@ def _validate_prepare_metadata(
     prepare = resolve_prepare_config(model)
     spec_manager = TemplateManager(template_type="spec")
     plan_manager = TemplateManager(template_type="plan")
-    template_managers = _declared_template_managers(model, skill_loader)
+    template_managers = declared_template_managers(model, skill_loader)
 
     _validate_prepare_template(
         spec_manager,
@@ -543,7 +544,7 @@ def _validate_prepare_metadata(
         assert_prepare_semantics_match(model.commands.prepare, parsed_fields)
 
 
-def _declared_template_managers(
+def declared_template_managers(
     model: PlaybookDefinition,
     skill_loader: SkillLoader,
 ) -> Dict[str, TemplateManager]:
@@ -624,6 +625,29 @@ def _validate_step_skills(step_name: str, step: StepConfig, skill_loader: SkillL
             skill_loader.get_skill_dir(skill_name)
         except (SkillDiscoveryError, FileNotFoundError) as exc:
             raise ValueError(f"Step '{step_name}' references unknown skill '{skill_name}'") from exc
+
+
+def _validate_step_required_prompt_inputs(
+    step_name: str,
+    step: StepConfig,
+    skill_loader: SkillLoader,
+) -> None:
+    """Reject a step whose artifact graph cannot satisfy a required mapping."""
+    if "input_artifacts" not in step.model_fields_set:
+        return
+    selectors = [step.skill] if isinstance(step.skill, str) else list(step.skill.values())
+    declared_artifacts = set(step.input_artifacts)
+    for skill_name in selectors:
+        contract = skill_loader.get_workflow_contract(skill_name)
+        for mapping in contract.prompt_inputs:
+            if mapping.required and not declared_artifacts.intersection(mapping.artifacts):
+                candidates = ", ".join(mapping.artifacts)
+                raise ValueError(
+                    f"Step {step_name!r}, skill {canonical_skill_name(skill_name)!r}: "
+                    f"required prompt input {mapping.placeholder!r} expects one of "
+                    f"[{candidates}], but input_artifacts declares "
+                    f"{sorted(declared_artifacts)}"
+                )
 
 
 def _validate_script_hook_stages(step_name: str, hooks: StepHooks) -> None:

--- a/src/cafe/core/playbook.py
+++ b/src/cafe/core/playbook.py
@@ -111,7 +111,10 @@ class StepConfig(BaseModel):
     skill: SkillSelector
     role: str
     assignee_type: Literal["agent", "human", "auto"] = "agent"
-    input_artifacts: List[str] = Field(default_factory=list)
+    # ``None`` means the legacy playbook omitted this field and therefore
+    # intentionally receives every recorded artifact. An explicit empty list
+    # remains the opt-in isolated scope.
+    input_artifacts: Optional[List[str]] = None
     output_artifact: Optional[str] = None
     template: Optional[str] = None
     allowed_tools: List[str] = Field(default_factory=list)
@@ -636,7 +639,7 @@ def _validate_step_required_prompt_inputs(
     if "input_artifacts" not in step.model_fields_set:
         return
     selectors = [step.skill] if isinstance(step.skill, str) else list(step.skill.values())
-    declared_artifacts = set(step.input_artifacts)
+    declared_artifacts = set(step.input_artifacts or [])
     for skill_name in selectors:
         contract = skill_loader.get_workflow_contract(skill_name)
         for mapping in contract.prompt_inputs:

--- a/src/cafe/core/playbook.py
+++ b/src/cafe/core/playbook.py
@@ -129,6 +129,12 @@ class StepConfig(BaseModel):
     alignment: Optional[StepAlignmentConfig] = None
     on: Dict[str, str]
 
+    @model_validator(mode="after")
+    def _validate_input_artifact_scope(self) -> "StepConfig":
+        if "input_artifacts" in self.model_fields_set and self.input_artifacts is None:
+            raise ValueError("input_artifacts must be a list when specified")
+        return self
+
     @field_validator("on")
     @classmethod
     def _validate_on_intents(cls, value: Dict[str, str]) -> Dict[str, str]:
@@ -567,7 +573,9 @@ def declared_template_managers(
             )
         if not catalogs:
             if step.template is not None:
-                raise ValueError(f"Step {step_name!r} declares a template without a skill template catalog")
+                raise ValueError(
+                    f"Step {step_name!r} declares a template without a skill template catalog"
+                )
             continue
         skill_name = canonical_skill_name(str(selectors[0]))
         manager = TemplateManager(

--- a/src/cafe/core/prepare_fields.py
+++ b/src/cafe/core/prepare_fields.py
@@ -34,6 +34,7 @@ ALLOWED_FIELD_TYPES = frozenset({"enum", "boolean", "template", "text", "setup_m
 ALLOWED_SHOW_WHEN_KEYS = frozenset({"github_repo", "issue_id_present", "setup_mode"})
 ALLOWED_SETUP_MODES = frozenset({"quick", "custom"})
 ALLOWED_STATIC_SUFFIXES = frozenset({".yaml", ".yml", ".json"})
+STEP_TEMPLATE_WRITE_PATTERN = re.compile(r"^[a-z][a-z0-9_-]*\.template$")
 
 SKILL_FIELDS_REF_PATTERN = re.compile(r"^skill://([^/]+)/assets/(.+)$")
 
@@ -94,7 +95,7 @@ class PrepareField(BaseModel):
     def _validate_write(cls, value: Optional[str]) -> Optional[str]:
         if value is None:
             return value
-        if value not in ALLOWED_WRITE_TARGETS:
+        if value not in ALLOWED_WRITE_TARGETS and not STEP_TEMPLATE_WRITE_PATTERN.fullmatch(value):
             raise ValueError(
                 f"unknown write target {value!r}; "
                 f"must be one of {sorted(ALLOWED_WRITE_TARGETS)}"
@@ -280,6 +281,7 @@ def validate_field_semantics(
     *,
     spec_manager: TemplateManager,
     plan_manager: TemplateManager,
+    template_managers: Optional[Dict[str, TemplateManager]] = None,
     enforce_legacy_setup_modes: bool = True,
 ) -> None:
     """Apply semantic validation to loaded prepare fields."""
@@ -293,7 +295,14 @@ def validate_field_semantics(
         validate_show_when(field.show_when, field_id=field.id)
 
         if field.type == "template" and field.default is not None:
-            manager = spec_manager if field.write and field.write.startswith("spec.") else plan_manager
+            step_name = field.write.split(".", 1)[0] if field.write else "plan"
+            manager = (template_managers or {}).get(step_name)
+            if manager is None:
+                manager = spec_manager if step_name == "spec" else plan_manager
+            if step_name not in {"spec", "plan"} and step_name not in (template_managers or {}):
+                raise ValueError(
+                    f"field {field.id!r} targets step {step_name!r} without a declared template catalog"
+                )
             _validate_template_default(manager, str(field.default), field)
 
         if field.write == "spec.rigor":

--- a/src/cafe/core/prepare_fields.py
+++ b/src/cafe/core/prepare_fields.py
@@ -301,7 +301,8 @@ def validate_field_semantics(
                 manager = spec_manager if step_name == "spec" else plan_manager
             if step_name not in {"spec", "plan"} and step_name not in (template_managers or {}):
                 raise ValueError(
-                    f"field {field.id!r} targets step {step_name!r} without a declared template catalog"
+                    f"field {field.id!r} targets step {step_name!r} "
+                    "without a declared template catalog"
                 )
             _validate_template_default(manager, str(field.default), field)
 

--- a/src/cafe/core/prepare_profile.py
+++ b/src/cafe/core/prepare_profile.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -17,11 +17,19 @@ class PrepareRigorError(ValueError):
 
 @dataclass(frozen=True)
 class PrepareIssueConfig:
-    """Resolved spec/plan/pr blocks for ``issue.yaml``."""
+    """Resolved step configuration blocks for ``issue.yaml``."""
 
     spec: Dict[str, Any]
     plan: Dict[str, Any]
     pr: Dict[str, Any]
+    steps: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+
+    def section(self, step_name: str) -> Dict[str, Any]:
+        """Return a mutable issue-config section, retaining legacy views."""
+        legacy = {"spec": self.spec, "plan": self.plan, "pr": self.pr}
+        if step_name in legacy:
+            return legacy[step_name]
+        return self.steps.setdefault(step_name, {})
 
 
 @dataclass(frozen=True)

--- a/src/cafe/data/playbooks/default.yaml
+++ b/src/cafe/data/playbooks/default.yaml
@@ -125,7 +125,7 @@ steps:
     handoff_label: "Continue implementation"
     chat_role: developer
     assignee_type: agent
-    input_artifacts: [spec, plan]
+    input_artifacts: [spec, plan, review_feedback, pr_result]
     output_artifact: code
     allowed_tools: [Read, Edit, Write, Grep, Glob, Bash, WebFetch, WebSearch]
     hooks:

--- a/src/cafe/data/playbooks/default.yaml
+++ b/src/cafe/data/playbooks/default.yaml
@@ -172,7 +172,7 @@ steps:
     handoff_label: "Refresh PR output"
     chat_role: developer
     assignee_type: agent
-    input_artifacts: [spec, code, review_feedback]
+    input_artifacts: [spec, plan, code, review_feedback]
     output_artifact: pr_result
     allowed_tools: [Read, Edit, Write, Grep, Glob]
     capability_requests: [cafe.pr.publish]

--- a/src/cafe/data/playbooks/hotfix.yaml
+++ b/src/cafe/data/playbooks/hotfix.yaml
@@ -51,7 +51,7 @@ steps:
     skill: cafe-develop
     role: developer
     assignee_type: agent
-    input_artifacts: []
+    input_artifacts: [review_feedback, pr_result]
     output_artifact: code
     allowed_tools: [Read, Edit, Write, Grep, Glob, Bash, WebFetch, WebSearch]
     hooks:

--- a/src/cafe/data/playbooks/tdd.yaml
+++ b/src/cafe/data/playbooks/tdd.yaml
@@ -110,7 +110,7 @@ steps:
     handoff_label: "Continue implementation"
     chat_role: developer
     assignee_type: agent
-    input_artifacts: [spec, plan]
+    input_artifacts: [spec, plan, review_feedback, pr_result]
     output_artifact: code
     allowed_tools: [Read, Edit, Write, Grep, Glob, Bash, WebFetch, WebSearch]
     hooks:

--- a/src/cafe/data/playbooks/tdd.yaml
+++ b/src/cafe/data/playbooks/tdd.yaml
@@ -150,7 +150,7 @@ steps:
     handoff_label: "Refresh PR output"
     chat_role: developer
     assignee_type: agent
-    input_artifacts: [spec, code, review_feedback]
+    input_artifacts: [spec, plan, code, review_feedback]
     output_artifact: pr_result
     allowed_tools: [Read, Edit, Write, Grep, Glob]
     allowed_goto: [develop, review]

--- a/src/cafe/data/skills/cafe-develop/SKILL.md
+++ b/src/cafe/data/skills/cafe-develop/SKILL.md
@@ -6,16 +6,16 @@ workflow:
   prompt_inputs:
     - artifacts: [spec]
       placeholder: spec_file
-      required: true
+      required: false
     - artifacts: [spec]
       placeholder: spec_file_path
-      required: true
+      required: false
     - artifacts: [plan]
       placeholder: plan_file
-      required: true
+      required: false
     - artifacts: [plan]
       placeholder: plan_file_path
-      required: true
+      required: false
     - artifacts: [review_feedback, pr_result]
       placeholder: feedback_file_path
       required: false

--- a/src/cafe/data/skills/cafe-develop/SKILL.md
+++ b/src/cafe/data/skills/cafe-develop/SKILL.md
@@ -2,6 +2,39 @@
 name: cafe-develop
 description: "依計畫進行程式開發與測試"
 version: 1.3.0
+workflow:
+  prompt_inputs:
+    - artifacts: [spec]
+      placeholder: spec_file
+      required: true
+    - artifacts: [spec]
+      placeholder: spec_file_path
+      required: true
+    - artifacts: [plan]
+      placeholder: plan_file
+      required: true
+    - artifacts: [plan]
+      placeholder: plan_file_path
+      required: true
+    - artifacts: [review_feedback, pr_result]
+      placeholder: feedback_file_path
+      required: false
+    - artifacts: [review_feedback, pr_result]
+      placeholder: feedback_file
+      required: false
+  checklist:
+    context_references:
+      xml_questions_instruction: xml_questions_instruction.md
+    variants:
+      - when: {feedback: true}
+        sections:
+          - reference: execution_steps_correction.md
+          - optional_checklist: basic_principles.md
+      - when: {}
+        sections:
+          - reference: execution_steps_normal.md
+          - optional_checklist: basic_principles.md
+    include_role_guidance: true
 ---
 
 # Develop

--- a/src/cafe/data/skills/cafe-develop/SKILL.md
+++ b/src/cafe/data/skills/cafe-develop/SKILL.md
@@ -24,6 +24,10 @@ workflow:
       required: false
   checklist:
     context_references:
+      normal_plan_context: normal_plan_context.md
+      normal_plan_verification: normal_plan_verification.md
+      correction_plan_context: correction_plan_context.md
+      correction_plan_test_list: correction_plan_test_list.md
       xml_questions_instruction: xml_questions_instruction.md
     variants:
       - when: {feedback: true}
@@ -43,17 +47,16 @@ workflow:
 Read your agent file: {agent_file}
 
 ## Context
-- Requirements Specification: {spec_file}
-- Implementation Plan: {plan_file}
+- Use the workflow inputs listed in the runtime context. When a specification or plan is supplied, treat it as authoritative for this run.
 
 ## Instructions
-- 依計畫逐項完成
+- 依目前 workflow 已提供的需求與計畫逐項完成；若此 workflow 未提供 spec 或 plan，依使用者輸入與 review feedback 完成範圍內修正
 - 先補測試再改程式
-- 第一次探索只做一輪：讀一次 spec、plan，再針對 Test List 與預計修改點搜尋程式碼；未出現新證據時不得重讀同一檔案或重跑相同的搜尋、`git status`、`git diff`
+- 第一次探索只做一輪：讀一次已提供的 spec、plan 與 feedback，再針對可用 Test List 與預計修改點搜尋程式碼；未出現新證據時不得重讀同一檔案或重跑相同的搜尋、`git status`、`git diff`
 - 在第一次實質修改前，以及任兩次實質修改之間，唯讀工具呼叫（read/search/list/status/diff 等）上限皆為 **20 次**；每次實質修改會重設計數，測試執行不會重設此上限
 - runtime 會硬性中止超過唯讀上限的 attempt，並只允許在同一 session 續跑一次；續跑時必須在 3 次唯讀呼叫內完成下一個相關檔案修改，不得重新開始探索
 - 到達上限前必須寫入第一個相關的 failing test；若依計畫不需新增測試，則寫入第一個實作修改。若仍無法安全修改，立即提出具體 clarification 並交棒給 user，不得繼續探索
-- 新增或修改的測試必須對應計畫 **Test List** 項目（範圍變更時先更新計畫）
+- 若 workflow 提供 plan，新增或修改的測試必須對應其 **Test List** 項目（範圍變更時先更新計畫）
 - 斷言以 invariant 為主：避免綁定 UI copy、CSS class、DOM 結構、內部 state shape；允許 a11y role/label、`data-testid`、以及規格明訂的文案（見 `cafe-plan/references/test_invariants_policy.md`）
 - 每輪完成後更新 checklist
 - 維持既有 commit 風格與程式碼註解語言

--- a/src/cafe/data/skills/cafe-develop/references/correction_plan_context.md
+++ b/src/cafe/data/skills/cafe-develop/references/correction_plan_context.md
@@ -1,0 +1,1 @@
+[ ] Carefully read {spec_file} and {plan_file}

--- a/src/cafe/data/skills/cafe-develop/references/correction_plan_test_list.md
+++ b/src/cafe/data/skills/cafe-develop/references/correction_plan_test_list.md
@@ -1,0 +1,1 @@
+[ ] Read the plan **Test List** in {plan_file}; new or changed tests still map to listed items and follow `src/cafe/data/skills/cafe-plan/references/test_invariants_policy.md`

--- a/src/cafe/data/skills/cafe-develop/references/execution_steps_correction.md
+++ b/src/cafe/data/skills/cafe-develop/references/execution_steps_correction.md
@@ -1,15 +1,15 @@
 ## Checklist
 
 [ ] Read {agent_file} to understand your role and native language
-[ ] Carefully read {spec_file_path} and {plan_file_path}
-[ ] Read feedback todo list in {feedback_file_path}
+[ ] Carefully read {spec_file} and {plan_file}
+[ ] Read feedback todo list in {feedback_file}
 [ ] Address each issue raised in the feedback
-[ ] Mark completed items in {feedback_file_path} if applicable (change - [ ] to - [x])
+[ ] Mark completed items in {feedback_file} if applicable (change - [ ] to - [x])
 [ ] Commit changes with descriptive messages
 [ ] Confirm: Maximized code reuse by looking for existing patterns and utilities
 [ ] Confirm: Commit messages strictly match existing format, language, and structure
 [ ] Confirm: All issues are fixed
-[ ] Read the plan **Test List** in {plan_file_path}; new or changed tests still map to listed items and follow `src/cafe/data/skills/cafe-plan/references/test_invariants_policy.md`
+[ ] Read the plan **Test List** in {plan_file}; new or changed tests still map to listed items and follow `src/cafe/data/skills/cafe-plan/references/test_invariants_policy.md`
 [ ] Confirm: Corrected tests do not reintroduce brittle bindings (UI copy, CSS classes, DOM structure, internal state shape) unless the spec explicitly allows them
 [ ] Confirm: All tests pass and are not fragile
 [ ] Update blackboard and next-step baton to hand off to the next workflow target

--- a/src/cafe/data/skills/cafe-develop/references/execution_steps_correction.md
+++ b/src/cafe/data/skills/cafe-develop/references/execution_steps_correction.md
@@ -1,16 +1,14 @@
 ## Checklist
 
 [ ] Read {agent_file} to understand your role and native language
-[ ] Carefully read {spec_file} and {plan_file}
-[ ] Read feedback todo list in {feedback_file}
+{correction_plan_context}[ ] Read feedback todo list in {feedback_file}
 [ ] Address each issue raised in the feedback
 [ ] Mark completed items in {feedback_file} if applicable (change - [ ] to - [x])
 [ ] Commit changes with descriptive messages
 [ ] Confirm: Maximized code reuse by looking for existing patterns and utilities
 [ ] Confirm: Commit messages strictly match existing format, language, and structure
 [ ] Confirm: All issues are fixed
-[ ] Read the plan **Test List** in {plan_file}; new or changed tests still map to listed items and follow `src/cafe/data/skills/cafe-plan/references/test_invariants_policy.md`
-[ ] Confirm: Corrected tests do not reintroduce brittle bindings (UI copy, CSS classes, DOM structure, internal state shape) unless the spec explicitly allows them
+{correction_plan_test_list}[ ] Confirm: Corrected tests do not reintroduce brittle bindings (UI copy, CSS classes, DOM structure, internal state shape) unless the spec explicitly allows them
 [ ] Confirm: All tests pass and are not fragile
 [ ] Update blackboard and next-step baton to hand off to the next workflow target
 

--- a/src/cafe/data/skills/cafe-develop/references/execution_steps_normal.md
+++ b/src/cafe/data/skills/cafe-develop/references/execution_steps_normal.md
@@ -1,15 +1,15 @@
 ## Checklist
 
 [ ] Read {agent_file} to understand your role and native language
-[ ] Carefully read {spec_file_path} and {plan_file_path}
+[ ] Carefully read {spec_file} and {plan_file}
 [ ] Execute development tasks in strict order according to the plan
-[ ] Mark each completed task as checked in {plan_file_path} (change - [ ] to - [x])
+[ ] Mark each completed task as checked in {plan_file} (change - [ ] to - [x])
 [ ] Follow existing commit message style, commit multiple times if needed
 [ ] Do NOT modify commits from other branches
 [ ] Confirm: Maximized code reuse by looking for existing patterns and utilities
 [ ] Confirm: Commit messages strictly match existing format, language, and structure
-[ ] Confirm: All tasks in {plan_file_path} are marked [x]
-[ ] Read the plan **Test List** (`## Test List` in {plan_file_path}); every new or changed test maps to a listed item (update the plan first if scope changed)
+[ ] Confirm: All tasks in {plan_file} are marked [x]
+[ ] Read the plan **Test List** (`## Test List` in {plan_file}); every new or changed test maps to a listed item (update the plan first if scope changed)
 [ ] Confirm: New/changed tests assert **invariants** (business rules, journey outcomes)—not UI copy, CSS classes, DOM structure, or internal state shape unless the spec explicitly requires it
 [ ] Confirm: Unit tests target extractable pure business logic in shared library modules when applicable; integration tests are named by **user journey** and **invariant outcome**, not by UI component
 [ ] Read `src/cafe/data/skills/cafe-plan/references/test_invariants_policy.md` before adding user-visible UI assertions (allowed: a11y roles/labels, test ids, spec-mandated copy)

--- a/src/cafe/data/skills/cafe-develop/references/execution_steps_normal.md
+++ b/src/cafe/data/skills/cafe-develop/references/execution_steps_normal.md
@@ -1,16 +1,11 @@
 ## Checklist
 
 [ ] Read {agent_file} to understand your role and native language
-[ ] Carefully read {spec_file} and {plan_file}
-[ ] Execute development tasks in strict order according to the plan
-[ ] Mark each completed task as checked in {plan_file} (change - [ ] to - [x])
-[ ] Follow existing commit message style, commit multiple times if needed
+{normal_plan_context}[ ] Follow existing commit message style, commit multiple times if needed
 [ ] Do NOT modify commits from other branches
 [ ] Confirm: Maximized code reuse by looking for existing patterns and utilities
 [ ] Confirm: Commit messages strictly match existing format, language, and structure
-[ ] Confirm: All tasks in {plan_file} are marked [x]
-[ ] Read the plan **Test List** (`## Test List` in {plan_file}); every new or changed test maps to a listed item (update the plan first if scope changed)
-[ ] Confirm: New/changed tests assert **invariants** (business rules, journey outcomes)—not UI copy, CSS classes, DOM structure, or internal state shape unless the spec explicitly requires it
+{normal_plan_verification}[ ] Confirm: New/changed tests assert **invariants** (business rules, journey outcomes)—not UI copy, CSS classes, DOM structure, or internal state shape unless the spec explicitly requires it
 [ ] Confirm: Unit tests target extractable pure business logic in shared library modules when applicable; integration tests are named by **user journey** and **invariant outcome**, not by UI component
 [ ] Read `src/cafe/data/skills/cafe-plan/references/test_invariants_policy.md` before adding user-visible UI assertions (allowed: a11y roles/labels, test ids, spec-mandated copy)
 [ ] Confirm: All tests pass and are not fragile

--- a/src/cafe/data/skills/cafe-develop/references/normal_plan_context.md
+++ b/src/cafe/data/skills/cafe-develop/references/normal_plan_context.md
@@ -1,0 +1,3 @@
+[ ] Carefully read {spec_file} and {plan_file}
+[ ] Execute development tasks in strict order according to the plan
+[ ] Mark each completed task as checked in {plan_file} (change - [ ] to - [x])

--- a/src/cafe/data/skills/cafe-develop/references/normal_plan_verification.md
+++ b/src/cafe/data/skills/cafe-develop/references/normal_plan_verification.md
@@ -1,0 +1,2 @@
+[ ] Confirm: All tasks in {plan_file} are marked [x]
+[ ] Read the plan **Test List** (`## Test List` in {plan_file}); every new or changed test maps to a listed item (update the plan first if scope changed)

--- a/src/cafe/data/skills/cafe-plan/SKILL.md
+++ b/src/cafe/data/skills/cafe-plan/SKILL.md
@@ -2,6 +2,32 @@
 name: cafe-plan
 description: "產出可執行的開發計畫"
 version: 1.0.0
+workflow:
+  prompt_inputs:
+    - artifacts: [spec]
+      placeholder: spec_file
+      required: true
+    - artifacts: [spec]
+      placeholder: spec_file_path
+      required: true
+  checklist:
+    context_references:
+      xml_questions_instruction: xml_questions_instruction.md
+    variants:
+      - when: {iteration: 1}
+        sections:
+          - reference: execution_steps_iteration_1.md
+          - template_catalog: true
+          - optional_checklist: basic_principles.md
+      - when: {min_iteration: 2}
+        sections:
+          - reference: execution_steps_iteration_n.md
+          - template_catalog: true
+          - optional_checklist: basic_principles.md
+    include_role_guidance: true
+  output_templates:
+    catalog: plan
+    follow_instruction: Follow template structure when writing plan
 ---
 
 # Plan

--- a/src/cafe/data/skills/cafe-plan/references/execution_steps_iteration_1.md
+++ b/src/cafe/data/skills/cafe-plan/references/execution_steps_iteration_1.md
@@ -1,8 +1,8 @@
 ## Checklist
 
 [ ] Read {agent_file} to understand your role and native language
-[ ] Read the development guide in {plan_file_path}
-[ ] Read the requirements document {spec_file_path}
+[ ] Read the development guide in {output_file}
+[ ] Read the requirements document {spec_file}
 [ ] Plan implementation steps (planning, not implementation)
 [ ] Fill required sections **Negative space**, **Layering map**, and **Dependency ADR** (explicit "none" / "no new dependencies" if applicable — empty placeholders are incomplete)
 [ ] If `.cafe/strategic_context.yaml` has `documents.principles.path` with `status: exists`, read that file and ground Negative space and Dependency ADR; otherwise leave principles cross-refs blank

--- a/src/cafe/data/skills/cafe-plan/references/execution_steps_iteration_n.md
+++ b/src/cafe/data/skills/cafe-plan/references/execution_steps_iteration_n.md
@@ -1,11 +1,11 @@
 ## Checklist
 
 [ ] Read {agent_file} to understand your role and native language
-[ ] Read {prev_plan_file} to review previous plan
+[ ] Read {previous_output_file} to review previous plan
 [ ] Review user's feedback (provided below)
 [ ] Integrate feedback and update the plan, DO NOT hint the existence of the previous iterations
 [ ] Keep **Negative space**, **Layering map**, and **Dependency ADR** filled and consistent with the revised plan (explicit "none" if still applicable)
-[ ] Write updated plan to {current_plan_file} (NOT in your response)
+[ ] Write updated plan to {output_file} (NOT in your response)
 [ ] Keep "## Development Guide" section unchanged
 [ ] Confirm: Only wrote plans and steps, NO actual code
 [ ] Confirm: No code was modified

--- a/src/cafe/data/skills/cafe-pr/SKILL.md
+++ b/src/cafe/data/skills/cafe-pr/SKILL.md
@@ -2,6 +2,37 @@
 name: cafe-pr
 description: "整理提交內容並產出 pull request 標題與描述"
 version: 1.0.0
+workflow:
+  prompt_inputs:
+    - artifacts: [spec]
+      placeholder: spec_file
+      required: true
+    - artifacts: [spec]
+      placeholder: spec_file_path
+      required: true
+    - artifacts: [plan]
+      placeholder: plan_file
+      required: true
+    - artifacts: [plan]
+      placeholder: plan_file_path
+      required: true
+    - artifacts: [code]
+      placeholder: develop_file
+      required: false
+    - artifacts: [review_feedback]
+      placeholder: feedback_file
+      required: false
+  checklist:
+    variants:
+      - when: {iteration: 1}
+        sections:
+          - reference: execution_steps_iteration_1.md
+          - optional_checklist: basic_principles.md
+      - when: {min_iteration: 2}
+        sections:
+          - reference: execution_steps_iteration_n.md
+          - optional_checklist: basic_principles.md
+    include_role_guidance: true
 ---
 
 # PR

--- a/src/cafe/data/skills/cafe-pr/SKILL.md
+++ b/src/cafe/data/skills/cafe-pr/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cafe-pr
 description: "整理提交內容並產出 pull request 標題與描述"
-version: 1.0.0
+version: 1.0.1
 workflow:
   prompt_inputs:
     - artifacts: [spec]
@@ -22,7 +22,13 @@ workflow:
     - artifacts: [review_feedback]
       placeholder: feedback_file
       required: false
+  prompt_references:
+    spec_context: pr_spec_context.md
+    plan_context: pr_plan_context.md
   checklist:
+    context_references:
+      spec_read_instruction: spec_read_instruction.md
+      plan_read_instruction: plan_read_instruction.md
     variants:
       - when: {iteration: 1}
         sections:
@@ -41,8 +47,7 @@ workflow:
 Read your agent file: {agent_file}
 
 ## Context
-- Requirements Specification: {spec_file}
-- Implementation Plan: {plan_file}
+{spec_context}{plan_context}
 
 ## Commits
 {commits}
@@ -74,7 +79,7 @@ alongside this skill.
 ### PR content mode
 其他情況（沒有 PR review comments）：
 
-1. 閱讀需求規格、實作計畫與目前分支上的 commits
+1. 閱讀本 workflow 提供的需求規格、實作計畫與目前分支上的 commits
 2. 編輯 `{output_file}`，產出 PR title 與 description：
    - Title 必須放在第一行 `#` 標題，精簡清楚，不超過 80 字元
    - Body 維持 `Summary`、`Changes`、`Test Plan` 結構

--- a/src/cafe/data/skills/cafe-pr/SKILL.md
+++ b/src/cafe/data/skills/cafe-pr/SKILL.md
@@ -6,16 +6,16 @@ workflow:
   prompt_inputs:
     - artifacts: [spec]
       placeholder: spec_file
-      required: true
+      required: false
     - artifacts: [spec]
       placeholder: spec_file_path
-      required: true
+      required: false
     - artifacts: [plan]
       placeholder: plan_file
-      required: true
+      required: false
     - artifacts: [plan]
       placeholder: plan_file_path
-      required: true
+      required: false
     - artifacts: [code]
       placeholder: develop_file
       required: false

--- a/src/cafe/data/skills/cafe-pr/references/execution_steps_iteration_1.md
+++ b/src/cafe/data/skills/cafe-pr/references/execution_steps_iteration_1.md
@@ -1,9 +1,7 @@
 ## Checklist
 
 [ ] Read {agent_file} to understand your role and native language
-[ ] Read the requirements specification {spec_file}
-[ ] Read the implementation plan {plan_file}
-[ ] Review all commits in the current branch
+{spec_read_instruction}{plan_read_instruction}[ ] Review all commits in the current branch
 [ ] Edit {output_file} to fill in PR title and description (NOT in your response)
 [ ] Ensure PR title is concise and descriptive (max 80 characters)
 [ ] Include reference to original requirements

--- a/src/cafe/data/skills/cafe-pr/references/execution_steps_iteration_1.md
+++ b/src/cafe/data/skills/cafe-pr/references/execution_steps_iteration_1.md
@@ -1,10 +1,10 @@
 ## Checklist
 
 [ ] Read {agent_file} to understand your role and native language
-[ ] Read the requirements specification {spec_file_path}
-[ ] Read the implementation plan {plan_file_path}
+[ ] Read the requirements specification {spec_file}
+[ ] Read the implementation plan {plan_file}
 [ ] Review all commits in the current branch
-[ ] Edit {pr_file} to fill in PR title and description (NOT in your response)
+[ ] Edit {output_file} to fill in PR title and description (NOT in your response)
 [ ] Ensure PR title is concise and descriptive (max 80 characters)
 [ ] Include reference to original requirements
 [ ] List all major changes and commits in the Changes section

--- a/src/cafe/data/skills/cafe-pr/references/execution_steps_iteration_n.md
+++ b/src/cafe/data/skills/cafe-pr/references/execution_steps_iteration_n.md
@@ -1,9 +1,9 @@
 ## Checklist
 
 [ ] Read {agent_file} to understand your role and native language
-[ ] Read {prev_pr_file} to review previous PR content
+[ ] Read {previous_output_file} to review previous PR content
 [ ] Review unpushed commits to identify new changes
-[ ] Edit {current_pr_file} to update PR content based on new changes (NOT in your response)
+[ ] Edit {output_file} to update PR content based on new changes (NOT in your response)
 [ ] Do not query or wait for a remote GitHub branch/PR; host-side publish runs after this phase returns
 [ ] Update blackboard and next-step baton to hand off to the next workflow target
 [ ] Mark this checklist complete before returning confirmed

--- a/src/cafe/data/skills/cafe-pr/references/plan_read_instruction.md
+++ b/src/cafe/data/skills/cafe-pr/references/plan_read_instruction.md
@@ -1,0 +1,1 @@
+[ ] Read the implementation plan {plan_file}

--- a/src/cafe/data/skills/cafe-pr/references/pr_plan_context.md
+++ b/src/cafe/data/skills/cafe-pr/references/pr_plan_context.md
@@ -1,0 +1,1 @@
+- Implementation Plan: {plan_file}

--- a/src/cafe/data/skills/cafe-pr/references/pr_spec_context.md
+++ b/src/cafe/data/skills/cafe-pr/references/pr_spec_context.md
@@ -1,0 +1,1 @@
+- Requirements Specification: {spec_file}

--- a/src/cafe/data/skills/cafe-pr/references/spec_read_instruction.md
+++ b/src/cafe/data/skills/cafe-pr/references/spec_read_instruction.md
@@ -1,0 +1,1 @@
+[ ] Read the requirements specification {spec_file}

--- a/src/cafe/data/skills/cafe-review/SKILL.md
+++ b/src/cafe/data/skills/cafe-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cafe-review
 description: "審查程式碼品質與風險"
-version: 1.0.0
+version: 1.0.1
 workflow:
   prompt_inputs:
     - artifacts: [spec]
@@ -24,7 +24,10 @@ workflow:
       required: false
   checklist:
     context_references:
+      spec_read_instruction: spec_read_instruction.md
+      plan_read_instruction: plan_read_instruction.md
       feedback_instruction: feedback_instruction.md
+      spec_comparison_instruction: spec_comparison_instruction.md
     variants:
       - when: {}
         sections:

--- a/src/cafe/data/skills/cafe-review/SKILL.md
+++ b/src/cafe/data/skills/cafe-review/SKILL.md
@@ -2,6 +2,33 @@
 name: cafe-review
 description: "審查程式碼品質與風險"
 version: 1.0.0
+workflow:
+  prompt_inputs:
+    - artifacts: [spec]
+      placeholder: spec_file
+      required: true
+    - artifacts: [spec]
+      placeholder: spec_file_path
+      required: true
+    - artifacts: [plan]
+      placeholder: plan_file
+      required: false
+    - artifacts: [plan]
+      placeholder: plan_file_path
+      required: false
+    - artifacts: [code]
+      placeholder: develop_file
+      required: false
+    - artifacts: [review_feedback, pr_result]
+      placeholder: feedback_file
+      required: false
+  checklist:
+    variants:
+      - when: {}
+        sections:
+          - reference: execution_steps.md
+          - optional_checklist: basic_principles.md
+    include_role_guidance: true
 ---
 
 # Review

--- a/src/cafe/data/skills/cafe-review/SKILL.md
+++ b/src/cafe/data/skills/cafe-review/SKILL.md
@@ -23,6 +23,8 @@ workflow:
       placeholder: feedback_file
       required: false
   checklist:
+    context_references:
+      feedback_instruction: feedback_instruction.md
     variants:
       - when: {}
         sections:
@@ -37,12 +39,11 @@ workflow:
 Read your agent file: {agent_file}
 
 ## Context
-- Requirements Specification: {spec_file}
-- Implementation Plan: {plan_file}
+- Use the workflow inputs listed in the runtime context. Review every supplied requirement, plan, implementation artifact, and feedback item that applies to this run.
 
 ## Instructions
 - 以缺陷與風險為主
-- 先確認需求、計畫與實作是否一致
+- 先確認目前提供的需求、計畫與實作是否一致
 - 優先指出行為回歸、缺少測試與高風險問題
 - 若需修改，把 next-step baton 寫成 `develop`
 - 通過時，把 next-step baton 寫成下一個 workflow step（預設 playbook 為 `pr`）

--- a/src/cafe/data/skills/cafe-review/SKILL.md
+++ b/src/cafe/data/skills/cafe-review/SKILL.md
@@ -6,10 +6,10 @@ workflow:
   prompt_inputs:
     - artifacts: [spec]
       placeholder: spec_file
-      required: true
+      required: false
     - artifacts: [spec]
       placeholder: spec_file_path
-      required: true
+      required: false
     - artifacts: [plan]
       placeholder: plan_file
       required: false

--- a/src/cafe/data/skills/cafe-review/references/execution_steps.md
+++ b/src/cafe/data/skills/cafe-review/references/execution_steps.md
@@ -1,9 +1,7 @@
 ## Checklist
 
 [ ] Read {agent_file} to understand your role and native language
-[ ] Read the requirements specification {spec_file}
-[ ] Read the implementation plan {plan_file}
-{feedback_instruction}[ ] Prioritize user feedback from PR comments over spec requirements if there are conflicts
+{spec_read_instruction}{plan_read_instruction}{feedback_instruction}[ ] Prioritize user feedback from PR comments over spec requirements if there are conflicts
 
 ## Git Status and Security Check
 [ ] Check if there are new commits (use `git log {base_branch}..HEAD`). If no commits exist, development is incomplete - hand off to `develop`
@@ -23,8 +21,7 @@
 
 ## Implementation Completeness Check
 [ ] Check for unfinished items in implementation plan
-[ ] Compare implementation against {spec_file}
-[ ] Verify all acceptance criteria are met
+{spec_comparison_instruction}[ ] Verify all acceptance criteria are met
 [ ] Confirm: Verified all requirements are met, nothing missed
 
 ## Code Quality Review

--- a/src/cafe/data/skills/cafe-review/references/execution_steps.md
+++ b/src/cafe/data/skills/cafe-review/references/execution_steps.md
@@ -3,8 +3,7 @@
 [ ] Read {agent_file} to understand your role and native language
 [ ] Read the requirements specification {spec_file}
 [ ] Read the implementation plan {plan_file}
-[ ] Read PR feedback in {feedback_file} (if exists) to see user feedback and requests
-[ ] Prioritize user feedback from PR comments over spec requirements if there are conflicts
+{feedback_instruction}[ ] Prioritize user feedback from PR comments over spec requirements if there are conflicts
 
 ## Git Status and Security Check
 [ ] Check if there are new commits (use `git log {base_branch}..HEAD`). If no commits exist, development is incomplete - hand off to `develop`

--- a/src/cafe/data/skills/cafe-review/references/execution_steps.md
+++ b/src/cafe/data/skills/cafe-review/references/execution_steps.md
@@ -1,9 +1,9 @@
 ## Checklist
 
 [ ] Read {agent_file} to understand your role and native language
-[ ] Read the requirements specification {spec_file_path}
-[ ] Read the implementation plan {plan_file_path}
-[ ] Read PR feedback in {pr_feedback_file_path} (if exists) to see user feedback and requests
+[ ] Read the requirements specification {spec_file}
+[ ] Read the implementation plan {plan_file}
+[ ] Read PR feedback in {feedback_file} (if exists) to see user feedback and requests
 [ ] Prioritize user feedback from PR comments over spec requirements if there are conflicts
 
 ## Git Status and Security Check
@@ -24,7 +24,7 @@
 
 ## Implementation Completeness Check
 [ ] Check for unfinished items in implementation plan
-[ ] Compare implementation against {spec_file_path}
+[ ] Compare implementation against {spec_file}
 [ ] Verify all acceptance criteria are met
 [ ] Confirm: Verified all requirements are met, nothing missed
 
@@ -61,7 +61,7 @@
 
 ## Final Steps
 [ ] Confirm: No code was modified
-[ ] Write review findings to {review_file_path} in todo list format (same format as PR phase)
+[ ] Write review findings to {output_file} in todo list format (same format as PR phase)
 [ ] Use this structure: ## Todo List / ### [Category] / - [ ] item or - [x] item
 [ ] Group issues by category (e.g., "Commit Message Style", "Code Quality", "Testing")
 [ ] Each issue should be a checkbox item with file path and line number

--- a/src/cafe/data/skills/cafe-review/references/feedback_instruction.md
+++ b/src/cafe/data/skills/cafe-review/references/feedback_instruction.md
@@ -1,0 +1,1 @@
+[ ] Read PR feedback in {feedback_file} (if exists) to see user feedback and requests

--- a/src/cafe/data/skills/cafe-review/references/plan_read_instruction.md
+++ b/src/cafe/data/skills/cafe-review/references/plan_read_instruction.md
@@ -1,0 +1,1 @@
+[ ] Read the implementation plan {plan_file}

--- a/src/cafe/data/skills/cafe-review/references/spec_comparison_instruction.md
+++ b/src/cafe/data/skills/cafe-review/references/spec_comparison_instruction.md
@@ -1,0 +1,1 @@
+[ ] Compare implementation against {spec_file}

--- a/src/cafe/data/skills/cafe-review/references/spec_read_instruction.md
+++ b/src/cafe/data/skills/cafe-review/references/spec_read_instruction.md
@@ -1,0 +1,1 @@
+[ ] Read the requirements specification {spec_file}

--- a/src/cafe/data/skills/cafe-spec/SKILL.md
+++ b/src/cafe/data/skills/cafe-spec/SKILL.md
@@ -12,19 +12,20 @@ workflow:
           - reference: execution_steps_iteration_1.md
           - template_catalog: true
           - optional_checklist: basic_principles.md
-          - reference: dod_instruction.md
+          - reference: dod_instruction_composed.md
       - when: {min_iteration: 2, max_iteration: 3}
         sections:
           - reference: execution_steps_iteration_n.md
           - optional_checklist: basic_principles.md
-          - reference: dod_instruction.md
+          - reference: dod_instruction_composed.md
       - when: {min_iteration: 4}
         sections:
           - reference: execution_steps_iteration_n.md
           - optional_checklist: basic_principles.md
-          - reference: important_notes_iteration_4_plus.md
-          - reference: dod_instruction.md
+          - reference: important_notes_iteration_4_plus_composed.md
+          - reference: dod_instruction_after_notes_composed.md
     include_role_guidance: true
+    compact_agent_guidance: true
   output_templates:
     catalog: spec
     follow_instruction: Follow template structure when writing analysis results

--- a/src/cafe/data/skills/cafe-spec/SKILL.md
+++ b/src/cafe/data/skills/cafe-spec/SKILL.md
@@ -2,6 +2,32 @@
 name: cafe-spec
 description: "收集、整理或修訂需求規格（依 iteration 切換行為）"
 version: 1.0.0
+workflow:
+  checklist:
+    context_references:
+      xml_questions_instruction: xml_questions_instruction.md
+    variants:
+      - when: {iteration: 1}
+        sections:
+          - reference: execution_steps_iteration_1.md
+          - template_catalog: true
+          - optional_checklist: basic_principles.md
+          - reference: dod_instruction.md
+      - when: {min_iteration: 2, max_iteration: 3}
+        sections:
+          - reference: execution_steps_iteration_n.md
+          - optional_checklist: basic_principles.md
+          - reference: dod_instruction.md
+      - when: {min_iteration: 4}
+        sections:
+          - reference: execution_steps_iteration_n.md
+          - optional_checklist: basic_principles.md
+          - reference: important_notes_iteration_4_plus.md
+          - reference: dod_instruction.md
+    include_role_guidance: true
+  output_templates:
+    catalog: spec
+    follow_instruction: Follow template structure when writing analysis results
 ---
 
 # Spec

--- a/src/cafe/data/skills/cafe-spec/references/dod_instruction_after_notes_composed.md
+++ b/src/cafe/data/skills/cafe-spec/references/dod_instruction_after_notes_composed.md
@@ -1,0 +1,7 @@
+## Definition of Done (DoD) -- MANDATORY
+
+[ ] You MUST include DoD questions in questions.xml and request clarification (even if requirements are already clear -- send DoD questions alone)
+[ ] DoD questions focus on functional requirements only (e.g., all major features working, error handling working, edge cases tested)
+[ ] Do NOT add "Other" or custom input options to checkbox questions -- the system automatically adds an "Other" option to every checkbox question
+[ ] NEVER mark the spec as ready for review without first confirming DoD with the user
+[ ] After receiving user's DoD answers, integrate selected items into the Acceptance Criteria section with "✅ **DoD:**" prefix

--- a/src/cafe/data/skills/cafe-spec/references/dod_instruction_composed.md
+++ b/src/cafe/data/skills/cafe-spec/references/dod_instruction_composed.md
@@ -1,0 +1,9 @@
+
+
+## Definition of Done (DoD) -- MANDATORY
+
+[ ] You MUST include DoD questions in questions.xml and request clarification (even if requirements are already clear -- send DoD questions alone)
+[ ] DoD questions focus on functional requirements only (e.g., all major features working, error handling working, edge cases tested)
+[ ] Do NOT add "Other" or custom input options to checkbox questions -- the system automatically adds an "Other" option to every checkbox question
+[ ] NEVER mark the spec as ready for review without first confirming DoD with the user
+[ ] After receiving user's DoD answers, integrate selected items into the Acceptance Criteria section with "✅ **DoD:**" prefix

--- a/src/cafe/data/skills/cafe-spec/references/execution_steps_iteration_1.md
+++ b/src/cafe/data/skills/cafe-spec/references/execution_steps_iteration_1.md
@@ -1,13 +1,13 @@
 ## Checklist
 
 [ ] Read {agent_file} to understand your role and native language
-[ ] Read {current_spec_file} to understand initial requirements
+[ ] Read {output_file} to understand initial requirements
 [ ] If images exist in spec/images/, read and analyze them for UI/UX requirements and visual context
 [ ] Read README.md for project context
 [ ] Search codebase using Read/Grep tools to find answers before asking users
 [ ] Identify unclear areas that need clarification
 [ ] Preserve original requirements content - Keep the "Initial Requirements" section and "Issue Title" (if present) unchanged, only add your analysis below
-[ ] Write analysis results to {current_spec_file} (NOT in your response)
+[ ] Write analysis results to {output_file} (NOT in your response)
 [ ] Update blackboard and next-step baton to hand off to the next workflow target
 [ ] Confirm: No technical details were included (no implementation, architecture, languages, frameworks, databases)
 [ ] Confirm: Only provided 2-3 high-level approach options if any, without prescribing specific technical solutions

--- a/src/cafe/data/skills/cafe-spec/references/execution_steps_iteration_n.md
+++ b/src/cafe/data/skills/cafe-spec/references/execution_steps_iteration_n.md
@@ -1,11 +1,11 @@
 ## Checklist
 
 [ ] Read {agent_file} to understand your role and native language
-[ ] Read {prev_spec_file} to review previous analysis
+[ ] Read {previous_output_file} to review previous analysis
 [ ] Review user's answer (provided below)
 [ ] Integrate new information into specification, DO NOT hint the existence of the previous iterations
 [ ] Preserve original requirements content - Keep the "Initial Requirements" section and "Issue Title" (if present) unchanged from the first iteration
-[ ] Write updated analysis to {current_spec_file} (NOT in your response)
+[ ] Write updated analysis to {output_file} (NOT in your response)
 [ ] Update blackboard and next-step baton to hand off to the next workflow target
 [ ] Confirm: No technical details were included (no implementation, architecture, languages, frameworks, databases)
 [ ] Confirm: Only provided 2-3 high-level approach options if any, without prescribing specific technical solutions

--- a/src/cafe/data/skills/cafe-spec/references/important_notes_iteration_4_plus_composed.md
+++ b/src/cafe/data/skills/cafe-spec/references/important_notes_iteration_4_plus_composed.md
@@ -1,0 +1,2 @@
+
+[ ] Round {iteration}: Only clarify existing questions, NO new questions

--- a/src/cafe/data/skills/write-cafe-phase/references/skill-spec.md
+++ b/src/cafe/data/skills/write-cafe-phase/references/skill-spec.md
@@ -49,6 +49,41 @@ version: 1.0.0
 ---
 ```
 
+### Workflow metadata contract
+
+Phase skills may declare workflow-facing behavior in frontmatter. Runtime-owned
+paths and blackboard state remain outside this block; a declaration only states
+how the skill consumes them:
+
+```yaml
+workflow:
+  prompt_inputs:
+    - artifacts: [research_notes]
+      placeholder: evidence_file
+      required: true
+  checklist:
+    context_references:
+      xml_questions_instruction: xml_questions_instruction.md
+    variants:
+      - when: {iteration: 1}
+        sections: [{reference: execution_first.md}]
+      - when: {artifact_present: [editor_feedback]}
+        sections: [{reference: execution_feedback.md}]
+    include_role_guidance: true
+  output_templates:
+    catalog: research-report
+```
+
+- `prompt_inputs` are resolved in listed candidate order. Required inputs stop
+  before agent invocation with the placeholder and candidates named; absent
+  optional inputs are omitted.
+- Checklist references must remain under `references/`; variants are evaluated
+  in declaration order using bounded iteration, artifact-presence, or feedback
+  selectors. Role guidance is included only when explicitly requested.
+- A template catalog is the owning skill's `assets/templates/` directory. A
+  selection is read from `<step>.template` in `issue.yaml`; `auto` leaves the
+  catalog available without selecting a file.
+
 - `name`：小寫。**內部 skill 一律 `cafe-` 開頭**，後段依類型沿用既有慣例：
   phase skill 用 snake_case（`cafe-brief_first`、`cafe-incident_triage`）、
   shared / chat skill 用 kebab-case（`cafe-chat-develop-change`、`cafe-workflow-common`）。
@@ -118,8 +153,9 @@ Write <artifact> to: {output_file}
 ## 5. Placeholder 契約
 
 Placeholder 是 activate 時的**純文字替換**（`{key}` → 值），不支援條件或運算。
-**只能使用下表的 key**；用了 runtime 沒提供的 key，`{x}` 會原樣漏進 agent prompt
-（既有反例：`cafe-spec` skill 曾用沒人提供的 `{blackboard_digest}`）。
+除了 runtime-owned key 外，skill 可用 `workflow.prompt_inputs` 宣告任意自己的
+placeholder 名稱。不要依賴 artifact 名稱或新增 Python mapping；未宣告 placeholder
+不會被 runtime 猜測或補成 development-phase 的檔案。
 
 | Placeholder | 提供時機 |
 | --- | --- |
@@ -128,13 +164,12 @@ Placeholder 是 activate 時的**純文字替換**（`{key}` → 值），不支
 | `{handoff_summary}` | 所有 phase step |
 | `{blackboard_path}`、`{next_step_path}` | 所有 phase step |
 | `{valid_to_steps}`、`{step_transitions}` | 所有 phase step |
-| `{spec_file}` | step 的 `input_artifacts` 含 `spec`，或 issue 目錄已有最新 spec |
-| `{plan_file}` | step 的 `input_artifacts` 含 `plan`，或 issue 目錄已有最新 plan |
-| `{develop_file}` | `input_artifacts` 含 `code` |
-| `{feedback_file}` | `input_artifacts` 含 `review_feedback` 或 `pr_result` |
-| `{commits}`、`{base_branch}` | 僅 `cafe-pr` skill |
+| skill-declared input | `workflow.prompt_inputs` 解析到記錄的 artifact |
+| `{template_file}`、`{template_catalog}` | skill 宣告 `output_templates` 時提供 |
+| `{commits}`、`{base_branch}` | runtime-owned Git context（需要時提供） |
 
-新增 placeholder 必須同步修改 `generic_workflow_step.py` 的 `_build_context()`，並更新本表。
+新增 artifact placeholder 必須修改 skill metadata 與此契約說明，不得新增
+`generic_workflow_step.py` 的 skill-name 分支。
 
 ## 6. Handoff 與 baton：單一權威在 cafe-workflow-common
 

--- a/src/cafe/data/skills/write-cafe-phase/references/skill-spec.md
+++ b/src/cafe/data/skills/write-cafe-phase/references/skill-spec.md
@@ -61,6 +61,8 @@ workflow:
     - artifacts: [research_notes]
       placeholder: evidence_file
       required: true
+  prompt_references:
+    optional_evidence_instruction: optional_evidence_instruction.md
   checklist:
     context_references:
       xml_questions_instruction: xml_questions_instruction.md
@@ -70,6 +72,7 @@ workflow:
       - when: {artifact_present: [editor_feedback]}
         sections: [{reference: execution_feedback.md}]
     include_role_guidance: true
+    compact_agent_guidance: false
   output_templates:
     catalog: research-report
 ```
@@ -77,9 +80,17 @@ workflow:
 - `prompt_inputs` are resolved in listed candidate order. Required inputs stop
   before agent invocation with the placeholder and candidates named; absent
   optional inputs are omitted.
+- `prompt_references` are named `references/*.md` sections interpolated into the
+  skill body. Use one for an instruction that depends on an optional input: it
+  renders only when every placeholder inside that reference is available;
+  otherwise the named marker and its instruction are omitted. Do not place an
+  optional input placeholder directly in `SKILL.md` prose.
 - Checklist references must remain under `references/`; variants are evaluated
   in declaration order using bounded iteration, artifact-presence, or feedback
   selectors. Role guidance is included only when explicitly requested.
+  `compact_agent_guidance: true` appends that guidance without inserting a
+  separator, for references that intentionally own the preceding spacing; the
+  default keeps a separating newline.
 - A template catalog is the owning skill's `assets/templates/` directory. A
   selection is read from `<step>.template` in `issue.yaml`; `auto` leaves the
   catalog available without selecting a file.

--- a/src/cafe/data/skills/write-cafe-playbook/references/playbook-spec.md
+++ b/src/cafe/data/skills/write-cafe-playbook/references/playbook-spec.md
@@ -98,6 +98,7 @@ artifacts.
 | `assignee_type` | Use `agent`; other values are currently reserved and warn |
 | `input_artifacts` | Artifact keys already produced by earlier or conditional paths |
 | `output_artifact` | The key registered when `{output_file}` exists |
+| `template` | Optional default selected from the step skill's declared output-template catalog |
 | `valid_intents` | Supported `PhaseStatusCode` tokens the phase may return |
 | `allowed_tools` | Least broad set that still allows the skill to complete |
 | `hooks` | Runtime-supported prepare/execute/publish hooks only |
@@ -206,7 +207,10 @@ Prefer an explicit forward skip:
 - `PermissionRetryHandler` belongs on execution phases that may hit permission boundaries.
 - Use specialized hooks only when their implementation exists and their lifecycle stage is valid.
 - Non-software playbooks should normally set `commands.prepare.prompt_for_spec_plan_config: false`; otherwise they inherit development-oriented preparation prompts.
-- Declarative prepare fields support only the write targets defined in `src/cafe/core/prepare_fields.py`. Do not invent domain write targets in YAML.
+- Declarative prepare fields support the fixed legacy targets plus
+  `<step>.template` when that step skill declares `workflow.output_templates`.
+  The selected value persists in the same named step block in `issue.yaml`.
+  Do not invent other domain write targets in YAML.
 
 ## 9. Validation Sequence
 

--- a/src/cafe/phases/generic_phase.py
+++ b/src/cafe/phases/generic_phase.py
@@ -38,6 +38,7 @@ class GenericPhase:
     """Build prompts from skill content and run lifecycle hooks."""
 
     GOTO_PATTERN = re.compile(r"GOTO\s*:\s*([a-zA-Z0-9_-]+)")
+    PLACEHOLDER_PATTERN = re.compile(r"\{([A-Za-z_][A-Za-z0-9_]*)\}")
     SCRIPT_HOOK_STAGES = {"before_execute", "after_execute"}
 
     def __init__(
@@ -63,19 +64,47 @@ class GenericPhase:
         """Install one skill for the target CLI and return its invocation syntax."""
         installed_dir = self.skill_bridge.install_skill(skill_name, agent_cli, context=context)
         contract = self.skill_loader.get_workflow_contract(skill_name)
+        prompt_references = self._render_prompt_references(
+            skill_name=skill_name,
+            references=contract.prompt_references,
+            context=context or {},
+        )
         resolved_inputs = [
             (mapping.placeholder, str((context or {})[mapping.placeholder]))
             for mapping in contract.prompt_inputs
             if (context or {}).get(mapping.placeholder)
         ]
-        if resolved_inputs:
+        if prompt_references or resolved_inputs:
             skill_file = installed_dir / "SKILL.md"
             rendered = skill_file.read_text(encoding="utf-8")
-            rendered += "\n\n## Workflow Inputs\n" + "\n".join(
-                f"- {placeholder}: {path}" for placeholder, path in resolved_inputs
-            )
+            for placeholder, content in prompt_references.items():
+                rendered = rendered.replace(f"{{{placeholder}}}", content)
+            if resolved_inputs:
+                rendered += "\n\n## Workflow Inputs\n" + "\n".join(
+                    f"- {placeholder}: {path}" for placeholder, path in resolved_inputs
+                )
             skill_file.write_text(rendered, encoding="utf-8")
         return self.skill_bridge.get_invocation(skill_name, agent_cli)
+
+    def _render_prompt_references(
+        self,
+        *,
+        skill_name: str,
+        references: Dict[str, str],
+        context: Dict[str, str],
+    ) -> Dict[str, str]:
+        """Render named prompt sections only when every referenced input is available."""
+        resolved: Dict[str, str] = {}
+        for placeholder, reference in references.items():
+            content = self.skill_loader.get_reference(skill_name, reference)
+            names = self.PLACEHOLDER_PATTERN.findall(content)
+            if not all(context.get(name) for name in names):
+                resolved[placeholder] = ""
+                continue
+            for name in set(names):
+                content = content.replace(f"{{{name}}}", str(context[name]))
+            resolved[placeholder] = content
+        return resolved
 
     def prepare_skills(
         self,

--- a/src/cafe/phases/generic_phase.py
+++ b/src/cafe/phases/generic_phase.py
@@ -61,7 +61,22 @@ class GenericPhase:
         context: Optional[Dict[str, str]] = None,
     ) -> str:
         """Install one skill for the target CLI and return its invocation syntax."""
-        self.skill_bridge.install_skill(skill_name, agent_cli, context=context)
+        installed_dir = self.skill_bridge.install_skill(skill_name, agent_cli, context=context)
+        contract = self.skill_loader.get_workflow_contract(skill_name)
+        absent_optional_inputs = {
+            mapping.placeholder
+            for mapping in contract.prompt_inputs
+            if not mapping.required and mapping.placeholder not in (context or {})
+        }
+        if absent_optional_inputs:
+            skill_file = installed_dir / "SKILL.md"
+            rendered = skill_file.read_text(encoding="utf-8")
+            rendered = "".join(
+                line
+                for line in rendered.splitlines(keepends=True)
+                if not any(f"{{{placeholder}}}" in line for placeholder in absent_optional_inputs)
+            )
+            skill_file.write_text(rendered, encoding="utf-8")
         return self.skill_bridge.get_invocation(skill_name, agent_cli)
 
     def prepare_skills(
@@ -72,8 +87,10 @@ class GenericPhase:
         context: Optional[Dict[str, str]] = None,
     ) -> list[str]:
         """Install a list of skills for the target CLI and return invocation syntax."""
-        self.skill_bridge.install_skills(skill_names, agent_cli, context=context)
-        return [self.skill_bridge.get_invocation(name, agent_cli) for name in skill_names]
+        return [
+            self.prepare_skill(skill_name=name, agent_cli=agent_cli, context=context)
+            for name in skill_names
+        ]
 
     def build_prompt(
         self,

--- a/src/cafe/phases/generic_phase.py
+++ b/src/cafe/phases/generic_phase.py
@@ -63,18 +63,16 @@ class GenericPhase:
         """Install one skill for the target CLI and return its invocation syntax."""
         installed_dir = self.skill_bridge.install_skill(skill_name, agent_cli, context=context)
         contract = self.skill_loader.get_workflow_contract(skill_name)
-        absent_optional_inputs = {
-            mapping.placeholder
+        resolved_inputs = [
+            (mapping.placeholder, str((context or {})[mapping.placeholder]))
             for mapping in contract.prompt_inputs
-            if not mapping.required and mapping.placeholder not in (context or {})
-        }
-        if absent_optional_inputs:
+            if (context or {}).get(mapping.placeholder)
+        ]
+        if resolved_inputs:
             skill_file = installed_dir / "SKILL.md"
             rendered = skill_file.read_text(encoding="utf-8")
-            rendered = "".join(
-                line
-                for line in rendered.splitlines(keepends=True)
-                if not any(f"{{{placeholder}}}" in line for placeholder in absent_optional_inputs)
+            rendered += "\n\n## Workflow Inputs\n" + "\n".join(
+                f"- {placeholder}: {path}" for placeholder, path in resolved_inputs
             )
             skill_file.write_text(rendered, encoding="utf-8")
         return self.skill_bridge.get_invocation(skill_name, agent_cli)

--- a/src/cafe/phases/generic_workflow_step.py
+++ b/src/cafe/phases/generic_workflow_step.py
@@ -203,9 +203,13 @@ class GenericWorkflowStepExecutor(Phase):
             agent_name=agent_name,
             output_file=output_file,
         )
-        self._template_allowed_directories = []
-        if template_file := context.get("template_file"):
-            self._template_allowed_directories.append(str(Path(template_file).parent))
+        contract = self._get_skill_loader().get_workflow_contract(skill_name)
+        self._template_allowed_directories = self._template_allowed_directories_for(
+            step_name=step_name,
+            step_def=step_def,
+            skill_name=skill_name,
+            contract=contract,
+        )
         shared_skill_invocations = self.generic_phase.prepare_skills(
             skill_names=self.SHARED_WORKFLOW_SKILLS,
             agent_cli=agent_cli,
@@ -770,8 +774,9 @@ class GenericWorkflowStepExecutor(Phase):
 
         skill_name = self._resolve_skill_name(step_def, self.iteration)
         contract = self._get_skill_loader().get_workflow_contract(skill_name)
+        input_artifacts = self._step_input_artifacts(step_def, blackboard_state)
         try:
-            declared_inputs = resolve_prompt_inputs(contract, blackboard_state.artifacts)
+            declared_inputs = resolve_prompt_inputs(contract, input_artifacts)
         except DeclaredArtifactError as exc:
             raise ValueError(
                 f"Step {step_name!r}, skill {canonical_skill_name(skill_name)!r}: {exc}"
@@ -782,10 +787,6 @@ class GenericWorkflowStepExecutor(Phase):
                 for placeholder, path in declared_inputs.items()
             }
         )
-        for mapping in contract.prompt_inputs:
-            if not mapping.required and mapping.placeholder not in context:
-                context[mapping.placeholder] = "(not available)"
-
         self._add_template_context(
             context=context,
             step_name=step_name,
@@ -804,6 +805,21 @@ class GenericWorkflowStepExecutor(Phase):
             )
 
         return context
+
+    @staticmethod
+    def _step_input_artifacts(
+        step_def: Dict[str, Any], blackboard_state: BlackboardState
+    ) -> Dict[str, Any]:
+        """Return only artifact records declared as inputs for this workflow step."""
+        declared = step_def.get("input_artifacts")
+        if declared is None:
+            return dict(blackboard_state.artifacts)
+        allowed = {str(name) for name in declared}
+        return {
+            name: artifact
+            for name, artifact in blackboard_state.artifacts.items()
+            if name in allowed
+        }
 
     @classmethod
     def _build_blackboard_digest(cls, state: BlackboardState) -> str:
@@ -863,8 +879,9 @@ class GenericWorkflowStepExecutor(Phase):
     ) -> None:
         canonical_name = canonical_skill_name(skill_name)
         contract = self._get_skill_loader().get_workflow_contract(skill_name)
+        input_artifacts = self._step_input_artifacts(step_def, blackboard_state)
         try:
-            declared_inputs = resolve_prompt_inputs(contract, blackboard_state.artifacts)
+            declared_inputs = resolve_prompt_inputs(contract, input_artifacts)
         except DeclaredArtifactError as exc:
             raise ValueError(f"Step {step_name!r}, skill {canonical_name!r}: {exc}") from exc
 
@@ -890,8 +907,7 @@ class GenericWorkflowStepExecutor(Phase):
             }
         )
         feedback = bool(
-            blackboard_state.artifacts.get("review_feedback")
-            or blackboard_state.artifacts.get("pr_result")
+            input_artifacts.get("review_feedback") or input_artifacts.get("pr_result")
         )
         compose_declared_checklist(
             skill_name=canonical_name,
@@ -901,7 +917,7 @@ class GenericWorkflowStepExecutor(Phase):
             checklist_file_path=checklist_file,
             iteration=self.iteration,
             context=context,
-            artifacts=blackboard_state.artifacts,
+            artifacts=input_artifacts,
             feedback=feedback,
             template_mode=self._resolved_template_mode(step_name, step_def),
             template_file=self._resolved_template_file(step_name, step_def, canonical_name, contract),
@@ -939,6 +955,39 @@ class GenericWorkflowStepExecutor(Phase):
                 f"from catalog {contract.output_templates.catalog!r}"
             )
         return self._display_path(template_file)
+
+    def _template_allowed_directories_for(
+        self,
+        *,
+        step_name: str,
+        step_def: Dict[str, Any],
+        skill_name: str,
+        contract: SkillWorkflowContract,
+    ) -> List[str]:
+        """Grant read access to the catalog templates a step can select."""
+        if contract.output_templates is None:
+            return []
+        manager = TemplateManager(
+            template_type=contract.output_templates.catalog,
+            skill_name=skill_name,
+            skill_loader=self._get_skill_loader(),
+        )
+        selection = self._resolved_template_mode(step_name, step_def)
+        if selection == "auto":
+            return list(
+                dict.fromkeys(
+                    str(path.parent)
+                    for name, _source in manager.list_templates()
+                    if (path := manager.get_template_path(name)) is not None
+                )
+            )
+        template_file = manager.get_template_path(selection)
+        if template_file is None:
+            raise ValueError(
+                f"Step {step_name!r} selected unknown template {selection!r} "
+                f"from catalog {contract.output_templates.catalog!r}"
+            )
+        return [str(template_file.parent)]
 
     def _add_template_context(
         self,

--- a/src/cafe/phases/generic_workflow_step.py
+++ b/src/cafe/phases/generic_workflow_step.py
@@ -33,17 +33,15 @@ from cafe.core.status_codes import (
 )
 from cafe.core.workflow_models import StepExecutionResult
 from cafe.phases.generic_phase import GenericPhase
-from cafe.skills.bridge import try_load_skill_reference
-from cafe.skills.checklist_composer import (
-    generate_custom_skill_checklist,
-    generate_develop_checklist,
-    generate_plan_checklist,
-    generate_pr_checklist,
-    generate_review_checklist,
-    generate_spec_checklist,
+from cafe.skills.checklist_composer import compose_declared_checklist
+from cafe.skills.contracts import (
+    DeclaredArtifactError,
+    SkillWorkflowContract,
+    resolve_prompt_inputs,
 )
-from cafe.skills.loader import canonical_skill_name
-from cafe.utils.git_utils import get_repo_root, to_cwd_relative_path, get_git_toplevel
+from cafe.skills.loader import SkillLoader, canonical_skill_name
+from cafe.templates.manager import TemplateManager
+from cafe.utils.git_utils import get_git_toplevel, get_repo_root, to_cwd_relative_path
 from cafe.utils.phase_config import load_phase_step_model
 
 
@@ -97,6 +95,11 @@ class GenericWorkflowStepExecutor(Phase):
     BLACKBOARD_DIGEST_EVENT_LIMIT = 5
     BLACKBOARD_DIGEST_ARTIFACT_LIMIT = 20
     BLACKBOARD_DIGEST_TEXT_LIMIT = 240
+
+    def _get_skill_loader(self) -> SkillLoader:
+        """Return the GenericPhase loader, with a standalone-test fallback."""
+        generic_phase = getattr(self, "generic_phase", None)
+        return getattr(generic_phase, "skill_loader", None) or SkillLoader()
 
     def __init__(
         self,
@@ -743,36 +746,30 @@ class GenericWorkflowStepExecutor(Phase):
             "step_transitions": ", ".join(f"{i}→{s}" for i, s in step_transitions.items()),
         }
 
-        for artifact_name in step_def.get("input_artifacts", []):
-            entry = blackboard_state.artifacts.get(str(artifact_name))
-            if not entry:
-                continue
-            artifact_path = self._display_path(Path(entry.path))
-            if artifact_name == "spec":
-                context["spec_file"] = artifact_path
-            elif artifact_name == "plan":
-                context["plan_file"] = artifact_path
-            elif artifact_name == "code":
-                context["develop_file"] = artifact_path
-            elif artifact_name == "review_feedback":
-                context["feedback_file"] = artifact_path
-            elif artifact_name == "pr_result":
-                context["feedback_file"] = artifact_path
+        skill_name = self._resolve_skill_name(step_def, self.iteration)
+        contract = self._get_skill_loader().get_workflow_contract(skill_name)
+        try:
+            declared_inputs = resolve_prompt_inputs(contract, blackboard_state.artifacts)
+        except DeclaredArtifactError as exc:
+            raise ValueError(
+                f"Step {step_name!r}, skill {canonical_skill_name(skill_name)!r}: {exc}"
+            ) from exc
+        context.update(
+            {
+                placeholder: self._display_path(Path(path))
+                for placeholder, path in declared_inputs.items()
+            }
+        )
 
-        if "spec_file" not in context:
-            latest_spec = self._get_latest_versioned_file("spec", self.issue_dir / "spec")
-            if latest_spec:
-                context["spec_file"] = self._display_path(latest_spec)
-        if "plan_file" not in context:
-            latest_plan = self._get_latest_versioned_file("plan", self.issue_dir / "plan")
-            if latest_plan:
-                context["plan_file"] = self._display_path(latest_plan)
-        if step_name == "develop" and "feedback_file" not in context:
-            pr_feedback = blackboard_state.artifacts.get("pr_result")
-            if pr_feedback:
-                context["feedback_file"] = self._display_path(Path(pr_feedback.path))
+        self._add_template_context(
+            context=context,
+            step_name=step_name,
+            step_def=step_def,
+            skill_name=skill_name,
+            contract=contract,
+        )
 
-        if canonical_skill_name(self._resolve_skill_name(step_def, self.iteration)) == "cafe-pr":
+        if canonical_skill_name(skill_name) == "cafe-pr":
             base_branch = self._get_issue_config_value(self.issue_dir / "issue.yaml", "base_branch")
             resolved_base = str(base_branch or self.git_ops.get_default_base_branch())
             context["base_branch"] = resolved_base
@@ -839,129 +836,101 @@ class GenericWorkflowStepExecutor(Phase):
         output_file: Path,
         questions_xml_file: Path,
     ) -> None:
-        output_display = self._display_path(output_file)
-        questions_display = self._display_path(questions_xml_file)
-        spec_path = self._artifact_or_latest_path(blackboard_state, "spec", "spec")
-        plan_path = self._artifact_or_latest_path(blackboard_state, "plan", "plan")
-        review_feedback = self._artifact_path(
-            blackboard_state, "review_feedback"
-        ) or self._artifact_path(blackboard_state, "pr_result")
+        canonical_name = canonical_skill_name(skill_name)
+        contract = self._get_skill_loader().get_workflow_contract(skill_name)
+        try:
+            declared_inputs = resolve_prompt_inputs(contract, blackboard_state.artifacts)
+        except DeclaredArtifactError as exc:
+            raise ValueError(f"Step {step_name!r}, skill {canonical_name!r}: {exc}") from exc
 
-        skill_name = canonical_skill_name(skill_name)
-        skill_basic_principles = try_load_skill_reference(
-            skill_name,
-            "basic_principles.md",
+        previous_output = ""
+        if self.iteration > 1:
+            previous_output = self._display_path(
+                self._get_versioned_file_path(step_name, self.iteration - 1, self.phase_dir)
+            )
+        context = {
+            placeholder: self._display_path(Path(path))
+            for placeholder, path in declared_inputs.items()
+        }
+        context.update(
+            {
+                "output_file": self._display_path(output_file),
+                "questions_xml_file": self._display_path(questions_xml_file),
+                "iteration": str(self.iteration),
+                "previous_output_file": previous_output,
+                "base_branch": str(
+                    self._get_issue_config_value(self.issue_dir / "issue.yaml", "base_branch")
+                    or self.git_ops.get_default_base_branch()
+                ),
+            }
         )
-        if skill_name == "cafe-spec":
-            prev_spec = None
-            if self.iteration > 1:
-                prev_spec_file = self._get_versioned_file_path(
-                    step_name, self.iteration - 1, self.phase_dir
-                )
-                prev_spec = self._display_path(prev_spec_file)
-            generate_spec_checklist(
-                iteration=self.iteration,
-                agent_name=agent_name,
-                current_spec_file=output_display,
-                prev_spec_file=prev_spec,
-                checklist_file_path=checklist_file,
-                questions_xml_file=questions_display,
-                basic_principles=skill_basic_principles,
-            )
-            return
-
-        if skill_name == "cafe-plan":
-            if not spec_path:
-                raise ValueError("Plan step requires spec artifact")
-            prev_plan = None
-            if self.iteration > 1:
-                prev_plan_file = self._get_versioned_file_path(
-                    step_name, self.iteration - 1, self.phase_dir
-                )
-                prev_plan = self._display_path(prev_plan_file)
-            generate_plan_checklist(
-                agent_name=agent_name,
-                plan_file_path=output_display,
-                spec_file_path=spec_path,
-                checklist_file_path=checklist_file,
-                iteration=self.iteration,
-                prev_plan_file=prev_plan,
-                questions_xml_file=questions_display,
-                basic_principles=skill_basic_principles,
-            )
-            return
-
-        if skill_name == "cafe-develop":
-            if not spec_path or not plan_path:
-                raise ValueError("Develop step requires spec and plan artifacts")
-            generate_develop_checklist(
-                agent_name=agent_name,
-                spec_file_path=spec_path,
-                plan_file_path=plan_path,
-                develop_file=None,
-                checklist_file_path=checklist_file,
-                correction_mode=review_feedback is not None,
-                feedback_file_path=review_feedback,
-                output_file=output_display,
-                questions_xml_file=questions_display,
-                basic_principles=skill_basic_principles,
-            )
-            return
-
-        if skill_name == "cafe-review":
-            if not spec_path:
-                raise ValueError("Review step requires spec artifact")
-            base_branch = self._get_issue_config_value(self.issue_dir / "issue.yaml", "base_branch")
-            generate_review_checklist(
-                agent_name=agent_name,
-                spec_file_path=spec_path,
-                plan_file_path=plan_path,
-                review_file_path=output_display,
-                base_branch=str(base_branch or self.git_ops.get_default_base_branch()),
-                checklist_file_path=checklist_file,
-                basic_principles=skill_basic_principles,
-            )
-            return
-
-        if skill_name == "cafe-pr":
-            if not spec_path or not plan_path:
-                raise ValueError("PR step requires spec and plan artifacts")
-            prev_pr = None
-            if self.iteration > 1:
-                prev_pr_file = self._get_versioned_file_path(
-                    step_name, self.iteration - 1, self.phase_dir
-                )
-                prev_pr = self._display_path(prev_pr_file)
-            generate_pr_checklist(
-                agent_name=agent_name,
-                spec_file_path=spec_path,
-                plan_file_path=plan_path,
-                pr_file=output_display,
-                checklist_file_path=checklist_file,
-                iteration=self.iteration,
-                prev_pr_file=prev_pr,
-                basic_principles=skill_basic_principles,
-            )
-            return
-
-        if generate_custom_skill_checklist(
-            skill_name=skill_name,
+        feedback = bool(
+            blackboard_state.artifacts.get("review_feedback")
+            or blackboard_state.artifacts.get("pr_result")
+        )
+        compose_declared_checklist(
+            skill_name=canonical_name,
+            contract=contract,
             agent_name=agent_name,
             role=str(step_def.get("role", "developer")),
             checklist_file_path=checklist_file,
-            correction_mode=review_feedback is not None,
-            placeholders={
-                "output_file": output_display,
-                "questions_xml_file": questions_display,
-                "spec_file_path": spec_path or "",
-                "plan_file_path": plan_path or "",
-                "develop_file": self._artifact_path(blackboard_state, "code") or "",
-                "feedback_file_path": review_feedback or "",
-            },
-        ):
-            return
+            iteration=self.iteration,
+            context=context,
+            artifacts=blackboard_state.artifacts,
+            feedback=feedback,
+            template_mode=self._resolved_template_mode(step_name, step_def),
+            template_file=self._resolved_template_file(step_name, step_def, canonical_name, contract),
+        )
 
-        checklist_file.write_text("", encoding="utf-8")
+    def _resolved_template_mode(self, step_name: str, step_def: Dict[str, Any]) -> str:
+        """Return the issue selection, playbook default, or auto for a declared catalog."""
+        issue_value = self._get_issue_config_value(
+            self.issue_dir / "issue.yaml", f"{step_name}.template"
+        )
+        return str(issue_value if issue_value is not None else step_def.get("template", "auto"))
+
+    def _resolved_template_file(
+        self,
+        step_name: str,
+        step_def: Dict[str, Any],
+        skill_name: str,
+        contract: SkillWorkflowContract,
+    ) -> Optional[str]:
+        """Resolve a named selection through the owning skill's catalog."""
+        if contract.output_templates is None:
+            return None
+        selection = self._resolved_template_mode(step_name, step_def)
+        if selection == "auto":
+            return None
+        manager = TemplateManager(
+            template_type=contract.output_templates.catalog,
+            skill_name=skill_name,
+            skill_loader=self._get_skill_loader(),
+        )
+        template_file = manager.get_template_path(selection)
+        if template_file is None:
+            raise ValueError(
+                f"Step {step_name!r} selected unknown template {selection!r} "
+                f"from catalog {contract.output_templates.catalog!r}"
+            )
+        return self._display_path(template_file)
+
+    def _add_template_context(
+        self,
+        *,
+        context: Dict[str, str],
+        step_name: str,
+        step_def: Dict[str, Any],
+        skill_name: str,
+        contract: SkillWorkflowContract,
+    ) -> None:
+        """Expose only the declared template catalog or resolved selected file."""
+        if contract.output_templates is None:
+            return
+        context["template_catalog"] = contract.output_templates.catalog
+        template_file = self._resolved_template_file(step_name, step_def, skill_name, contract)
+        if template_file is not None:
+            context["template_file"] = template_file
 
     def _write_artifact_record(
         self,

--- a/src/cafe/phases/generic_workflow_step.py
+++ b/src/cafe/phases/generic_workflow_step.py
@@ -920,7 +920,12 @@ class GenericWorkflowStepExecutor(Phase):
             artifacts=input_artifacts,
             feedback=feedback,
             template_mode=self._resolved_template_mode(step_name, step_def),
-            template_file=self._resolved_template_file(step_name, step_def, canonical_name, contract),
+            template_file=self._resolved_template_file(
+                step_name,
+                step_def,
+                canonical_name,
+                contract,
+            ),
         )
 
     def _resolved_template_mode(self, step_name: str, step_def: Dict[str, Any]) -> str:

--- a/src/cafe/phases/generic_workflow_step.py
+++ b/src/cafe/phases/generic_workflow_step.py
@@ -134,11 +134,17 @@ class GenericWorkflowStepExecutor(Phase):
         self._resolved_iteration_user_input: Optional[str] = None
         self._config_allowed_directories: List[str] = list(config_allowed_directories or [])
         self._extra_allowed_directories: List[str] = list(extra_allowed_directories or [])
+        self._template_allowed_directories: List[str] = []
 
     def _get_allowed_directories(self) -> List[str]:
         base = super()._get_allowed_directories()
         merged = list(
-            dict.fromkeys(base + self._config_allowed_directories + self._extra_allowed_directories)
+            dict.fromkeys(
+                base
+                + self._config_allowed_directories
+                + self._extra_allowed_directories
+                + self._template_allowed_directories
+            )
         )
         return merged
 
@@ -197,6 +203,9 @@ class GenericWorkflowStepExecutor(Phase):
             agent_name=agent_name,
             output_file=output_file,
         )
+        self._template_allowed_directories = []
+        if template_file := context.get("template_file"):
+            self._template_allowed_directories.append(str(Path(template_file).parent))
         shared_skill_invocations = self.generic_phase.prepare_skills(
             skill_names=self.SHARED_WORKFLOW_SKILLS,
             agent_cli=agent_cli,
@@ -497,13 +506,26 @@ class GenericWorkflowStepExecutor(Phase):
             current_iteration_data=current_data,
         ):
             artifact_lines = []
-            for key in ("develop_file", "spec_file", "plan_file", "feedback_file"):
+            declared = self._declared_prompt_input_placeholders(step_name)
+            fallback_keys = ("develop_file", "spec_file", "plan_file", "feedback_file")
+            keys = list(dict.fromkeys(declared + fallback_keys))
+            for key in keys:
                 if updated.get(key):
                     artifact_lines.append(f"- {key}: {updated[key]}")
             if artifact_lines:
                 updated["resume_input_artifacts"] = "\n".join(artifact_lines)
 
         return updated
+
+    def _declared_prompt_input_placeholders(self, step_name: str) -> tuple[str, ...]:
+        """Return declared prompt-input keys for the current step in contract order."""
+        steps = self.playbook.get("steps", {})
+        step_def = steps.get(step_name) if isinstance(steps, dict) else None
+        if not isinstance(step_def, dict):
+            return ()
+        skill_name = self._resolve_skill_name(step_def, self.iteration)
+        contract = self._get_skill_loader().get_workflow_contract(skill_name)
+        return tuple(mapping.placeholder for mapping in contract.prompt_inputs)
 
     def _detect_written_output_files(self) -> List[Path]:
         if self._current_output_file and self._current_output_file.exists():
@@ -760,6 +782,9 @@ class GenericWorkflowStepExecutor(Phase):
                 for placeholder, path in declared_inputs.items()
             }
         )
+        for mapping in contract.prompt_inputs:
+            if not mapping.required and mapping.placeholder not in context:
+                context[mapping.placeholder] = "(not available)"
 
         self._add_template_context(
             context=context,

--- a/src/cafe/skills/checklist_composer.py
+++ b/src/cafe/skills/checklist_composer.py
@@ -20,7 +20,11 @@ def _load_skill_checklist_reference(skill_name: str, ref_name: str) -> str:
     return load_skill_reference(canonical_skill_name(skill_name), ref_name)
 
 
-def _resolve_xml_questions_instruction(skill_name: str, ref_name: str, questions_xml_file: str) -> str:
+def _resolve_xml_questions_instruction(
+    skill_name: str,
+    ref_name: str,
+    questions_xml_file: str,
+) -> str:
     """Pre-resolve questions_xml_file in the XML instruction reference."""
     template = _load_skill_checklist_reference(skill_name, ref_name)
     return template.replace("{questions_xml_file}", questions_xml_file)
@@ -200,7 +204,9 @@ def compose_declared_checklist(
     content = resolve_checklist_placeholders(content, placeholders)
     unresolved = sorted(set(_PLACEHOLDER_PATTERN.findall(content)))
     if unresolved:
-        raise ValueError(f"Unresolved checklist placeholders for {skill_name}: {', '.join(unresolved)}")
+        raise ValueError(
+            f"Unresolved checklist placeholders for {skill_name}: {', '.join(unresolved)}"
+        )
     generate_checklist_file(checklist_file_path, content)
     return True
 
@@ -507,11 +513,12 @@ def generate_review_checklist(
 
     pr_todo_list_section = ""
     if pr_todo_list_file_path:
-        pr_todo_list_section = f"""
-## PR Todo List Check
-[ ] Read {pr_todo_list_file_path} - this is the todo list from the PR phase
-[ ] Check that ALL todo items are marked as completed [x]. If any unchecked items [ ] remain, return needs_changes
-"""
+        pr_todo_list_section = (
+            "\n## PR Todo List Check\n"
+            f"[ ] Read {pr_todo_list_file_path} - this is the todo list from the PR phase\n"
+            "[ ] Check that ALL todo items are marked as completed [x]. "
+            "If any unchecked items [ ] remain, return needs_changes\n"
+        )
 
     basic_principles_checklist = ""
     if basic_principles:
@@ -541,6 +548,14 @@ def generate_review_checklist(
     placeholders["feedback_instruction"] = resolve_checklist_placeholders(
         _load_skill_checklist_reference("review", "feedback_instruction.md"), placeholders
     )
+    for placeholder, reference in {
+        "spec_read_instruction": "spec_read_instruction.md",
+        "plan_read_instruction": "plan_read_instruction.md",
+        "spec_comparison_instruction": "spec_comparison_instruction.md",
+    }.items():
+        placeholders[placeholder] = resolve_checklist_placeholders(
+            _load_skill_checklist_reference("review", reference), placeholders
+        )
 
     checklist_content = resolve_checklist_placeholders(checklist_content, placeholders)
     checklist_content = checklist_content.rstrip() + "\n"
@@ -593,6 +608,14 @@ def generate_pr_checklist(
     if iteration > 1:
         placeholders["prev_pr_file"] = prev_pr_file if prev_pr_file else pr_file
         placeholders["current_pr_file"] = pr_file
+
+    for placeholder, reference in {
+        "spec_read_instruction": "spec_read_instruction.md",
+        "plan_read_instruction": "plan_read_instruction.md",
+    }.items():
+        placeholders[placeholder] = resolve_checklist_placeholders(
+            _load_skill_checklist_reference("pr", reference), placeholders
+        )
 
     checklist_content = resolve_checklist_placeholders(checklist_content, placeholders)
     generate_checklist_file(checklist_file_path, checklist_content)

--- a/src/cafe/skills/checklist_composer.py
+++ b/src/cafe/skills/checklist_composer.py
@@ -118,6 +118,26 @@ def _reference_context(
     return resolved
 
 
+def _omit_absent_optional_input_lines(
+    content: str,
+    contract: SkillWorkflowContract,
+    placeholders: Mapping[str, str],
+) -> str:
+    """Remove checklist instructions that require an unavailable optional input."""
+    absent = {
+        mapping.placeholder
+        for mapping in contract.prompt_inputs
+        if not mapping.required and mapping.placeholder not in placeholders
+    }
+    if not absent:
+        return content
+    return "".join(
+        line
+        for line in content.splitlines(keepends=True)
+        if not any(f"{{{placeholder}}}" in line for placeholder in absent)
+    )
+
+
 def compose_declared_checklist(
     *,
     skill_name: str,
@@ -174,9 +194,6 @@ def compose_declared_checklist(
         parts.append(extract_agent_guidelines_checklist(agent_file))
 
     placeholders = {key: str(value) for key, value in context.items() if value is not None}
-    for mapping in contract.prompt_inputs:
-        if not mapping.required and mapping.placeholder not in placeholders:
-            placeholders[mapping.placeholder] = "(not available)"
     placeholders["agent_file"] = agent_file
     placeholders.update(
         _reference_context(
@@ -185,7 +202,10 @@ def compose_declared_checklist(
             context=placeholders,
         )
     )
-    content = resolve_checklist_placeholders("\n".join(part for part in parts if part), placeholders)
+    content = _omit_absent_optional_input_lines(
+        "\n".join(part for part in parts if part), contract, placeholders
+    )
+    content = resolve_checklist_placeholders(content, placeholders)
     unresolved = sorted(set(_PLACEHOLDER_PATTERN.findall(content)))
     if unresolved:
         raise ValueError(f"Unresolved checklist placeholders for {skill_name}: {', '.join(unresolved)}")

--- a/src/cafe/skills/checklist_composer.py
+++ b/src/cafe/skills/checklist_composer.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
-from typing import Optional
+from typing import Any, Mapping, Optional
 
 from cafe.agents.manager import AgentManager
 from cafe.skills.bridge import load_skill_reference, try_load_skill_reference
+from cafe.skills.contracts import ChecklistVariant, SkillWorkflowContract
 from cafe.skills.loader import canonical_skill_name
 from cafe.templates.manager import TemplateManager
 from cafe.utils.checklist_utils import generate_checklist_file, resolve_checklist_placeholders
@@ -22,6 +24,173 @@ def _resolve_xml_questions_instruction(skill_name: str, ref_name: str, questions
     """Pre-resolve questions_xml_file in the XML instruction reference."""
     template = _load_skill_checklist_reference(skill_name, ref_name)
     return template.replace("{questions_xml_file}", questions_xml_file)
+
+
+_PLACEHOLDER_PATTERN = re.compile(r"\{([A-Za-z_][A-Za-z0-9_]*)\}")
+
+
+def _variant_matches(
+    variant: ChecklistVariant,
+    *,
+    iteration: int,
+    artifacts: Mapping[str, Any],
+    feedback: bool,
+) -> bool:
+    """Return whether one bounded, declared checklist selector applies."""
+    when = variant.when
+    if when.iteration is not None and when.iteration != iteration:
+        return False
+    if when.min_iteration is not None and iteration < when.min_iteration:
+        return False
+    if when.max_iteration is not None and iteration > when.max_iteration:
+        return False
+    if when.feedback is not None and when.feedback != feedback:
+        return False
+    return all(bool(artifacts.get(name)) for name in when.artifact_present)
+
+
+def select_checklist_variant(
+    contract: SkillWorkflowContract,
+    *,
+    iteration: int,
+    artifacts: Mapping[str, Any],
+    feedback: bool,
+) -> ChecklistVariant:
+    """Select the first matching, declaration-ordered checklist variant."""
+    if contract.checklist is None:
+        raise ValueError("Skill does not declare checklist composition")
+    for variant in contract.checklist.variants:
+        if _variant_matches(variant, iteration=iteration, artifacts=artifacts, feedback=feedback):
+            return variant
+    raise ValueError(f"No checklist variant matches iteration {iteration}")
+
+
+def _template_instruction(
+    *,
+    skill_name: str,
+    contract: SkillWorkflowContract,
+    template_mode: str,
+    template_file: Optional[str],
+) -> str:
+    """Render the existing template-choice guidance from a declared catalog."""
+    if contract.output_templates is None:
+        return ""
+    catalog = contract.output_templates.catalog
+    if template_mode == "auto":
+        manager = TemplateManager(template_type=catalog, skill_name=skill_name)
+        template_lines = [
+            f"  - `{name}`: {path}"
+            for name, _source in manager.list_templates()
+            if (path := manager.get_template_path(name)) is not None
+        ]
+        if not template_lines:
+            return ""
+        template_list = "\n".join(template_lines)
+        label = contract.output_templates.label or catalog
+        return (
+            f"[ ] Pick a most suitable {label} template and read it. Available templates:\n"
+            f"{template_list}\n"
+            f"[ ] {contract.output_templates.follow_instruction}\n"
+        )
+    if template_file:
+        return (
+            f"[ ] Read {template_file} as reference for output format and structure\n"
+            f"[ ] {contract.output_templates.follow_instruction}\n"
+        )
+    return ""
+
+
+def _reference_context(
+    *,
+    skill_name: str,
+    references: Mapping[str, str],
+    context: Mapping[str, str],
+) -> dict[str, str]:
+    """Render declared context references only when their inputs are available."""
+    resolved: dict[str, str] = {}
+    for placeholder, reference in references.items():
+        content = _load_skill_checklist_reference(skill_name, reference)
+        names = _PLACEHOLDER_PATTERN.findall(content)
+        if all(context.get(name) for name in names):
+            resolved[placeholder] = resolve_checklist_placeholders(content, dict(context))
+        else:
+            resolved[placeholder] = ""
+    return resolved
+
+
+def compose_declared_checklist(
+    *,
+    skill_name: str,
+    contract: SkillWorkflowContract,
+    agent_name: str,
+    role: str,
+    checklist_file_path: Path,
+    iteration: int,
+    context: Mapping[str, str],
+    artifacts: Mapping[str, Any],
+    feedback: bool = False,
+    template_mode: str = "auto",
+    template_file: Optional[str] = None,
+) -> bool:
+    """Compose a skill-declared checklist without phase-name behavior branches."""
+    if contract.checklist is None:
+        checklist_file_path.write_text("", encoding="utf-8")
+        return False
+
+    variant = select_checklist_variant(
+        contract,
+        iteration=iteration,
+        artifacts=artifacts,
+        feedback=feedback,
+    )
+    parts: list[str] = []
+    for section in variant.sections:
+        if section.reference:
+            parts.append(_load_skill_checklist_reference(skill_name, section.reference))
+        elif section.optional_checklist:
+            optional = try_load_skill_reference(skill_name, section.optional_checklist)
+            if optional:
+                parts.append(convert_to_checklist(optional, "Basic Principles"))
+        elif section.template_catalog:
+            parts.append(
+                _template_instruction(
+                    skill_name=skill_name,
+                    contract=contract,
+                    template_mode=template_mode,
+                    template_file=template_file,
+                )
+            )
+
+    role_dirs = {
+        "pm": "pm",
+        "reviewer": "reviewer",
+        "writer": "writer",
+        "editor": "editor",
+        "researcher": "researcher",
+        "ops": "ops",
+    }
+    agent_file = AgentManager.get_agent_file_path(agent_name, role_dirs.get(role, "developer"))
+    if contract.checklist.include_role_guidance:
+        parts.append(extract_agent_guidelines_checklist(agent_file))
+
+    placeholders = {key: str(value) for key, value in context.items() if value is not None}
+    for mapping in contract.prompt_inputs:
+        if not mapping.required and mapping.placeholder not in placeholders:
+            placeholders[mapping.placeholder] = "(not available)"
+    placeholders["agent_file"] = agent_file
+    placeholders.update(
+        _reference_context(
+            skill_name=skill_name,
+            references=contract.checklist.context_references,
+            context=placeholders,
+        )
+    )
+    content = resolve_checklist_placeholders("\n".join(part for part in parts if part), placeholders)
+    unresolved = sorted(set(_PLACEHOLDER_PATTERN.findall(content)))
+    if unresolved:
+        raise ValueError(f"Unresolved checklist placeholders for {skill_name}: {', '.join(unresolved)}")
+    generate_checklist_file(checklist_file_path, content)
+    return True
 
 
 def generate_custom_skill_checklist(
@@ -131,6 +300,8 @@ def generate_spec_checklist(
     placeholders = {
         "agent_file": agent_file,
         "current_spec_file": current_spec_file,
+        "output_file": current_spec_file,
+        "previous_output_file": prev_spec_file or "",
         "iteration": str(iteration),
     }
     if prev_spec_file:
@@ -210,7 +381,10 @@ def generate_plan_checklist(
     placeholders = {
         "agent_file": agent_file,
         "plan_file_path": plan_file_path,
+        "output_file": plan_file_path,
         "spec_file_path": spec_file_path,
+        "spec_file": spec_file_path,
+        "previous_output_file": prev_plan_file or "",
     }
 
     if iteration > 1:
@@ -276,13 +450,16 @@ def generate_develop_checklist(
     placeholders = {
         "agent_file": agent_file,
         "spec_file_path": spec_file_path,
+        "spec_file": spec_file_path,
         "plan_file_path": plan_file_path,
+        "plan_file": plan_file_path,
         "xml_questions_instruction": xml_questions_instruction,
     }
     if develop_file:
         placeholders["develop_file"] = develop_file
     if feedback_file_path:
         placeholders["feedback_file_path"] = feedback_file_path
+        placeholders["feedback_file"] = feedback_file_path
     if output_file:
         placeholders["output_file"] = output_file
 
@@ -330,10 +507,14 @@ def generate_review_checklist(
     placeholders = {
         "agent_file": agent_file,
         "spec_file_path": spec_file_path,
+        "spec_file": spec_file_path,
         "plan_file_path": plan_file_path or "(not available)",
+        "plan_file": plan_file_path or "(not available)",
         "review_file_path": review_file_path,
+        "output_file": review_file_path,
         "base_branch": base_branch,
         "pr_feedback_file_path": pr_feedback_file_path or "(not available)",
+        "feedback_file": pr_feedback_file_path or "(not available)",
     }
 
     checklist_content = resolve_checklist_placeholders(checklist_content, placeholders)
@@ -375,8 +556,12 @@ def generate_pr_checklist(
     placeholders = {
         "agent_file": agent_file,
         "spec_file_path": spec_file_path,
+        "spec_file": spec_file_path,
         "plan_file_path": plan_file_path,
+        "plan_file": plan_file_path,
         "pr_file": pr_file,
+        "output_file": pr_file,
+        "previous_output_file": prev_pr_file or "",
     }
 
     if iteration > 1:

--- a/src/cafe/skills/checklist_composer.py
+++ b/src/cafe/skills/checklist_composer.py
@@ -118,26 +118,6 @@ def _reference_context(
     return resolved
 
 
-def _omit_absent_optional_input_lines(
-    content: str,
-    contract: SkillWorkflowContract,
-    placeholders: Mapping[str, str],
-) -> str:
-    """Remove checklist instructions that require an unavailable optional input."""
-    absent = {
-        mapping.placeholder
-        for mapping in contract.prompt_inputs
-        if not mapping.required and mapping.placeholder not in placeholders
-    }
-    if not absent:
-        return content
-    return "".join(
-        line
-        for line in content.splitlines(keepends=True)
-        if not any(f"{{{placeholder}}}" in line for placeholder in absent)
-    )
-
-
 def compose_declared_checklist(
     *,
     skill_name: str,
@@ -191,20 +171,32 @@ def compose_declared_checklist(
     }
     agent_file = AgentManager.get_agent_file_path(agent_name, role_dirs.get(role, "developer"))
     if contract.checklist.include_role_guidance:
-        parts.append(extract_agent_guidelines_checklist(agent_file))
+        guidelines = extract_agent_guidelines_checklist(agent_file)
+        if guidelines:
+            if contract.checklist.compact_agent_guidance:
+                parts.append(guidelines)
+            else:
+                # References traditionally own their terminal spacing. Add the
+                # missing separator only when the preceding section has not
+                # already supplied a blank line.
+                separator = "" if parts and parts[-1].endswith("\n\n") else "\n"
+                parts.append(f"{separator}{guidelines}")
 
     placeholders = {key: str(value) for key, value in context.items() if value is not None}
     placeholders["agent_file"] = agent_file
-    placeholders.update(
-        _reference_context(
-            skill_name=skill_name,
-            references=contract.checklist.context_references,
-            context=placeholders,
+    reference_context = _reference_context(
+        skill_name=skill_name,
+        references=contract.checklist.context_references,
+        context=placeholders,
+    )
+    overlap = set(placeholders) & set(reference_context)
+    if overlap:
+        raise ValueError(
+            "Checklist context references would overwrite placeholders for "
+            f"{skill_name}: {', '.join(sorted(overlap))}"
         )
-    )
-    content = _omit_absent_optional_input_lines(
-        "\n".join(part for part in parts if part), contract, placeholders
-    )
+    placeholders.update(reference_context)
+    content = "\n".join(part for part in parts if part)
     content = resolve_checklist_placeholders(content, placeholders)
     unresolved = sorted(set(_PLACEHOLDER_PATTERN.findall(content)))
     if unresolved:
@@ -483,6 +475,16 @@ def generate_develop_checklist(
     if output_file:
         placeholders["output_file"] = output_file
 
+    for placeholder, reference in {
+        "normal_plan_context": "normal_plan_context.md",
+        "normal_plan_verification": "normal_plan_verification.md",
+        "correction_plan_context": "correction_plan_context.md",
+        "correction_plan_test_list": "correction_plan_test_list.md",
+    }.items():
+        placeholders[placeholder] = resolve_checklist_placeholders(
+            _load_skill_checklist_reference("develop", reference), placeholders
+        )
+
     checklist_content = resolve_checklist_placeholders(checklist_content, placeholders)
     generate_checklist_file(checklist_file_path, checklist_content)
 
@@ -536,8 +538,12 @@ def generate_review_checklist(
         "pr_feedback_file_path": pr_feedback_file_path or "(not available)",
         "feedback_file": pr_feedback_file_path or "(not available)",
     }
+    placeholders["feedback_instruction"] = resolve_checklist_placeholders(
+        _load_skill_checklist_reference("review", "feedback_instruction.md"), placeholders
+    )
 
     checklist_content = resolve_checklist_placeholders(checklist_content, placeholders)
+    checklist_content = checklist_content.rstrip() + "\n"
     generate_checklist_file(checklist_file_path, checklist_content)
 
 

--- a/src/cafe/skills/contracts.py
+++ b/src/cafe/skills/contracts.py
@@ -173,6 +173,7 @@ class ChecklistContract(BaseModel):
     context_references: dict[str, str] = Field(default_factory=dict)
     variants: Tuple[ChecklistVariant, ...]
     include_role_guidance: bool = False
+    compact_agent_guidance: bool = False
 
     @field_validator("context_references")
     @classmethod
@@ -230,6 +231,13 @@ class SkillWorkflowContract(BaseModel):
         placeholders = [item.placeholder for item in self.prompt_inputs]
         if len(set(placeholders)) != len(placeholders):
             raise ValueError("prompt input placeholders must be unique")
+        if self.checklist is not None:
+            overlap = set(placeholders) & set(self.checklist.context_references)
+            if overlap:
+                raise ValueError(
+                    "checklist context reference placeholders must not overlap prompt input "
+                    f"placeholders: {', '.join(sorted(overlap))}"
+                )
         return self
 
 

--- a/src/cafe/skills/contracts.py
+++ b/src/cafe/skills/contracts.py
@@ -9,6 +9,30 @@ from typing import Any, Optional, Tuple
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
+RUNTIME_OWNED_PROMPT_PLACEHOLDERS = frozenset(
+    {
+        "agent_file",
+        "base_branch",
+        "blackboard_digest",
+        "blackboard_path",
+        "checklist_file",
+        "commits",
+        "handoff_summary",
+        "iteration",
+        "next_step_path",
+        "output_file",
+        "previous_output_file",
+        "questions_xml_file",
+        "resume_input_artifacts",
+        "step_transitions",
+        "template_catalog",
+        "template_file",
+        "user_input",
+        "valid_to_steps",
+    }
+)
+
+
 def _safe_token(value: str, *, field_name: str) -> str:
     token = value.strip()
     if not token or "/" in token or "\\" in token or token in {".", ".."}:
@@ -51,7 +75,10 @@ class PromptInputContract(BaseModel):
     @field_validator("placeholder")
     @classmethod
     def _validate_placeholder(cls, value: str) -> str:
-        return _safe_token(value, field_name="placeholder")
+        value = _safe_token(value, field_name="placeholder")
+        if value in RUNTIME_OWNED_PROMPT_PLACEHOLDERS:
+            raise ValueError(f"placeholder {value!r} is runtime-owned")
+        return value
 
 
 class ChecklistWhen(BaseModel):

--- a/src/cafe/skills/contracts.py
+++ b/src/cafe/skills/contracts.py
@@ -223,20 +223,46 @@ class SkillWorkflowContract(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     prompt_inputs: Tuple[PromptInputContract, ...] = ()
+    prompt_references: dict[str, str] = Field(default_factory=dict)
     checklist: Optional[ChecklistContract] = None
     output_templates: Optional[OutputTemplatesContract] = None
 
+    @field_validator("prompt_references")
+    @classmethod
+    def _validate_prompt_references(cls, value: dict[str, str]) -> dict[str, str]:
+        return {
+            _safe_placeholder(
+                placeholder, field_name="prompt reference placeholder"
+            ): _safe_reference(reference)
+            for placeholder, reference in value.items()
+        }
+
     @model_validator(mode="after")
     def _validate_unique_placeholders(self) -> "SkillWorkflowContract":
-        placeholders = [item.placeholder for item in self.prompt_inputs]
-        if len(set(placeholders)) != len(placeholders):
+        input_placeholders = [item.placeholder for item in self.prompt_inputs]
+        if len(set(input_placeholders)) != len(input_placeholders):
             raise ValueError("prompt input placeholders must be unique")
+        prompt_reference_placeholders = set(self.prompt_references)
+        input_placeholder_set = set(input_placeholders)
+        overlap = input_placeholder_set & prompt_reference_placeholders
+        if overlap:
+            raise ValueError(
+                "prompt reference placeholders must not overlap prompt input placeholders: "
+                f"{', '.join(sorted(overlap))}"
+            )
         if self.checklist is not None:
-            overlap = set(placeholders) & set(self.checklist.context_references)
+            checklist_references = set(self.checklist.context_references)
+            overlap = input_placeholder_set & checklist_references
             if overlap:
                 raise ValueError(
                     "checklist context reference placeholders must not overlap prompt input "
                     f"placeholders: {', '.join(sorted(overlap))}"
+                )
+            overlap = prompt_reference_placeholders & checklist_references
+            if overlap:
+                raise ValueError(
+                    "prompt and checklist reference placeholders must not overlap: "
+                    f"{', '.join(sorted(overlap))}"
                 )
         return self
 

--- a/src/cafe/skills/contracts.py
+++ b/src/cafe/skills/contracts.py
@@ -8,7 +8,6 @@ from typing import Any, Optional, Tuple
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
-
 RUNTIME_OWNED_PROMPT_PLACEHOLDERS = frozenset(
     {
         "agent_file",
@@ -53,6 +52,14 @@ def _safe_reference(value: str) -> str:
     return token
 
 
+def _safe_placeholder(value: str, *, field_name: str) -> str:
+    """Validate a skill-owned placeholder without allowing runtime overrides."""
+    token = _safe_token(value, field_name=field_name)
+    if token in RUNTIME_OWNED_PROMPT_PLACEHOLDERS:
+        raise ValueError(f"{field_name} {token!r} is runtime-owned")
+    return token
+
+
 class PromptInputContract(BaseModel):
     """One artifact mapping exposed under a skill-selected placeholder."""
 
@@ -75,10 +82,7 @@ class PromptInputContract(BaseModel):
     @field_validator("placeholder")
     @classmethod
     def _validate_placeholder(cls, value: str) -> str:
-        value = _safe_token(value, field_name="placeholder")
-        if value in RUNTIME_OWNED_PROMPT_PLACEHOLDERS:
-            raise ValueError(f"placeholder {value!r} is runtime-owned")
-        return value
+        return _safe_placeholder(value, field_name="placeholder")
 
 
 class ChecklistWhen(BaseModel):
@@ -153,7 +157,9 @@ class ChecklistVariant(BaseModel):
 
     @field_validator("sections")
     @classmethod
-    def _validate_sections(cls, value: Tuple[ChecklistSection, ...]) -> Tuple[ChecklistSection, ...]:
+    def _validate_sections(
+        cls, value: Tuple[ChecklistSection, ...]
+    ) -> Tuple[ChecklistSection, ...]:
         if not value:
             raise ValueError("checklist variant requires at least one section")
         return value
@@ -172,13 +178,17 @@ class ChecklistContract(BaseModel):
     @classmethod
     def _validate_context_references(cls, value: dict[str, str]) -> dict[str, str]:
         return {
-            _safe_token(placeholder, field_name="context reference placeholder"): _safe_reference(ref)
+            _safe_placeholder(
+                placeholder, field_name="context reference placeholder"
+            ): _safe_reference(ref)
             for placeholder, ref in value.items()
         }
 
     @field_validator("variants")
     @classmethod
-    def _validate_variants(cls, value: Tuple[ChecklistVariant, ...]) -> Tuple[ChecklistVariant, ...]:
+    def _validate_variants(
+        cls, value: Tuple[ChecklistVariant, ...]
+    ) -> Tuple[ChecklistVariant, ...]:
         if not value:
             raise ValueError("checklist requires at least one variant")
         return value

--- a/src/cafe/skills/contracts.py
+++ b/src/cafe/skills/contracts.py
@@ -1,0 +1,239 @@
+"""Typed, skill-owned declarations for workflow execution behavior."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, Optional, Tuple
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+
+def _safe_token(value: str, *, field_name: str) -> str:
+    token = value.strip()
+    if not token or "/" in token or "\\" in token or token in {".", ".."}:
+        raise ValueError(f"{field_name} must be a non-empty name, not a path")
+    return token
+
+
+def _safe_reference(value: str) -> str:
+    token = value.strip()
+    if (
+        not token
+        or token.startswith(("/", "\\"))
+        or "\\" in token
+        or any(part in {"", ".", ".."} for part in token.split("/"))
+        or not token.endswith(".md")
+    ):
+        raise ValueError("checklist reference must be a relative Markdown file inside references")
+    return token
+
+
+class PromptInputContract(BaseModel):
+    """One artifact mapping exposed under a skill-selected placeholder."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    artifacts: Tuple[str, ...]
+    placeholder: str
+    required: bool = False
+
+    @field_validator("artifacts")
+    @classmethod
+    def _validate_artifacts(cls, value: Tuple[str, ...]) -> Tuple[str, ...]:
+        if not value:
+            raise ValueError("prompt input artifacts must not be empty")
+        cleaned = tuple(_safe_token(item, field_name="artifact") for item in value)
+        if len(set(cleaned)) != len(cleaned):
+            raise ValueError("prompt input artifact candidates must be unique")
+        return cleaned
+
+    @field_validator("placeholder")
+    @classmethod
+    def _validate_placeholder(cls, value: str) -> str:
+        return _safe_token(value, field_name="placeholder")
+
+
+class ChecklistWhen(BaseModel):
+    """Bounded runtime facts used to select a checklist variant."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    iteration: Optional[int] = None
+    min_iteration: Optional[int] = None
+    max_iteration: Optional[int] = None
+    artifact_present: Tuple[str, ...] = ()
+    feedback: Optional[bool] = None
+
+    @field_validator("iteration", "min_iteration", "max_iteration")
+    @classmethod
+    def _validate_iteration(cls, value: Optional[int]) -> Optional[int]:
+        if value is not None and value < 1:
+            raise ValueError("iteration selectors must be positive")
+        return value
+
+    @field_validator("artifact_present")
+    @classmethod
+    def _validate_artifact_presence(cls, value: Tuple[str, ...]) -> Tuple[str, ...]:
+        return tuple(_safe_token(item, field_name="artifact_present") for item in value)
+
+    @model_validator(mode="after")
+    def _validate_bounds(self) -> "ChecklistWhen":
+        if self.iteration is not None and any(
+            bound is not None for bound in (self.min_iteration, self.max_iteration)
+        ):
+            raise ValueError("iteration cannot be combined with min_iteration or max_iteration")
+        if (
+            self.min_iteration is not None
+            and self.max_iteration is not None
+            and self.min_iteration > self.max_iteration
+        ):
+            raise ValueError("min_iteration must not exceed max_iteration")
+        return self
+
+
+class ChecklistSection(BaseModel):
+    """One ordered part of a generated checklist."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    reference: Optional[str] = None
+    optional_checklist: Optional[str] = None
+    template_catalog: bool = False
+
+    @field_validator("reference", "optional_checklist")
+    @classmethod
+    def _validate_reference(cls, value: Optional[str]) -> Optional[str]:
+        return _safe_reference(value) if value is not None else None
+
+    @model_validator(mode="after")
+    def _validate_source(self) -> "ChecklistSection":
+        if sum(
+            value is not None and value is not False
+            for value in (self.reference, self.optional_checklist, self.template_catalog)
+        ) != 1:
+            raise ValueError("checklist section requires exactly one source")
+        return self
+
+
+class ChecklistVariant(BaseModel):
+    """A declaration-selected ordered list of checklist sections."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    when: ChecklistWhen = Field(default_factory=ChecklistWhen)
+    sections: Tuple[ChecklistSection, ...]
+
+    @field_validator("sections")
+    @classmethod
+    def _validate_sections(cls, value: Tuple[ChecklistSection, ...]) -> Tuple[ChecklistSection, ...]:
+        if not value:
+            raise ValueError("checklist variant requires at least one section")
+        return value
+
+
+class ChecklistContract(BaseModel):
+    """Checklist references and explicit role-guideline behavior for a skill."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    context_references: dict[str, str] = Field(default_factory=dict)
+    variants: Tuple[ChecklistVariant, ...]
+    include_role_guidance: bool = False
+
+    @field_validator("context_references")
+    @classmethod
+    def _validate_context_references(cls, value: dict[str, str]) -> dict[str, str]:
+        return {
+            _safe_token(placeholder, field_name="context reference placeholder"): _safe_reference(ref)
+            for placeholder, ref in value.items()
+        }
+
+    @field_validator("variants")
+    @classmethod
+    def _validate_variants(cls, value: Tuple[ChecklistVariant, ...]) -> Tuple[ChecklistVariant, ...]:
+        if not value:
+            raise ValueError("checklist requires at least one variant")
+        return value
+
+
+class OutputTemplatesContract(BaseModel):
+    """Skill-owned template catalog exposed by a workflow step."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    catalog: str
+    label: Optional[str] = None
+    follow_instruction: str = "Follow template structure when writing analysis results"
+
+    @field_validator("catalog")
+    @classmethod
+    def _validate_catalog(cls, value: str) -> str:
+        return _safe_token(value, field_name="template catalog")
+
+    @field_validator("label", "follow_instruction")
+    @classmethod
+    def _validate_template_copy(cls, value: Optional[str]) -> Optional[str]:
+        if value is not None and not value.strip():
+            raise ValueError("template guidance must not be empty")
+        return value
+
+
+class SkillWorkflowContract(BaseModel):
+    """All optional workflow metadata carried in a skill frontmatter block."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    prompt_inputs: Tuple[PromptInputContract, ...] = ()
+    checklist: Optional[ChecklistContract] = None
+    output_templates: Optional[OutputTemplatesContract] = None
+
+    @model_validator(mode="after")
+    def _validate_unique_placeholders(self) -> "SkillWorkflowContract":
+        placeholders = [item.placeholder for item in self.prompt_inputs]
+        if len(set(placeholders)) != len(placeholders):
+            raise ValueError("prompt input placeholders must be unique")
+        return self
+
+
+@dataclass(frozen=True)
+class DeclaredArtifactError(ValueError):
+    """A required skill-declared input has no recorded artifact."""
+
+    placeholder: str
+    artifacts: Tuple[str, ...]
+
+    def __str__(self) -> str:
+        candidates = ", ".join(self.artifacts)
+        return (
+            f"Missing required prompt input {self.placeholder!r}; "
+            f"expected one of declared artifacts: {candidates}"
+        )
+
+
+def _artifact_path(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    path = getattr(value, "path", value)
+    if path is None:
+        return None
+    text = str(path).strip()
+    return text or None
+
+
+def resolve_prompt_inputs(
+    contract: SkillWorkflowContract,
+    artifacts: Mapping[str, Any],
+) -> dict[str, str]:
+    """Resolve declared artifacts in order without any implicit fallback names."""
+    resolved: dict[str, str] = {}
+    for mapping in contract.prompt_inputs:
+        for artifact_name in mapping.artifacts:
+            path = _artifact_path(artifacts.get(artifact_name))
+            if path:
+                resolved[mapping.placeholder] = path
+                break
+        else:
+            if mapping.required:
+                raise DeclaredArtifactError(mapping.placeholder, mapping.artifacts)
+    return resolved

--- a/src/cafe/skills/loader.py
+++ b/src/cafe/skills/loader.py
@@ -233,13 +233,13 @@ class SkillLoader:
                 for section in variant.sections
                 if section.reference is not None
             )
-            for reference in references:
-                reference_path = skill_dir / "references" / reference
-                if not reference_path.is_file():
-                    raise ValueError(
-                        f"Invalid workflow contract for skill {skill_dir.name}: "
-                        f"workflow reference not found: {reference}"
-                    )
+        for reference in references:
+            reference_path = skill_dir / "references" / reference
+            if not reference_path.is_file():
+                raise ValueError(
+                    f"Invalid workflow contract for skill {skill_dir.name}: "
+                    f"workflow reference not found: {reference}"
+                )
         if contract.output_templates is not None:
             template_dir = skill_dir / "assets" / "templates"
             if not template_dir.is_dir():

--- a/src/cafe/skills/loader.py
+++ b/src/cafe/skills/loader.py
@@ -9,6 +9,7 @@ from typing import Dict, List, Optional
 
 import yaml
 
+from cafe.skills.contracts import SkillWorkflowContract
 from cafe.skills.exceptions import SkillDiscoveryError
 from cafe.utils.config import get_global_cafe_dir
 
@@ -66,7 +67,7 @@ def canonical_skill_name(name: str) -> str:
     return _SKILL_ALIASES.get(name, name)
 
 
-def read_skill_frontmatter(skill_file: Path) -> Dict[str, str]:
+def read_skill_frontmatter(skill_file: Path) -> Dict[str, object]:
     """Read YAML frontmatter from one skill file."""
     content = skill_file.read_text(encoding="utf-8")
     if not content.startswith("---"):
@@ -122,7 +123,7 @@ class SkillLoader:
         ]
 
     @staticmethod
-    def _read_skill_frontmatter(skill_file: Path) -> Dict[str, str]:
+    def _read_skill_frontmatter(skill_file: Path) -> Dict[str, object]:
         return read_skill_frontmatter(skill_file)
 
     def discover(self, *, strict: bool = False) -> List[SkillCatalogEntry]:
@@ -211,6 +212,41 @@ class SkillLoader:
         for key, value in context.items():
             text = text.replace(f"{{{key}}}", str(value))
         return text
+
+    def get_workflow_contract(self, name: str) -> SkillWorkflowContract:
+        """Load and validate optional workflow metadata from the resolved skill."""
+        skill_dir = self.get_skill_dir(name)
+        metadata = self._read_skill_frontmatter(skill_dir / "SKILL.md")
+        raw_contract = metadata.get("workflow", {})
+        try:
+            contract = SkillWorkflowContract.model_validate(raw_contract)
+        except Exception as exc:
+            raise ValueError(
+                f"Invalid workflow contract for skill {skill_dir.name}: {exc}"
+            ) from exc
+        if contract.checklist is not None:
+            references = list(contract.checklist.context_references.values())
+            references.extend(
+                section.reference
+                for variant in contract.checklist.variants
+                for section in variant.sections
+                if section.reference is not None
+            )
+            for reference in references:
+                reference_path = skill_dir / "references" / reference
+                if not reference_path.is_file():
+                    raise ValueError(
+                        f"Invalid workflow contract for skill {skill_dir.name}: "
+                        f"checklist reference not found: {reference}"
+                    )
+        if contract.output_templates is not None:
+            template_dir = skill_dir / "assets" / "templates"
+            if not template_dir.is_dir():
+                raise ValueError(
+                    f"Invalid workflow contract for skill {skill_dir.name}: "
+                    f"template catalog {contract.output_templates.catalog!r} is unavailable"
+                )
+        return contract
 
     def get_reference(self, name: str, ref: str) -> str:
         """Read one reference file under skill references directory."""

--- a/src/cafe/skills/loader.py
+++ b/src/cafe/skills/loader.py
@@ -224,8 +224,9 @@ class SkillLoader:
             raise ValueError(
                 f"Invalid workflow contract for skill {skill_dir.name}: {exc}"
             ) from exc
+        references = list(contract.prompt_references.values())
         if contract.checklist is not None:
-            references = list(contract.checklist.context_references.values())
+            references.extend(contract.checklist.context_references.values())
             references.extend(
                 section.reference
                 for variant in contract.checklist.variants
@@ -237,7 +238,7 @@ class SkillLoader:
                 if not reference_path.is_file():
                     raise ValueError(
                         f"Invalid workflow contract for skill {skill_dir.name}: "
-                        f"checklist reference not found: {reference}"
+                        f"workflow reference not found: {reference}"
                     )
         if contract.output_templates is not None:
             template_dir = skill_dir / "assets" / "templates"

--- a/src/cafe/templates/manager.py
+++ b/src/cafe/templates/manager.py
@@ -183,6 +183,9 @@ class TemplateManager:
         Returns:
             Path to the template file, or None if not found
         """
+        if not template_name or "/" in template_name or "\\" in template_name:
+            raise ValueError(f"Invalid template name: {template_name}")
+
         # Ensure .md extension
         if not template_name.endswith(".md"):
             template_name = f"{template_name}.md"

--- a/src/cafe/templates/manager.py
+++ b/src/cafe/templates/manager.py
@@ -2,21 +2,32 @@
 
 import shutil
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import TYPE_CHECKING, List, Optional, Tuple
 
 from cafe.utils.config import get_global_cafe_dir
+
+if TYPE_CHECKING:
+    from cafe.skills.loader import SkillLoader
 
 
 class TemplateManager:
     """Manage plan and spec templates."""
 
-    def __init__(self, template_type: str = "plan"):
+    def __init__(
+        self,
+        template_type: str = "plan",
+        *,
+        skill_name: Optional[str] = None,
+        skill_loader: Optional["SkillLoader"] = None,
+    ) -> None:
         """Initialize template manager.
 
         Args:
             template_type: Type of template to manage ('plan' or 'spec')
         """
         self.template_type = template_type
+        self.skill_name = skill_name
+        self.skill_loader = skill_loader
 
     def _builtin_dir(self) -> Path:
         """Builtin template directory under the owning skill's assets/.
@@ -25,16 +36,16 @@ class TemplateManager:
         skill, plan → plan skill). The owning skill's directory name matches
         the template type.
         """
-        from cafe.skills.loader import canonical_skill_name
+        from cafe.skills.loader import SkillLoader, canonical_skill_name
 
-        return (
-            Path(__file__).parent.parent
-            / "data"
-            / "skills"
-            / canonical_skill_name(self.template_type)
-            / "assets"
-            / "templates"
-        )
+        owner = self.skill_name or canonical_skill_name(self.template_type)
+        loader = self.skill_loader or SkillLoader()
+        try:
+            return loader.get_skill_dir(owner) / "assets" / "templates"
+        except Exception:
+            # Keep the historic package lookup as a compatibility fallback for
+            # callers that construct a manager outside a discovered project.
+            return Path(__file__).parent.parent / "data" / "skills" / owner / "assets" / "templates"
 
     def add_template(self, source_path: str, template_name: str) -> Path:
         """Add a new template from a file to global directory.

--- a/src/cafe/ui/commands/lifecycle.py
+++ b/src/cafe/ui/commands/lifecycle.py
@@ -204,7 +204,7 @@ def _run_field_driven_prepare_prompts(
     *,
     display: Any,
     github_ops: Any,
-) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], Optional[int]]:
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, dict[str, Any]], Optional[int]]:
     """Run interactive prepare prompts from declarative PrepareField definitions."""
     from cafe.ui.prepare_field_renderer import RendererDeps, run_field_driven_prepare_flow
 
@@ -221,7 +221,7 @@ def _run_field_driven_prepare_prompts(
         github_ops=github_ops,
     )
     config, issue_id = run_field_driven_prepare_flow(parsed, profile, deps=deps)
-    return config.spec, config.plan, config.pr, issue_id
+    return config.spec, config.plan, config.pr, config.steps, issue_id
 
 
 def prepare(
@@ -484,6 +484,7 @@ def prepare(
         spec_config = {}
         plan_config = {}
         pr_config = {}
+        step_configs: dict[str, dict[str, Any]] = {}
 
         if profile.should_prompt_spec_plan_config(should_prompt_for_config):
             console.print()
@@ -510,12 +511,16 @@ def prepare(
                     issue_name=issue_name,
                 )
             else:
-                spec_config, plan_config, pr_config, issue_id = _run_field_driven_prepare_prompts(
+                field_result = _run_field_driven_prepare_prompts(
                     profile,
                     parsed_fields,
                     display=display,
                     github_ops=github_ops,
                 )
+                if len(field_result) == 4:
+                    spec_config, plan_config, pr_config, issue_id = field_result
+                else:
+                    spec_config, plan_config, pr_config, step_configs, issue_id = field_result
         elif not interactive:
             from cafe.skills.loader import SkillLoader
             from cafe.ui.prepare_field_renderer import (
@@ -572,6 +577,7 @@ def prepare(
             spec_config = resolved_config.spec
             plan_config = resolved_config.plan
             pr_config = resolved_config.pr
+            step_configs = resolved_config.steps
         # else: issue_name was provided as argument but not --no-interactive
         #       Don't save any config (old behavior for backward compatibility)
 
@@ -604,6 +610,10 @@ def prepare(
         # Add pr config if present
         if pr_config:
             config_data["pr"] = pr_config
+
+        for step_name, step_config in step_configs.items():
+            if step_config:
+                config_data[step_name] = step_config
 
         # Add worktree_path if using worktree mode
         if use_worktree:
@@ -1490,8 +1500,9 @@ def reset(
 
         # 2. If phase not provided, find the last phase with iterations based on end_time or timestamp
         if phase is None:
-            from cafe.services.summary_service import SummaryService
             from datetime import datetime
+
+            from cafe.services.summary_service import SummaryService
 
             service = SummaryService()
             latest_phase = None

--- a/src/cafe/ui/commands/lifecycle.py
+++ b/src/cafe/ui/commands/lifecycle.py
@@ -204,7 +204,14 @@ def _run_field_driven_prepare_prompts(
     *,
     display: Any,
     github_ops: Any,
-) -> tuple[dict[str, Any], dict[str, Any], dict[str, dict[str, Any]], Optional[int]]:
+    template_managers: Optional[dict[str, Any]] = None,
+) -> tuple[
+    dict[str, Any],
+    dict[str, Any],
+    dict[str, Any],
+    dict[str, dict[str, Any]],
+    Optional[int],
+]:
     """Run interactive prepare prompts from declarative PrepareField definitions."""
     from cafe.ui.prepare_field_renderer import RendererDeps, run_field_driven_prepare_flow
 
@@ -216,6 +223,7 @@ def _run_field_driven_prepare_prompts(
         select_template=select_template,
         spec_template_manager=TemplateManager(template_type="spec"),
         plan_template_manager=TemplateManager(template_type="plan"),
+        template_managers=template_managers or {},
         console=console,
         display=display,
         github_ops=github_ops,
@@ -496,11 +504,13 @@ def prepare(
 
             display = Display()
             github_ops = GitHubOps()
+            from cafe.core.playbook import declared_template_managers
             from cafe.skills.loader import SkillLoader
 
+            skill_loader = SkillLoader()
             parsed_fields = profile.resolved_prepare_fields(
                 playbook_path=loaded_playbook.path,
-                skill_loader=SkillLoader(),
+                skill_loader=skill_loader,
             )
             issue_id: Optional[int] = None
             if parsed_fields is None:
@@ -516,12 +526,17 @@ def prepare(
                     parsed_fields,
                     display=display,
                     github_ops=github_ops,
+                    template_managers=declared_template_managers(
+                        loaded_playbook.model,
+                        skill_loader,
+                    ),
                 )
                 if len(field_result) == 4:
                     spec_config, plan_config, pr_config, issue_id = field_result
                 else:
                     spec_config, plan_config, pr_config, step_configs, issue_id = field_result
         elif not interactive:
+            from cafe.core.playbook import declared_template_managers
             from cafe.skills.loader import SkillLoader
             from cafe.ui.prepare_field_renderer import (
                 NonInteractiveCliAnswers,
@@ -531,13 +546,18 @@ def prepare(
                 resolve_non_interactive_issue_config,
             )
 
+            skill_loader = SkillLoader()
             parsed_fields = profile.resolved_prepare_fields(
                 playbook_path=loaded_playbook.path,
-                skill_loader=SkillLoader(),
+                skill_loader=skill_loader,
             )
             resolver_deps = NonInteractiveResolverDeps(
                 spec_template_manager=TemplateManager(template_type="spec"),
                 plan_template_manager=TemplateManager(template_type="plan"),
+                template_managers=declared_template_managers(
+                    loaded_playbook.model,
+                    skill_loader,
+                ),
             )
             try:
                 resolved_config = resolve_non_interactive_issue_config(

--- a/src/cafe/ui/prepare_field_renderer.py
+++ b/src/cafe/ui/prepare_field_renderer.py
@@ -261,14 +261,13 @@ def resolve_non_interactive_issue_config(
             issue_id=answers.issue_id if answers.input_method == "github" else None,
             profile=profile,
         )
-        if not explicit_legacy_defaults:
-            for field in visible_fields_for_non_interactive(parsed_fields, ctx):
-                if (
-                    field.default is not None
-                    and field.write is not None
-                    and field.write not in field_defaults
-                ):
-                    field_defaults[field.write] = field.default
+        for field in visible_fields_for_non_interactive(parsed_fields, ctx):
+            if (
+                field.default is not None
+                and field.write is not None
+                and field.write not in field_defaults
+            ):
+                field_defaults[field.write] = field.default
 
     default_rigor = (
         defaults.rigor

--- a/src/cafe/ui/prepare_field_renderer.py
+++ b/src/cafe/ui/prepare_field_renderer.py
@@ -67,6 +67,7 @@ class NonInteractiveResolverDeps:
 
     spec_template_manager: TemplateManager
     plan_template_manager: TemplateManager
+    template_managers: dict[str, TemplateManager] = field(default_factory=dict)
 
 
 @dataclass
@@ -253,15 +254,20 @@ def resolve_non_interactive_issue_config(
     defaults = profile.non_interactive_defaults()
     explicit_legacy_defaults = "non_interactive_defaults" in profile.prepare.model_fields_set
     field_defaults: dict[str, Any] = {}
-    if parsed_fields is not None and not explicit_legacy_defaults:
+    ctx: Optional[PrepareNonInteractiveContext] = None
+    if parsed_fields is not None:
         ctx = PrepareNonInteractiveContext(
             is_github_repo=profile.is_github_repo,
             issue_id=answers.issue_id if answers.input_method == "github" else None,
             profile=profile,
         )
-        for field in visible_fields_for_non_interactive(parsed_fields, ctx):
-            if field.write in {"spec.rigor", "spec.template", "plan.template"}:
-                if field.default is not None and field.write not in field_defaults:
+        if not explicit_legacy_defaults:
+            for field in visible_fields_for_non_interactive(parsed_fields, ctx):
+                if (
+                    field.default is not None
+                    and field.write is not None
+                    and field.write not in field_defaults
+                ):
                     field_defaults[field.write] = field.default
 
     default_rigor = (
@@ -307,6 +313,25 @@ def resolve_non_interactive_issue_config(
         set_write_value(config, "plan.template", plan_template)
     if answers.sync_plan_github is not None:
         set_write_value(config, "plan.sync_github", answers.sync_plan_github)
+
+    if parsed_fields is not None:
+        assert ctx is not None
+        for field in visible_fields_for_non_interactive(parsed_fields, ctx):
+            if field.type != "template" or field.write is None:
+                continue
+            section, _key = field.write.split(".", 1)
+            if section in {"spec", "plan"}:
+                continue
+            template_name = field_defaults.get(field.write)
+            if template_name is None:
+                continue
+            manager = deps.template_managers.get(section)
+            if manager is None:
+                raise PrepareNonInteractiveError(
+                    f"prepare field {field.id!r} targets undeclared template step {section!r}"
+                )
+            _validate_template_name(manager, field.label, str(template_name))
+            set_write_value(config, field.write, template_name)
 
     supports_pr_config = profile.supports_pr_config(parsed_fields)
     if not supports_pr_config and (

--- a/src/cafe/ui/prepare_field_renderer.py
+++ b/src/cafe/ui/prepare_field_renderer.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Callable, List, Literal, Optional, Tuple
 
 from cafe.core.prepare_fields import ParsedPrepareFields, PrepareField, PrepareFieldChoice
@@ -91,6 +91,7 @@ class RendererDeps:
     select_template: Callable[..., Optional[str]]
     spec_template_manager: TemplateManager
     plan_template_manager: TemplateManager
+    template_managers: dict[str, TemplateManager] = field(default_factory=dict)
     console: Any = None
     display: Any = None
     github_ops: Any = None
@@ -340,10 +341,9 @@ def parse_enum_selection(selection: str, choices: List[PrepareFieldChoice]) -> s
 
 
 def set_write_value(config: PrepareIssueConfig, write: str, value: Any) -> None:
-    """Write one answer into spec/plan/pr blocks."""
+    """Write one answer into a legacy or arbitrary declared step block."""
     section, key = write.split(".", 1)
-    target = {"spec": config.spec, "plan": config.plan, "pr": config.pr}[section]
-    target[key] = value
+    config.section(section)[key] = value
 
 
 def empty_issue_config() -> PrepareIssueConfig:
@@ -407,7 +407,7 @@ def format_quick_summary(
         if field.write is None or field.type == "setup_mode":
             continue
         section, key = field.write.split(".", 1)
-        value = {"spec": config.spec, "plan": config.plan, "pr": config.pr}[section].get(key)
+        value = config.section(section).get(key)
         if value is None:
             continue
         lines.append(f"{field.label}: {value}")
@@ -462,11 +462,10 @@ def _prompt_enum_field(field: PrepareField, ctx: PreparePromptContext, deps: Ren
 
 
 def _prompt_template_field(field: PrepareField, deps: RendererDeps) -> Optional[str]:
-    manager = (
-        deps.spec_template_manager
-        if field.write and field.write.startswith("spec.")
-        else deps.plan_template_manager
-    )
+    step_name = field.write.split(".", 1)[0] if field.write else "plan"
+    manager = deps.template_managers.get(step_name)
+    if manager is None:
+        manager = deps.spec_template_manager if step_name == "spec" else deps.plan_template_manager
     templates_with_source = manager.list_templates()
     template_names = [name for name, _ in templates_with_source]
     if not template_names:
@@ -582,6 +581,7 @@ def run_field_driven_prepare_flow(
         spec_config.spec.update(quick_config.spec)
         spec_config.plan.update(quick_config.plan)
         spec_config.pr.update(quick_config.pr)
+        spec_config.steps.update(quick_config.steps)
         if deps.console is not None:
             deps.console.print()
             deps.console.print("[green]✓ Quick setup applied with recommended defaults:[/green]")
@@ -594,6 +594,7 @@ def run_field_driven_prepare_flow(
     spec_config.spec.update(custom_config.spec)
     spec_config.plan.update(custom_config.plan)
     spec_config.pr.update(custom_config.pr)
+    spec_config.steps.update(custom_config.steps)
     if not profile.is_github_repo:
         spec_config.pr.setdefault("auto_create", False)
     return spec_config, issue_id

--- a/tests/MIGRATION.md
+++ b/tests/MIGRATION.md
@@ -3,6 +3,16 @@
 This file records behaviors removed or re-homed when retiring legacy per-phase Python classes.
 Related issues: #290 (SpecPhase), #291–#294 (sibling retirements).
 
+## Issue 344 — Declarative skill workflow metadata
+
+Prompt inputs, checklist variants, role-guidance opt-in, and template catalogs
+are now declared in skill frontmatter rather than dispatched by phase name.
+`tests/unit/test_skill_workflow_contract.py` owns parser/resolution/composition
+contracts, and `tests/integration/test_declarative_skill_workflow.py` covers a
+custom non-development synthesis step. Legacy checklist helper functions remain
+as compatibility adapters for historic fixture tests; production execution uses
+the contract-driven composer exclusively.
+
 ## Issue 290 — Retire SpecPhase
 
 GitHub: issue #290

--- a/tests/fixtures/checklists/review.md
+++ b/tests/fixtures/checklists/review.md
@@ -69,4 +69,3 @@
 [ ] Do NOT provide code solutions, only identify issues
 [ ] Update blackboard and next-step baton to hand off to the next workflow target
 [ ] Keep the response brief; workflow transitions are controlled by the baton
-

--- a/tests/integration/test_declarative_skill_workflow.py
+++ b/tests/integration/test_declarative_skill_workflow.py
@@ -1,0 +1,156 @@
+"""Integration coverage for a non-development skill declared entirely in metadata."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from cafe.core.blackboard import BlackboardStore
+from cafe.core.types import AgentCLI, TokenUsage
+from cafe.phases.generic_phase import GenericPhase
+from cafe.phases.generic_workflow_step import GenericWorkflowStepExecutor
+from cafe.skills.loader import SkillLoader
+from cafe.skills.native_bridge import NativeSkillBridge
+
+
+class _AgentManager:
+    def __init__(self) -> None:
+        self.prompts: list[str] = []
+        self.agent = SimpleNamespace(config=SimpleNamespace(cli=AgentCLI.CODEX, session_id=None, model=None))
+
+    def get_agent(self, _name: str):
+        return self.agent
+
+    def execute(self, _name: str, prompt: str, **_kwargs):
+        self.prompts.append(prompt)
+        return "confirmed", TokenUsage(), [], [], [], None
+
+
+class _GitOps:
+    def get_default_base_branch(self) -> str:
+        return "main"
+
+    def get_commits_between(self, *, base: str, head: str) -> str:
+        return ""
+
+
+def _write_skill(root: Path, name: str, body: str = "") -> None:
+    directory = root / name
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: {name}\n---\n\n{body}", encoding="utf-8"
+    )
+
+
+def test_custom_synthesis_step_uses_declared_artifact_checklist_and_template(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A custom skill runs with its named input, feedback checklist, and selected catalog file."""
+    monkeypatch.chdir(tmp_path)
+    builtin_root = tmp_path / "builtin"
+    for name in ("cafe-workflow-common", "cafe-github_sync"):
+        _write_skill(builtin_root / "skills", name)
+
+    skill_dir = tmp_path / ".cafe" / "skills" / "synthesis"
+    (skill_dir / "references").mkdir(parents=True)
+    (skill_dir / "assets" / "templates").mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        """---
+name: synthesis
+description: synthesis
+workflow:
+  prompt_inputs:
+    - artifacts: [research_notes]
+      placeholder: evidence_file
+      required: true
+    - artifacts: [editor_feedback]
+      placeholder: feedback_file
+      required: false
+  checklist:
+    variants:
+      - when: {artifact_present: [editor_feedback]}
+        sections: [{reference: feedback.md}, {template_catalog: true}]
+      - when: {}
+        sections: [{reference: first.md}, {template_catalog: true}]
+    include_role_guidance: false
+  output_templates:
+    catalog: synthesis-report
+---
+
+Read {evidence_file} and use {template_file}.
+""",
+        encoding="utf-8",
+    )
+    (skill_dir / "references" / "first.md").write_text(
+        "[ ] Read {evidence_file}\n", encoding="utf-8"
+    )
+    (skill_dir / "references" / "feedback.md").write_text(
+        "[ ] Address {feedback_file} using {evidence_file}\n", encoding="utf-8"
+    )
+    selected_template = skill_dir / "assets" / "templates" / "evidence.md"
+    selected_template.write_text("# Evidence report\n", encoding="utf-8")
+
+    loader = SkillLoader(
+        project_root=tmp_path,
+        global_root=tmp_path / "global",
+        builtin_root=builtin_root,
+    )
+    loader.discover()
+    generic_phase = GenericPhase(
+        loader,
+        skill_bridge=NativeSkillBridge(loader, project_root=tmp_path, home_dir=tmp_path / "home"),
+    )
+    issue_dir = tmp_path / ".cafe" / "issues" / "synthesis-test"
+    (issue_dir / "issue.yaml").parent.mkdir(parents=True)
+    (issue_dir / "issue.yaml").write_text("synthesis:\n  template: evidence\n", encoding="utf-8")
+    state = BlackboardStore(issue_dir).load_or_create("synthesis")
+    research = issue_dir / "research" / "iteration_001" / "output.md"
+    feedback = issue_dir / "editorial" / "iteration_001" / "output.md"
+    research.parent.mkdir(parents=True)
+    feedback.parent.mkdir(parents=True)
+    research.write_text("evidence", encoding="utf-8")
+    feedback.write_text("clarify sources", encoding="utf-8")
+    store = BlackboardStore(issue_dir)
+    store.set_artifact(state, "research_notes", str(research))
+    store.set_artifact(state, "editor_feedback", str(feedback))
+    manager = _AgentManager()
+    step = {
+        "skill": "synthesis",
+        "role": "researcher",
+        "output_artifact": "report",
+        "allowed_tools": ["Read"],
+        "valid_intents": ["confirmed"],
+        "on": {"await_agent": "_done"},
+    }
+    executor = GenericWorkflowStepExecutor(
+        issue_dir=issue_dir,
+        issue_name="synthesis-test",
+        playbook={
+            "playbook": {"id": "synthesis"},
+            "roles": {"researcher": {"default_agent": "David"}},
+            "steps": {"synthesis": step},
+        },
+        generic_phase=generic_phase,
+        agent_manager=manager,
+        git_ops=_GitOps(),
+        role_agent_map={"researcher": "David"},
+    )
+
+    executor.execute_step("synthesis", step, state)
+
+    checklist = (issue_dir / "synthesis" / "iteration_001" / "checklist.md").read_text(
+        encoding="utf-8"
+    )
+    assert "editorial/iteration_001/output.md" in checklist
+    assert "research/iteration_001/output.md" in checklist
+    assert "evidence.md" in checklist
+    context = executor._build_context(
+        step_name="synthesis",
+        step_def=step,
+        blackboard_state=state,
+        agent_name="David",
+        output_file=issue_dir / "synthesis" / "iteration_001" / "output.md",
+    )
+    activated = loader.activate("synthesis", context)
+    assert "research/iteration_001/output.md" in activated
+    assert "evidence.md" in activated

--- a/tests/integration/test_declarative_skill_workflow.py
+++ b/tests/integration/test_declarative_skill_workflow.py
@@ -16,7 +16,9 @@ from cafe.skills.native_bridge import NativeSkillBridge
 class _AgentManager:
     def __init__(self) -> None:
         self.prompts: list[str] = []
-        self.agent = SimpleNamespace(config=SimpleNamespace(cli=AgentCLI.CODEX, session_id=None, model=None))
+        self.agent = SimpleNamespace(
+            config=SimpleNamespace(cli=AgentCLI.CODEX, session_id=None, model=None)
+        )
 
     def get_agent(self, _name: str):
         return self.agent

--- a/tests/integration/test_prepare_field_driven.py
+++ b/tests/integration/test_prepare_field_driven.py
@@ -1,6 +1,7 @@
 """Integration tests for field-driven cafe prepare interactive prompts."""
 
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -179,3 +180,29 @@ commands:
         assert result.exit_code == 0
         mock_legacy.assert_called_once()
         mock_field.assert_not_called()
+
+
+def test_field_driven_prepare_passes_declared_custom_template_managers() -> None:
+    """Lifecycle wiring keeps custom step catalogs available to the renderer."""
+    from cafe.ui.commands.lifecycle import _run_field_driven_prepare_prompts
+
+    custom_manager = MagicMock()
+    rendered_config = SimpleNamespace(spec={}, plan={}, pr={}, steps={})
+    with (
+        patch("cafe.ui.commands.lifecycle.TemplateManager") as manager_cls,
+        patch("cafe.ui.prepare_field_renderer.run_field_driven_prepare_flow") as run_flow,
+    ):
+        manager_cls.side_effect = [MagicMock(), MagicMock()]
+        run_flow.return_value = (rendered_config, None)
+
+        _run_field_driven_prepare_prompts(
+            MagicMock(),
+            MagicMock(),
+            display=MagicMock(),
+            github_ops=MagicMock(),
+            template_managers={"synthesis": custom_manager},
+        )
+
+    assert run_flow.call_args.kwargs["deps"].template_managers == {
+        "synthesis": custom_manager
+    }

--- a/tests/unit/test_develop_checklist_test_policy.py
+++ b/tests/unit/test_develop_checklist_test_policy.py
@@ -13,20 +13,27 @@ BRITTLE_KEYWORDS = (
 )
 
 
-def _assert_develop_steps_include_test_policy(reference_name: str) -> None:
-    content = load_skill_reference("cafe-develop", reference_name)
+def _assert_develop_steps_include_test_policy(*reference_names: str) -> None:
+    content = "\n".join(
+        load_skill_reference("cafe-develop", reference_name)
+        for reference_name in reference_names
+    )
     lower = content.lower()
     assert any(kw.lower() in lower for kw in TEST_LIST_KEYWORDS), (
-        f"develop/{reference_name} must mention plan Test List"
+        f"develop/{', '.join(reference_names)} must mention plan Test List"
     )
     assert sum(1 for kw in BRITTLE_KEYWORDS if kw.lower() in lower) >= 2, (
-        f"develop/{reference_name} must warn about brittle test bindings"
+        f"develop/{', '.join(reference_names)} must warn about brittle test bindings"
     )
 
 
 def test_develop_normal_execution_steps_reference_test_policy() -> None:
-    _assert_develop_steps_include_test_policy("execution_steps_normal.md")
+    _assert_develop_steps_include_test_policy(
+        "execution_steps_normal.md", "normal_plan_verification.md"
+    )
 
 
 def test_develop_correction_execution_steps_reference_test_policy() -> None:
-    _assert_develop_steps_include_test_policy("execution_steps_correction.md")
+    _assert_develop_steps_include_test_policy(
+        "execution_steps_correction.md", "correction_plan_test_list.md"
+    )

--- a/tests/unit/test_generic_phase.py
+++ b/tests/unit/test_generic_phase.py
@@ -508,6 +508,48 @@ def test_prepare_skill_renders_iteration_context_without_mutating_source(
     assert source_file.read_text(encoding="utf-8") == source_before
 
 
+def test_prepare_skill_omits_absent_optional_input_lines(tmp_path: Path) -> None:
+    """Absent optional artifacts do not leave fake or unresolved prompt instructions."""
+    loader = _setup_loader(tmp_path)
+    source_file = loader.get_skill_dir("cafe-plan") / "SKILL.md"
+    source_file.write_text(
+        """---
+name: cafe-plan
+description: desc
+workflow:
+  prompt_inputs:
+    - artifacts: [optional_notes]
+      placeholder: notes_file
+      required: false
+---
+
+Read optional notes: {notes_file}
+Write the plan.
+""",
+        encoding="utf-8",
+    )
+    loader.discover()
+    project_root = tmp_path / "project"
+    project_root.mkdir(parents=True, exist_ok=True)
+    phase = GenericPhase(
+        loader,
+        skill_bridge=NativeSkillBridge(
+            loader,
+            project_root=project_root,
+            home_dir=tmp_path / "home",
+        ),
+    )
+
+    phase.prepare_skill(skill_name="cafe-plan", agent_cli=AgentCLI.CODEX, context={})
+
+    installed = (project_root / ".codex" / "skills" / "cafe-plan" / "SKILL.md").read_text(
+        encoding="utf-8"
+    )
+    assert "Read optional notes" not in installed
+    assert "{notes_file}" not in installed
+    assert "Write the plan." in installed
+
+
 def test_prepare_skills_installs_shared_and_phase_skills(tmp_path: Path) -> None:
     loader = _setup_loader(tmp_path)
     project_root = tmp_path / "project"

--- a/tests/unit/test_generic_phase.py
+++ b/tests/unit/test_generic_phase.py
@@ -508,10 +508,18 @@ def test_prepare_skill_renders_iteration_context_without_mutating_source(
     assert source_file.read_text(encoding="utf-8") == source_before
 
 
-def test_prepare_skill_keeps_optional_instruction_lines_when_input_is_absent(tmp_path: Path) -> None:
-    """The runtime never deletes arbitrary skill-owned instruction lines."""
+def test_prepare_skill_omits_declared_optional_prompt_reference_when_input_is_absent(
+    tmp_path: Path,
+) -> None:
+    """Optional prompt instructions are rendered only through their named reference."""
     loader = _setup_loader(tmp_path)
     source_file = loader.get_skill_dir("cafe-plan") / "SKILL.md"
+    references_dir = source_file.parent / "references"
+    references_dir.mkdir()
+    (references_dir / "optional_notes_instruction.md").write_text(
+        "Read optional notes: {notes_file}\n",
+        encoding="utf-8",
+    )
     source_file.write_text(
         """---
 name: cafe-plan
@@ -521,9 +529,11 @@ workflow:
     - artifacts: [optional_notes]
       placeholder: notes_file
       required: false
+  prompt_references:
+    optional_notes_instruction: optional_notes_instruction.md
 ---
 
-Read optional notes: {notes_file}
+{optional_notes_instruction}
 Write the plan.
 """,
         encoding="utf-8",
@@ -545,8 +555,50 @@ Write the plan.
     installed = (project_root / ".codex" / "skills" / "cafe-plan" / "SKILL.md").read_text(
         encoding="utf-8"
     )
-    assert "Read optional notes: {notes_file}" in installed
+    assert "Read optional notes" not in installed
+    assert "{notes_file}" not in installed
+    assert "{optional_notes_instruction}" not in installed
     assert "Write the plan." in installed
+
+    phase.prepare_skill(
+        skill_name="cafe-plan",
+        agent_cli=AgentCLI.CODEX,
+        context={"notes_file": "notes.md"},
+    )
+
+    installed = (project_root / ".codex" / "skills" / "cafe-plan" / "SKILL.md").read_text(
+        encoding="utf-8"
+    )
+    assert "Read optional notes: notes.md" in installed
+
+
+def test_prepare_builtin_pr_skill_omits_unavailable_contexts(tmp_path: Path) -> None:
+    """The shipped PR skill has no fake spec or plan path in short workflows."""
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    loader = SkillLoader(
+        project_root=project_root,
+        global_root=tmp_path / "global",
+    )
+    loader.discover()
+    phase = GenericPhase(
+        loader,
+        skill_bridge=NativeSkillBridge(
+            loader,
+            project_root=project_root,
+            home_dir=tmp_path / "home",
+        ),
+    )
+
+    phase.prepare_skill(skill_name="cafe-pr", agent_cli=AgentCLI.CODEX, context={})
+
+    installed = (project_root / ".codex" / "skills" / "cafe-pr" / "SKILL.md").read_text(
+        encoding="utf-8"
+    )
+    assert "Requirements Specification:" not in installed
+    assert "Implementation Plan:" not in installed
+    assert "{spec_file}" not in installed
+    assert "{plan_file}" not in installed
 
 
 def test_prepare_skills_installs_shared_and_phase_skills(tmp_path: Path) -> None:

--- a/tests/unit/test_generic_phase.py
+++ b/tests/unit/test_generic_phase.py
@@ -508,8 +508,8 @@ def test_prepare_skill_renders_iteration_context_without_mutating_source(
     assert source_file.read_text(encoding="utf-8") == source_before
 
 
-def test_prepare_skill_omits_absent_optional_input_lines(tmp_path: Path) -> None:
-    """Absent optional artifacts do not leave fake or unresolved prompt instructions."""
+def test_prepare_skill_keeps_optional_instruction_lines_when_input_is_absent(tmp_path: Path) -> None:
+    """The runtime never deletes arbitrary skill-owned instruction lines."""
     loader = _setup_loader(tmp_path)
     source_file = loader.get_skill_dir("cafe-plan") / "SKILL.md"
     source_file.write_text(
@@ -545,8 +545,7 @@ Write the plan.
     installed = (project_root / ".codex" / "skills" / "cafe-plan" / "SKILL.md").read_text(
         encoding="utf-8"
     )
-    assert "Read optional notes" not in installed
-    assert "{notes_file}" not in installed
+    assert "Read optional notes: {notes_file}" in installed
     assert "Write the plan." in installed
 
 

--- a/tests/unit/test_generic_workflow_step.py
+++ b/tests/unit/test_generic_workflow_step.py
@@ -2536,6 +2536,108 @@ def test_workflow_allows_selected_global_template_directory(tmp_path: Path, monk
     )
 
 
+def test_workflow_allows_auto_catalog_template_directories(tmp_path: Path, monkeypatch) -> None:
+    """Auto selection grants read access to each catalog candidate directory."""
+    monkeypatch.chdir(tmp_path)
+    issue_dir = tmp_path / ".cafe" / "issues" / "issue-auto-global-template"
+    research_file = tmp_path / "research.md"
+    research_file.write_text("evidence", encoding="utf-8")
+    global_template = (
+        tmp_path.parent
+        / f"{tmp_path.name}-auto-global-cafe"
+        / "templates"
+        / "synthesis"
+        / "evidence.md"
+    )
+    global_template.parent.mkdir(parents=True)
+    global_template.write_text("# Global evidence\n", encoding="utf-8")
+    playbook = {
+        "playbook": {"id": "custom"},
+        "roles": {"developer": {"default_agent": "David"}},
+        "steps": {
+            "synthesis": {
+                "skill": "synthesis",
+                "role": "developer",
+                "template": "auto",
+                "output_artifact": "report",
+                "allowed_tools": ["Read"],
+                "on": {"await_agent": "_done"},
+            }
+        },
+    }
+    store = BlackboardStore(issue_dir)
+    state = store.load_or_create("synthesis")
+    store.set_artifact(state, "research_notes", str(research_file))
+    agent_manager = FakeAgentManager("await_agent")
+    executor = GenericWorkflowStepExecutor(
+        issue_dir=issue_dir,
+        issue_name="issue-auto-global-template",
+        playbook=playbook,
+        generic_phase=_build_loader(tmp_path),
+        agent_manager=agent_manager,
+        git_ops=FakeGitOperations(),
+        role_agent_map={"developer": "David"},
+    )
+
+    with (
+        patch(
+            "cafe.phases.generic_workflow_step.TemplateManager.list_templates",
+            return_value=[("evidence", "global")],
+        ),
+        patch(
+            "cafe.phases.generic_workflow_step.TemplateManager.get_template_path",
+            return_value=global_template,
+        ),
+    ):
+        executor.execute_step("synthesis", playbook["steps"]["synthesis"], state)
+
+    assert any(
+        Path(directory).resolve() == global_template.parent.resolve()
+        for directory in agent_manager.allowed_directories_calls[-1]
+    )
+
+
+def test_workflow_limits_prompt_inputs_to_step_artifacts(tmp_path: Path) -> None:
+    """A skill cannot receive a blackboard artifact undeclared by its step."""
+    executor = _make_minimal_executor(tmp_path)
+    state = BlackboardStore(executor.issue_dir).load_or_create("synthesis")
+    BlackboardStore(executor.issue_dir).set_artifact(
+        state, "research_notes", str(tmp_path / "research.md")
+    )
+    step_def = {"skill": "synthesis", "role": "developer", "input_artifacts": []}
+
+    with pytest.raises(ValueError, match="evidence_file"):
+        executor._build_context(
+            step_name="synthesis",
+            step_def=step_def,
+            blackboard_state=state,
+            agent_name="David",
+            output_file=tmp_path / "output.md",
+        )
+
+
+def test_workflow_limits_checklist_inputs_to_step_artifacts(tmp_path: Path) -> None:
+    """Checklist generation uses the same declared artifact boundary as the prompt."""
+    executor = _make_minimal_executor(tmp_path)
+    state = BlackboardStore(executor.issue_dir).load_or_create("synthesis")
+    BlackboardStore(executor.issue_dir).set_artifact(
+        state, "research_notes", str(tmp_path / "research.md")
+    )
+    step_def = {"skill": "synthesis", "role": "developer", "input_artifacts": []}
+
+    with pytest.raises(ValueError, match="evidence_file"):
+        executor._generate_checklist(
+            step_name="synthesis",
+            skill_name="synthesis",
+            agent_name="David",
+            step_def=step_def,
+            blackboard_state=state,
+            checklist_file=tmp_path / "checklist.md",
+            output_file=tmp_path / "output.md",
+            questions_xml_file=tmp_path / "questions.xml",
+        )
+
+
 def _plan_step_playbook() -> dict:
     return {
         "playbook": {"id": "default"},

--- a/tests/unit/test_generic_workflow_step.py
+++ b/tests/unit/test_generic_workflow_step.py
@@ -116,6 +116,7 @@ def _build_loader(tmp_path: Path) -> GenericPhase:
         "cafe-github_sync": "Shared GitHub sync helper.\n",
         "cafe-review": "Review the latest changes.\n",
         "cafe-pr": "Write PR content to: {output_file}\n",
+        "synthesis": "Synthesize {evidence_file}.\n",
     }.items():
         skill_dir = skill_root / name
         skill_dir.mkdir(parents=True, exist_ok=True)
@@ -125,10 +126,22 @@ def _build_loader(tmp_path: Path) -> GenericPhase:
                 "workflow:\n  prompt_inputs:\n"
                 "    - artifacts: [code]\n      placeholder: develop_file\n      required: false\n"
             )
+        if name == "synthesis":
+            workflow = (
+                "workflow:\n  prompt_inputs:\n"
+                "    - artifacts: [research_notes]\n"
+                "      placeholder: evidence_file\n"
+                "      required: true\n"
+                "  output_templates:\n"
+                "    catalog: synthesis\n"
+            )
         (skill_dir / "SKILL.md").write_text(
             f"---\nname: {name}\ndescription: desc\n{workflow}---\n\n{body}",
             encoding="utf-8",
         )
+    synthesis_templates = skill_root / "synthesis" / "assets" / "templates"
+    synthesis_templates.mkdir(parents=True, exist_ok=True)
+    (synthesis_templates / "evidence.md").write_text("# Evidence\n", encoding="utf-8")
     loader = SkillLoader(
         project_root=tmp_path,
         global_root=tmp_path / "global",
@@ -2468,6 +2481,61 @@ def test_workflow_legacy_behavior_unchanged_when_no_config(tmp_path: Path, monke
     assert agent_manager.allowed_directories_calls[-1] == [".cafe"]
 
 
+def test_workflow_allows_selected_global_template_directory(tmp_path: Path, monkeypatch) -> None:
+    """A selected template outside the worktree remains readable by the agent."""
+    monkeypatch.chdir(tmp_path)
+    issue_dir = tmp_path / ".cafe" / "issues" / "issue-global-template"
+    research_file = tmp_path / "research.md"
+    research_file.write_text("evidence", encoding="utf-8")
+    global_template = (
+        tmp_path.parent
+        / f"{tmp_path.name}-global-cafe"
+        / "templates"
+        / "synthesis"
+        / "evidence.md"
+    )
+    global_template.parent.mkdir(parents=True)
+    global_template.write_text("# Global evidence\n", encoding="utf-8")
+    playbook = {
+        "playbook": {"id": "custom"},
+        "roles": {"developer": {"default_agent": "David"}},
+        "steps": {
+            "synthesis": {
+                "skill": "synthesis",
+                "role": "developer",
+                "template": "evidence",
+                "output_artifact": "report",
+                "allowed_tools": ["Read"],
+                "on": {"await_agent": "_done"},
+            }
+        },
+    }
+    store = BlackboardStore(issue_dir)
+    state = store.load_or_create("synthesis")
+    store.set_artifact(state, "research_notes", str(research_file))
+    agent_manager = FakeAgentManager("await_agent")
+    executor = GenericWorkflowStepExecutor(
+        issue_dir=issue_dir,
+        issue_name="issue-global-template",
+        playbook=playbook,
+        generic_phase=_build_loader(tmp_path),
+        agent_manager=agent_manager,
+        git_ops=FakeGitOperations(),
+        role_agent_map={"developer": "David"},
+    )
+
+    with patch(
+        "cafe.phases.generic_workflow_step.TemplateManager.get_template_path",
+        return_value=global_template,
+    ):
+        executor.execute_step("synthesis", playbook["steps"]["synthesis"], state)
+
+    assert any(
+        Path(directory).resolve() == global_template.parent.resolve()
+        for directory in agent_manager.allowed_directories_calls[-1]
+    )
+
+
 def _plan_step_playbook() -> dict:
     return {
         "playbook": {"id": "default"},
@@ -3261,6 +3329,35 @@ def test_apply_resume_to_runtime_context_lists_all_present_artifacts(tmp_path: P
             "- feedback_file: review.md",
         ]
     )
+
+
+def test_apply_resume_to_runtime_context_lists_declared_custom_artifacts(tmp_path: Path) -> None:
+    """Resume context preserves a custom skill's declared placeholder name."""
+    issue_dir = tmp_path / ".cafe" / "issues" / "issue-resume-custom-artifacts"
+    phase_dir = issue_dir / "synthesize"
+    previous = phase_dir / "iteration_001"
+    previous.mkdir(parents=True)
+    (previous / "iteration.json").write_text(
+        json.dumps({"cli": "codex", "session_id": "session-1"}), encoding="utf-8"
+    )
+    current = phase_dir / "iteration_002"
+    current.mkdir()
+    (current / "iteration.json").write_text(
+        json.dumps({"cli": "codex", "session_id": "session-1"}), encoding="utf-8"
+    )
+    executor = _minimal_spec_executor(tmp_path, agent_manager=FakeAgentManager("confirmed"))
+    executor.playbook = {
+        "steps": {"synthesize": {"skill": "synthesis", "role": "developer"}}
+    }
+    executor.phase_dir = phase_dir
+    executor.iteration = 2
+    executor._step_agent_name = "David"
+
+    updated = executor._apply_resume_to_runtime_context(
+        {"evidence_file": "research-notes.md"}, "synthesize"
+    )
+
+    assert updated["resume_input_artifacts"] == "- evidence_file: research-notes.md"
 
 
 def test_execute_step_same_session_resume_keeps_real_input_in_prompt_and_user_input_md(

--- a/tests/unit/test_generic_workflow_step.py
+++ b/tests/unit/test_generic_workflow_step.py
@@ -111,7 +111,7 @@ def _build_loader(tmp_path: Path) -> GenericPhase:
     for name, body in {
         "cafe-spec": "## Role\nRead your agent file: {agent_file}\n\n## Context\n{blackboard_digest}\n",
         "cafe-plan": "Write plan to: {output_file}\n",
-        "cafe-develop": "Implement the current request.\n",
+        "cafe-develop": "Implement the current request. {develop_file}\n",
         "cafe-workflow-common": "Read blackboard first.\n",
         "cafe-github_sync": "Shared GitHub sync helper.\n",
         "cafe-review": "Review the latest changes.\n",
@@ -119,8 +119,14 @@ def _build_loader(tmp_path: Path) -> GenericPhase:
     }.items():
         skill_dir = skill_root / name
         skill_dir.mkdir(parents=True, exist_ok=True)
+        workflow = ""
+        if name == "cafe-develop":
+            workflow = (
+                "workflow:\n  prompt_inputs:\n"
+                "    - artifacts: [code]\n      placeholder: develop_file\n      required: false\n"
+            )
         (skill_dir / "SKILL.md").write_text(
-            f"---\nname: {name}\ndescription: desc\n---\n\n{body}",
+            f"---\nname: {name}\ndescription: desc\n{workflow}---\n\n{body}",
             encoding="utf-8",
         )
     loader = SkillLoader(
@@ -2582,23 +2588,45 @@ def test_develop_checklist_prefers_review_feedback_over_pr_result(
     store.set_artifact(state, "review_feedback", str(review_file))
     store.set_artifact(state, "pr_result", str(pr_file))
 
-    with patch("cafe.phases.generic_workflow_step.generate_develop_checklist") as mock_gen:
-        executor = GenericWorkflowStepExecutor(
-            issue_dir=issue_dir,
-            issue_name="issue-develop-feedback",
-            playbook=playbook,
-            generic_phase=_build_loader(tmp_path),
-            agent_manager=FakeAgentManager("confirmed"),
-            git_ops=FakeGitOperations(),
-            role_agent_map={"developer": "David"},
-        )
-        executor.execute_step("develop", playbook["steps"]["develop"], state)
+    skill_dir = tmp_path / ".cafe" / "skills" / "cafe-develop"
+    (skill_dir / "references").mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        """---
+name: cafe-develop
+description: test skill
+workflow:
+  prompt_inputs:
+    - artifacts: [review_feedback, pr_result]
+      placeholder: feedback_file
+      required: false
+  checklist:
+    variants:
+      - when: {feedback: true}
+        sections: [{reference: execution.md}]
+    include_role_guidance: false
+---
+""",
+        encoding="utf-8",
+    )
+    (skill_dir / "references" / "execution.md").write_text(
+        "[ ] Use {feedback_file}\n", encoding="utf-8"
+    )
+    executor = GenericWorkflowStepExecutor(
+        issue_dir=issue_dir,
+        issue_name="issue-develop-feedback",
+        playbook=playbook,
+        generic_phase=_build_loader(tmp_path),
+        agent_manager=FakeAgentManager("confirmed"),
+        git_ops=FakeGitOperations(),
+        role_agent_map={"developer": "David"},
+    )
+    executor.execute_step("develop", playbook["steps"]["develop"], state)
 
-    mock_gen.assert_called_once()
-    call_kwargs = mock_gen.call_args.kwargs
-    assert call_kwargs["correction_mode"] is True
-    assert "review" in call_kwargs["feedback_file_path"]
-    assert "pr" not in call_kwargs["feedback_file_path"]
+    checklist = (issue_dir / "develop" / "iteration_001" / "checklist.md").read_text(
+        encoding="utf-8"
+    )
+    assert "review/iteration_001/output.md" in checklist
+    assert "pr/iteration_001/output.md" not in checklist
 
 
 def _write_skill_with_basic_principles(
@@ -2610,7 +2638,17 @@ def _write_skill_with_basic_principles(
     skill_dir = tmp_path / ".cafe" / "skills" / skill_name
     skill_dir.mkdir(parents=True, exist_ok=True)
     (skill_dir / "SKILL.md").write_text(
-        f"---\nname: {skill_name}\ndescription: test skill\n---\n",
+        f"""---
+name: {skill_name}
+description: test skill
+workflow:
+  checklist:
+    variants:
+      - when: {{}}
+        sections: [{{optional_checklist: basic_principles.md}}]
+    include_role_guidance: false
+---
+""",
         encoding="utf-8",
     )
     references = skill_dir / "references"
@@ -2662,20 +2700,20 @@ def test_spec_checklist_loads_custom_basic_principles_reference(
     questions_xml_file = issue_dir / "questions.xml"
 
     state = BlackboardStore(issue_dir).load_or_create("spec")
-    with patch("cafe.phases.generic_workflow_step.generate_spec_checklist") as mock_gen:
-        executor._generate_checklist(
-            step_name="spec",
-            skill_name="spec",
-            agent_name="David",
-            step_def={"skill": "spec"},
-            blackboard_state=state,
-            checklist_file=checklist_file,
-            output_file=output_file,
-            questions_xml_file=questions_xml_file,
-        )
+    executor._generate_checklist(
+        step_name="spec",
+        skill_name="spec",
+        agent_name="David",
+        step_def={"skill": "spec"},
+        blackboard_state=state,
+        checklist_file=checklist_file,
+        output_file=output_file,
+        questions_xml_file=questions_xml_file,
+    )
 
-    mock_gen.assert_called_once()
-    assert mock_gen.call_args.kwargs["basic_principles"] == "- Stay scoped\n- Keep behavior stable"
+    checklist = checklist_file.read_text(encoding="utf-8")
+    assert "Stay scoped" in checklist
+    assert "Keep behavior stable" in checklist
 
 
 def test_spec_checklist_omits_missing_basic_principles_reference(
@@ -2714,20 +2752,18 @@ def test_spec_checklist_omits_missing_basic_principles_reference(
     questions_xml_file = issue_dir / "questions.xml"
     state = BlackboardStore(issue_dir).load_or_create("spec")
 
-    with patch("cafe.phases.generic_workflow_step.generate_spec_checklist") as mock_gen:
-        executor._generate_checklist(
-            step_name="spec",
-            skill_name="spec",
-            agent_name="David",
-            step_def={"skill": "spec"},
-            blackboard_state=state,
-            checklist_file=checklist_file,
-            output_file=output_file,
-            questions_xml_file=questions_xml_file,
-        )
+    executor._generate_checklist(
+        step_name="spec",
+        skill_name="spec",
+        agent_name="David",
+        step_def={"skill": "spec"},
+        blackboard_state=state,
+        checklist_file=checklist_file,
+        output_file=output_file,
+        questions_xml_file=questions_xml_file,
+    )
 
-    mock_gen.assert_called_once()
-    assert mock_gen.call_args.kwargs["basic_principles"] == ""
+    assert checklist_file.read_text(encoding="utf-8") == ""
 
 
 def test_update_iteration_history_preserves_model_and_stats_on_second_call(

--- a/tests/unit/test_playbook_loader.py
+++ b/tests/unit/test_playbook_loader.py
@@ -667,15 +667,50 @@ def test_builtin_hotfix_and_simple_playbooks_load() -> None:
     loader = PlaybookLoader()
 
     hotfix = loader.load_model("hotfix").model
+    tdd = loader.load_model("tdd").model
     simple = loader.load_model("simple").model
 
     assert hotfix.entry_point == "develop"
     assert list(hotfix.steps.keys()) == ["develop", "review", "pr"]
     assert hotfix.steps["review"].max_iterations == 1
+    assert hotfix.steps["develop"].input_artifacts == ["review_feedback", "pr_result"]
+    assert tdd.steps["develop"].input_artifacts == [
+        "spec",
+        "plan",
+        "review_feedback",
+        "pr_result",
+    ]
 
     assert simple.entry_point == "spec"
     assert list(simple.steps.keys()) == ["spec", "develop", "pr"]
     assert simple.steps["develop"].on["await_agent"] == "pr"
+
+
+def test_legacy_playbook_omits_input_artifact_scope_after_loading(tmp_path: Path) -> None:
+    """An omitted field remains distinguishable from explicit input_artifacts: []."""
+    builtin_root = tmp_path / "builtin"
+    _write_skill(builtin_root / "skills", "spec_first")
+    _write_playbook(
+        builtin_root / "playbooks",
+        "legacy",
+        """
+playbook: {id: legacy}
+steps:
+  draft:
+    role: pm
+    skill: spec_first
+    on:
+      await_agent: _done
+""",
+    )
+
+    loaded = PlaybookLoader(
+        project_root=tmp_path / "project",
+        global_root=tmp_path / "global",
+        builtin_root=builtin_root,
+    ).load("legacy")
+
+    assert "input_artifacts" not in loaded["steps"]["draft"]
 
 
 def test_builtin_non_software_playbooks_define_non_default_handoff_metadata() -> None:

--- a/tests/unit/test_playbook_loader.py
+++ b/tests/unit/test_playbook_loader.py
@@ -713,6 +713,35 @@ steps:
     assert "input_artifacts" not in loaded["steps"]["draft"]
 
 
+def test_playbook_rejects_explicit_null_input_artifact_scope(tmp_path: Path) -> None:
+    """Explicit null must not bypass an isolated artifact scope."""
+    builtin_root = tmp_path / "builtin"
+    _write_skill(builtin_root / "skills", "spec_first")
+    _write_playbook(
+        builtin_root / "playbooks",
+        "invalid-null-scope",
+        """
+playbook: {id: invalid-null-scope}
+steps:
+  draft:
+    role: pm
+    skill: spec_first
+    input_artifacts: null
+    on:
+      await_agent: _done
+""",
+    )
+
+    loader = PlaybookLoader(
+        project_root=tmp_path / "project",
+        global_root=tmp_path / "global",
+        builtin_root=builtin_root,
+    )
+
+    with pytest.raises(ValueError, match="input_artifacts must be a list when specified"):
+        loader.load("invalid-null-scope")
+
+
 def test_builtin_non_software_playbooks_define_non_default_handoff_metadata() -> None:
     loader = PlaybookLoader()
 

--- a/tests/unit/test_playbook_prepare_metadata.py
+++ b/tests/unit/test_playbook_prepare_metadata.py
@@ -115,6 +115,41 @@ def test_omitted_prepare_section_resolves_defaults(tmp_path: Path) -> None:
     assert resolved.model_dump() == expected.model_dump()
 
 
+def test_required_skill_inputs_must_be_declared_by_the_playbook_step(tmp_path: Path) -> None:
+    """A strict load rejects a step that cannot supply its skill's required artifact."""
+    loader = _loader(tmp_path)
+    skill_dir = tmp_path / "builtin" / "skills" / "requires-brief"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: requires-brief\n"
+        "description: requires a brief\n"
+        "workflow:\n"
+        "  prompt_inputs:\n"
+        "    - artifacts: [brief]\n"
+        "      placeholder: brief_file\n"
+        "      required: true\n"
+        "---\n",
+        encoding="utf-8",
+    )
+    _write_playbook(
+        loader._roots()[0],
+        "missing-input",
+        """
+playbook: {id: missing-input}
+steps:
+  synthesize:
+    role: pm
+    skill: requires-brief
+    input_artifacts: []
+    "on": {await_agent: _done}
+""",
+    )
+
+    with pytest.raises(ValueError, match="synthesize.*brief"):
+        loader.load_model("missing-input", strict=True)
+
+
 def test_invalid_rigor_rejected_with_field_path() -> None:
     data = yaml.safe_load(
         _minimal_playbook_yaml(

--- a/tests/unit/test_prepare_field_renderer.py
+++ b/tests/unit/test_prepare_field_renderer.py
@@ -151,6 +151,41 @@ class TestWriteTargetMapping:
         assert config.steps == {"synthesis": {"template": "evidence"}}
 
 
+def test_non_interactive_prepare_persists_custom_template_field_default() -> None:
+    """A declared custom catalog default is retained outside the spec/plan aliases."""
+    field_defs = [
+        {
+            "id": "synthesis_template",
+            "type": "template",
+            "label": "Synthesis template",
+            "write": "synthesis.template",
+            "default": "evidence",
+        }
+    ]
+    profile = PrepareProfile(
+        prepare=PrepareConfig.model_validate({"fields": field_defs}),
+        is_github_repo=True,
+        step_names=frozenset({"synthesis"}),
+    )
+    parsed = ParsedPrepareFields(fields=parse_prepare_fields(field_defs))
+    synthesis_manager = MagicMock()
+    synthesis_manager.template_exists.return_value = True
+    deps = NonInteractiveResolverDeps(
+        spec_template_manager=MagicMock(),
+        plan_template_manager=MagicMock(),
+        template_managers={"synthesis": synthesis_manager},
+    )
+
+    config = resolve_non_interactive_issue_config(
+        profile,
+        NonInteractiveCliAnswers(input_method="manual"),
+        parsed_fields=parsed,
+        deps=deps,
+    )
+
+    assert config.steps == {"synthesis": {"template": "evidence"}}
+
+
 class TestQuickDefaults:
     def test_matches_profile_quick_setup_for_github_issue(self) -> None:
         parsed = _default_fields()

--- a/tests/unit/test_prepare_field_renderer.py
+++ b/tests/unit/test_prepare_field_renderer.py
@@ -143,6 +143,13 @@ class TestWriteTargetMapping:
         assert config.plan["template"] == "default"
         assert config.pr["auto_create"] is True
 
+    def test_maps_custom_step_template_selection(self) -> None:
+        config = PrepareIssueConfig(spec={}, plan={}, pr={})
+
+        set_write_value(config, "synthesis.template", "evidence")
+
+        assert config.steps == {"synthesis": {"template": "evidence"}}
+
 
 class TestQuickDefaults:
     def test_matches_profile_quick_setup_for_github_issue(self) -> None:

--- a/tests/unit/test_prepare_field_renderer.py
+++ b/tests/unit/test_prepare_field_renderer.py
@@ -186,6 +186,50 @@ def test_non_interactive_prepare_persists_custom_template_field_default() -> Non
     assert config.steps == {"synthesis": {"template": "evidence"}}
 
 
+def test_non_interactive_custom_template_default_survives_legacy_defaults() -> None:
+    """Legacy spec/plan defaults do not discard declarative custom defaults."""
+    field_defs = [
+        {
+            "id": "synthesis_template",
+            "type": "template",
+            "label": "Synthesis template",
+            "write": "synthesis.template",
+            "default": "evidence",
+        }
+    ]
+    profile = PrepareProfile(
+        prepare=PrepareConfig.model_validate(
+            {
+                "fields": field_defs,
+                "non_interactive_defaults": {
+                    "rigor": "medium",
+                    "spec_template": "auto",
+                    "plan_template": "auto",
+                },
+            }
+        ),
+        is_github_repo=True,
+        step_names=frozenset({"synthesis"}),
+    )
+    parsed = ParsedPrepareFields(fields=parse_prepare_fields(field_defs))
+    synthesis_manager = MagicMock()
+    synthesis_manager.template_exists.return_value = True
+    deps = NonInteractiveResolverDeps(
+        spec_template_manager=MagicMock(),
+        plan_template_manager=MagicMock(),
+        template_managers={"synthesis": synthesis_manager},
+    )
+
+    config = resolve_non_interactive_issue_config(
+        profile,
+        NonInteractiveCliAnswers(input_method="manual"),
+        parsed_fields=parsed,
+        deps=deps,
+    )
+
+    assert config.steps == {"synthesis": {"template": "evidence"}}
+
+
 class TestQuickDefaults:
     def test_matches_profile_quick_setup_for_github_issue(self) -> None:
         parsed = _default_fields()

--- a/tests/unit/test_prepare_fields_loader.py
+++ b/tests/unit/test_prepare_fields_loader.py
@@ -55,6 +55,15 @@ def test_prepare_field_schema_rejects_invalid_type() -> None:
         parse_prepare_fields([invalid])
 
 
+def test_prepare_field_schema_accepts_declared_custom_step_template_target() -> None:
+    field = dict(MINIMAL_FIELD, id="report_template", type="template", write="synthesis.template")
+    field.pop("choices")
+
+    parsed = parse_prepare_fields([field])
+
+    assert parsed[0].write == "synthesis.template"
+
+
 def _write_skill(root: Path, name: str) -> None:
     skill_dir = root / name
     skill_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/unit/test_skill_checklist_composer.py
+++ b/tests/unit/test_skill_checklist_composer.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import re
 from pathlib import Path
 
 import pytest
@@ -27,6 +26,9 @@ REQUIRED_SKILL_REFERENCES = {
         "execution_steps_iteration_1.md",
         "important_notes_iteration_4_plus.md",
         "dod_instruction.md",
+        "dod_instruction_composed.md",
+        "dod_instruction_after_notes_composed.md",
+        "important_notes_iteration_4_plus_composed.md",
         "xml_questions_instruction.md",
     ],
     "spec_revise": ["execution_steps_iteration_n.md"],
@@ -38,9 +40,13 @@ REQUIRED_SKILL_REFERENCES = {
     "develop": [
         "execution_steps_normal.md",
         "execution_steps_correction.md",
+        "normal_plan_context.md",
+        "normal_plan_verification.md",
+        "correction_plan_context.md",
+        "correction_plan_test_list.md",
         "xml_questions_instruction.md",
     ],
-    "review": ["execution_steps.md"],
+    "review": ["execution_steps.md", "feedback_instruction.md"],
     "pr": [
         "execution_steps_iteration_1.md",
         "execution_steps_iteration_n.md",
@@ -297,11 +303,6 @@ def _builtin_agent_path(cls, name, role, **_kw: object) -> str:
     return f"src/cafe/data/agents/{role}/{name}.md"
 
 
-def _normalized_checklist(content: str) -> str:
-    """Ignore formatting-only blank-line differences across legacy wrappers."""
-    return re.sub(r"\n{2,}", "\n\n", content).rstrip() + "\n"
-
-
 @pytest.mark.parametrize("case_name", json.loads((FIXTURES_DIR / "manifest.json").read_text(encoding="utf-8")))
 def test_golden_checklist_matches_fixture(case_name: str, tmp_path: Path) -> None:
     """Composed checklists stay equivalent to the pre-migration golden snapshots."""
@@ -310,10 +311,8 @@ def test_golden_checklist_matches_fixture(case_name: str, tmp_path: Path) -> Non
     try:
         output_path = tmp_path / f"{case_name}.md"
         GOLDEN_RUNNERS[case_name](output_path)
-        expected = _normalized_checklist(
-            (FIXTURES_DIR / f"{case_name}.md").read_text(encoding="utf-8")
-        )
-        actual = _normalized_checklist(output_path.read_text(encoding="utf-8"))
+        expected = (FIXTURES_DIR / f"{case_name}.md").read_text(encoding="utf-8")
+        actual = output_path.read_text(encoding="utf-8")
         if actual != expected:
             for i, (a, e) in enumerate(zip(actual.splitlines(), expected.splitlines())):
                 if a != e:
@@ -349,11 +348,10 @@ def test_production_composer_golden_checklist_matches_fixture(
             feedback=case.get("feedback", False),
             template_mode="manual",
         )
-        actual = _normalized_checklist(output_path.read_text(encoding="utf-8"))
+        actual = output_path.read_text(encoding="utf-8")
         expected = (FIXTURES_DIR / f"{case_name}.md").read_text(encoding="utf-8")
         for line in case.get("omitted_optional_lines", ()):
             expected = expected.replace(f"{line}\n", "")
-        expected = _normalized_checklist(expected)
         assert actual == expected
     finally:
         AgentManager.get_agent_file_path = saved

--- a/tests/unit/test_skill_checklist_composer.py
+++ b/tests/unit/test_skill_checklist_composer.py
@@ -169,9 +169,8 @@ GOLDEN_RUNNERS = {
 
 
 # These are the normal workflow cases.  Keep the legacy-wrapper snapshots below
-# as compatibility coverage for their extra arguments, but exercise the
-# production declarative composer against the same snapshots as the source of
-# truth for normal phase execution.
+# as compatibility coverage for their extra arguments. Production cases use
+# the same snapshots, with explicit expected omissions for optional artifacts.
 PRODUCTION_GOLDEN_CASES = {
     "spec_iter1": {
         "skill": "cafe-spec",
@@ -263,6 +262,9 @@ PRODUCTION_GOLDEN_CASES = {
             "output_file": ".cafe/issues/test/review/iteration_001/output.md",
             "base_branch": "develop",
         },
+        "omitted_optional_lines": (
+            "[ ] Read PR feedback in (not available) (if exists) to see user feedback and requests",
+        ),
     },
     "pr_iter1": {
         "skill": "cafe-pr",
@@ -308,8 +310,10 @@ def test_golden_checklist_matches_fixture(case_name: str, tmp_path: Path) -> Non
     try:
         output_path = tmp_path / f"{case_name}.md"
         GOLDEN_RUNNERS[case_name](output_path)
-        expected = (FIXTURES_DIR / f"{case_name}.md").read_text(encoding="utf-8")
-        actual = output_path.read_text(encoding="utf-8")
+        expected = _normalized_checklist(
+            (FIXTURES_DIR / f"{case_name}.md").read_text(encoding="utf-8")
+        )
+        actual = _normalized_checklist(output_path.read_text(encoding="utf-8"))
         if actual != expected:
             for i, (a, e) in enumerate(zip(actual.splitlines(), expected.splitlines())):
                 if a != e:
@@ -346,9 +350,10 @@ def test_production_composer_golden_checklist_matches_fixture(
             template_mode="manual",
         )
         actual = _normalized_checklist(output_path.read_text(encoding="utf-8"))
-        expected = _normalized_checklist(
-            (FIXTURES_DIR / f"{case_name}.md").read_text(encoding="utf-8")
-        )
+        expected = (FIXTURES_DIR / f"{case_name}.md").read_text(encoding="utf-8")
+        for line in case.get("omitted_optional_lines", ()):
+            expected = expected.replace(f"{line}\n", "")
+        expected = _normalized_checklist(expected)
         assert actual == expected
     finally:
         AgentManager.get_agent_file_path = saved

--- a/tests/unit/test_skill_checklist_composer.py
+++ b/tests/unit/test_skill_checklist_composer.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 from cafe.agents.manager import AgentManager
+from cafe.playbooks.loader import PlaybookLoader
 from cafe.skills.bridge import load_skill_reference
 from cafe.skills.checklist_composer import (
     compose_declared_checklist,
@@ -46,11 +47,21 @@ REQUIRED_SKILL_REFERENCES = {
         "correction_plan_test_list.md",
         "xml_questions_instruction.md",
     ],
-    "review": ["execution_steps.md", "feedback_instruction.md"],
+    "review": [
+        "execution_steps.md",
+        "feedback_instruction.md",
+        "spec_read_instruction.md",
+        "plan_read_instruction.md",
+        "spec_comparison_instruction.md",
+    ],
     "pr": [
         "execution_steps_iteration_1.md",
         "execution_steps_iteration_n.md",
         "comments_organization_steps.md",
+        "spec_read_instruction.md",
+        "plan_read_instruction.md",
+        "pr_spec_context.md",
+        "pr_plan_context.md",
     ],
 }
 
@@ -355,6 +366,72 @@ def test_production_composer_golden_checklist_matches_fixture(
         assert actual == expected
     finally:
         AgentManager.get_agent_file_path = saved
+
+
+@pytest.mark.parametrize(
+    ("playbook_id", "step_name", "available_artifacts"),
+    [
+        ("hotfix", "review", {"code": "code.md"}),
+        ("hotfix", "pr", {"code": "code.md", "review_feedback": "review.md"}),
+        ("simple", "pr", {"spec": "spec.md", "code": "code.md"}),
+        (
+            "tdd",
+            "pr",
+            {
+                "spec": "spec.md",
+                "plan": "plan.md",
+                "code": "code.md",
+                "review_feedback": "review.md",
+            },
+        ),
+    ],
+)
+def test_short_builtin_playbook_checklists_compose_with_declared_artifact_scope(
+    playbook_id: str,
+    step_name: str,
+    available_artifacts: dict[str, str],
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Shipped short workflows omit unavailable optional checklist instructions."""
+    step = PlaybookLoader().load_model(playbook_id).model.steps[step_name]
+    scope = set(step.input_artifacts or [])
+    context = {
+        "output_file": "output.md",
+        "base_branch": "main",
+        **{
+            f"{artifact}_file": path
+            for artifact, path in available_artifacts.items()
+            if artifact in scope and artifact in {"spec", "plan", "review_feedback"}
+        },
+    }
+    monkeypatch.setattr(
+        "cafe.skills.checklist_composer.AgentManager.get_agent_file_path",
+        lambda *_: "agent.md",
+    )
+    checklist = tmp_path / f"{playbook_id}-{step_name}.md"
+    assert compose_declared_checklist(
+        skill_name=step.skill,
+        contract=SkillLoader().get_workflow_contract(step.skill),
+        agent_name="Ada",
+        role=step.role,
+        checklist_file_path=checklist,
+        iteration=1,
+        context=context,
+        artifacts={
+            name: available_artifacts[name]
+            for name in scope
+            if name in available_artifacts
+        },
+    )
+
+    content = checklist.read_text(encoding="utf-8")
+    assert "{spec_file}" not in content
+    assert "{plan_file}" not in content
+    if "spec" not in scope:
+        assert "Read the requirements specification" not in content
+    if "plan" not in scope:
+        assert "Read the implementation plan" not in content
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_skill_checklist_composer.py
+++ b/tests/unit/test_skill_checklist_composer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 import pytest
@@ -10,12 +11,14 @@ import pytest
 from cafe.agents.manager import AgentManager
 from cafe.skills.bridge import load_skill_reference
 from cafe.skills.checklist_composer import (
+    compose_declared_checklist,
     generate_develop_checklist,
     generate_plan_checklist,
     generate_pr_checklist,
     generate_review_checklist,
     generate_spec_checklist,
 )
+from cafe.skills.loader import SkillLoader
 
 FIXTURES_DIR = Path(__file__).resolve().parent.parent / "fixtures" / "checklists"
 
@@ -165,9 +168,136 @@ GOLDEN_RUNNERS = {
 }
 
 
+# These are the normal workflow cases.  Keep the legacy-wrapper snapshots below
+# as compatibility coverage for their extra arguments, but exercise the
+# production declarative composer against the same snapshots as the source of
+# truth for normal phase execution.
+PRODUCTION_GOLDEN_CASES = {
+    "spec_iter1": {
+        "skill": "cafe-spec",
+        "agent": "Roger",
+        "role": "pm",
+        "iteration": 1,
+        "context": {
+            "output_file": ".cafe/issues/test/spec/iteration_001/output.md",
+            "previous_output_file": "",
+            "questions_xml_file": ".cafe/issues/test/spec/iteration_001/questions.xml",
+        },
+    },
+    "spec_iter2": {
+        "skill": "cafe-spec",
+        "agent": "Roger",
+        "role": "pm",
+        "iteration": 2,
+        "context": {
+            "output_file": ".cafe/issues/test/spec/iteration_002/output.md",
+            "previous_output_file": ".cafe/issues/test/spec/iteration_001/output.md",
+        },
+    },
+    "spec_iter4": {
+        "skill": "cafe-spec",
+        "agent": "Roger",
+        "role": "pm",
+        "iteration": 4,
+        "context": {
+            "output_file": ".cafe/issues/test/spec/iteration_004/output.md",
+            "previous_output_file": ".cafe/issues/test/spec/iteration_003/output.md",
+            "iteration": "4",
+        },
+    },
+    "plan_iter1": {
+        "skill": "cafe-plan",
+        "agent": "Nick",
+        "role": "developer",
+        "iteration": 1,
+        "context": {
+            "spec_file": ".cafe/issues/test/spec/iteration_001/output.md",
+            "output_file": ".cafe/issues/test/plan/iteration_001/output.md",
+            "previous_output_file": "",
+            "questions_xml_file": ".cafe/issues/test/plan/iteration_001/questions.xml",
+        },
+    },
+    "plan_iter2": {
+        "skill": "cafe-plan",
+        "agent": "Nick",
+        "role": "developer",
+        "iteration": 2,
+        "context": {
+            "spec_file": ".cafe/issues/test/spec/iteration_001/output.md",
+            "output_file": ".cafe/issues/test/plan/iteration_002/output.md",
+            "previous_output_file": ".cafe/issues/test/plan/iteration_001/output.md",
+        },
+    },
+    "develop_normal": {
+        "skill": "cafe-develop",
+        "agent": "Nick",
+        "role": "developer",
+        "iteration": 1,
+        "context": {
+            "spec_file": ".cafe/issues/test/spec/iteration_001/output.md",
+            "plan_file": ".cafe/issues/test/plan/iteration_001/output.md",
+            "output_file": ".cafe/issues/test/develop/iteration_001/output.md",
+        },
+    },
+    "develop_correction": {
+        "skill": "cafe-develop",
+        "agent": "Nick",
+        "role": "developer",
+        "iteration": 1,
+        "feedback": True,
+        "context": {
+            "spec_file": ".cafe/issues/test/spec/iteration_001/output.md",
+            "plan_file": ".cafe/issues/test/plan/iteration_001/output.md",
+            "feedback_file": ".cafe/issues/test/review/iteration_001/output.md",
+            "output_file": ".cafe/issues/test/develop/iteration_001/output.md",
+        },
+    },
+    "review": {
+        "skill": "cafe-review",
+        "agent": "Alice",
+        "role": "reviewer",
+        "iteration": 1,
+        "context": {
+            "spec_file": ".cafe/issues/test/spec/iteration_001/output.md",
+            "plan_file": ".cafe/issues/test/plan/iteration_001/output.md",
+            "output_file": ".cafe/issues/test/review/iteration_001/output.md",
+            "base_branch": "develop",
+        },
+    },
+    "pr_iter1": {
+        "skill": "cafe-pr",
+        "agent": "Nick",
+        "role": "developer",
+        "iteration": 1,
+        "context": {
+            "spec_file": ".cafe/issues/test/spec/iteration_001/output.md",
+            "plan_file": ".cafe/issues/test/plan/iteration_001/output.md",
+            "output_file": ".cafe/issues/test/pr/iteration_001/output.md",
+        },
+    },
+    "pr_iter2": {
+        "skill": "cafe-pr",
+        "agent": "Nick",
+        "role": "developer",
+        "iteration": 2,
+        "context": {
+            "spec_file": ".cafe/issues/test/spec/iteration_001/output.md",
+            "plan_file": ".cafe/issues/test/plan/iteration_001/output.md",
+            "output_file": ".cafe/issues/test/pr/iteration_002/output.md",
+            "previous_output_file": ".cafe/issues/test/pr/iteration_001/output.md",
+        },
+    },
+}
+
+
 def _builtin_agent_path(cls, name, role, **_kw: object) -> str:
     """Always resolve to builtin agent files (ignores local overrides)."""
     return f"src/cafe/data/agents/{role}/{name}.md"
+
+
+def _normalized_checklist(content: str) -> str:
+    """Ignore formatting-only blank-line differences across legacy wrappers."""
+    return re.sub(r"\n{2,}", "\n\n", content).rstrip() + "\n"
 
 
 @pytest.mark.parametrize("case_name", json.loads((FIXTURES_DIR / "manifest.json").read_text(encoding="utf-8")))
@@ -189,6 +319,37 @@ def test_golden_checklist_matches_fixture(case_name: str, tmp_path: Path) -> Non
             raise AssertionError(
                 f"Line count differs: actual={len(actual.splitlines())} expected={len(expected.splitlines())}"
             )
+    finally:
+        AgentManager.get_agent_file_path = saved
+
+
+@pytest.mark.parametrize("case_name", sorted(PRODUCTION_GOLDEN_CASES))
+def test_production_composer_golden_checklist_matches_fixture(
+    case_name: str, tmp_path: Path
+) -> None:
+    """The workflow runtime's declarative composer preserves golden output."""
+    case = PRODUCTION_GOLDEN_CASES[case_name]
+    saved = AgentManager.get_agent_file_path
+    AgentManager.get_agent_file_path = classmethod(_builtin_agent_path)  # type: ignore[assignment]
+    try:
+        output_path = tmp_path / f"production-{case_name}.md"
+        assert compose_declared_checklist(
+            skill_name=case["skill"],
+            contract=SkillLoader().get_workflow_contract(case["skill"]),
+            agent_name=case["agent"],
+            role=case["role"],
+            checklist_file_path=output_path,
+            iteration=case["iteration"],
+            context=case["context"],
+            artifacts={},
+            feedback=case.get("feedback", False),
+            template_mode="manual",
+        )
+        actual = _normalized_checklist(output_path.read_text(encoding="utf-8"))
+        expected = _normalized_checklist(
+            (FIXTURES_DIR / f"{case_name}.md").read_text(encoding="utf-8")
+        )
+        assert actual == expected
     finally:
         AgentManager.get_agent_file_path = saved
 

--- a/tests/unit/test_skill_loader.py
+++ b/tests/unit/test_skill_loader.py
@@ -72,6 +72,33 @@ def test_activate_replaces_placeholders(tmp_path: Path) -> None:
     assert "Hello World" in text
 
 
+def test_prompt_only_workflow_rejects_missing_reference(tmp_path: Path) -> None:
+    project_root = tmp_path / "project"
+    skill_dir = project_root / ".cafe" / "skills" / "prompt-only"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        """---
+name: prompt-only
+description: Prompt-only workflow contract.
+workflow:
+  prompt_references:
+    optional_instruction: missing.md
+---
+""",
+        encoding="utf-8",
+    )
+    loader = SkillLoader(
+        project_root=project_root,
+        global_root=tmp_path / "global",
+        builtin_root=tmp_path / "builtin",
+    )
+
+    loader.discover()
+
+    with pytest.raises(ValueError, match="workflow reference not found: missing.md"):
+        loader.get_workflow_contract("prompt-only")
+
+
 def test_builtin_catalog_includes_pr_skill(tmp_path: Path) -> None:
     builtin_root = Path(__file__).resolve().parents[2] / "src" / "cafe" / "data"
     loader = SkillLoader(

--- a/tests/unit/test_skill_workflow_contract.py
+++ b/tests/unit/test_skill_workflow_contract.py
@@ -71,6 +71,21 @@ def test_workflow_contract_rejects_runtime_owned_input_placeholders(placeholder:
 
 
 @pytest.mark.parametrize(
+    "placeholder",
+    ["output_file", "checklist_file", "questions_xml_file", "next_step_path"],
+)
+def test_workflow_contract_rejects_runtime_owned_context_reference_placeholders(
+    placeholder: str,
+) -> None:
+    """Checklist references cannot replace values supplied by the runtime."""
+    data = _contract_data()
+    data["checklist"]["context_references"] = {placeholder: "xml_questions.md"}
+
+    with pytest.raises(ValidationError, match="runtime-owned"):
+        SkillWorkflowContract.model_validate(data)
+
+
+@pytest.mark.parametrize(
     "mutate",
     [
         lambda data: data["prompt_inputs"].append(
@@ -167,3 +182,48 @@ def test_custom_contract_composes_selected_variant_and_explicit_role_guidance(
         artifacts={"research": "research.md"},
     )
     assert output.read_text(encoding="utf-8") == "[ ] Revise research.md\n"
+
+
+def test_custom_contract_omits_optional_input_checklist_lines_when_absent(
+    tmp_path, monkeypatch
+) -> None:
+    """Optional artifacts do not create fake paths or unresolved instructions."""
+    monkeypatch.chdir(tmp_path)
+    skill_dir = tmp_path / ".cafe" / "skills" / "synthesis"
+    (skill_dir / "references").mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: synthesis\ndescription: synthesis\n---\n", encoding="utf-8"
+    )
+    (skill_dir / "references" / "execution.md").write_text(
+        "[ ] Read optional review {review_file}\n[ ] Write the result\n",
+        encoding="utf-8",
+    )
+    contract = SkillWorkflowContract.model_validate(
+        {
+            "prompt_inputs": [
+                {"artifacts": ["review"], "placeholder": "review_file", "required": False}
+            ],
+            "checklist": {
+                "variants": [{"sections": [{"reference": "execution.md"}]}],
+                "include_role_guidance": False,
+            },
+        }
+    )
+    loader = SkillLoader(project_root=tmp_path)
+    loader.discover()
+    monkeypatch.setattr(
+        "cafe.skills.checklist_composer.AgentManager.get_agent_file_path", lambda *_: "agent.md"
+    )
+    output = tmp_path / "checklist.md"
+
+    assert compose_declared_checklist(
+        skill_name="synthesis",
+        contract=contract,
+        agent_name="Ada",
+        role="researcher",
+        checklist_file_path=output,
+        iteration=1,
+        context={},
+        artifacts={},
+    )
+    assert output.read_text(encoding="utf-8") == "[ ] Write the result\n"

--- a/tests/unit/test_skill_workflow_contract.py
+++ b/tests/unit/test_skill_workflow_contract.py
@@ -28,6 +28,7 @@ def _contract_data() -> dict:
                 "required": False,
             },
         ],
+        "prompt_references": {"optional_review_instruction": "optional_review.md"},
         "checklist": {
             "context_references": {"xml_questions_instruction": "xml_questions.md"},
             "variants": [
@@ -51,6 +52,7 @@ def test_workflow_contract_parses_declared_inputs_checklists_and_templates() -> 
     contract = SkillWorkflowContract.model_validate(_contract_data())
 
     assert contract.prompt_inputs[0].artifacts == ("research_notes", "legacy_notes")
+    assert contract.prompt_references == {"optional_review_instruction": "optional_review.md"}
     assert contract.checklist is not None
     assert contract.checklist.variants[1].when.min_iteration == 2
     assert contract.output_templates is not None
@@ -89,6 +91,15 @@ def test_workflow_contract_rejects_context_reference_that_overlaps_prompt_input(
     """Context references cannot overwrite declared artifact input values."""
     data = _contract_data()
     data["checklist"]["context_references"] = {"evidence_file": "evidence.md"}
+
+    with pytest.raises(ValidationError, match="must not overlap"):
+        SkillWorkflowContract.model_validate(data)
+
+
+def test_workflow_contract_rejects_prompt_reference_that_overlaps_prompt_input() -> None:
+    """Prompt references reserve their own marker names."""
+    data = _contract_data()
+    data["prompt_references"] = {"evidence_file": "evidence.md"}
 
     with pytest.raises(ValidationError, match="must not overlap"):
         SkillWorkflowContract.model_validate(data)

--- a/tests/unit/test_skill_workflow_contract.py
+++ b/tests/unit/test_skill_workflow_contract.py
@@ -1,0 +1,156 @@
+"""Tests for skill-owned workflow metadata contracts."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from cafe.skills.checklist_composer import compose_declared_checklist
+from cafe.skills.contracts import (
+    DeclaredArtifactError,
+    SkillWorkflowContract,
+    resolve_prompt_inputs,
+)
+from cafe.skills.loader import SkillLoader
+
+
+def _contract_data() -> dict:
+    return {
+        "prompt_inputs": [
+            {
+                "artifacts": ["research_notes", "legacy_notes"],
+                "placeholder": "evidence_file",
+                "required": True,
+            },
+            {
+                "artifacts": ["optional_review"],
+                "placeholder": "review_file",
+                "required": False,
+            },
+        ],
+        "checklist": {
+            "context_references": {"xml_questions_instruction": "xml_questions.md"},
+            "variants": [
+                {
+                    "when": {"iteration": 1},
+                    "sections": [{"reference": "execution_first.md"}],
+                },
+                {
+                    "when": {"min_iteration": 2},
+                    "sections": [{"reference": "execution_later.md"}],
+                },
+            ],
+            "include_role_guidance": True,
+        },
+        "output_templates": {"catalog": "research-report"},
+    }
+
+
+def test_workflow_contract_parses_declared_inputs_checklists_and_templates() -> None:
+    """Valid metadata keeps declared ordering and the custom catalog intact."""
+    contract = SkillWorkflowContract.model_validate(_contract_data())
+
+    assert contract.prompt_inputs[0].artifacts == ("research_notes", "legacy_notes")
+    assert contract.checklist is not None
+    assert contract.checklist.variants[1].when.min_iteration == 2
+    assert contract.output_templates is not None
+    assert contract.output_templates.catalog == "research-report"
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda data: data["prompt_inputs"].append(
+            {
+                "artifacts": ["other"],
+                "placeholder": "evidence_file",
+                "required": True,
+            }
+        ),
+        lambda data: data["checklist"]["variants"][0]["sections"].__setitem__(
+            0, {"reference": "../outside.md"}
+        ),
+        lambda data: data["checklist"].__setitem__("unexpected", True),
+        lambda data: data["checklist"]["variants"].__setitem__(
+            0, {"when": {"iteration": 1}}
+        ),
+    ],
+)
+def test_workflow_contract_rejects_ambiguous_or_unsafe_declarations(mutate) -> None:
+    """Authors receive a validation failure for invalid contract fields."""
+    data = _contract_data()
+    mutate(data)
+
+    with pytest.raises(ValidationError):
+        SkillWorkflowContract.model_validate(data)
+
+
+def test_declared_inputs_use_first_available_artifact_and_omit_optional_absences() -> None:
+    """Artifact resolution is deterministic and never invents legacy context keys."""
+    contract = SkillWorkflowContract.model_validate(_contract_data())
+
+    resolved = resolve_prompt_inputs(
+        contract,
+        {"legacy_notes": ".cafe/issues/42/research/notes.md"},
+    )
+
+    assert resolved == {"evidence_file": ".cafe/issues/42/research/notes.md"}
+
+
+def test_declared_inputs_report_missing_required_mapping_before_execution() -> None:
+    """A missing required input names the contract placeholder and candidates."""
+    contract = SkillWorkflowContract.model_validate(_contract_data())
+
+    with pytest.raises(DeclaredArtifactError) as exc_info:
+        resolve_prompt_inputs(contract, {})
+
+    assert exc_info.value.placeholder == "evidence_file"
+    assert exc_info.value.artifacts == ("research_notes", "legacy_notes")
+
+
+def test_custom_contract_composes_selected_variant_and_explicit_role_guidance(
+    tmp_path, monkeypatch
+) -> None:
+    """A custom skill owns first/later checklist choice and role-guidance opt-in."""
+    monkeypatch.chdir(tmp_path)
+    skill_dir = tmp_path / ".cafe" / "skills" / "synthesis"
+    (skill_dir / "references").mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: synthesis\ndescription: synthesis\n---\n", encoding="utf-8"
+    )
+    (skill_dir / "references" / "first.md").write_text(
+        "[ ] Read {evidence_file}\n", encoding="utf-8"
+    )
+    (skill_dir / "references" / "later.md").write_text(
+        "[ ] Revise {evidence_file}\n", encoding="utf-8"
+    )
+    contract = SkillWorkflowContract.model_validate(
+        {
+            "prompt_inputs": [
+                {"artifacts": ["research"], "placeholder": "evidence_file", "required": True}
+            ],
+            "checklist": {
+                "variants": [
+                    {"when": {"iteration": 1}, "sections": [{"reference": "first.md"}]},
+                    {"when": {"min_iteration": 2}, "sections": [{"reference": "later.md"}]},
+                ],
+                "include_role_guidance": False,
+            },
+        }
+    )
+    loader = SkillLoader(project_root=tmp_path)
+    loader.discover()
+    monkeypatch.setattr("cafe.skills.checklist_composer.AgentManager.get_agent_file_path", lambda *_: "agent.md")
+    output = tmp_path / "checklist.md"
+
+    assert compose_declared_checklist(
+        skill_name="synthesis",
+        contract=contract,
+        agent_name="Ada",
+        role="researcher",
+        checklist_file_path=output,
+        iteration=2,
+        context={"evidence_file": "research.md"},
+        artifacts={"research": "research.md"},
+    )
+    assert output.read_text(encoding="utf-8") == "[ ] Revise research.md\n"

--- a/tests/unit/test_skill_workflow_contract.py
+++ b/tests/unit/test_skill_workflow_contract.py
@@ -58,6 +58,19 @@ def test_workflow_contract_parses_declared_inputs_checklists_and_templates() -> 
 
 
 @pytest.mark.parametrize(
+    "placeholder",
+    ["output_file", "checklist_file", "questions_xml_file", "next_step_path"],
+)
+def test_workflow_contract_rejects_runtime_owned_input_placeholders(placeholder: str) -> None:
+    """Skill inputs cannot replace locations that the runtime exclusively owns."""
+    data = _contract_data()
+    data["prompt_inputs"][0]["placeholder"] = placeholder
+
+    with pytest.raises(ValidationError, match="runtime-owned"):
+        SkillWorkflowContract.model_validate(data)
+
+
+@pytest.mark.parametrize(
     "mutate",
     [
         lambda data: data["prompt_inputs"].append(

--- a/tests/unit/test_skill_workflow_contract.py
+++ b/tests/unit/test_skill_workflow_contract.py
@@ -85,6 +85,15 @@ def test_workflow_contract_rejects_runtime_owned_context_reference_placeholders(
         SkillWorkflowContract.model_validate(data)
 
 
+def test_workflow_contract_rejects_context_reference_that_overlaps_prompt_input() -> None:
+    """Context references cannot overwrite declared artifact input values."""
+    data = _contract_data()
+    data["checklist"]["context_references"] = {"evidence_file": "evidence.md"}
+
+    with pytest.raises(ValidationError, match="must not overlap"):
+        SkillWorkflowContract.model_validate(data)
+
+
 @pytest.mark.parametrize(
     "mutate",
     [
@@ -184,10 +193,10 @@ def test_custom_contract_composes_selected_variant_and_explicit_role_guidance(
     assert output.read_text(encoding="utf-8") == "[ ] Revise research.md\n"
 
 
-def test_custom_contract_omits_optional_input_checklist_lines_when_absent(
+def test_custom_contract_rejects_unresolved_optional_instruction_when_absent(
     tmp_path, monkeypatch
 ) -> None:
-    """Optional artifacts do not create fake paths or unresolved instructions."""
+    """Optional inputs need an explicit context reference, never line deletion."""
     monkeypatch.chdir(tmp_path)
     skill_dir = tmp_path / ".cafe" / "skills" / "synthesis"
     (skill_dir / "references").mkdir(parents=True)
@@ -216,14 +225,77 @@ def test_custom_contract_omits_optional_input_checklist_lines_when_absent(
     )
     output = tmp_path / "checklist.md"
 
+    with pytest.raises(ValueError, match="review_file"):
+        compose_declared_checklist(
+            skill_name="synthesis",
+            contract=contract,
+            agent_name="Ada",
+            role="researcher",
+            checklist_file_path=output,
+            iteration=1,
+            context={},
+            artifacts={},
+        )
+
+
+def test_context_reference_omits_only_its_dedicated_optional_instruction(
+    tmp_path, monkeypatch
+) -> None:
+    """A declared context reference is safely empty when its optional input is absent."""
+    monkeypatch.chdir(tmp_path)
+    skill_dir = tmp_path / ".cafe" / "skills" / "synthesis"
+    (skill_dir / "references").mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: synthesis\ndescription: synthesis\n---\n", encoding="utf-8"
+    )
+    (skill_dir / "references" / "execution.md").write_text(
+        "[ ] Prepare result\n{optional_review_instruction}\n[ ] Write the result\n",
+        encoding="utf-8",
+    )
+    (skill_dir / "references" / "optional_review.md").write_text(
+        "[ ] Read optional review {review_file}\n", encoding="utf-8"
+    )
+    contract = SkillWorkflowContract.model_validate(
+        {
+            "prompt_inputs": [
+                {"artifacts": ["review"], "placeholder": "review_file", "required": False}
+            ],
+            "checklist": {
+                "context_references": {"optional_review_instruction": "optional_review.md"},
+                "variants": [{"sections": [{"reference": "execution.md"}]}],
+                "include_role_guidance": False,
+            },
+        }
+    )
+    loader = SkillLoader(project_root=tmp_path)
+    loader.discover()
+    monkeypatch.setattr(
+        "cafe.skills.checklist_composer.AgentManager.get_agent_file_path", lambda *_: "agent.md"
+    )
+
+    without_review = tmp_path / "without-review.md"
     assert compose_declared_checklist(
         skill_name="synthesis",
         contract=contract,
         agent_name="Ada",
         role="researcher",
-        checklist_file_path=output,
+        checklist_file_path=without_review,
         iteration=1,
         context={},
         artifacts={},
     )
-    assert output.read_text(encoding="utf-8") == "[ ] Write the result\n"
+    assert "Read optional review" not in without_review.read_text(encoding="utf-8")
+    assert "Write the result" in without_review.read_text(encoding="utf-8")
+
+    with_review = tmp_path / "with-review.md"
+    assert compose_declared_checklist(
+        skill_name="synthesis",
+        contract=contract,
+        agent_name="Ada",
+        role="researcher",
+        checklist_file_path=with_review,
+        iteration=1,
+        context={"review_file": "review.md"},
+        artifacts={"review": "review.md"},
+    )
+    assert "[ ] Read optional review review.md" in with_review.read_text(encoding="utf-8")

--- a/tests/unit/test_skill_workflow_contract.py
+++ b/tests/unit/test_skill_workflow_contract.py
@@ -188,7 +188,10 @@ def test_custom_contract_composes_selected_variant_and_explicit_role_guidance(
     )
     loader = SkillLoader(project_root=tmp_path)
     loader.discover()
-    monkeypatch.setattr("cafe.skills.checklist_composer.AgentManager.get_agent_file_path", lambda *_: "agent.md")
+    monkeypatch.setattr(
+        "cafe.skills.checklist_composer.AgentManager.get_agent_file_path",
+        lambda *_: "agent.md",
+    )
     output = tmp_path / "checklist.md"
 
     assert compose_declared_checklist(

--- a/tests/unit/test_template_manager.py
+++ b/tests/unit/test_template_manager.py
@@ -41,7 +41,9 @@ class TestTemplateManager:
         )
 
         assert manager.list_templates() == [("evidence", "system")]
-        assert manager.get_template_path("evidence") == skill_dir / "assets" / "templates" / "evidence.md"
+        assert manager.get_template_path("evidence") == (
+            skill_dir / "assets" / "templates" / "evidence.md"
+        )
 
     def test_add_template_copies_file(self, tmp_path: Path) -> None:
         """Test that adding a template copies the file to the global directory."""

--- a/tests/unit/test_template_manager.py
+++ b/tests/unit/test_template_manager.py
@@ -113,6 +113,13 @@ class TestTemplateManager:
         with pytest.raises(ValueError, match="Invalid template name"):
             manager.add_template(str(source_file), "")
 
+    def test_get_template_path_rejects_path_components(self) -> None:
+        """Named template selection cannot escape the catalog with traversal."""
+        manager = TemplateManager(template_type="plan", skill_name="cafe-plan")
+
+        with pytest.raises(ValueError, match="Invalid template name"):
+            manager.get_template_path("../../SKILL.md")
+
     def test_add_template_raises_file_exists_error_if_duplicate(self, tmp_path: Path) -> None:
         """Test that adding a duplicate template raises FileExistsError."""
         fake_home = tmp_path / "home"

--- a/tests/unit/test_template_manager.py
+++ b/tests/unit/test_template_manager.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 import pytest
 
 from cafe.templates.manager import TemplateManager
+from cafe.skills.loader import SkillLoader
 
 
 class TestTemplateManager:
@@ -19,6 +20,28 @@ class TestTemplateManager:
         # Should NOT create project-level directory
         project_template_dir = config_dir / "templates" / "plan"
         assert not project_template_dir.exists()
+
+    def test_custom_skill_catalog_uses_own_bundled_templates(self, tmp_path: Path) -> None:
+        """An arbitrary declared catalog is discovered through its owning skill."""
+        skill_dir = tmp_path / ".cafe" / "skills" / "research-report"
+        (skill_dir / "assets" / "templates").mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: research-report\ndescription: report\n---\n", encoding="utf-8"
+        )
+        (skill_dir / "assets" / "templates" / "evidence.md").write_text(
+            "# Evidence\n", encoding="utf-8"
+        )
+        loader = SkillLoader(project_root=tmp_path)
+        loader.discover()
+
+        manager = TemplateManager(
+            template_type="research-report",
+            skill_name="research-report",
+            skill_loader=loader,
+        )
+
+        assert manager.list_templates() == [("evidence", "system")]
+        assert manager.get_template_path("evidence") == skill_dir / "assets" / "templates" / "evidence.md"
 
     def test_add_template_copies_file(self, tmp_path: Path) -> None:
         """Test that adding a template copies the file to the global directory."""

--- a/tests/unit/test_workflow_skill_guardrails.py
+++ b/tests/unit/test_workflow_skill_guardrails.py
@@ -30,11 +30,3 @@ def test_packaged_develop_skill_has_read_only_budget() -> None:
     assert "不得繼續探索" in text
     assert "任兩次實質修改之間" in text
     assert "3 次唯讀呼叫內" in text
-
-
-def test_project_skill_mirrors_match_packaged_sources() -> None:
-    builtin_root = PROJECT_ROOT / "src" / "cafe" / "data" / "skills"
-    project_root = PROJECT_ROOT / ".codex" / "skills"
-
-    for name in ("cafe-workflow-common", "cafe-develop"):
-        assert _skill_text(project_root, name) == _skill_text(builtin_root, name)


### PR DESCRIPTION
## Summary

Implemented Issue #344 so workflow-specific behavior is driven by skill/playbook declarations instead of hard-coded step names. This PR aligns with the approved requirements and implementation plan to declare prompt inputs, checklist composition, and template catalogs in metadata while keeping execution ownership in the workflow runtime.
Reference: [.cafe/issues/issue344/spec/iteration_003/output.md](./.cafe/issues/issue344/spec/iteration_003/output.md) and [.cafe/issues/issue344/plan/iteration_002/output.md](./.cafe/issues/issue344/plan/iteration_002/output.md).

## Changes

- Added a typed workflow contract model (`workflow` metadata) and integrated it into skill loading/bridging.
- Generalized runtime context and artifact resolution so declared placeholders are used instead of fixed `spec`/`plan`/`develop`/`review` branching.
- Replaced phase-specific checklist composition with contract-driven selection (iteration/feedback variants, role guidance, and declared references).
- Generalized template catalog selection and prepare-field plumbing for non-development/custom catalog use.
- Updated built-in `cafe-spec`, `cafe-plan`, `cafe-develop`, `cafe-review`, and `cafe-pr` to declare execution contracts.
- Migrated default workflow behavior to declared artifacts and maintained default equivalence behavior.
- Added/updated unit + integration tests for contract validation, runtime context, checklist composition, template selection, and default/custom workflow equivalence.
- Included commit-level progression since initial PR attempt: `5db0498`, `e019b38`, `fd99a52`, `5deb3a4`, `ac6fd96` (most recent)

## Test Plan

- Verified the review-response checks from iteration-006 (including full suite: `2416 passed, 1 skipped, 1 xfailed`) and focused suite results captured in development/review artifacts.
- No GitHub CLI/API/network actions in this step; publish is performed later by the host-side hook.