### PR TITLE
Ignore alignment signals in negative-space exclusions

### DIFF
--- a/src/cafe/core/alignment.py
+++ b/src/cafe/core/alignment.py
@@ -266,10 +266,14 @@ _NEGATED_ACTION_PREFIX_RE = re.compile(
     (?:
         \b(?:do|does|did|will|would|should|must|can)\s+not
         |\b(?:don't|doesn't|didn't|won't|wouldn't|shouldn't|mustn't|can't)
+        |\b(?:do|does|did|will|would|should|must|can)\s+not
+            \s+(?:require|involve|entail)
+        |\b(?:don't|doesn't|didn't|won't|wouldn't|shouldn't|mustn't|can't)
+            \s+(?:require|involve|entail)
         |\bwithout
         |\bno
         |\bnot
-        |不(?:會|再|要|應|得|需)?
+        |不(?:會|再|要|應|得|需|需要)?
         |無需
         |毋須
         |避免
@@ -299,6 +303,7 @@ _NEGATED_SCOPE_CLAUSE_RE = re.compile(
 
 _NON_SCOPE_LINE_MARKERS: tuple[str, ...] = (
     "out of scope",
+    "negative space",
     "non-goal",
     "non-goals",
     "not doing",
@@ -601,10 +606,9 @@ def _matches_actionable_change_intent(
 ) -> bool:
     for action in _STRATEGIC_CHANGE_ACTION_RE.finditer(text):
         clause_start, clause_end = _clause_bounds(text, action.start())
-        clause = text[clause_start:clause_end]
         line_prefix = text[clause_start : action.start()].rstrip()
         nearby_prefix = line_prefix[-32:]
-        if any(marker in clause.lower() for marker in _NON_SCOPE_LINE_MARKERS):
+        if _is_non_scope_context(text, action.start()):
             continue
         if _NEGATED_ACTION_PREFIX_RE.search(nearby_prefix):
             continue

--- a/tests/unit/test_alignment_policy.py
+++ b/tests/unit/test_alignment_policy.py
@@ -513,6 +513,58 @@ def test_confirmed_capability_boundary_scope_does_not_pause(
     assert not any(rule.rule_id == "trusted_capability_boundary" for rule in result.triggered_rules)
 
 
+def test_negative_space_table_does_not_turn_declined_boundaries_into_signals(
+    tmp_path: Path,
+) -> None:
+    plan_text = """
+    ### Negative space
+
+    | Declined | Reason |
+    | --- | --- |
+    | Host capability, external mutation, or permission changes |
+      Human-response collection does not require expanding the trusted host boundary. |
+    """
+
+    result = evaluate_alignment_policy(
+        AlignmentPolicyInput(step_name="develop", artifacts={"plan": plan_text}),
+        strategic_context=_context_with_confirmed_strategy(tmp_path),
+        config=AlignmentPolicyConfig(
+            affected_document_categories=(
+                "roadmap",
+                "product_direction",
+                "principles",
+                "positioning",
+                "strategic_context",
+            ),
+            pause_threshold=5,
+            note_threshold=2,
+        ),
+    )
+
+    assert result.level == AlignmentDecisionLevel.NO_ALIGNMENT
+    assert result.triggered_rules == ()
+
+
+def test_negated_requirement_does_not_escalate_trusted_boundary_change(
+    tmp_path: Path,
+) -> None:
+    result = evaluate_alignment_policy(
+        AlignmentPolicyInput(
+            step_name="develop",
+            artifacts={
+                "plan": (
+                    "Human-response collection does not require expanding "
+                    "the trusted host boundary."
+                )
+            },
+        ),
+        strategic_context=_context_with_confirmed_strategy(tmp_path),
+    )
+
+    assert result.level == AlignmentDecisionLevel.NO_ALIGNMENT
+    assert not any(rule.rule_id == "trusted_capability_boundary" for rule in result.triggered_rules)
+
+
 def test_medium_risk_records_note_only(tmp_path: Path) -> None:
     result = evaluate_alignment_policy(
         AlignmentPolicyInput(


### PR DESCRIPTION
## Summary

Prevent routine plans from triggering `alignment_checkpoint` when trusted-host or external-mutation phrases appear only in an explicit `Negative space` section or in a negated requirement such as “does not require expanding”.

## Changes

- Treat `Negative space` headings as explicit non-scope context.
- Reuse non-scope context detection for actionable trusted-boundary changes.
- Recognize `does not require/involve/entail …` and equivalent negation forms.
- Add regression coverage for the exact #345 false-positive shape while preserving true trusted-boundary escalation tests.

## Test plan

- 100 focused alignment/runtime tests passed.
- Full suite passed three times across local, pre-commit, and pre-push validation: `2418 passed, 1 skipped, 1 xfailed`.