### PR TITLE
feat: declarative human-task handoff contracts

### DIFF
--- a/src/cafe/core/hooks/native.py
+++ b/src/cafe/core/hooks/native.py
@@ -440,6 +440,7 @@ class UserInputCollector(NoOpHook):
                 playbook_data={"steps": {step_name: step_def}},
                 step_name=step_name,
                 trigger=trigger,
+                iteration=int(getattr(phase, "iteration", 1)),
             )
         except HumanTaskPolicyError:
             return None
@@ -461,6 +462,7 @@ class UserInputCollector(NoOpHook):
             step_name=step_name,
             trigger=trigger,
             raw_payload=payload or {},
+            iteration=int(getattr(phase, "iteration", 1)),
         )
         if not isinstance(result, HumanTaskCompletion):
             return HookResult(

--- a/src/cafe/core/hooks/native.py
+++ b/src/cafe/core/hooks/native.py
@@ -6,18 +6,17 @@ import json
 import sys
 import uuid
 import webbrowser
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Optional
-
-from datetime import datetime
 
 from cafe.core.blackboard import BlackboardState, HandoffContract, HandoffIntent, HandoffOwner
 from cafe.core.hooks import HookResult, NoOpHook
 from cafe.core.questions_schema import parse_questions_xml, validate_questions_xml
 from cafe.core.status_codes import PhaseStatusCode, step_on_declares
 from cafe.skills.loader import SkillLoader
-from cafe.ui.interactive_qa import interactive_qa_flow
 from cafe.ui.inquirer_prompts import prompt_multiline
+from cafe.ui.interactive_qa import interactive_qa_flow
 from cafe.utils.github import (
     GitHubError,
     GitHubOps,
@@ -236,12 +235,7 @@ class UserInputCollector(NoOpHook):
     ) -> None:
         if previous_output_file is None:
             return
-        title_map = {
-            "spec": "requirements specification",
-            "plan": "plan",
-        }
-        title = title_map.get(step_name, f"{step_name} output")
-        print(f"\nLoading latest {title} file: {previous_output_file}\n")
+        print(f"\nLoading latest {step_name} output: {previous_output_file}\n")
         if previous_output_file.exists():
             print("=" * 60)
             print(previous_output_file.read_text(encoding="utf-8"))
@@ -269,20 +263,13 @@ class UserInputCollector(NoOpHook):
 
     @staticmethod
     def _resolve_review_item_name(step_name: str) -> str:
-        return {
-            "spec": "Requirements specification",
-            "plan": "Implementation plan",
-        }.get(step_name, step_name)
+        """Use the playbook step identifier instead of development-flow labels."""
+        return step_name
 
     @staticmethod
-    def _resolve_phase_specific_data(step_name: str, agent_name: str) -> dict[str, str]:
-        if not agent_name:
-            return {}
-        if step_name == "spec":
-            return {"pm_agent": agent_name}
-        if step_name == "plan":
-            return {"dev_agent": agent_name}
-        return {"agent_name": agent_name}
+    def _resolve_phase_specific_data(agent_name: str) -> dict[str, str]:
+        """Keep review helpers supplied with a generic optional agent name."""
+        return {"agent_name": agent_name} if agent_name else {}
 
     def run(self, **kwargs: Any) -> HookResult:
         stage = kwargs.get("stage")
@@ -298,41 +285,26 @@ class UserInputCollector(NoOpHook):
         agent_name = str(kwargs.get("agent_name") or "")
         role = str(step_def.get("role", "developer"))
 
-        # Restore plan phase iteration-1 initial user input (development guide).
-        if step_name == "plan" and getattr(phase, "iteration", 0) == 1:
-            if step_name not in phase.step_user_inputs:
-                if getattr(phase, "interactive", False):
-                    development_guide_prompt = (
-                        "Please enter development guide (can be left empty)\n"
-                        "Suggested content:\n"
-                        "- Technical solution/direction\n"
-                        "- Related code locations\n"
-                        "- Technical constraints or dependencies\n"
-                        "- Key background information\n"
-                        "(Press Esc + Enter to finish)"
-                    )
-                    user_input = prompt_multiline(development_guide_prompt).strip()
-                else:
-                    user_input = ""
-                phase.step_user_inputs[step_name] = user_input
-            return HookResult(
-                context_updates={"user_input": phase.step_user_inputs.get(step_name, "")},
-                events=[
-                    {
-                        "type": "user_input_collected",
-                        "step": step_name,
-                        "source": "initial_prompt",
-                    }
-                ],
-            )
-
-        previous_status = _get_previous_iteration_status(phase)
-        if previous_status == "no_changes_needed" and step_name == "develop":
-            return self._handle_develop_no_changes_user_input(
+        if getattr(phase, "iteration", 0) == 1:
+            initial = self._collect_declared_human_task(
                 phase=phase,
                 step_name=step_name,
-                agent_name=agent_name,
+                step_def=step_def,
+                trigger="initial",
             )
+            if initial is not None:
+                return initial
+
+        previous_status = _get_previous_iteration_status(phase)
+        if previous_status == "no_changes_needed":
+            result = self._collect_declared_human_task(
+                phase=phase,
+                step_name=step_name,
+                step_def=step_def,
+                trigger="no_changes_needed",
+            )
+            if result is not None:
+                return result
 
         if previous_status not in {"need_clarification", "ready_for_review"}:
             return HookResult()
@@ -380,13 +352,11 @@ class UserInputCollector(NoOpHook):
             prev_data = phase._load_previous_iteration_data() or {}
             # Show diff again after returning from chat/edit, but never print full output.
             if delta_displayed:
-                redisplay_callback = lambda: self._display_previous_iteration_delta(
-                    phase, previous_output_file
-                )
+                def redisplay_callback() -> None:
+                    self._display_previous_iteration_delta(phase, previous_output_file)
             else:
-                redisplay_callback = lambda: self._display_previous_output(
-                    phase, step_name, previous_output_file
-                )
+                def redisplay_callback() -> None:
+                    self._display_previous_output(phase, step_name, previous_output_file)
             choice = phase._ask_user_for_review_decision(
                 self._resolve_review_item_name(step_name),
                 agent_name=agent_name,
@@ -399,7 +369,7 @@ class UserInputCollector(NoOpHook):
                 choice,
                 prev_data,
                 self._resolve_review_item_name(step_name),
-                self._resolve_phase_specific_data(step_name, agent_name),
+                self._resolve_phase_specific_data(agent_name),
             )
             if choice == "confirm":
                 return HookResult(
@@ -450,94 +420,89 @@ class UserInputCollector(NoOpHook):
         )
 
     @staticmethod
-    def _ask_develop_no_changes_decision(phase: Any, agent_name: str) -> str:
-        """Ask whether the user agrees with the developer's no-changes-needed decision."""
-        from InquirerPy.separator import Separator
-
-        from cafe.ui.chat import launch_chat_session
-        from cafe.ui.inquirer_prompts import prompt_list, prompt_multiline
-
-        print(f"\n{'=' * 60}")
-        print(f"Developer ({agent_name}) believes no changes are needed.")
-        print(f"{'=' * 60}\n")
-
-        develop_dir = phase.issue_dir / "develop"
-        develop_file = develop_dir / f"iteration_{phase.iteration - 1:03d}" / "output.md"
-        if develop_file.exists():
-            print(f"Developer's response: {develop_file}\n")
-            print(develop_file.read_text(encoding="utf-8"))
-            print(f"\n{'=' * 60}\n")
-
-        while True:
-            choices = [
-                {"name": "Agree - Skip review and proceed to PR", "value": "c"},
-                {"name": "Disagree - Provide feedback for developer", "value": "m"},
-                Separator(),
-                {"name": f"Chat with {agent_name}", "value": "chat"},
-            ]
-            choice = prompt_list("Do you agree with the developer?", choices, default=None)
-            if choice == "chat":
-                launch_chat_session("developer", phase.issue_name)
-                continue
-            if choice == "c":
-                return "confirm"
-            feedback = prompt_multiline("Please provide feedback for the developer")
-            if feedback.strip():
-                print("\n✅ Received your feedback...\n")
-                return feedback
-            print("\n⚠️  No feedback entered, please try again.")
-
-    def _handle_develop_no_changes_user_input(
-        self,
+    def _collect_declared_human_task(
         *,
         phase: Any,
         step_name: str,
-        agent_name: str,
-    ) -> HookResult:
-        if not getattr(phase, "interactive", False):
-            choice = self._load_no_changes_non_interactive_input(phase)
-            phase.user_input = ""
-            if not choice:
-                return HookResult(
-                    continue_pipeline=False,
-                    events=[{"type": "no_changes_missing_user_input", "step": step_name}],
-                )
-        else:
-            choice = self._ask_develop_no_changes_decision(phase, agent_name)
-
-        if choice.strip().lower() in {"confirm", "confirmed", "c", "agree"}:
-            return HookResult(
-                continue_pipeline=False,
-                override_status_code=PhaseStatusCode.MANUAL_HANDOFF,
-                events=[{"type": "no_changes_user_confirmed", "step": step_name}],
-            )
-
-        phase.step_user_inputs[step_name] = choice
-        return HookResult(
-            context_updates={"user_input": choice},
-            events=[{"type": "no_changes_user_feedback", "step": step_name}],
+        step_def: dict[str, Any],
+        trigger: str,
+    ) -> Optional[HookResult]:
+        """Collect a policy-declared initial or resumed response when available."""
+        from cafe.core.human_tasks import HumanTaskCompletion, HumanTaskPolicyError
+        from cafe.ui.human_tasks import (
+            collect_human_task_payload,
+            resolve_step_human_task,
+            validate_step_human_task_completion,
         )
 
-    @staticmethod
-    def _load_no_changes_non_interactive_input(phase: Any) -> str:
-        current_input_file: Optional[Path] = None
-        get_iteration_dir = getattr(phase, "_get_iteration_dir", None)
-        if callable(get_iteration_dir):
-            current_input_file = get_iteration_dir(phase.iteration) / "user_input.md"
+        try:
+            policy, _binding = resolve_step_human_task(
+                playbook_data={"steps": {step_name: step_def}},
+                step_name=step_name,
+                trigger=trigger,
+            )
+        except HumanTaskPolicyError:
+            return None
+
+        if getattr(phase, "interactive", False):
+            payload = collect_human_task_payload(policy)
         else:
-            phase_dir = getattr(phase, "phase_dir", None)
-            iteration = getattr(phase, "iteration", None)
-            if phase_dir is not None and iteration is not None:
-                current_input_file = (
-                    Path(phase_dir) / f"iteration_{int(iteration):03d}" / "user_input.md"
-                )
+            payload = str(getattr(phase, "user_input", "") or "").strip()
+            if not payload:
+                iteration_dir = phase._get_iteration_dir(getattr(phase, "iteration", 1))
+                input_file = iteration_dir / "user_input.md"
+                if input_file.exists():
+                    payload = input_file.read_text(encoding="utf-8").strip()
+            if not payload and trigger == "initial":
+                payload = {"task": policy.id, "feedback": ""}
 
-        if current_input_file and current_input_file.exists():
-            file_input = current_input_file.read_text(encoding="utf-8").strip()
-            if file_input:
-                return file_input
+        _policy, _binding, result = validate_step_human_task_completion(
+            playbook_data={"steps": {step_name: step_def}},
+            step_name=step_name,
+            trigger=trigger,
+            raw_payload=payload or {},
+        )
+        if not isinstance(result, HumanTaskCompletion):
+            return HookResult(
+                continue_pipeline=False,
+                events=[
+                    {
+                        "type": "human_task_rejected",
+                        "step": step_name,
+                        "trigger": trigger,
+                        "task_id": policy.id,
+                        "reason": result.message,
+                    }
+                ],
+            )
 
-        return str(getattr(phase, "user_input", "") or "").strip()
+        if result.decision in {"confirm", "approve", "agree"}:
+            return HookResult(
+                continue_pipeline=False,
+                override_status_code=PhaseStatusCode.CONFIRMED,
+                events=[
+                    {
+                        "type": "human_task_completed",
+                        "step": step_name,
+                        "trigger": trigger,
+                        "task_id": policy.id,
+                    }
+                ],
+            )
+
+        user_input = result.agent_input()
+        phase.step_user_inputs[step_name] = user_input
+        return HookResult(
+            context_updates={"user_input": user_input},
+            events=[
+                {
+                    "type": "human_task_completed",
+                    "step": step_name,
+                    "trigger": trigger,
+                    "task_id": policy.id,
+                }
+            ],
+        )
 
 
 class NoChangesNeededHandler(NoOpHook):
@@ -551,7 +516,8 @@ class NoChangesNeededHandler(NoOpHook):
             return HookResult()
 
         step_name = str(kwargs.get("step_name") or "")
-        if step_name != "develop":
+        step_def = kwargs.get("step_def")
+        if not _declares_no_changes_task(step_def):
             return HookResult()
 
         response = str(kwargs.get("response") or "")
@@ -577,8 +543,7 @@ class NoChangesNeededHandler(NoOpHook):
         if not has_reasoning:
             continuation = (
                 "Your response returned no_changes_needed.\n\n"
-                "You MUST provide your reasoning and explain why the reviewer's "
-                "feedback is incorrect or unnecessary.\n\n"
+                "You MUST provide the reasoning that supports this outcome.\n\n"
                 f"Please:\n1. Write your detailed reasoning to {output_display}\n"
                 "2. Return no_changes_needed again\n\n"
                 "Do NOT return any other status code until you have written your reasoning."
@@ -594,6 +559,19 @@ class NoChangesNeededHandler(NoOpHook):
             override_status_code=PhaseStatusCode.NO_CHANGES_NEEDED,
             events=[{"type": "no_changes_awaiting_user", "step": step_name}],
         )
+
+
+def _declares_no_changes_task(step_def: Any) -> bool:
+    """Return whether this step explicitly opts into a no-changes user gate."""
+    if not isinstance(step_def, dict):
+        return False
+    tasks = step_def.get("human_tasks")
+    if not isinstance(tasks, (list, tuple)):
+        return False
+    return any(
+        isinstance(task, dict) and task.get("trigger") == "no_changes_needed"
+        for task in tasks
+    )
 
 
 class GitHubIssueFetcher(NoOpHook):
@@ -881,11 +859,11 @@ class GitHubPRCreator(NoOpHook):
     def _publish_output(self, **kwargs: Any) -> HookResult:
         from cafe.core.blackboard import BlackboardStore
         from cafe.core.capabilities import (
+            CAPABILITY_PR_PUBLISH_ID,
             SCRIPT_EXIT_ERROR,
             TIMEOUT_ERROR,
             VALIDATION_ERROR,
             CapabilityRegistryError,
-            CAPABILITY_PR_PUBLISH_ID,
             capability_receipt_hook_event,
             default_capability_definition_dirs,
             load_capability_registry,

--- a/src/cafe/core/human_tasks.py
+++ b/src/cafe/core/human_tasks.py
@@ -86,9 +86,11 @@ class HumanTaskPolicy(BaseModel):
     pattern: HumanTaskPattern
     prompt: str
     input_schema: HumanTaskInputSchema
+    required: bool = True
     correction_guidance: str = "Provide a complete response using the requested format."
     decisions: tuple[HumanTaskDecision, ...] = ()
     questions: tuple[HumanTaskQuestion, ...] = ()
+    questions_from_xml: bool = False
     allowed_targets: tuple[str, ...] = ()
 
     @field_validator("id", "prompt", "correction_guidance")
@@ -119,14 +121,16 @@ class HumanTaskPolicy(BaseModel):
             raise ValueError("question ids must be unique")
         if self.input_schema == "decision" and not self.decisions:
             raise ValueError("decision policies require at least one decision")
-        if self.input_schema == "answers" and not self.questions:
-            raise ValueError("answer policies require at least one question")
+        if self.input_schema == "answers" and not self.questions and not self.questions_from_xml:
+            raise ValueError("answer policies require inline questions or questions_from_xml")
         if self.input_schema == "target" and not self.allowed_targets:
             raise ValueError("target policies require at least one allowed target")
         if self.input_schema != "decision" and self.decisions:
             raise ValueError("only decision policies may declare decisions")
         if self.input_schema != "answers" and self.questions:
             raise ValueError("only answer policies may declare questions")
+        if self.input_schema != "answers" and self.questions_from_xml:
+            raise ValueError("only answer policies may use questions_from_xml")
         return self
 
 
@@ -226,6 +230,8 @@ def resolve_human_task_policy(
 def validate_human_task_completion(
     policy: HumanTaskPolicy,
     raw_payload: str | Mapping[str, Any],
+    *,
+    questions: Optional[Sequence[HumanTaskQuestion]] = None,
 ) -> HumanTaskCompletion | HumanTaskRejection:
     """Normalize interactive or command input without changing workflow state."""
     payload = _parse_payload(policy, raw_payload)
@@ -236,9 +242,9 @@ def validate_human_task_completion(
         return _reject(policy, "This response belongs to a different human task.")
     if policy.input_schema == "feedback":
         feedback = str(payload.get("feedback") or "").strip()
-        if not feedback:
+        if not feedback and policy.required:
             return _reject(policy, "Feedback is required before this task can continue.")
-        return HumanTaskCompletion(task_id=policy.id, feedback=feedback)
+        return HumanTaskCompletion(task_id=policy.id, feedback=feedback or None)
     if policy.input_schema == "decision":
         decision = str(payload.get("decision") or "").strip()
         valid = {item.id: item for item in policy.decisions}
@@ -257,15 +263,22 @@ def validate_human_task_completion(
     raw_answers = payload.get("answers")
     if not isinstance(raw_answers, Mapping):
         return _reject(policy, "Answers must be an object keyed by question id.")
+    questions_to_validate = tuple(questions) if questions is not None else policy.questions
+    if policy.questions_from_xml and not questions_to_validate:
+        return _reject(policy, "The workflow has no valid clarification questions to answer.")
     answers: dict[str, tuple[str, ...]] = {}
-    for question in policy.questions:
+    for question in questions_to_validate:
         provided = raw_answers.get(question.id)
         values = _answer_values(provided)
         if not values:
             return _reject(policy, f"Answer the required question {question.id!r}.")
         if not question.multiple and len(values) != 1:
             return _reject(policy, f"Question {question.id!r} accepts one answer.")
-        if question.options and any(value not in question.options for value in values):
+        if (
+            question.options
+            and not policy.questions_from_xml
+            and any(value not in question.options for value in values)
+        ):
             return _reject(policy, f"Question {question.id!r} has an unsupported answer.")
         answers[question.id] = values
     return HumanTaskCompletion(task_id=policy.id, answers=answers)
@@ -288,7 +301,7 @@ def resolve_human_task_continuation(
     allowed = set(binding.allowed_targets or policy.allowed_targets)
     if allowed and target not in allowed:
         return _reject(policy, "The selected continuation is not permitted by this task.")
-    if target not in set(playbook_steps):
+    if target != "_done" and target not in set(playbook_steps):
         return _reject(policy, "The selected continuation is not declared by this playbook.")
     return target
 

--- a/src/cafe/core/human_tasks.py
+++ b/src/cafe/core/human_tasks.py
@@ -1,0 +1,324 @@
+"""Declarative contracts and validation for workflow human handoffs.
+
+Policies describe what a person must provide.  They deliberately do not own
+blackboard state, iteration files, or baton ownership; those remain runtime
+responsibilities.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Literal, Mapping, Optional, Sequence
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+HumanTaskPattern = Literal[
+    "confirm_output",
+    "answer_questions",
+    "revision_feedback",
+    "no_changes_needed",
+    "select_next_step",
+]
+HumanTaskInputSchema = Literal["decision", "answers", "feedback", "target"]
+
+_SCHEMA_BY_PATTERN: dict[str, str] = {
+    "confirm_output": "decision",
+    "answer_questions": "answers",
+    "revision_feedback": "feedback",
+    "no_changes_needed": "decision",
+    "select_next_step": "target",
+}
+
+
+def _non_empty(value: str, *, field_name: str) -> str:
+    text = value.strip()
+    if not text:
+        raise ValueError(f"{field_name} must not be empty")
+    return text
+
+
+class HumanTaskDecision(BaseModel):
+    """One declared choice for a decision-based task."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    label: str
+    requires_feedback: bool = False
+
+    @field_validator("id", "label")
+    @classmethod
+    def _validate_copy(cls, value: str, info) -> str:
+        return _non_empty(value, field_name=info.field_name)
+
+
+class HumanTaskQuestion(BaseModel):
+    """One required structured answer in an answer-questions policy."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    prompt: str
+    options: tuple[str, ...] = ()
+    multiple: bool = False
+
+    @field_validator("id", "prompt")
+    @classmethod
+    def _validate_copy(cls, value: str, info) -> str:
+        return _non_empty(value, field_name=info.field_name)
+
+    @field_validator("options")
+    @classmethod
+    def _validate_options(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        cleaned = tuple(_non_empty(item, field_name="question option") for item in value)
+        if len(set(cleaned)) != len(cleaned):
+            raise ValueError("question options must be unique")
+        return cleaned
+
+
+class HumanTaskPolicy(BaseModel):
+    """Reusable presentation and completion contract owned by a skill."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    pattern: HumanTaskPattern
+    prompt: str
+    input_schema: HumanTaskInputSchema
+    correction_guidance: str = "Provide a complete response using the requested format."
+    decisions: tuple[HumanTaskDecision, ...] = ()
+    questions: tuple[HumanTaskQuestion, ...] = ()
+    allowed_targets: tuple[str, ...] = ()
+
+    @field_validator("id", "prompt", "correction_guidance")
+    @classmethod
+    def _validate_copy(cls, value: str, info) -> str:
+        return _non_empty(value, field_name=info.field_name)
+
+    @field_validator("allowed_targets")
+    @classmethod
+    def _validate_targets(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        cleaned = tuple(_non_empty(item, field_name="allowed target") for item in value)
+        if len(set(cleaned)) != len(cleaned):
+            raise ValueError("allowed targets must be unique")
+        return cleaned
+
+    @model_validator(mode="after")
+    def _validate_shape(self) -> "HumanTaskPolicy":
+        expected = _SCHEMA_BY_PATTERN[self.pattern]
+        if self.input_schema != expected:
+            raise ValueError(
+                f"pattern {self.pattern!r} requires input_schema {expected!r}"
+            )
+        decision_ids = [item.id for item in self.decisions]
+        if len(set(decision_ids)) != len(decision_ids):
+            raise ValueError("decision ids must be unique")
+        question_ids = [item.id for item in self.questions]
+        if len(set(question_ids)) != len(question_ids):
+            raise ValueError("question ids must be unique")
+        if self.input_schema == "decision" and not self.decisions:
+            raise ValueError("decision policies require at least one decision")
+        if self.input_schema == "answers" and not self.questions:
+            raise ValueError("answer policies require at least one question")
+        if self.input_schema == "target" and not self.allowed_targets:
+            raise ValueError("target policies require at least one allowed target")
+        if self.input_schema != "decision" and self.decisions:
+            raise ValueError("only decision policies may declare decisions")
+        if self.input_schema != "answers" and self.questions:
+            raise ValueError("only answer policies may declare questions")
+        return self
+
+
+class HumanTaskBinding(BaseModel):
+    """Step-level binding of a skill policy to declared continuation targets."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    trigger: str
+    task_id: str
+    outcomes: dict[str, str] = Field(default_factory=dict)
+    allowed_targets: tuple[str, ...] = ()
+    prompt: Optional[str] = None
+    correction_guidance: Optional[str] = None
+
+    @field_validator("trigger", "task_id")
+    @classmethod
+    def _validate_identifier(cls, value: str, info) -> str:
+        return _non_empty(value, field_name=info.field_name)
+
+    @field_validator("outcomes")
+    @classmethod
+    def _validate_outcomes(cls, value: dict[str, str]) -> dict[str, str]:
+        return {
+            _non_empty(key, field_name="outcome id"): _non_empty(
+                target, field_name="outcome target"
+            )
+            for key, target in value.items()
+        }
+
+    @field_validator("allowed_targets")
+    @classmethod
+    def _validate_allowed_targets(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        cleaned = tuple(_non_empty(item, field_name="allowed target") for item in value)
+        if len(set(cleaned)) != len(cleaned):
+            raise ValueError("allowed targets must be unique")
+        return cleaned
+
+
+class HumanTaskPolicyError(ValueError):
+    """Raised when a task declaration cannot be resolved safely."""
+
+
+@dataclass(frozen=True)
+class HumanTaskCompletion:
+    """Validated, transport-neutral participant response."""
+
+    task_id: str
+    decision: Optional[str] = None
+    answers: Optional[dict[str, tuple[str, ...]]] = None
+    feedback: Optional[str] = None
+    target: Optional[str] = None
+
+    def agent_input(self) -> str:
+        """Preserve the existing agent-facing text-file boundary."""
+        if self.feedback:
+            return self.feedback
+        if self.answers:
+            return "\n".join(
+                f"{question}: {', '.join(answer)}" for question, answer in self.answers.items()
+            )
+        if self.decision:
+            return self.decision
+        return self.target or ""
+
+
+@dataclass(frozen=True)
+class HumanTaskRejection:
+    """Actionable validation failure that deliberately has no continuation."""
+
+    message: str
+    correction_guidance: str
+
+
+def resolve_human_task_policy(
+    *,
+    defaults: Sequence[HumanTaskPolicy],
+    binding: HumanTaskBinding,
+) -> HumanTaskPolicy:
+    """Merge a selected skill default with permitted step-level copy overrides."""
+    matching = [policy for policy in defaults if policy.id == binding.task_id]
+    if len(matching) != 1:
+        raise HumanTaskPolicyError(
+            f"No declared human-task policy matches task_id {binding.task_id!r}"
+        )
+    policy = matching[0]
+    changes: dict[str, Any] = {}
+    if binding.prompt is not None:
+        changes["prompt"] = binding.prompt
+    if binding.correction_guidance is not None:
+        changes["correction_guidance"] = binding.correction_guidance
+    if binding.allowed_targets:
+        changes["allowed_targets"] = binding.allowed_targets
+    return HumanTaskPolicy.model_validate({**policy.model_dump(), **changes})
+
+
+def validate_human_task_completion(
+    policy: HumanTaskPolicy,
+    raw_payload: str | Mapping[str, Any],
+) -> HumanTaskCompletion | HumanTaskRejection:
+    """Normalize interactive or command input without changing workflow state."""
+    payload = _parse_payload(policy, raw_payload)
+    if isinstance(payload, HumanTaskRejection):
+        return payload
+    task_id = str(payload.get("task") or payload.get("task_id") or policy.id).strip()
+    if task_id != policy.id:
+        return _reject(policy, "This response belongs to a different human task.")
+    if policy.input_schema == "feedback":
+        feedback = str(payload.get("feedback") or "").strip()
+        if not feedback:
+            return _reject(policy, "Feedback is required before this task can continue.")
+        return HumanTaskCompletion(task_id=policy.id, feedback=feedback)
+    if policy.input_schema == "decision":
+        decision = str(payload.get("decision") or "").strip()
+        valid = {item.id: item for item in policy.decisions}
+        selected = valid.get(decision)
+        if selected is None:
+            return _reject(policy, "Choose one of the declared decisions.")
+        feedback = str(payload.get("feedback") or "").strip() or None
+        if selected.requires_feedback and not feedback:
+            return _reject(policy, "This decision requires feedback.")
+        return HumanTaskCompletion(task_id=policy.id, decision=decision, feedback=feedback)
+    if policy.input_schema == "target":
+        target = str(payload.get("target") or "").strip()
+        if target not in policy.allowed_targets:
+            return _reject(policy, "Choose a target declared by this task.")
+        return HumanTaskCompletion(task_id=policy.id, target=target)
+    raw_answers = payload.get("answers")
+    if not isinstance(raw_answers, Mapping):
+        return _reject(policy, "Answers must be an object keyed by question id.")
+    answers: dict[str, tuple[str, ...]] = {}
+    for question in policy.questions:
+        provided = raw_answers.get(question.id)
+        values = _answer_values(provided)
+        if not values:
+            return _reject(policy, f"Answer the required question {question.id!r}.")
+        if not question.multiple and len(values) != 1:
+            return _reject(policy, f"Question {question.id!r} accepts one answer.")
+        if question.options and any(value not in question.options for value in values):
+            return _reject(policy, f"Question {question.id!r} has an unsupported answer.")
+        answers[question.id] = values
+    return HumanTaskCompletion(task_id=policy.id, answers=answers)
+
+
+def resolve_human_task_continuation(
+    *,
+    policy: HumanTaskPolicy,
+    binding: HumanTaskBinding,
+    completion: HumanTaskCompletion,
+    playbook_steps: Sequence[str],
+) -> str | HumanTaskRejection:
+    """Return only a step explicitly declared by the binding and playbook."""
+    key = completion.target or completion.decision or "submit"
+    target = binding.outcomes.get(key)
+    if target is None and completion.target is not None:
+        target = completion.target
+    if not target:
+        return _reject(policy, "This response has no declared continuation.")
+    allowed = set(binding.allowed_targets or policy.allowed_targets)
+    if allowed and target not in allowed:
+        return _reject(policy, "The selected continuation is not permitted by this task.")
+    if target not in set(playbook_steps):
+        return _reject(policy, "The selected continuation is not declared by this playbook.")
+    return target
+
+
+def _parse_payload(
+    policy: HumanTaskPolicy, raw_payload: str | Mapping[str, Any]
+) -> dict[str, Any] | HumanTaskRejection:
+    if isinstance(raw_payload, Mapping):
+        return dict(raw_payload)
+    if not isinstance(raw_payload, str) or not raw_payload.strip():
+        return _reject(policy, "A response is required.")
+    text = raw_payload.strip()
+    try:
+        decoded = json.loads(text)
+    except json.JSONDecodeError:
+        if policy.input_schema == "feedback":
+            return {"task": policy.id, "feedback": text}
+        return _reject(policy, "Use the declared structured response format.")
+    if not isinstance(decoded, dict):
+        return _reject(policy, "The response must be a JSON object.")
+    return decoded
+
+
+def _answer_values(value: Any) -> tuple[str, ...]:
+    if isinstance(value, str):
+        return (value.strip(),) if value.strip() else ()
+    if isinstance(value, list):
+        return tuple(str(item).strip() for item in value if str(item).strip())
+    return ()
+
+
+def _reject(policy: HumanTaskPolicy, message: str) -> HumanTaskRejection:
+    return HumanTaskRejection(message=message, correction_guidance=policy.correction_guidance)

--- a/src/cafe/core/playbook.py
+++ b/src/cafe/core/playbook.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, List, Literal, Optional, Union
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from cafe.core.human_tasks import HumanTaskBinding
 from cafe.core.prepare_fields import (
     PrepareField,
     assert_prepare_semantics_match,
@@ -127,6 +128,7 @@ class StepConfig(BaseModel):
     handoff_label: Optional[str] = None
     chat_role: Optional[str] = None
     alignment: Optional[StepAlignmentConfig] = None
+    human_tasks: tuple[HumanTaskBinding, ...] = ()
     on: Dict[str, str]
 
     @model_validator(mode="after")
@@ -134,6 +136,16 @@ class StepConfig(BaseModel):
         if "input_artifacts" in self.model_fields_set and self.input_artifacts is None:
             raise ValueError("input_artifacts must be a list when specified")
         return self
+
+    @field_validator("human_tasks")
+    @classmethod
+    def _validate_human_task_bindings(
+        cls, value: tuple[HumanTaskBinding, ...]
+    ) -> tuple[HumanTaskBinding, ...]:
+        triggers = [binding.trigger for binding in value]
+        if len(set(triggers)) != len(triggers):
+            raise ValueError("human task triggers must be unique per step")
+        return value
 
     @field_validator("on")
     @classmethod
@@ -462,6 +474,7 @@ def validate_playbook(
         _validate_step_chat_role(step_name, step, model.roles)
         _validate_step_skills(step_name, step, skill_loader)
         _validate_step_required_prompt_inputs(step_name, step, skill_loader)
+        _validate_step_human_tasks(step_name, step, steps, skill_loader)
         _validate_script_hook_stages(step_name, step.hooks)
         _validate_targets(step_name, step.allowed_goto, steps, "allowed_goto")
         _validate_transition_targets(step_name, step.on, steps)
@@ -658,6 +671,36 @@ def _validate_step_required_prompt_inputs(
                     f"required prompt input {mapping.placeholder!r} expects one of "
                     f"[{candidates}], but input_artifacts declares "
                     f"{sorted(declared_artifacts)}"
+                )
+
+
+def _validate_step_human_tasks(
+    step_name: str,
+    step: StepConfig,
+    steps: Dict[str, StepConfig],
+    skill_loader: SkillLoader,
+) -> None:
+    """Ensure every policy binding names a skill task and declared destinations."""
+    if not step.human_tasks:
+        return
+    selectors = [step.skill] if isinstance(step.skill, str) else list(step.skill.values())
+    contracts = [skill_loader.get_workflow_contract(skill) for skill in selectors]
+    for binding in step.human_tasks:
+        if binding.trigger != "initial" and binding.trigger not in step.on:
+            raise ValueError(
+                f"Step '{step_name}' human task trigger {binding.trigger!r} "
+                "is not declared in its transitions"
+            )
+        for skill_name, contract in zip(selectors, contracts):
+            if not any(policy.id == binding.task_id for policy in contract.human_tasks):
+                raise ValueError(
+                    f"Step '{step_name}', skill {canonical_skill_name(str(skill_name))!r}: "
+                    f"unknown human task {binding.task_id!r}"
+                )
+        for target in [*binding.outcomes.values(), *binding.allowed_targets]:
+            if target != DONE_TARGET and target not in steps:
+                raise ValueError(
+                    f"Step '{step_name}' has invalid human task outcome target {target!r}"
                 )
 
 

--- a/src/cafe/data/playbooks/default.yaml
+++ b/src/cafe/data/playbooks/default.yaml
@@ -60,6 +60,13 @@ steps:
     assignee_type: agent
     input_artifacts: []
     output_artifact: spec
+    human_tasks:
+      - trigger: confirm_output
+        task_id: output-review
+        outcomes: {confirm: plan, revise: spec}
+      - trigger: need_clarification
+        task_id: clarification-answers
+        outcomes: {submit: spec}
     allowed_tools: [Read, Grep, Glob, WebFetch, WebSearch]
     hooks:
       prepare_input: [GitHubIssueFetcher, UserInputCollector, AlignmentCheckpointGate]
@@ -86,6 +93,15 @@ steps:
     assignee_type: agent
     input_artifacts: [spec]
     output_artifact: plan
+    human_tasks:
+      - trigger: initial
+        task_id: development-guide
+      - trigger: confirm_output
+        task_id: output-review
+        outcomes: {confirm: develop, revise: plan}
+      - trigger: need_clarification
+        task_id: clarification-answers
+        outcomes: {submit: plan}
     allowed_tools: [Read, Grep, Glob, WebFetch, WebSearch]
     hooks:
       prepare_input: [UserInputCollector, AlignmentCheckpointGate]
@@ -127,6 +143,13 @@ steps:
     assignee_type: agent
     input_artifacts: [spec, plan, review_feedback, pr_result]
     output_artifact: code
+    human_tasks:
+      - trigger: need_clarification
+        task_id: clarification-feedback
+        outcomes: {submit: develop}
+      - trigger: no_changes_needed
+        task_id: no-change-decision
+        outcomes: {agree: review, disagree: develop}
     allowed_tools: [Read, Edit, Write, Grep, Glob, Bash, WebFetch, WebSearch]
     hooks:
       prepare_input: [UserInputCollector, AlignmentCheckpointGate]
@@ -154,6 +177,10 @@ steps:
     assignee_type: agent
     input_artifacts: [spec, plan, code]
     output_artifact: review_feedback
+    human_tasks:
+      - trigger: need_clarification
+        task_id: clarification-feedback
+        outcomes: {submit: review}
     allowed_tools: [Read, Grep, Glob, "Bash(git:*)"]
     max_iterations: 3
     allowed_goto: [spec, develop, plan]

--- a/src/cafe/data/playbooks/default.yaml
+++ b/src/cafe/data/playbooks/default.yaml
@@ -149,7 +149,7 @@ steps:
         outcomes: {submit: develop}
       - trigger: no_changes_needed
         task_id: no-change-decision
-        outcomes: {agree: review, disagree: develop}
+        outcomes: {agree: pr, disagree: develop}
     allowed_tools: [Read, Edit, Write, Grep, Glob, Bash, WebFetch, WebSearch]
     hooks:
       prepare_input: [UserInputCollector, AlignmentCheckpointGate]

--- a/src/cafe/data/playbooks/editorial.yaml
+++ b/src/cafe/data/playbooks/editorial.yaml
@@ -24,11 +24,20 @@ steps:
     chat_role: editor
     assignee_type: agent
     output_artifact: brief
+    human_tasks:
+      - trigger: confirm_output
+        task_id: editorial-output-review
+        outcomes: {approve: draft, revise: brief}
+      - trigger: need_clarification
+        task_id: editorial-clarification
+        outcomes: {submit: brief}
     valid_intents:
       - confirmed
       - need_clarification
       - ready_for_review
     allowed_tools: [Read, Grep, Glob, WebFetch, WebSearch]
+    hooks:
+      prepare_input: [UserInputCollector]
     "on":
       await_agent: draft
       need_clarification: brief
@@ -43,6 +52,10 @@ steps:
     assignee_type: agent
     input_artifacts: [brief]
     output_artifact: manuscript
+    human_tasks:
+      - trigger: need_clarification
+        task_id: clarification-feedback
+        outcomes: {submit: draft}
     valid_intents:
       - confirmed
       - need_clarification

--- a/src/cafe/data/playbooks/hotfix.yaml
+++ b/src/cafe/data/playbooks/hotfix.yaml
@@ -53,6 +53,10 @@ steps:
     assignee_type: agent
     input_artifacts: [review_feedback, pr_result]
     output_artifact: code
+    human_tasks:
+      - trigger: need_clarification
+        task_id: clarification-feedback
+        outcomes: {submit: develop}
     allowed_tools: [Read, Edit, Write, Grep, Glob, Bash, WebFetch, WebSearch]
     hooks:
       prepare_input: [UserInputCollector]
@@ -70,6 +74,10 @@ steps:
     assignee_type: agent
     input_artifacts: [code]
     output_artifact: review_feedback
+    human_tasks:
+      - trigger: need_clarification
+        task_id: clarification-feedback
+        outcomes: {submit: review}
     allowed_tools: [Read, Grep, Glob, "Bash(git:*)"]
     max_iterations: 1
     allowed_goto: [develop]

--- a/src/cafe/data/playbooks/incident.yaml
+++ b/src/cafe/data/playbooks/incident.yaml
@@ -16,6 +16,10 @@ steps:
     role: ops
     assignee_type: agent
     output_artifact: incident_signal
+    human_tasks:
+      - trigger: need_clarification
+        task_id: clarification-feedback
+        outcomes: {submit: detect}
     valid_intents:
       - confirmed
       - need_clarification
@@ -31,6 +35,10 @@ steps:
     assignee_type: agent
     input_artifacts: [incident_signal]
     output_artifact: incident_plan
+    human_tasks:
+      - trigger: need_clarification
+        task_id: clarification-feedback
+        outcomes: {submit: triage}
     valid_intents:
       - confirmed
       - need_clarification
@@ -47,6 +55,10 @@ steps:
     assignee_type: agent
     input_artifacts: [incident_signal, incident_plan]
     output_artifact: incident_recovery
+    human_tasks:
+      - trigger: need_clarification
+        task_id: clarification-feedback
+        outcomes: {submit: mitigate}
     valid_intents:
       - confirmed
       - need_clarification
@@ -63,6 +75,10 @@ steps:
     assignee_type: agent
     input_artifacts: [incident_signal, incident_plan, incident_recovery]
     output_artifact: incident_learning
+    human_tasks:
+      - trigger: need_clarification
+        task_id: clarification-feedback
+        outcomes: {submit: postmortem}
     valid_intents:
       - confirmed
       - need_clarification

--- a/src/cafe/data/playbooks/research.yaml
+++ b/src/cafe/data/playbooks/research.yaml
@@ -18,6 +18,10 @@ steps:
     chat_role: researcher
     assignee_type: agent
     output_artifact: research_question_brief
+    human_tasks:
+      - trigger: need_clarification
+        task_id: clarification-feedback
+        outcomes: {submit: question}
     valid_intents:
       - confirmed
       - need_clarification
@@ -35,6 +39,10 @@ steps:
     assignee_type: agent
     input_artifacts: [research_question_brief]
     output_artifact: research_notes
+    human_tasks:
+      - trigger: need_clarification
+        task_id: clarification-feedback
+        outcomes: {submit: collect}
     valid_intents:
       - confirmed
       - need_clarification
@@ -53,6 +61,10 @@ steps:
     assignee_type: agent
     input_artifacts: [research_question_brief, research_notes]
     output_artifact: research_synthesis
+    human_tasks:
+      - trigger: need_clarification
+        task_id: clarification-feedback
+        outcomes: {submit: synthesize}
     valid_intents:
       - confirmed
       - need_clarification
@@ -71,6 +83,10 @@ steps:
     assignee_type: agent
     input_artifacts: [research_question_brief, research_notes, research_synthesis]
     output_artifact: research_report_doc
+    human_tasks:
+      - trigger: need_clarification
+        task_id: clarification-feedback
+        outcomes: {submit: report}
     valid_intents:
       - confirmed
       - need_clarification

--- a/src/cafe/data/playbooks/simple.yaml
+++ b/src/cafe/data/playbooks/simple.yaml
@@ -53,6 +53,13 @@ steps:
     assignee_type: agent
     input_artifacts: []
     output_artifact: spec
+    human_tasks:
+      - trigger: confirm_output
+        task_id: output-review
+        outcomes: {confirm: develop, revise: spec}
+      - trigger: need_clarification
+        task_id: clarification-answers
+        outcomes: {submit: spec}
     allowed_tools: [Read, Grep, Glob, WebFetch, WebSearch]
     hooks:
       prepare_input: [GitHubIssueFetcher, UserInputCollector]
@@ -70,6 +77,10 @@ steps:
     assignee_type: agent
     input_artifacts: [spec]
     output_artifact: code
+    human_tasks:
+      - trigger: need_clarification
+        task_id: clarification-feedback
+        outcomes: {submit: develop}
     allowed_tools: [Read, Edit, Write, Grep, Glob, Bash, WebFetch, WebSearch]
     hooks:
       prepare_input: [UserInputCollector]

--- a/src/cafe/data/playbooks/tdd.yaml
+++ b/src/cafe/data/playbooks/tdd.yaml
@@ -134,7 +134,7 @@ steps:
         outcomes: {submit: develop}
       - trigger: no_changes_needed
         task_id: no-change-decision
-        outcomes: {agree: review, disagree: develop}
+        outcomes: {agree: pr, disagree: develop}
     allowed_tools: [Read, Edit, Write, Grep, Glob, Bash, WebFetch, WebSearch]
     hooks:
       prepare_input: [UserInputCollector]

--- a/src/cafe/data/playbooks/tdd.yaml
+++ b/src/cafe/data/playbooks/tdd.yaml
@@ -59,6 +59,13 @@ steps:
     assignee_type: agent
     input_artifacts: []
     output_artifact: spec
+    human_tasks:
+      - trigger: confirm_output
+        task_id: output-review
+        outcomes: {confirm: plan, revise: spec}
+      - trigger: need_clarification
+        task_id: clarification-answers
+        outcomes: {submit: spec}
     allowed_tools: [Read, Grep, Glob, WebFetch, WebSearch]
     hooks:
       prepare_input: [GitHubIssueFetcher, UserInputCollector]
@@ -78,6 +85,15 @@ steps:
     assignee_type: agent
     input_artifacts: [spec]
     output_artifact: plan
+    human_tasks:
+      - trigger: initial
+        task_id: development-guide
+      - trigger: confirm_output
+        task_id: output-review
+        outcomes: {confirm: develop, revise: plan}
+      - trigger: need_clarification
+        task_id: clarification-answers
+        outcomes: {submit: plan}
     allowed_tools: [Read, Grep, Glob, WebFetch, WebSearch]
     hooks:
       prepare_input: [UserInputCollector]
@@ -112,6 +128,13 @@ steps:
     assignee_type: agent
     input_artifacts: [spec, plan, review_feedback, pr_result]
     output_artifact: code
+    human_tasks:
+      - trigger: need_clarification
+        task_id: clarification-feedback
+        outcomes: {submit: develop}
+      - trigger: no_changes_needed
+        task_id: no-change-decision
+        outcomes: {agree: review, disagree: develop}
     allowed_tools: [Read, Edit, Write, Grep, Glob, Bash, WebFetch, WebSearch]
     hooks:
       prepare_input: [UserInputCollector]
@@ -132,6 +155,10 @@ steps:
     assignee_type: agent
     input_artifacts: [spec, plan, code]
     output_artifact: review_feedback
+    human_tasks:
+      - trigger: need_clarification
+        task_id: clarification-feedback
+        outcomes: {submit: review}
     allowed_tools: [Read, Grep, Glob, "Bash(git:*)"]
     max_iterations: 3
     allowed_goto: [spec, develop, plan]

--- a/src/cafe/data/skills/cafe-brief_first/SKILL.md
+++ b/src/cafe/data/skills/cafe-brief_first/SKILL.md
@@ -1,7 +1,26 @@
 ---
 name: cafe-brief_first
 description: 建立初版內容大綱與撰稿需求（編輯流程）
-version: 1.0.0
+version: 1.0.1
+workflow:
+  human_tasks:
+    - id: editorial-output-review
+      pattern: confirm_output
+      prompt: Approve the editorial brief or request a revision.
+      input_schema: decision
+      decisions:
+        - id: approve
+          label: Approve brief
+        - id: revise
+          label: Request brief revision
+          requires_feedback: true
+    - id: editorial-clarification
+      pattern: answer_questions
+      prompt: Answer the editorial clarification questions.
+      input_schema: answers
+      questions:
+        - id: audience
+          prompt: Who is the intended audience?
 ---
 
 # Editorial Brief

--- a/src/cafe/data/skills/cafe-brief_revise/SKILL.md
+++ b/src/cafe/data/skills/cafe-brief_revise/SKILL.md
@@ -1,7 +1,26 @@
 ---
 name: cafe-brief_revise
 description: 依回饋修訂內容大綱（編輯流程）
-version: 1.0.0
+version: 1.0.1
+workflow:
+  human_tasks:
+    - id: editorial-output-review
+      pattern: confirm_output
+      prompt: Approve the editorial brief or request a revision.
+      input_schema: decision
+      decisions:
+        - id: approve
+          label: Approve brief
+        - id: revise
+          label: Request brief revision
+          requires_feedback: true
+    - id: editorial-clarification
+      pattern: answer_questions
+      prompt: Answer the editorial clarification questions.
+      input_schema: answers
+      questions:
+        - id: audience
+          prompt: Who is the intended audience?
 ---
 
 # Revise Editorial Brief

--- a/src/cafe/data/skills/cafe-develop/SKILL.md
+++ b/src/cafe/data/skills/cafe-develop/SKILL.md
@@ -1,8 +1,23 @@
 ---
 name: cafe-develop
 description: "依計畫進行程式開發與測試"
-version: 1.3.0
+version: 1.4.0
 workflow:
+  human_tasks:
+    - id: no-change-decision
+      pattern: no_changes_needed
+      prompt: Review the implementation reasoning and choose how to continue.
+      input_schema: decision
+      decisions:
+        - id: agree
+          label: Agree that no further changes are needed
+        - id: disagree
+          label: Request further changes
+          requires_feedback: true
+    - id: clarification-feedback
+      pattern: revision_feedback
+      prompt: Provide the clarification or implementation feedback needed to continue.
+      input_schema: feedback
   prompt_inputs:
     - artifacts: [spec]
       placeholder: spec_file

--- a/src/cafe/data/skills/cafe-draft/SKILL.md
+++ b/src/cafe/data/skills/cafe-draft/SKILL.md
@@ -1,7 +1,13 @@
 ---
 name: cafe-draft
 description: 依核定大綱撰寫初稿
-version: 1.0.0
+version: 1.0.1
+workflow:
+  human_tasks:
+    - id: clarification-feedback
+      pattern: revision_feedback
+      prompt: Provide the clarification needed to continue drafting.
+      input_schema: feedback
 ---
 
 # Draft Article

--- a/src/cafe/data/skills/cafe-incident_detect/SKILL.md
+++ b/src/cafe/data/skills/cafe-incident_detect/SKILL.md
@@ -1,7 +1,13 @@
 ---
 name: cafe-incident_detect
 description: 偵測與通報事件徵兆（維運應變流程）
-version: 1.0.0
+version: 1.0.1
+workflow:
+  human_tasks:
+    - id: clarification-feedback
+      pattern: revision_feedback
+      prompt: Provide the incident details needed to continue detection.
+      input_schema: feedback
 ---
 
 # Incident Detect

--- a/src/cafe/data/skills/cafe-incident_mitigate/SKILL.md
+++ b/src/cafe/data/skills/cafe-incident_mitigate/SKILL.md
@@ -1,7 +1,13 @@
 ---
 name: cafe-incident_mitigate
 description: 緩解與復原（維運應變流程）
-version: 1.0.0
+version: 1.0.1
+workflow:
+  human_tasks:
+    - id: clarification-feedback
+      pattern: revision_feedback
+      prompt: Provide the incident details needed to continue mitigation.
+      input_schema: feedback
 ---
 
 # Incident Mitigate

--- a/src/cafe/data/skills/cafe-incident_postmortem/SKILL.md
+++ b/src/cafe/data/skills/cafe-incident_postmortem/SKILL.md
@@ -1,7 +1,13 @@
 ---
 name: cafe-incident_postmortem
 description: 事後檢討與行動項目（維運應變流程）
-version: 1.0.0
+version: 1.0.1
+workflow:
+  human_tasks:
+    - id: clarification-feedback
+      pattern: revision_feedback
+      prompt: Provide the incident details needed to continue the postmortem.
+      input_schema: feedback
 ---
 
 # Incident Postmortem

--- a/src/cafe/data/skills/cafe-incident_triage/SKILL.md
+++ b/src/cafe/data/skills/cafe-incident_triage/SKILL.md
@@ -1,7 +1,13 @@
 ---
 name: cafe-incident_triage
 description: 分類與處置決策（維運應變流程）
-version: 1.0.0
+version: 1.0.1
+workflow:
+  human_tasks:
+    - id: clarification-feedback
+      pattern: revision_feedback
+      prompt: Provide the incident details needed to continue triage.
+      input_schema: feedback
 ---
 
 # Incident Triage

--- a/src/cafe/data/skills/cafe-plan/SKILL.md
+++ b/src/cafe/data/skills/cafe-plan/SKILL.md
@@ -1,8 +1,29 @@
 ---
 name: cafe-plan
 description: "產出可執行的開發計畫"
-version: 1.0.0
+version: 1.0.1
 workflow:
+  human_tasks:
+    - id: development-guide
+      pattern: revision_feedback
+      prompt: "Please enter development guide (can be left empty)"
+      input_schema: feedback
+      required: false
+    - id: output-review
+      pattern: confirm_output
+      prompt: Review the implementation plan and choose how to continue.
+      input_schema: decision
+      decisions:
+        - id: confirm
+          label: Confirm and continue
+        - id: revise
+          label: Request revision
+          requires_feedback: true
+    - id: clarification-answers
+      pattern: answer_questions
+      prompt: Answer the requested clarification questions.
+      input_schema: answers
+      questions_from_xml: true
   prompt_inputs:
     - artifacts: [spec]
       placeholder: spec_file

--- a/src/cafe/data/skills/cafe-research_collect/SKILL.md
+++ b/src/cafe/data/skills/cafe-research_collect/SKILL.md
@@ -1,7 +1,13 @@
 ---
 name: cafe-research_collect
 description: 搜尋、整理與記錄來源（非軟體研究流程）
-version: 1.0.0
+version: 1.0.1
+workflow:
+  human_tasks:
+    - id: clarification-feedback
+      pattern: revision_feedback
+      prompt: Provide the clarification needed to continue evidence collection.
+      input_schema: feedback
 ---
 
 # Research Collect

--- a/src/cafe/data/skills/cafe-research_question/SKILL.md
+++ b/src/cafe/data/skills/cafe-research_question/SKILL.md
@@ -1,7 +1,13 @@
 ---
 name: cafe-research_question
 description: 成形研究問題與假設邊界（非軟體研究流程）
-version: 1.0.0
+version: 1.0.1
+workflow:
+  human_tasks:
+    - id: clarification-feedback
+      pattern: revision_feedback
+      prompt: Provide the clarification needed to refine the research question.
+      input_schema: feedback
 ---
 
 # Research Question

--- a/src/cafe/data/skills/cafe-research_report/SKILL.md
+++ b/src/cafe/data/skills/cafe-research_report/SKILL.md
@@ -1,7 +1,13 @@
 ---
 name: cafe-research_report
 description: 產出研究報告（非軟體研究流程）
-version: 1.0.0
+version: 1.0.1
+workflow:
+  human_tasks:
+    - id: clarification-feedback
+      pattern: revision_feedback
+      prompt: Provide the clarification needed to complete the report.
+      input_schema: feedback
 ---
 
 # Research Report

--- a/src/cafe/data/skills/cafe-research_synthesize/SKILL.md
+++ b/src/cafe/data/skills/cafe-research_synthesize/SKILL.md
@@ -1,7 +1,13 @@
 ---
 name: cafe-research_synthesize
 description: 綜合發現與交叉驗證（非軟體研究流程）
-version: 1.0.0
+version: 1.0.1
+workflow:
+  human_tasks:
+    - id: clarification-feedback
+      pattern: revision_feedback
+      prompt: Provide the clarification needed to continue synthesis.
+      input_schema: feedback
 ---
 
 # Research Synthesize

--- a/src/cafe/data/skills/cafe-review/SKILL.md
+++ b/src/cafe/data/skills/cafe-review/SKILL.md
@@ -1,8 +1,13 @@
 ---
 name: cafe-review
 description: "審查程式碼品質與風險"
-version: 1.0.1
+version: 1.0.2
 workflow:
+  human_tasks:
+    - id: clarification-feedback
+      pattern: revision_feedback
+      prompt: Provide the clarification needed to continue the review.
+      input_schema: feedback
   prompt_inputs:
     - artifacts: [spec]
       placeholder: spec_file

--- a/src/cafe/data/skills/cafe-spec/SKILL.md
+++ b/src/cafe/data/skills/cafe-spec/SKILL.md
@@ -1,8 +1,24 @@
 ---
 name: cafe-spec
 description: "收集、整理或修訂需求規格（依 iteration 切換行為）"
-version: 1.0.0
+version: 1.0.1
 workflow:
+  human_tasks:
+    - id: output-review
+      pattern: confirm_output
+      prompt: Review the requirements specification and choose how to continue.
+      input_schema: decision
+      decisions:
+        - id: confirm
+          label: Confirm and continue
+        - id: revise
+          label: Request revision
+          requires_feedback: true
+    - id: clarification-answers
+      pattern: answer_questions
+      prompt: Answer the requested clarification questions.
+      input_schema: answers
+      questions_from_xml: true
   checklist:
     context_references:
       xml_questions_instruction: xml_questions_instruction.md

--- a/src/cafe/data/skills/write-cafe-phase/references/skill-spec.md
+++ b/src/cafe/data/skills/write-cafe-phase/references/skill-spec.md
@@ -77,6 +77,42 @@ workflow:
     catalog: research-report
 ```
 
+### Human-task policy contract
+
+When a phase may pause for a person, declare its reusable policy under
+`workflow.human_tasks`; the playbook then binds that policy to a trigger and
+declares the allowed continuations. The skill owns wording and input validation,
+while the playbook owns routing. Runtime state, files, and baton mutation remain
+runtime-owned.
+
+```yaml
+workflow:
+  human_tasks:
+    - id: output-review
+      pattern: confirm_output
+      prompt: Review the result and choose how to continue.
+      input_schema: decision
+      decisions:
+        - id: confirm
+          label: Confirm and continue
+        - id: revise
+          label: Request revision
+          requires_feedback: true
+```
+
+- The valid patterns and matching schemas are: `confirm_output` → `decision`,
+  `answer_questions` → `answers`, `revision_feedback` → `feedback`,
+  `no_changes_needed` → `decision`, and `select_next_step` → `target`.
+- Decision policies declare every choice; `requires_feedback: true` makes the
+  feedback field mandatory for that choice. Answer policies use inline questions
+  or `questions_from_xml: true`; target policies declare `allowed_targets`.
+- `required: false` is only for optional feedback. Use `correction_guidance` for
+  the actionable message shown after invalid interactive or command input.
+- Keep policy identifiers stable. Do not duplicate a policy's wording or input
+  rules in a playbook, hook, or CLI branch. If a matching policy/binding is
+  absent, the workflow remains paused and records a configuration error rather
+  than guessing a continuation.
+
 - `prompt_inputs` are resolved in listed candidate order. Required inputs stop
   before agent invocation with the placeholder and candidates named; absent
   optional inputs are omitted.

--- a/src/cafe/data/skills/write-cafe-playbook/references/playbook-spec.md
+++ b/src/cafe/data/skills/write-cafe-playbook/references/playbook-spec.md
@@ -104,8 +104,38 @@ artifacts.
 | `hooks` | Runtime-supported prepare/execute/publish hooks only |
 | `allowed_goto` | Explicit non-default routes; do not use as the happy path |
 | `"on"` | Complete intent-key → step transition map |
+| `human_tasks` | Explicit user-task bindings for user-facing handoff triggers |
 
 Quote `"on"`; unquoted YAML 1.1 may parse it as a boolean before normalization.
+
+### Human-task bindings
+
+`human_tasks` makes a user handoff explicit.  A binding selects a policy declared
+by the step's selected skill and maps each accepted outcome to a playbook step:
+
+```yaml
+human_tasks:
+  - trigger: confirm_output
+    task_id: output-review
+    outcomes: {confirm: execute_work, revise: plan_work}
+```
+
+- Supported policy patterns are `confirm_output`, `answer_questions`,
+  `revision_feedback`, `no_changes_needed`, and `select_next_step`.
+- Bind every user-facing `confirm_output`, `need_clarification`, or
+  `no_changes_needed` pause. `initial` is available for an optional first-run
+  input task and does not require an `"on"` entry.
+- A binding must name exactly one policy supplied by the selected skill. Its
+  non-terminal outcome targets must be existing playbook steps; use `_done` only
+  for a declared terminal outcome.
+- Do not put prompts, decision labels, questions, or validation rules in the
+  playbook. Those belong to the skill policy. A binding may only override prompt
+  or correction copy and constrain allowed targets.
+- CLI `--user-input` supplies the same payload as the interactive UI: JSON
+  objects using `task` plus `decision`, `answers`, `feedback`, or `target` as
+  required by the selected policy. Plain text is accepted only for a feedback
+  policy. Invalid payloads keep the workflow paused and display the policy's
+  correction guidance.
 
 ## 4. Outcome To Transition Mapping
 
@@ -246,6 +276,8 @@ assert steps["bridge"]["output_artifact"] == "plan"
 - [ ] Every role and `chat_role` is declared.
 - [ ] Every step is reachable from `entry_point`.
 - [ ] Every declared intent has an `"on"` handler.
+- [ ] Every user-facing pause has a matching `human_tasks` binding and a policy
+      in the selected skill.
 - [ ] Every normal path reaches `_done` or an intentional user pause.
 - [ ] Plan producers output `plan`; execute consumers input `plan` and read `{plan_file}`.
 - [ ] Serial bridges distinguish incoming `{plan_file}` from next `{output_file}`.

--- a/src/cafe/phases/generic_workflow_step.py
+++ b/src/cafe/phases/generic_workflow_step.py
@@ -416,7 +416,8 @@ class GenericWorkflowStepExecutor(Phase):
             if content.strip():
                 return content
 
-        if step_name == "plan" and self.iteration == 1:
+        step_def = self.playbook.get("steps", {}).get(step_name, {})
+        if self.iteration == 1 and self._declared_human_task_id(step_def, "initial"):
             return ""
         return "workflow execute"
 
@@ -1085,6 +1086,21 @@ class GenericWorkflowStepExecutor(Phase):
             return "no_changes_needed"
         return None
 
+    @staticmethod
+    def _declared_human_task_id(step_def: Dict[str, Any], trigger: str) -> Optional[str]:
+        """Return the task id selected by a step without inferring its name."""
+        raw_tasks = step_def.get("human_tasks")
+        if not isinstance(raw_tasks, (list, tuple)):
+            return None
+        matches = [
+            item.get("task_id")
+            for item in raw_tasks
+            if isinstance(item, dict) and item.get("trigger") == trigger
+        ]
+        if len(matches) != 1 or not isinstance(matches[0], str) or not matches[0].strip():
+            return None
+        return matches[0].strip()
+
     def _agent_wrote_baton(self, step_name: str) -> bool:
         """Check whether the agent already wrote a valid baton (next_step.txt).
 
@@ -1132,10 +1148,12 @@ class GenericWorkflowStepExecutor(Phase):
             return
 
         store = BlackboardStore(self.issue_dir)
+        task_id = self._declared_human_task_id(
+            step_def, self._resolve_handoff_intent(step_def, status_code) or ""
+        )
 
         if status_code == PhaseStatusCode.NO_CHANGES_NEEDED:
-            if self.interactive:
-                # Interactive: always pause so UserInputCollector can show agree/disagree/chat.
+            if task_id or self.interactive:
                 store.update_handoff_contract(
                     blackboard_state,
                     from_step=step_name,
@@ -1145,6 +1163,16 @@ class GenericWorkflowStepExecutor(Phase):
                     status_code=status_code.value,
                     source="workflow.status_transition_adapter",
                 )
+                if task_id:
+                    store.record_event(
+                        blackboard_state,
+                        "human_task_requested",
+                        {
+                            "step": step_name,
+                            "trigger": "no_changes_needed",
+                            "task_id": task_id,
+                        },
+                    )
             else:
                 # Non-interactive: follow playbook on.no_changes_needed routing.
                 target = step_def.get("on", {}).get("no_changes_needed")
@@ -1188,6 +1216,26 @@ class GenericWorkflowStepExecutor(Phase):
                 status_code=status_code.value,
                 source="workflow.status_transition_adapter",
             )
+            if task_id:
+                store.record_event(
+                    blackboard_state,
+                    "human_task_requested",
+                    {
+                        "step": step_name,
+                        "trigger": raw_intent,
+                        "task_id": task_id,
+                    },
+                )
+            elif raw_intent in {"confirm_output", "need_clarification"}:
+                store.record_event(
+                    blackboard_state,
+                    "human_task_configuration_error",
+                    {
+                        "step": step_name,
+                        "trigger": raw_intent,
+                        "reason": "No declared human-task policy matches this handoff.",
+                    },
+                )
             return
 
         next_step = self._resolve_next_step_for_status(

--- a/src/cafe/skills/contracts.py
+++ b/src/cafe/skills/contracts.py
@@ -8,6 +8,8 @@ from typing import Any, Optional, Tuple
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from cafe.core.human_tasks import HumanTaskPolicy
+
 RUNTIME_OWNED_PROMPT_PLACEHOLDERS = frozenset(
     {
         "agent_file",
@@ -226,6 +228,7 @@ class SkillWorkflowContract(BaseModel):
     prompt_references: dict[str, str] = Field(default_factory=dict)
     checklist: Optional[ChecklistContract] = None
     output_templates: Optional[OutputTemplatesContract] = None
+    human_tasks: Tuple[HumanTaskPolicy, ...] = ()
 
     @field_validator("prompt_references")
     @classmethod
@@ -250,6 +253,9 @@ class SkillWorkflowContract(BaseModel):
                 "prompt reference placeholders must not overlap prompt input placeholders: "
                 f"{', '.join(sorted(overlap))}"
             )
+        task_ids = [task.id for task in self.human_tasks]
+        if len(set(task_ids)) != len(task_ids):
+            raise ValueError("human task ids must be unique")
         if self.checklist is not None:
             checklist_references = set(self.checklist.context_references)
             overlap = input_placeholder_set & checklist_references

--- a/src/cafe/ui/cli_shared.py
+++ b/src/cafe/ui/cli_shared.py
@@ -980,6 +980,7 @@ def _handle_declared_human_task_handoff(
     from cafe.ui.human_tasks import (
         apply_human_task_payload,
         collect_human_task_payload,
+        latest_step_iteration,
         resolve_step_human_task,
     )
 
@@ -990,6 +991,7 @@ def _handle_declared_human_task_handoff(
             playbook_data=playbook_data,
             step_name=from_step,
             trigger=trigger,
+            iteration=latest_step_iteration(issue_dir=issue_dir, step_name=from_step),
         )
     except HumanTaskPolicyError:
         result = apply_human_task_payload(
@@ -1004,7 +1006,7 @@ def _handle_declared_human_task_handoff(
         console.print(f"[red]{result.rejection.message}[/red]")
         return None
 
-    if policy.pattern == "confirm_output":
+    if policy.pattern in {"confirm_output", "no_changes_needed"}:
         output_files = sorted((issue_dir / from_step).glob("iteration_*/output.md"))
         if output_files:
             _print_output_file(output_files[-1])

--- a/src/cafe/ui/cli_shared.py
+++ b/src/cafe/ui/cli_shared.py
@@ -925,19 +925,6 @@ def _handle_user_phase(
     handoff_intent = getattr(contract, "intent", None) if contract else None
     from_step = getattr(contract, "from_step", None) if contract else None
 
-    if handoff_intent == HandoffIntent.CONFIRM_OUTPUT and from_step in playbook_data.get(
-        "steps", {}
-    ):
-        return _handle_review_confirmation(
-            issue_name=issue_name,
-            issue_dir=issue_dir,
-            playbook_data=playbook_data,
-            blackboard=blackboard,
-            store=store,
-            from_step=from_step,
-            summary=summary,
-        )
-
     if handoff_intent == HandoffIntent.ALIGNMENT_CHECKPOINT and from_step in playbook_data.get(
         "steps", {}
     ):
@@ -951,27 +938,19 @@ def _handle_user_phase(
             summary=summary,
         )
 
-    if handoff_intent == HandoffIntent.NEED_CLARIFICATION and from_step in playbook_data.get(
-        "steps", {}
-    ):
-        return _handle_clarification_handoff(
+    if handoff_intent in {
+        HandoffIntent.CONFIRM_OUTPUT,
+        HandoffIntent.NEED_CLARIFICATION,
+        HandoffIntent.NO_CHANGES_NEEDED,
+    } and from_step in playbook_data.get("steps", {}):
+        return _handle_declared_human_task_handoff(
             issue_name=issue_name,
             issue_dir=issue_dir,
-            playbook_data=playbook_data,
             blackboard=blackboard,
-            store=store,
-            from_step=from_step,
-            summary=summary,
-        )
-
-    if handoff_intent == HandoffIntent.NO_CHANGES_NEEDED and from_step == "develop":
-        return _handle_develop_no_changes_needed_handoff(
-            issue_dir=issue_dir,
-            blackboard=blackboard,
-            store=store,
             from_step=from_step,
             summary=summary,
             playbook_data=playbook_data,
+            trigger=handoff_intent.value,
         )
 
     # Default generic user-phase menu
@@ -985,44 +964,101 @@ def _handle_user_phase(
     )
 
 
-def _handle_develop_no_changes_needed_handoff(
+def _handle_declared_human_task_handoff(
     *,
+    issue_name: str,
     issue_dir: Path,
     blackboard,
-    store: BlackboardStore,
     from_step: str,
     summary: str,
     playbook_data: Dict[str, Any],
+    trigger: str,
 ) -> Optional[str]:
-    """Route develop no_changes_needed pauses back to develop's input collector."""
-    if from_step not in playbook_data.get("steps", {}):
-        return None
+    """Render and apply any step-declared human task through one shared path."""
+    from cafe.core.human_tasks import HumanTaskPolicyError
+    from cafe.core.questions_schema import parse_questions_xml, validate_questions_xml
+    from cafe.ui.human_tasks import (
+        apply_human_task_payload,
+        collect_human_task_payload,
+        resolve_step_human_task,
+    )
 
-    console.print(f"[yellow]No changes confirmation requested[/yellow] step={from_step}")
     if summary:
         console.print(f"[dim]{summary}[/dim]")
+    try:
+        policy, _binding = resolve_step_human_task(
+            playbook_data=playbook_data,
+            step_name=from_step,
+            trigger=trigger,
+        )
+    except HumanTaskPolicyError:
+        result = apply_human_task_payload(
+            issue_dir=issue_dir,
+            playbook_data=playbook_data,
+            blackboard=blackboard,
+            from_step=from_step,
+            trigger=trigger,
+            raw_payload={},
+            source="interactive",
+        )
+        console.print(f"[red]{result.rejection.message}[/red]")
+        return None
 
-    # The migrated agree/disagree/chat flow lives in UserInputCollector for the
-    # next develop iteration.  Resume develop directly so users do not have to
-    # manually pick it from the generic user menu first.
-    store.set_current_step(blackboard, from_step)
-    store.set_handoff_summary(blackboard, f"Resuming {from_step} to resolve no_changes_needed")
-    store.update_handoff_contract(
-        blackboard,
+    if policy.pattern == "confirm_output":
+        output_files = sorted((issue_dir / from_step).glob("iteration_*/output.md"))
+        if output_files:
+            _print_output_file(output_files[-1])
+    questions = None
+    if policy.questions_from_xml:
+        iteration_dirs = sorted((issue_dir / from_step).glob("iteration_*"))
+        questions_file = iteration_dirs[-1] / "questions.xml" if iteration_dirs else None
+        if questions_file is not None and questions_file.exists() and validate_questions_xml(questions_file):
+            questions = parse_questions_xml(questions_file)
+    payload = collect_human_task_payload(
+        policy,
+        questions=questions,
+        role=_resolve_step_chat_role(playbook_data, from_step),
+        issue_name=issue_name,
+        agent_name=_resolve_role_agent_name(
+            playbook_data, _resolve_step_chat_role(playbook_data, from_step)
+        ),
+    )
+    if isinstance(payload, dict) and payload.get("decision") == "chat":
+        from cafe.ui.cli import _consume_pending_chat_handoff, launch_chat_session
+
+        role = _resolve_step_chat_role(playbook_data, from_step)
+        launch_chat_session(role, issue_name)
+        target = _consume_pending_chat_handoff(
+            issue_dir=issue_dir,
+            playbook_data=playbook_data,
+            requested_start_step=None,
+        )
+        if target is not None:
+            return target
+        return _handle_declared_human_task_handoff(
+            issue_name=issue_name,
+            issue_dir=issue_dir,
+            blackboard=blackboard,
+            from_step=from_step,
+            summary=summary,
+            playbook_data=playbook_data,
+            trigger=trigger,
+        )
+    result = apply_human_task_payload(
+        issue_dir=issue_dir,
+        playbook_data=playbook_data,
+        blackboard=blackboard,
         from_step=from_step,
-        to_owner=HandoffOwner.AGENT,
-        to_step=from_step,
-        intent=HandoffIntent.AWAIT_AGENT,
-        status_code="",
-        source="user.no_changes_needed_resume",
+        trigger=trigger,
+        raw_payload=payload or {},
+        source="interactive",
     )
-    store.record_event(
-        blackboard,
-        "no_changes_needed_resume",
-        {"step": from_step, "issue_dir": str(issue_dir)},
-    )
-    console.print(f"[green]Resuming[/green] {from_step}")
-    return from_step
+    if result.rejection is not None:
+        console.print(f"[yellow]{result.rejection.message}[/yellow]")
+        console.print(f"[dim]{result.rejection.correction_guidance}[/dim]")
+        return None
+    console.print(f"[green]Completed human task[/green] {policy.id} -> {result.target}")
+    return result.target
 
 
 def parse_alignment_decision_payload(user_input: Optional[str]) -> Optional[Dict[str, Any]]:

--- a/src/cafe/ui/commands/workflow.py
+++ b/src/cafe/ui/commands/workflow.py
@@ -26,6 +26,7 @@ from cafe.ui.cli_shared import (
     parse_alignment_decision_payload,
     resolve_iteration_number as _resolve_iteration_number,
 )
+from cafe.ui.human_tasks import apply_human_task_payload
 from cafe.agents.executor import AgentExecutionError
 from cafe.utils.config import ConfigError, validate_directories_exist
 
@@ -883,6 +884,29 @@ def workflow(
                                 pending_start_step = selected_step
                                 continue
                             return
+                        if contract.intent in {
+                            HandoffIntent.CONFIRM_OUTPUT,
+                            HandoffIntent.NEED_CLARIFICATION,
+                            HandoffIntent.NO_CHANGES_NEEDED,
+                        }:
+                            result = apply_human_task_payload(
+                                issue_dir=issue_dir,
+                                playbook_data=playbook_data,
+                                blackboard=blackboard,
+                                from_step=from_step,
+                                trigger=contract.intent.value,
+                                raw_payload=user_input,
+                                source="command",
+                            )
+                            if result.rejection is not None:
+                                console.print(f"[yellow]{result.rejection.message}[/yellow]")
+                                console.print(
+                                    f"[dim]{result.rejection.correction_guidance}[/dim]"
+                                )
+                                return
+                            user_input = None
+                            pending_start_step = result.target
+                            continue
                         store = BlackboardStore(issue_dir)
                         from_step_dir = issue_dir / from_step
                         iteration_dirs = sorted(from_step_dir.glob("iteration_*")) if from_step_dir.exists() else []

--- a/src/cafe/ui/human_tasks.py
+++ b/src/cafe/ui/human_tasks.py
@@ -1,0 +1,319 @@
+"""Policy-backed rendering and coordination for workflow human handoffs."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional, Sequence
+
+from cafe.core.blackboard import BlackboardStore, HandoffIntent, HandoffOwner
+from cafe.core.human_tasks import (
+    HumanTaskBinding,
+    HumanTaskCompletion,
+    HumanTaskPolicy,
+    HumanTaskPolicyError,
+    HumanTaskQuestion,
+    HumanTaskRejection,
+    resolve_human_task_continuation,
+    resolve_human_task_policy,
+    validate_human_task_completion,
+)
+from cafe.skills.loader import SkillLoader
+
+
+def resolve_step_human_task(
+    *,
+    playbook_data: Mapping[str, Any],
+    step_name: str,
+    trigger: str,
+    skill_loader: Optional[SkillLoader] = None,
+) -> tuple[HumanTaskPolicy, HumanTaskBinding]:
+    """Resolve one declared step binding without inferring workflow semantics."""
+    raw_steps = playbook_data.get("steps")
+    if not isinstance(raw_steps, Mapping):
+        raise HumanTaskPolicyError("Playbook has no step declarations")
+    raw_step = raw_steps.get(step_name)
+    if not isinstance(raw_step, Mapping):
+        raise HumanTaskPolicyError(f"Unknown playbook step {step_name!r}")
+    raw_bindings = raw_step.get("human_tasks")
+    if not isinstance(raw_bindings, Sequence) or isinstance(raw_bindings, (str, bytes)):
+        raise HumanTaskPolicyError(
+            f"Step {step_name!r} has no declared human task for trigger {trigger!r}"
+        )
+    bindings = [
+        HumanTaskBinding.model_validate(raw)
+        for raw in raw_bindings
+        if isinstance(raw, Mapping) and raw.get("trigger") == trigger
+    ]
+    if len(bindings) != 1:
+        raise HumanTaskPolicyError(
+            f"Step {step_name!r} requires exactly one human task for trigger {trigger!r}"
+        )
+    skill_name = _select_skill_name(raw_step)
+    contract = (skill_loader or SkillLoader()).get_workflow_contract(skill_name)
+    policy = resolve_human_task_policy(defaults=contract.human_tasks, binding=bindings[0])
+    return policy, bindings[0]
+
+
+def validate_step_human_task_completion(
+    *,
+    playbook_data: Mapping[str, Any],
+    step_name: str,
+    trigger: str,
+    raw_payload: str | Mapping[str, Any],
+    skill_loader: Optional[SkillLoader] = None,
+    questions: Optional[Sequence[HumanTaskQuestion]] = None,
+) -> tuple[HumanTaskPolicy, HumanTaskBinding, HumanTaskCompletion | HumanTaskRejection]:
+    """Resolve and validate a response without mutating the paused workflow."""
+    policy, binding = resolve_step_human_task(
+        playbook_data=playbook_data,
+        step_name=step_name,
+        trigger=trigger,
+        skill_loader=skill_loader,
+    )
+    return policy, binding, validate_human_task_completion(
+        policy, raw_payload, questions=questions
+    )
+
+
+def resolve_step_human_task_continuation(
+    *,
+    playbook_data: Mapping[str, Any],
+    policy: HumanTaskPolicy,
+    binding: HumanTaskBinding,
+    completion: HumanTaskCompletion,
+) -> str | HumanTaskRejection:
+    """Return the single policy-permitted continuation for a validated response."""
+    raw_steps = playbook_data.get("steps")
+    if not isinstance(raw_steps, Mapping):
+        return HumanTaskRejection(
+            message="The playbook has no declared steps.",
+            correction_guidance=policy.correction_guidance,
+        )
+    return resolve_human_task_continuation(
+        policy=policy,
+        binding=binding,
+        completion=completion,
+        playbook_steps=list(raw_steps),
+    )
+
+
+def collect_human_task_payload(
+    policy: HumanTaskPolicy,
+    *,
+    questions: Optional[Sequence[Any]] = None,
+    role: Optional[str] = None,
+    issue_name: Optional[str] = None,
+    agent_name: Optional[str] = None,
+) -> Optional[dict[str, Any]]:
+    """Collect one interactive response in the policy's declared input shape."""
+    from cafe.ui.inquirer_prompts import prompt_list, prompt_multiline
+
+    if policy.input_schema == "feedback":
+        return {"task": policy.id, "feedback": prompt_multiline(policy.prompt).strip()}
+    if policy.input_schema == "decision":
+        choices = [{"name": item.label, "value": item.id} for item in policy.decisions]
+        if role and issue_name:
+            choices.append({"name": f"Chat with {agent_name or role}", "value": "chat"})
+        decision = prompt_list(policy.prompt, choices, default=None)
+        selected = next((item for item in policy.decisions if item.id == decision), None)
+        feedback = ""
+        if selected is not None and selected.requires_feedback:
+            feedback = prompt_multiline(policy.prompt).strip()
+        return {"task": policy.id, "decision": decision, "feedback": feedback}
+    if policy.input_schema == "target":
+        target = prompt_list(
+            policy.prompt,
+            [{"name": target, "value": target} for target in policy.allowed_targets],
+            default=None,
+        )
+        return {"task": policy.id, "target": target}
+
+    if policy.questions_from_xml:
+        if not questions:
+            return None
+        from cafe.ui.interactive_qa import interactive_qa_answers
+
+        return {
+            "task": policy.id,
+            "answers": interactive_qa_answers(
+                list(questions), role=role, issue_name=issue_name, agent_name=agent_name
+            ),
+        }
+
+    answers: dict[str, str] = {}
+    for question in policy.questions:
+        answer = prompt_multiline(question.prompt).strip()
+        answers[question.id] = answer
+    return {"task": policy.id, "answers": answers}
+
+
+@dataclass(frozen=True)
+class HumanTaskApplication:
+    """Result of attempting to complete a paused human task."""
+
+    target: Optional[str]
+    policy: Optional[HumanTaskPolicy]
+    rejection: Optional[HumanTaskRejection] = None
+
+
+def apply_human_task_payload(
+    *,
+    issue_dir: Path,
+    playbook_data: Mapping[str, Any],
+    blackboard: Any,
+    from_step: str,
+    trigger: str,
+    raw_payload: str | Mapping[str, Any],
+    source: str,
+) -> HumanTaskApplication:
+    """Validate and apply one response while retaining a pause on rejection."""
+    store = BlackboardStore(issue_dir)
+    try:
+        questions = _load_dynamic_questions(
+            issue_dir=issue_dir,
+            step_name=from_step,
+            playbook_data=playbook_data,
+            trigger=trigger,
+        )
+        policy, binding, completion = validate_step_human_task_completion(
+            playbook_data=playbook_data,
+            step_name=from_step,
+            trigger=trigger,
+            raw_payload=raw_payload,
+            questions=questions,
+        )
+    except HumanTaskPolicyError as exc:
+        rejection = HumanTaskRejection(
+            message=str(exc),
+            correction_guidance=(
+                "Declare a matching human-task policy before resuming the workflow."
+            ),
+        )
+        store.record_event(
+            blackboard,
+            "human_task_configuration_error",
+            {"step": from_step, "trigger": trigger, "reason": rejection.message},
+        )
+        return HumanTaskApplication(target=None, policy=None, rejection=rejection)
+
+    if isinstance(completion, HumanTaskRejection):
+        store.record_event(
+            blackboard,
+            "human_task_rejected",
+            {
+                "step": from_step,
+                "trigger": trigger,
+                "task_id": policy.id,
+                "reason": completion.message,
+            },
+        )
+        return HumanTaskApplication(target=None, policy=policy, rejection=completion)
+
+    continuation = resolve_step_human_task_continuation(
+        playbook_data=playbook_data,
+        policy=policy,
+        binding=binding,
+        completion=completion,
+    )
+    if isinstance(continuation, HumanTaskRejection):
+        store.record_event(
+            blackboard,
+            "human_task_rejected",
+            {
+                "step": from_step,
+                "trigger": trigger,
+                "task_id": policy.id,
+                "reason": continuation.message,
+            },
+        )
+        return HumanTaskApplication(target=None, policy=policy, rejection=continuation)
+
+    agent_input = completion.agent_input()
+    if agent_input:
+        _write_next_iteration_user_input(issue_dir=issue_dir, step_name=from_step, text=agent_input)
+    is_done = continuation == "_done"
+    store.set_current_step(blackboard, "done" if is_done else continuation)
+    store.set_handoff_summary(blackboard, f"Completed human task {policy.id} for {from_step}")
+    store.update_handoff_contract(
+        blackboard,
+        from_step=from_step,
+        to_owner=HandoffOwner.DONE if is_done else HandoffOwner.AGENT,
+        to_step="done" if is_done else continuation,
+        intent=HandoffIntent.WORKFLOW_COMPLETE if is_done else HandoffIntent.AWAIT_AGENT,
+        status_code="",
+        source=f"human_task.{source}",
+    )
+    store.record_event(
+        blackboard,
+        "human_task_completed",
+        {
+            "step": from_step,
+            "trigger": trigger,
+            "task_id": policy.id,
+            "pattern": policy.pattern,
+            "to_step": continuation,
+            "source": source,
+        },
+    )
+    return HumanTaskApplication(target="done" if is_done else continuation, policy=policy)
+
+
+def _write_next_iteration_user_input(*, issue_dir: Path, step_name: str, text: str) -> None:
+    step_dir = issue_dir / step_name
+    iteration_dirs = sorted(step_dir.glob("iteration_*")) if step_dir.exists() else []
+    target = step_dir / f"iteration_{len(iteration_dirs) + 1:03d}"
+    target.mkdir(parents=True, exist_ok=True)
+    (target / "user_input.md").write_text(text, encoding="utf-8")
+
+
+def _load_dynamic_questions(
+    *,
+    issue_dir: Path,
+    step_name: str,
+    playbook_data: Mapping[str, Any],
+    trigger: str,
+) -> Optional[tuple[HumanTaskQuestion, ...]]:
+    """Return the current XML question contract for a dynamic answer task."""
+    try:
+        policy, _binding = resolve_step_human_task(
+            playbook_data=playbook_data,
+            step_name=step_name,
+            trigger=trigger,
+        )
+    except HumanTaskPolicyError:
+        return None
+    if not policy.questions_from_xml:
+        return None
+
+    from cafe.core.questions_schema import parse_questions_xml, validate_questions_xml
+
+    step_dir = issue_dir / step_name
+    iteration_dirs = sorted(step_dir.glob("iteration_*")) if step_dir.exists() else []
+    questions_file = iteration_dirs[-1] / "questions.xml" if iteration_dirs else None
+    if questions_file is None or not validate_questions_xml(questions_file):
+        return ()
+    return tuple(
+        HumanTaskQuestion(
+            id=question.id,
+            prompt=question.title,
+            options=tuple(question.options),
+            multiple=question.multi_select,
+        )
+        for question in parse_questions_xml(questions_file)
+    )
+
+
+def _select_skill_name(step_def: Mapping[str, Any]) -> str:
+    raw_skill = step_def.get("skill")
+    if isinstance(raw_skill, str) and raw_skill.strip():
+        return raw_skill
+    if isinstance(raw_skill, Mapping):
+        default = raw_skill.get("default")
+        if isinstance(default, str) and default.strip():
+            return default
+        for value in raw_skill.values():
+            if isinstance(value, str) and value.strip():
+                return value
+    raise HumanTaskPolicyError("Human-task step must select a skill")

--- a/src/cafe/ui/human_tasks.py
+++ b/src/cafe/ui/human_tasks.py
@@ -28,6 +28,7 @@ def resolve_step_human_task(
     step_name: str,
     trigger: str,
     skill_loader: Optional[SkillLoader] = None,
+    iteration: int = 1,
 ) -> tuple[HumanTaskPolicy, HumanTaskBinding]:
     """Resolve one declared step binding without inferring workflow semantics."""
     raw_steps = playbook_data.get("steps")
@@ -50,7 +51,7 @@ def resolve_step_human_task(
         raise HumanTaskPolicyError(
             f"Step {step_name!r} requires exactly one human task for trigger {trigger!r}"
         )
-    skill_name = _select_skill_name(raw_step)
+    skill_name = _select_skill_name(raw_step, iteration)
     contract = (skill_loader or SkillLoader()).get_workflow_contract(skill_name)
     policy = resolve_human_task_policy(defaults=contract.human_tasks, binding=bindings[0])
     return policy, bindings[0]
@@ -64,6 +65,7 @@ def validate_step_human_task_completion(
     raw_payload: str | Mapping[str, Any],
     skill_loader: Optional[SkillLoader] = None,
     questions: Optional[Sequence[HumanTaskQuestion]] = None,
+    iteration: int = 1,
 ) -> tuple[HumanTaskPolicy, HumanTaskBinding, HumanTaskCompletion | HumanTaskRejection]:
     """Resolve and validate a response without mutating the paused workflow."""
     policy, binding = resolve_step_human_task(
@@ -71,6 +73,7 @@ def validate_step_human_task_completion(
         step_name=step_name,
         trigger=trigger,
         skill_loader=skill_loader,
+        iteration=iteration,
     )
     return policy, binding, validate_human_task_completion(
         policy, raw_payload, questions=questions
@@ -108,7 +111,7 @@ def collect_human_task_payload(
     agent_name: Optional[str] = None,
 ) -> Optional[dict[str, Any]]:
     """Collect one interactive response in the policy's declared input shape."""
-    from cafe.ui.inquirer_prompts import prompt_list, prompt_multiline
+    from cafe.ui.inquirer_prompts import prompt_checkbox, prompt_list, prompt_multiline
 
     if policy.input_schema == "feedback":
         return {"task": policy.id, "feedback": prompt_multiline(policy.prompt).strip()}
@@ -142,9 +145,12 @@ def collect_human_task_payload(
             ),
         }
 
-    answers: dict[str, str] = {}
+    answers: dict[str, str | list[str]] = {}
     for question in policy.questions:
-        answer = prompt_multiline(question.prompt).strip()
+        if question.multiple and question.options:
+            answer = prompt_checkbox(question.prompt, list(question.options))
+        else:
+            answer = prompt_multiline(question.prompt).strip()
         answers[question.id] = answer
     return {"task": policy.id, "answers": answers}
 
@@ -171,11 +177,13 @@ def apply_human_task_payload(
     """Validate and apply one response while retaining a pause on rejection."""
     store = BlackboardStore(issue_dir)
     try:
+        iteration = latest_step_iteration(issue_dir=issue_dir, step_name=from_step)
         questions = _load_dynamic_questions(
             issue_dir=issue_dir,
             step_name=from_step,
             playbook_data=playbook_data,
             trigger=trigger,
+            iteration=iteration,
         )
         policy, binding, completion = validate_step_human_task_completion(
             playbook_data=playbook_data,
@@ -183,6 +191,7 @@ def apply_human_task_payload(
             trigger=trigger,
             raw_payload=raw_payload,
             questions=questions,
+            iteration=iteration,
         )
     except HumanTaskPolicyError as exc:
         rejection = HumanTaskRejection(
@@ -274,6 +283,7 @@ def _load_dynamic_questions(
     step_name: str,
     playbook_data: Mapping[str, Any],
     trigger: str,
+    iteration: int,
 ) -> Optional[tuple[HumanTaskQuestion, ...]]:
     """Return the current XML question contract for a dynamic answer task."""
     try:
@@ -281,6 +291,7 @@ def _load_dynamic_questions(
             playbook_data=playbook_data,
             step_name=step_name,
             trigger=trigger,
+            iteration=iteration,
         )
     except HumanTaskPolicyError:
         return None
@@ -305,11 +316,29 @@ def _load_dynamic_questions(
     )
 
 
-def _select_skill_name(step_def: Mapping[str, Any]) -> str:
+def latest_step_iteration(*, issue_dir: Path, step_name: str) -> int:
+    """Return the latest numeric iteration for policy-skill selection."""
+    step_dir = issue_dir / step_name
+    iterations = []
+    if step_dir.exists():
+        for candidate in step_dir.glob("iteration_*"):
+            if not candidate.is_dir():
+                continue
+            try:
+                iterations.append(int(candidate.name.removeprefix("iteration_")))
+            except ValueError:
+                continue
+    return max(iterations, default=1)
+
+
+def _select_skill_name(step_def: Mapping[str, Any], iteration: int) -> str:
     raw_skill = step_def.get("skill")
     if isinstance(raw_skill, str) and raw_skill.strip():
         return raw_skill
     if isinstance(raw_skill, Mapping):
+        exact = raw_skill.get(str(iteration))
+        if isinstance(exact, str) and exact.strip():
+            return exact
         default = raw_skill.get("default")
         if isinstance(default, str) and default.strip():
             return default

--- a/src/cafe/ui/human_tasks.py
+++ b/src/cafe/ui/human_tasks.py
@@ -149,6 +149,8 @@ def collect_human_task_payload(
     for question in policy.questions:
         if question.multiple and question.options:
             answer = prompt_checkbox(question.prompt, list(question.options))
+        elif question.options:
+            answer = prompt_list(question.prompt, list(question.options), default=None)
         else:
             answer = prompt_multiline(question.prompt).strip()
         answers[question.id] = answer

--- a/src/cafe/ui/interactive_qa.py
+++ b/src/cafe/ui/interactive_qa.py
@@ -153,6 +153,33 @@ def interactive_qa_flow(
     return _format_answers(questions, answers)
 
 
+def interactive_qa_answers(
+    questions: list[Question],
+    role: Optional[str] = None,
+    issue_name: Optional[str] = None,
+    agent_name: Optional[str] = None,
+    after_chat: Optional[Callable[[], list[Question] | None]] = None,
+) -> dict[str, str]:
+    """Collect the existing interactive flow and expose its answers by question id."""
+    formatted = interactive_qa_flow(
+        questions,
+        role=role,
+        issue_name=issue_name,
+        agent_name=agent_name,
+        after_chat=after_chat,
+    )
+    answers: dict[str, str] = {}
+    for index, question in enumerate(questions, start=1):
+        marker = f"A{index}: "
+        start = formatted.find(marker)
+        if start < 0:
+            continue
+        value_start = start + len(marker)
+        next_question = formatted.find(f"\n\nQ{index + 1}: ", value_start)
+        answers[question.id] = formatted[value_start:next_question if next_question >= 0 else None]
+    return answers
+
+
 def _ask_select(
     question: Question,
     idx: int,

--- a/tests/integration/test_human_task_workflow.py
+++ b/tests/integration/test_human_task_workflow.py
@@ -109,6 +109,28 @@ def test_invalid_default_human_task_response_keeps_the_user_pause(tmp_path: Path
     assert any(event.event_type == "human_task_rejected" for event in reloaded.events)
 
 
+def test_tdd_no_change_agreement_skips_review_to_pr(tmp_path: Path) -> None:
+    """Built-in TDD retains the established no-change continuation."""
+    issue_dir = tmp_path / ".cafe" / "issues" / "tdd-no-change"
+    playbook = PlaybookLoader().load("tdd")
+    store, state = _paused_default_state(
+        issue_dir, from_step="develop", intent=HandoffIntent.NO_CHANGES_NEEDED
+    )
+
+    result = apply_human_task_payload(
+        issue_dir=issue_dir,
+        playbook_data=playbook,
+        blackboard=state,
+        from_step="develop",
+        trigger="no_changes_needed",
+        raw_payload={"task": "no-change-decision", "decision": "agree"},
+        source="integration",
+    )
+
+    assert result.target == "pr"
+    assert store.load_or_create("develop").current_step == "pr"
+
+
 def test_editorial_human_tasks_use_editorial_contracts_without_development_copy(
     tmp_path: Path,
 ) -> None:

--- a/tests/integration/test_human_task_workflow.py
+++ b/tests/integration/test_human_task_workflow.py
@@ -79,8 +79,8 @@ def test_default_human_tasks_validate_and_route_all_user_handoff_patterns(tmp_pa
         source="integration",
     )
 
-    assert no_change.target == "review"
-    assert no_change_store.load_or_create("develop").current_step == "review"
+    assert no_change.target == "pr"
+    assert no_change_store.load_or_create("develop").current_step == "pr"
 
 
 def test_invalid_default_human_task_response_keeps_the_user_pause(tmp_path: Path) -> None:

--- a/tests/integration/test_human_task_workflow.py
+++ b/tests/integration/test_human_task_workflow.py
@@ -1,0 +1,155 @@
+"""End-to-end contract coverage for builtin human-task workflow handoffs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from cafe.core.blackboard import BlackboardStore, HandoffIntent, HandoffOwner
+from cafe.playbooks.loader import PlaybookLoader
+from cafe.ui.human_tasks import apply_human_task_payload
+
+
+def _paused_default_state(issue_dir: Path, *, from_step: str, intent: HandoffIntent):
+    store = BlackboardStore(issue_dir)
+    state = store.load_or_create(from_step, playbook_id="default")
+    store.set_current_step(state, "user")
+    store.update_handoff_contract(
+        state,
+        from_step=from_step,
+        to_owner=HandoffOwner.USER,
+        to_step="user",
+        intent=intent,
+        source="test",
+    )
+    return store, state
+
+
+def test_default_human_tasks_validate_and_route_all_user_handoff_patterns(tmp_path: Path) -> None:
+    """Builtin policy responses share one validator and only declared routes advance."""
+    playbook = PlaybookLoader().load("default")
+
+    confirm_dir = tmp_path / ".cafe" / "issues" / "confirm"
+    confirm_store, confirm_state = _paused_default_state(
+        confirm_dir, from_step="spec", intent=HandoffIntent.CONFIRM_OUTPUT
+    )
+    confirmed = apply_human_task_payload(
+        issue_dir=confirm_dir,
+        playbook_data=playbook,
+        blackboard=confirm_state,
+        from_step="spec",
+        trigger="confirm_output",
+        raw_payload={"task": "output-review", "decision": "confirm"},
+        source="integration",
+    )
+
+    assert confirmed.target == "plan"
+    assert confirm_store.load_or_create("spec").current_step == "plan"
+
+    clarification_dir = tmp_path / ".cafe" / "issues" / "clarification"
+    clarification_store, clarification_state = _paused_default_state(
+        clarification_dir, from_step="develop", intent=HandoffIntent.NEED_CLARIFICATION
+    )
+    clarified = apply_human_task_payload(
+        issue_dir=clarification_dir,
+        playbook_data=playbook,
+        blackboard=clarification_state,
+        from_step="develop",
+        trigger="need_clarification",
+        raw_payload="Explain the required compatibility behavior.",
+        source="integration",
+    )
+
+    assert clarified.target == "develop"
+    assert (
+        clarification_dir / "develop" / "iteration_001" / "user_input.md"
+    ).read_text(encoding="utf-8") == "Explain the required compatibility behavior."
+    assert clarification_store.load_or_create("develop").current_step == "develop"
+
+    no_change_dir = tmp_path / ".cafe" / "issues" / "no-change"
+    no_change_store, no_change_state = _paused_default_state(
+        no_change_dir, from_step="develop", intent=HandoffIntent.NO_CHANGES_NEEDED
+    )
+    no_change = apply_human_task_payload(
+        issue_dir=no_change_dir,
+        playbook_data=playbook,
+        blackboard=no_change_state,
+        from_step="develop",
+        trigger="no_changes_needed",
+        raw_payload={"task": "no-change-decision", "decision": "agree"},
+        source="integration",
+    )
+
+    assert no_change.target == "review"
+    assert no_change_store.load_or_create("develop").current_step == "review"
+
+
+def test_invalid_default_human_task_response_keeps_the_user_pause(tmp_path: Path) -> None:
+    """Bad command or interactive data cannot mutate the paused handoff."""
+    issue_dir = tmp_path / ".cafe" / "issues" / "invalid"
+    playbook = PlaybookLoader().load("default")
+    store, state = _paused_default_state(
+        issue_dir, from_step="develop", intent=HandoffIntent.NO_CHANGES_NEEDED
+    )
+
+    result = apply_human_task_payload(
+        issue_dir=issue_dir,
+        playbook_data=playbook,
+        blackboard=state,
+        from_step="develop",
+        trigger="no_changes_needed",
+        raw_payload={"task": "no-change-decision", "decision": "unknown"},
+        source="integration",
+    )
+
+    assert result.target is None
+    assert result.rejection is not None
+    reloaded = store.load_or_create("develop")
+    assert reloaded.current_step == "user"
+    assert reloaded.handoff_contract.to_owner == HandoffOwner.USER
+    assert any(event.event_type == "human_task_rejected" for event in reloaded.events)
+
+
+def test_editorial_human_tasks_use_editorial_contracts_without_development_copy(
+    tmp_path: Path,
+) -> None:
+    """A non-development flow confirms and clarifies through its own policies."""
+    playbook = PlaybookLoader().load("editorial")
+
+    approval_dir = tmp_path / ".cafe" / "issues" / "editorial-approval"
+    approval_store, approval_state = _paused_default_state(
+        approval_dir, from_step="brief", intent=HandoffIntent.CONFIRM_OUTPUT
+    )
+    approval = apply_human_task_payload(
+        issue_dir=approval_dir,
+        playbook_data=playbook,
+        blackboard=approval_state,
+        from_step="brief",
+        trigger="confirm_output",
+        raw_payload={"task": "editorial-output-review", "decision": "approve"},
+        source="integration",
+    )
+
+    assert approval.target == "draft"
+    assert approval.policy is not None
+    assert "editorial brief" in approval.policy.prompt.lower()
+    assert approval_store.load_or_create("brief").current_step == "draft"
+
+    clarification_dir = tmp_path / ".cafe" / "issues" / "editorial-clarification"
+    clarification_store, clarification_state = _paused_default_state(
+        clarification_dir, from_step="brief", intent=HandoffIntent.NEED_CLARIFICATION
+    )
+    clarification = apply_human_task_payload(
+        issue_dir=clarification_dir,
+        playbook_data=playbook,
+        blackboard=clarification_state,
+        from_step="brief",
+        trigger="need_clarification",
+        raw_payload={"task": "editorial-clarification", "answers": {"audience": "Editors"}},
+        source="integration",
+    )
+
+    assert clarification.target == "brief"
+    assert (
+        clarification_dir / "brief" / "iteration_001" / "user_input.md"
+    ).read_text(encoding="utf-8") == "audience: Editors"
+    assert clarification_store.load_or_create("brief").current_step == "brief"

--- a/tests/unit/test_cli_shared_human_tasks.py
+++ b/tests/unit/test_cli_shared_human_tasks.py
@@ -1,0 +1,40 @@
+"""Regression coverage for interactive human-task presentation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from cafe.core.blackboard import BlackboardStore
+from cafe.playbooks.loader import PlaybookLoader
+from cafe.ui import cli_shared
+
+
+def test_no_change_handoff_shows_implementation_output_before_decision(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """The participant sees the implementation evidence before deciding no-change."""
+    issue_dir = tmp_path / ".cafe" / "issues" / "no-change"
+    output_file = issue_dir / "develop" / "iteration_001" / "output.md"
+    output_file.parent.mkdir(parents=True)
+    output_file.write_text("Implementation reasoning", encoding="utf-8")
+    store = BlackboardStore(issue_dir)
+    blackboard = store.load_or_create("develop", playbook_id="default")
+    displayed: list[Path] = []
+    monkeypatch.setattr(cli_shared, "_print_output_file", displayed.append)
+    monkeypatch.setattr(
+        "cafe.ui.human_tasks.collect_human_task_payload",
+        lambda policy, **_kwargs: {"task": policy.id, "decision": "agree"},
+    )
+
+    target = cli_shared._handle_declared_human_task_handoff(
+        issue_name="no-change",
+        issue_dir=issue_dir,
+        blackboard=blackboard,
+        from_step="develop",
+        summary="",
+        playbook_data=PlaybookLoader().load("default"),
+        trigger="no_changes_needed",
+    )
+
+    assert displayed == [output_file]
+    assert target == "pr"

--- a/tests/unit/test_cli_workflow_command.py
+++ b/tests/unit/test_cli_workflow_command.py
@@ -393,6 +393,14 @@ def test_workflow_command_resume_user_input_targets_handoff_from_step(
     monkeypatch.chdir(tmp_path)
     issue_dir = tmp_path / ".cafe" / "issues" / "issue-resume-plan"
     issue_dir.mkdir(parents=True, exist_ok=True)
+    questions_dir = issue_dir / "plan" / "iteration_001"
+    questions_dir.mkdir(parents=True)
+    (questions_dir / "questions.xml").write_text(
+        """<questions>
+  <question id="scope"><title>Scope?</title><options><option>Include CSV export</option></options></question>
+</questions>""",
+        encoding="utf-8",
+    )
     store = BlackboardStore(issue_dir)
     blackboard = store.load_or_create("user", playbook_id="default")
     store.set_current_step(blackboard, "user")
@@ -429,18 +437,20 @@ def test_workflow_command_resume_user_input_targets_handoff_from_step(
                 "--playbook",
                 "default",
                 "--execute",
-                "--single-step",
-                "--user-input",
-                "Clarification: include CSV export in scope.",
+                    "--single-step",
+                    "--user-input",
+                    '{"task":"clarification-answers","answers":{"scope":"include CSV export in scope"}}',
             ],
         )
 
     assert result.exit_code == 0
     assert mock_builder.call_args.kwargs["step_user_inputs"] is None
-    resume_input = issue_dir / "plan" / "iteration_001" / "user_input.md"
-    assert resume_input.read_text(encoding="utf-8") == "Clarification: include CSV export in scope."
+    resume_input = issue_dir / "plan" / "iteration_002" / "user_input.md"
+    assert resume_input.read_text(encoding="utf-8") == "scope: include CSV export in scope"
     reloaded = store.load_or_create("spec", playbook_id="default")
-    assert "resuming plan" in (reloaded.handoff_summary or "").lower()
+    assert "completed human task clarification-answers for plan" in (
+        reloaded.handoff_summary or ""
+    ).lower()
     assert reloaded.current_step == "develop"
 
 
@@ -1253,15 +1263,13 @@ def test_workflow_command_resume_confirm_output_keeps_await_agent_intent(
                 "workflow",
                 "--playbook",
                 "default",
-                "--execute",
-                "--user-input",
-                "Approved with minor wording tweaks.",
+                    "--execute",
+                    "--user-input",
+                    '{"task":"output-review","decision":"confirm"}',
             ],
         )
 
     assert result.exit_code == 0
-    resume_input = issue_dir / "spec" / "iteration_001" / "user_input.md"
-    assert resume_input.read_text(encoding="utf-8") == "Approved with minor wording tweaks."
     reloaded = store.load_or_create("spec", playbook_id="default")
     assert reloaded.handoff_contract.intent == HandoffIntent.AWAIT_AGENT
 
@@ -2019,11 +2027,19 @@ def test_confirm_output_chat_uses_playbook_chat_role(tmp_path: Path, monkeypatch
             "writer": {"default_agent": "David"},
         },
         "steps": {
-            "brief": {
-                "role": "editor",
-                "chat_role": "writer",
-                "on": {"await_agent": "draft", "confirm_output": "brief"},
-            },
+                "brief": {
+                    "role": "editor",
+                    "chat_role": "writer",
+                    "skill": "cafe-brief_first",
+                    "human_tasks": [
+                        {
+                            "trigger": "confirm_output",
+                            "task_id": "editorial-output-review",
+                            "outcomes": {"approve": "draft", "revise": "brief"},
+                        }
+                    ],
+                    "on": {"await_agent": "draft", "confirm_output": "brief"},
+                },
             "draft": {"role": "writer", "on": {"await_agent": "_done"}},
         },
     }
@@ -2067,18 +2083,26 @@ def test_brief_confirm_output_routes_to_review_confirmation(tmp_path: Path, monk
         "entry_point": "brief",
         "roles": {"editor": {"default_agent": "Roger"}},
         "steps": {
-            "brief": {
-                "role": "editor",
-                "on": {"confirm_output": "brief", "await_agent": "draft"},
-            },
+                "brief": {
+                    "role": "editor",
+                    "skill": "cafe-brief_first",
+                    "human_tasks": [
+                        {
+                            "trigger": "confirm_output",
+                            "task_id": "editorial-output-review",
+                            "outcomes": {"approve": "draft", "revise": "brief"},
+                        }
+                    ],
+                    "on": {"confirm_output": "brief", "await_agent": "draft"},
+                },
             "draft": {"role": "writer", "on": {"await_agent": "_done"}},
         },
     }
 
     with patch(
-        "cafe.ui.cli_shared._handle_review_confirmation",
-        return_value="draft",
-    ) as mock_confirm:
+        "cafe.ui.human_tasks.collect_human_task_payload",
+        return_value={"task": "editorial-output-review", "decision": "approve"},
+    ):
         result = _handle_user_phase(
             issue_name="editorial-confirm",
             issue_dir=issue_dir,
@@ -2087,7 +2111,6 @@ def test_brief_confirm_output_routes_to_review_confirmation(tmp_path: Path, monk
         )
 
     assert result == "draft"
-    mock_confirm.assert_called_once()
 
 
 def test_user_phase_no_changes_needed_resumes_develop_without_generic_menu(
@@ -2104,9 +2127,17 @@ def test_user_phase_no_changes_needed_resumes_develop_without_generic_menu(
         "playbook": {"id": "default"},
         "roles": {"developer": {"default_agent": "David"}},
         "steps": {
-            "develop": {
-                "role": "developer",
-                "on": {
+                "develop": {
+                    "role": "developer",
+                    "skill": "cafe-develop",
+                    "human_tasks": [
+                        {
+                            "trigger": "no_changes_needed",
+                            "task_id": "no-change-decision",
+                            "outcomes": {"agree": "review", "disagree": "develop"},
+                        }
+                    ],
+                    "on": {
                     "await_agent": "review",
                     "manual_handoff": "pr",
                     "no_changes_needed": "develop",
@@ -2129,7 +2160,13 @@ def test_user_phase_no_changes_needed_resumes_develop_without_generic_menu(
         source="test",
     )
 
-    with patch("cafe.ui.cli_shared._handle_user_phase_generic") as mock_generic:
+    with (
+        patch("cafe.ui.cli_shared._handle_user_phase_generic") as mock_generic,
+        patch(
+            "cafe.ui.human_tasks.collect_human_task_payload",
+            return_value={"task": "no-change-decision", "decision": "agree"},
+        ),
+    ):
         result = _handle_user_phase(
             issue_name="issue-no-changes",
             issue_dir=issue_dir,
@@ -2137,15 +2174,15 @@ def test_user_phase_no_changes_needed_resumes_develop_without_generic_menu(
             blackboard=blackboard,
         )
 
-    assert result == "develop"
+    assert result == "review"
     mock_generic.assert_not_called()
     reloaded = store.load_or_create("develop", playbook_id="default")
-    assert reloaded.current_step == "develop"
+    assert reloaded.current_step == "review"
     assert reloaded.handoff_contract is not None
     assert reloaded.handoff_contract.to_owner == HandoffOwner.AGENT
-    assert reloaded.handoff_contract.to_step == "develop"
+    assert reloaded.handoff_contract.to_step == "review"
     assert reloaded.handoff_contract.intent == HandoffIntent.AWAIT_AGENT
-    assert any(event.event_type == "no_changes_needed_resume" for event in reloaded.events)
+    assert any(event.event_type == "human_task_completed" for event in reloaded.events)
 
 
 def test_workflow_command_user_owner_can_complete_workflow(tmp_path: Path, monkeypatch) -> None:
@@ -2397,6 +2434,14 @@ def test_user_phase_need_clarification_collects_questions_and_resumes_step(
         "steps": {
             "spec": {
                 "role": "pm",
+                "skill": "cafe-spec",
+                "human_tasks": [
+                    {
+                        "trigger": "need_clarification",
+                        "task_id": "clarification-answers",
+                        "outcomes": {"submit": "spec"},
+                    }
+                ],
                 "on": {"need_clarification": "spec", "await_agent": "plan"},
             },
             "plan": {"role": "developer", "on": {}},
@@ -2415,29 +2460,10 @@ def test_user_phase_need_clarification_collects_questions_and_resumes_step(
         source="test",
     )
 
-    def fake_interactive_qa(questions, **kwargs):
-        assert questions[0].title == "Confirm scope?"
-        (spec_iter_dir / "output.md").write_text(
-            "# Updated Spec Draft\n\nUpdated after chat.", encoding="utf-8"
-        )
-        (spec_iter_dir / "questions.xml").write_text(
-            """<?xml version="1.0" encoding="UTF-8"?>
-<questions>
-  <question id="2">
-    <title>Updated scope?</title>
-    <options>
-      <option>All roles</option>
-    </options>
-  </question>
-</questions>
-""",
-            encoding="utf-8",
-        )
-        refreshed = kwargs["after_chat"]()
-        assert refreshed[0].title == "Updated scope?"
-        return "Q1: Updated scope?\nA1: All roles"
-
-    with patch("cafe.ui.interactive_qa.interactive_qa_flow", side_effect=fake_interactive_qa):
+    with patch(
+        "cafe.ui.human_tasks.collect_human_task_payload",
+        return_value={"task": "clarification-answers", "answers": {"1": "All roles"}},
+    ):
         result = _handle_user_phase(
             issue_name="issue-clarification",
             issue_dir=issue_dir,
@@ -2447,10 +2473,9 @@ def test_user_phase_need_clarification_collects_questions_and_resumes_step(
 
     assert result == "spec"
     output = capsys.readouterr().out
-    assert "# Spec Draft" in output
-    assert "# Updated Spec Draft" in output
+    assert "Completed human task clarification-answers -> spec" in output
     next_input = issue_dir / "spec" / "iteration_002" / "user_input.md"
-    assert next_input.read_text(encoding="utf-8") == "Q1: Updated scope?\nA1: All roles"
+    assert next_input.read_text(encoding="utf-8") == "1: All roles"
     reloaded = store.load_or_create("spec", playbook_id="default")
     assert reloaded.current_step == "spec"
     assert reloaded.handoff_contract is not None
@@ -2458,7 +2483,7 @@ def test_user_phase_need_clarification_collects_questions_and_resumes_step(
     assert reloaded.handoff_contract.to_step == "spec"
 
 
-def test_user_phase_question_need_clarification_resumes_question_step(
+def test_user_phase_question_need_clarification_requires_declared_policy(
     tmp_path: Path, capsys
 ) -> None:
     issue_dir = tmp_path / ".cafe" / "issues" / "issue-research-clarify"
@@ -2504,23 +2529,19 @@ def test_user_phase_question_need_clarification_resumes_question_step(
         source="test",
     )
 
-    with patch(
-        "cafe.ui.interactive_qa.interactive_qa_flow",
-        return_value="Q1: Primary source?\nA1: Academic papers",
-    ):
-        result = _handle_user_phase(
-            issue_name="issue-research-clarify",
-            issue_dir=issue_dir,
-            playbook_data=playbook_data,
-            blackboard=blackboard,
-        )
+    result = _handle_user_phase(
+        issue_name="issue-research-clarify",
+        issue_dir=issue_dir,
+        playbook_data=playbook_data,
+        blackboard=blackboard,
+    )
 
-    assert result == "question"
-    next_input = issue_dir / "question" / "iteration_002" / "user_input.md"
-    assert next_input.read_text(encoding="utf-8") == "Q1: Primary source?\nA1: Academic papers"
+    assert result is None
+    assert not (issue_dir / "question" / "iteration_002" / "user_input.md").exists()
     reloaded = store.load_or_create("question", playbook_id="research")
-    assert reloaded.current_step == "question"
-    assert reloaded.handoff_contract.intent == HandoffIntent.AWAIT_AGENT
+    assert reloaded.current_step == "user"
+    assert reloaded.handoff_contract.intent == HandoffIntent.NEED_CLARIFICATION
+    assert reloaded.events[-1].event_type == "human_task_configuration_error"
 
 
 def test_workflow_command_done_phase_can_restart_workflow(tmp_path: Path, monkeypatch) -> None:

--- a/tests/unit/test_generic_workflow_step.py
+++ b/tests/unit/test_generic_workflow_step.py
@@ -826,6 +826,38 @@ def test_generic_workflow_step_resume_user_input_rejects_different_execution_cli
     assert resolved == "workflow execute"
 
 
+def test_first_iteration_declared_initial_task_uses_empty_optional_input(
+    tmp_path: Path,
+) -> None:
+    """Optional first-run input follows the declaration, not a plan step name."""
+    issue_dir = tmp_path / ".cafe" / "issues" / "issue-initial-task"
+    playbook = {
+        "playbook": {"id": "custom"},
+        "roles": {"writer": {"default_agent": "David"}},
+        "steps": {
+            "draft": {
+                "skill": "cafe-plan",
+                "role": "writer",
+                "human_tasks": [{"trigger": "initial", "task_id": "optional-guide"}],
+                "on": {"await_agent": "_done"},
+            }
+        },
+    }
+    executor = GenericWorkflowStepExecutor(
+        issue_dir=issue_dir,
+        issue_name="issue-initial-task",
+        playbook=playbook,
+        generic_phase=_build_loader(tmp_path),
+        agent_manager=FakeAgentManager("confirmed"),
+        git_ops=FakeGitOperations(),
+        role_agent_map={"writer": "David"},
+    )
+    executor.phase_dir = issue_dir / "draft"
+    executor.iteration = 1
+
+    assert executor._load_iteration_user_input_candidate("draft") == ""
+
+
 def test_generic_workflow_step_executor_installs_workflow_common_and_phase_skill(
     tmp_path: Path, monkeypatch
 ) -> None:

--- a/tests/unit/test_human_task_policy.py
+++ b/tests/unit/test_human_task_policy.py
@@ -1,0 +1,70 @@
+"""Tests for declarative human-task policy contracts."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from cafe.core.human_tasks import HumanTaskPolicy
+
+
+def _decisions(*ids: str) -> list[dict[str, str]]:
+    return [{"id": item, "label": item.title()} for item in ids]
+
+
+@pytest.mark.parametrize(
+    ("pattern", "input_schema", "extra"),
+    [
+        ("confirm_output", "decision", {"decisions": _decisions("confirm", "revise")}),
+        (
+            "answer_questions",
+            "answers",
+            {"questions": [{"id": "source", "prompt": "Choose a source"}]},
+        ),
+        ("revision_feedback", "feedback", {}),
+        ("no_changes_needed", "decision", {"decisions": _decisions("agree", "disagree")}),
+        ("select_next_step", "target", {"allowed_targets": ["collect"]}),
+    ],
+)
+def test_policy_accepts_each_supported_response_pattern(
+    pattern: str, input_schema: str, extra: dict,
+) -> None:
+    """Every declared pattern has one compatible, explicit answer shape."""
+    policy = HumanTaskPolicy.model_validate(
+        {
+            "id": pattern,
+            "pattern": pattern,
+            "prompt": "Provide the requested response",
+            "input_schema": input_schema,
+            **extra,
+        }
+    )
+
+    assert policy.pattern == pattern
+    assert policy.input_schema == input_schema
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"id": "unknown", "pattern": "unknown", "prompt": "Choose", "input_schema": "decision"},
+        {"id": "empty", "pattern": "revision_feedback", "prompt": "  ", "input_schema": "feedback"},
+        {
+            "id": "duplicates",
+            "pattern": "confirm_output",
+            "prompt": "Choose",
+            "input_schema": "decision",
+            "decisions": _decisions("confirm", "confirm"),
+        },
+        {
+            "id": "wrong-shape",
+            "pattern": "answer_questions",
+            "prompt": "Answer",
+            "input_schema": "feedback",
+        },
+    ],
+)
+def test_policy_rejects_invalid_or_incompatible_declarations(payload: dict) -> None:
+    """Malformed declarations fail before a workflow can pause for a person."""
+    with pytest.raises(ValidationError):
+        HumanTaskPolicy.model_validate(payload)

--- a/tests/unit/test_human_task_policy.py
+++ b/tests/unit/test_human_task_policy.py
@@ -5,7 +5,15 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
-from cafe.core.human_tasks import HumanTaskPolicy
+from cafe.core.human_tasks import (
+    HumanTaskBinding,
+    HumanTaskCompletion,
+    HumanTaskPolicy,
+    HumanTaskQuestion,
+    HumanTaskRejection,
+    resolve_human_task_continuation,
+    validate_human_task_completion,
+)
 
 
 def _decisions(*ids: str) -> list[dict[str, str]]:
@@ -68,3 +76,115 @@ def test_policy_rejects_invalid_or_incompatible_declarations(payload: dict) -> N
     """Malformed declarations fail before a workflow can pause for a person."""
     with pytest.raises(ValidationError):
         HumanTaskPolicy.model_validate(payload)
+
+
+def test_interactive_and_json_answers_normalize_to_the_same_completion() -> None:
+    """Every transport reaches the same answer and agent-facing input boundary."""
+    policy = HumanTaskPolicy.model_validate(
+        {
+            "id": "source-questions",
+            "pattern": "answer_questions",
+            "prompt": "Select the evidence source",
+            "input_schema": "answers",
+            "questions": [{"id": "source", "prompt": "Source", "options": ["Papers"]}],
+        }
+    )
+    interactive = validate_human_task_completion(policy, {"answers": {"source": "Papers"}})
+    command = validate_human_task_completion(
+        policy,
+        '{"task":"source-questions","answers":{"source":"Papers"}}',
+    )
+
+    assert interactive == command == HumanTaskCompletion(
+        task_id="source-questions", answers={"source": ("Papers",)}
+    )
+    assert interactive.agent_input() == "source: Papers"
+
+
+def test_dynamic_question_answers_require_every_current_xml_question() -> None:
+    """The caller-provided XML contract governs both interactive and command answers."""
+    policy = HumanTaskPolicy.model_validate(
+        {
+            "id": "clarification-answers",
+            "pattern": "answer_questions",
+            "prompt": "Answer the pending questions",
+            "input_schema": "answers",
+            "questions_from_xml": True,
+        }
+    )
+    questions = (
+        HumanTaskQuestion(id="scope", prompt="Scope", options=("Small",)),
+        HumanTaskQuestion(id="compatibility", prompt="Compatibility", options=("Yes",)),
+    )
+
+    incomplete = validate_human_task_completion(
+        policy,
+        {"answers": {"scope": "Small"}},
+        questions=questions,
+    )
+    complete = validate_human_task_completion(
+        policy,
+        {"answers": {"scope": "Small", "compatibility": "Yes"}},
+        questions=questions,
+    )
+
+    assert isinstance(incomplete, HumanTaskRejection)
+    assert complete == HumanTaskCompletion(
+        task_id="clarification-answers",
+        answers={"scope": ("Small",), "compatibility": ("Yes",)},
+    )
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        '{"task":"review","decision":"unknown"}',
+        '{"task":"other","decision":"confirm"}',
+        '{"task":"review","decision":"revise"}',
+        "not-json",
+    ],
+)
+def test_invalid_completion_has_no_continuation(payload: str) -> None:
+    """Incomplete or unsupported decisions remain actionable and un-routed."""
+    policy = HumanTaskPolicy.model_validate(
+        {
+            "id": "review",
+            "pattern": "confirm_output",
+            "prompt": "Review output",
+            "input_schema": "decision",
+            "decisions": [
+                {"id": "confirm", "label": "Approve"},
+                {"id": "revise", "label": "Revise", "requires_feedback": True},
+            ],
+        }
+    )
+
+    result = validate_human_task_completion(policy, payload)
+
+    assert isinstance(result, HumanTaskRejection)
+
+
+def test_continuation_must_be_declared_by_binding_and_playbook() -> None:
+    """A decision cannot use an undeclared or unavailable target."""
+    policy = HumanTaskPolicy.model_validate(
+        {
+            "id": "choose-step",
+            "pattern": "select_next_step",
+            "prompt": "Choose a next step",
+            "input_schema": "target",
+            "allowed_targets": ["collect"],
+        }
+    )
+    completion = validate_human_task_completion(policy, {"target": "collect"})
+
+    assert isinstance(completion, HumanTaskCompletion)
+    result = resolve_human_task_continuation(
+        policy=policy,
+        binding=HumanTaskBinding(
+            trigger="need_clarification", task_id="choose-step", allowed_targets=("collect",)
+        ),
+        completion=completion,
+        playbook_steps=["draft"],
+    )
+
+    assert isinstance(result, HumanTaskRejection)

--- a/tests/unit/test_native_user_input_hook.py
+++ b/tests/unit/test_native_user_input_hook.py
@@ -12,8 +12,8 @@ from cafe.core.hooks.native import (
     PRLinkOpener,
     UserInputCollector,
 )
-from cafe.core.workflow_models import StepExecutionResult
 from cafe.core.status_codes import PhaseStatusCode
+from cafe.core.workflow_models import StepExecutionResult
 from cafe.phases.generic_phase import GenericPhaseExecution
 from cafe.phases.generic_workflow_step import GenericWorkflowStepExecutor
 
@@ -398,24 +398,25 @@ def test_user_input_collector_prompts_initial_plan_user_input_on_first_iteration
     hook = UserInputCollector()
 
     with patch(
-        "cafe.core.hooks.native.prompt_multiline", return_value="Follow strict TDD first"
+        "cafe.ui.inquirer_prompts.prompt_multiline", return_value="Follow strict TDD first"
     ) as mock_prompt:
         result = hook.run(
             stage="prepare_input",
             phase=phase,
             step_name="plan",
-            step_def={"role": "developer"},
+            step_def={
+                "role": "developer",
+                "skill": "cafe-plan",
+                "human_tasks": [{"trigger": "initial", "task_id": "development-guide"}],
+            },
             agent_name="David",
         )
 
     assert result.context_updates["user_input"] == "Follow strict TDD first"
-    assert result.events == [
-        {"type": "user_input_collected", "step": "plan", "source": "initial_prompt"}
-    ]
+    assert result.events[0]["type"] == "human_task_completed"
     assert phase.step_user_inputs["plan"] == "Follow strict TDD first"
     prompt_text = mock_prompt.call_args.args[0]
-    assert "Suggested content:" in prompt_text
-    assert "Technical solution/direction" in prompt_text
+    assert prompt_text == "Please enter development guide (can be left empty)"
 
 
 def test_user_input_collector_skips_initial_plan_prompt_in_noninteractive_mode(
@@ -427,19 +428,21 @@ def test_user_input_collector_skips_initial_plan_prompt_in_noninteractive_mode(
     phase.interactive = False
     hook = UserInputCollector()
 
-    with patch("cafe.core.hooks.native.prompt_multiline") as mock_prompt:
+    with patch("cafe.ui.inquirer_prompts.prompt_multiline") as mock_prompt:
         result = hook.run(
             stage="prepare_input",
             phase=phase,
             step_name="plan",
-            step_def={"role": "developer"},
+            step_def={
+                "role": "developer",
+                "skill": "cafe-plan",
+                "human_tasks": [{"trigger": "initial", "task_id": "development-guide"}],
+            },
             agent_name="David",
         )
 
     assert result.context_updates["user_input"] == ""
-    assert result.events == [
-        {"type": "user_input_collected", "step": "plan", "source": "initial_prompt"}
-    ]
+    assert result.events[0]["type"] == "human_task_completed"
     assert phase.step_user_inputs["plan"] == ""
     mock_prompt.assert_not_called()
 

--- a/tests/unit/test_no_changes_needed_handler.py
+++ b/tests/unit/test_no_changes_needed_handler.py
@@ -7,6 +7,14 @@ from cafe.core.hooks.native import NoChangesNeededHandler, UserInputCollector
 from cafe.core.status_codes import PhaseStatusCode
 
 
+def _no_change_step_def() -> dict:
+    return {
+        "role": "developer",
+        "skill": "cafe-develop",
+        "human_tasks": [{"trigger": "no_changes_needed", "task_id": "no-change-decision"}],
+    }
+
+
 class _FakeDevelopStep:
     def __init__(self, issue_dir: Path, iteration: int = 2, interactive: bool = True) -> None:
         self.issue_dir = issue_dir
@@ -45,6 +53,7 @@ def test_no_changes_handler_retries_when_output_missing(tmp_path: Path, monkeypa
     result = handler.run(
         stage="after_execute",
         step_name="develop",
+        step_def=_no_change_step_def(),
         response="no_changes_needed",
         context={"output_file": str(output_file)},
     )
@@ -69,6 +78,7 @@ def test_no_changes_handler_pauses_when_reasoning_present(tmp_path: Path, monkey
     result = handler.run(
         stage="after_execute",
         step_name="develop",
+        step_def=_no_change_step_def(),
         response="no_changes_needed",
         context={"output_file": str(output_file)},
     )
@@ -78,8 +88,8 @@ def test_no_changes_handler_pauses_when_reasoning_present(tmp_path: Path, monkey
     assert result.override_status_code == PhaseStatusCode.NO_CHANGES_NEEDED
 
 
-@patch("cafe.ui.inquirer_prompts.prompt_list", return_value="c")
-def test_user_input_collector_confirm_routes_manual_handoff(
+@patch("cafe.ui.inquirer_prompts.prompt_list", return_value="agree")
+def test_user_input_collector_confirm_routes_declared_successor(
     mock_prompt_list,
     tmp_path: Path,
 ) -> None:
@@ -97,12 +107,12 @@ def test_user_input_collector_confirm_routes_manual_handoff(
         stage="prepare_input",
         phase=phase,
         step_name="develop",
-        step_def={"role": "developer", "name": "develop"},
+        step_def=_no_change_step_def(),
         agent_name="David",
     )
 
-    assert result.override_status_code == PhaseStatusCode.MANUAL_HANDOFF
-    assert result.events[0]["type"] == "no_changes_user_confirmed"
+    assert result.override_status_code == PhaseStatusCode.CONFIRMED
+    assert result.events[0]["type"] == "human_task_completed"
 
 
 def test_user_input_collector_non_interactive_confirm_reads_user_input_file(
@@ -116,7 +126,9 @@ def test_user_input_collector_non_interactive_confirm_reads_user_input_file(
 
     current_iter = phase_dir / "iteration_002"
     current_iter.mkdir(parents=True, exist_ok=True)
-    (current_iter / "user_input.md").write_text("confirm", encoding="utf-8")
+    (current_iter / "user_input.md").write_text(
+        '{"task":"no-change-decision","decision":"agree"}', encoding="utf-8"
+    )
 
     _record_no_changes_event(issue_dir)
 
@@ -126,16 +138,16 @@ def test_user_input_collector_non_interactive_confirm_reads_user_input_file(
         stage="prepare_input",
         phase=phase,
         step_name="develop",
-        step_def={"role": "developer", "name": "develop"},
+        step_def=_no_change_step_def(),
         agent_name="David",
     )
 
-    assert result.override_status_code == PhaseStatusCode.MANUAL_HANDOFF
-    assert result.events[0]["type"] == "no_changes_user_confirmed"
+    assert result.override_status_code == PhaseStatusCode.CONFIRMED
+    assert result.events[0]["type"] == "human_task_completed"
 
 
 @patch("cafe.ui.inquirer_prompts.prompt_multiline", return_value="Please fix the naming")
-@patch("cafe.ui.inquirer_prompts.prompt_list", return_value="m")
+@patch("cafe.ui.inquirer_prompts.prompt_list", return_value="disagree")
 def test_user_input_collector_disagree_returns_feedback(
     mock_prompt_list, mock_multiline, tmp_path: Path
 ) -> None:
@@ -153,19 +165,17 @@ def test_user_input_collector_disagree_returns_feedback(
         stage="prepare_input",
         phase=phase,
         step_name="develop",
-        step_def={"role": "developer", "name": "develop"},
+        step_def=_no_change_step_def(),
         agent_name="David",
     )
 
     assert result.context_updates["user_input"] == "Please fix the naming"
-    assert result.events[0]["type"] == "no_changes_user_feedback"
+    assert result.events[0]["type"] == "human_task_completed"
 
 
-@patch("cafe.ui.chat.launch_chat_session")
-@patch("cafe.ui.inquirer_prompts.prompt_list", side_effect=["chat", "c"])
-def test_user_input_collector_chat_then_confirm(
+@patch("cafe.ui.inquirer_prompts.prompt_list", return_value="agree")
+def test_user_input_collector_decision_labels_are_policy_owned(
     mock_prompt_list,
-    mock_chat,
     tmp_path: Path,
 ) -> None:
     issue_dir = tmp_path / ".cafe" / "issues" / "demo"
@@ -182,12 +192,15 @@ def test_user_input_collector_chat_then_confirm(
         stage="prepare_input",
         phase=phase,
         step_name="develop",
-        step_def={"role": "developer", "name": "develop"},
+        step_def=_no_change_step_def(),
         agent_name="David",
     )
 
-    mock_chat.assert_called_once_with("developer", "demo")
-    assert result.override_status_code == PhaseStatusCode.MANUAL_HANDOFF
+    assert result.override_status_code == PhaseStatusCode.CONFIRMED
+    assert (
+        mock_prompt_list.call_args.args[0]
+        == "Review the implementation reasoning and choose how to continue."
+    )
 
 
 def test_user_input_collector_non_interactive_pauses_when_no_user_input_file_present(
@@ -218,9 +231,9 @@ def test_user_input_collector_non_interactive_pauses_when_no_user_input_file_pre
         stage="prepare_input",
         phase=phase,
         step_name="develop",
-        step_def={"role": "developer", "name": "develop"},
+        step_def=_no_change_step_def(),
         agent_name="David",
     )
 
     assert result.continue_pipeline is False
-    assert any(e.get("type") == "no_changes_missing_user_input" for e in result.events)
+    assert any(e.get("type") == "human_task_rejected" for e in result.events)

--- a/tests/unit/test_playbook_loader.py
+++ b/tests/unit/test_playbook_loader.py
@@ -21,6 +21,55 @@ def _write_playbook(root: Path, name: str, content: str) -> None:
     (root / f"{name}.yaml").write_text(content, encoding="utf-8")
 
 
+def test_playbook_rejects_human_task_outcome_outside_declared_steps(tmp_path: Path) -> None:
+    """A task cannot nominate a continuation absent from its own playbook."""
+    builtin_root = tmp_path / "builtin"
+    skill_dir = builtin_root / "skills" / "reviewer"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        """---
+name: reviewer
+description: reviewer
+workflow:
+  human_tasks:
+    - id: review-output
+      pattern: confirm_output
+      prompt: Review output
+      input_schema: decision
+      decisions:
+        - id: confirm
+          label: Approve
+---
+""",
+        encoding="utf-8",
+    )
+    _write_playbook(
+        builtin_root / "playbooks",
+        "invalid-human-task",
+        """
+playbook: {id: invalid-human-task}
+steps:
+  review:
+    role: reviewer
+    skill: reviewer
+    human_tasks:
+      - trigger: confirm_output
+        task_id: review-output
+        outcomes: {confirm: unknown}
+    on: {confirm_output: review, await_agent: _done}
+""",
+    )
+
+    loader = PlaybookLoader(
+        project_root=tmp_path / "project",
+        global_root=tmp_path / "global",
+        builtin_root=builtin_root,
+    )
+
+    with pytest.raises(ValueError, match="human task outcome"):
+        loader.load_model("invalid-human-task")
+
+
 def test_load_uses_project_override(tmp_path: Path) -> None:
     builtin_root = tmp_path / "builtin"
     global_root = tmp_path / "global"

--- a/tests/unit/test_playbook_loader.py
+++ b/tests/unit/test_playbook_loader.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from cafe.playbooks.loader import PlaybookLoader
+from cafe.ui.human_tasks import resolve_step_human_task
 
 
 def _write_skill(root: Path, name: str) -> None:
@@ -803,3 +804,22 @@ def test_builtin_non_software_playbooks_define_non_default_handoff_metadata() ->
     assert editorial.steps["draft"].chat_role == "writer"
     assert "implementation" not in (research.steps["question"].handoff_label or "").lower()
     assert "requirements" not in (editorial.steps["draft"].handoff_label or "").lower()
+
+
+def test_builtin_user_handoffs_resolve_nonempty_declared_policies() -> None:
+    """Builtin user pauses must not fall back to implicit development behavior."""
+    loader = PlaybookLoader()
+    triggers = {"confirm_output", "need_clarification", "no_changes_needed"}
+
+    for playbook_id in ("default", "simple", "tdd", "hotfix", "editorial", "incident", "research"):
+        playbook = loader.load(playbook_id)
+        for step_name, step in playbook["steps"].items():
+            for trigger in triggers.intersection(step.get("on", {})):
+                policy, binding = resolve_step_human_task(
+                    playbook_data=playbook,
+                    step_name=step_name,
+                    trigger=trigger,
+                )
+
+                assert policy.prompt
+                assert binding.task_id == policy.id

--- a/tests/unit/test_skill_workflow_contract.py
+++ b/tests/unit/test_skill_workflow_contract.py
@@ -59,6 +59,32 @@ def test_workflow_contract_parses_declared_inputs_checklists_and_templates() -> 
     assert contract.output_templates.catalog == "research-report"
 
 
+def test_workflow_contract_parses_reusable_human_task_defaults() -> None:
+    """Skills may own reusable response shape and participant-facing copy."""
+    contract = SkillWorkflowContract.model_validate(
+        {
+            "human_tasks": [
+                {
+                    "id": "review-output",
+                    "pattern": "confirm_output",
+                    "prompt": "Review the proposed brief",
+                    "input_schema": "decision",
+                    "decisions": [
+                        {"id": "confirm", "label": "Approve"},
+                        {
+                            "id": "revise",
+                            "label": "Request revision",
+                            "requires_feedback": True,
+                        },
+                    ],
+                }
+            ]
+        }
+    )
+
+    assert contract.human_tasks[0].id == "review-output"
+
+
 @pytest.mark.parametrize(
     "placeholder",
     ["output_file", "checklist_file", "questions_xml_file", "next_step_path"],

--- a/tests/unit/test_ui_human_tasks.py
+++ b/tests/unit/test_ui_human_tasks.py
@@ -155,6 +155,40 @@ def test_inline_multiple_choice_uses_checkbox_answers(monkeypatch) -> None:
     assert calls == [("Choose all channels", ["Email", "Events"])]
 
 
+def test_inline_single_choice_uses_declared_options(monkeypatch) -> None:
+    """Interactive single-choice responses come from the policy allowlist."""
+    calls: list[tuple[str, list[str]]] = []
+
+    def collect_list(message: str, choices: list[str], default=None) -> str:
+        calls.append((message, choices))
+        return "Email"
+
+    monkeypatch.setattr("cafe.ui.inquirer_prompts.prompt_list", collect_list)
+    monkeypatch.setattr(
+        "cafe.ui.inquirer_prompts.prompt_multiline", lambda *_args, **_kwargs: "Unlisted"
+    )
+    policy = HumanTaskPolicy.model_validate(
+        {
+            "id": "channel",
+            "pattern": "answer_questions",
+            "prompt": "Select a channel",
+            "input_schema": "answers",
+            "questions": [
+                {
+                    "id": "primary",
+                    "prompt": "Choose one channel",
+                    "options": ["Email", "Events"],
+                }
+            ],
+        }
+    )
+
+    payload = collect_human_task_payload(policy)
+
+    assert payload == {"task": "channel", "answers": {"primary": "Email"}}
+    assert calls == [("Choose one channel", ["Email", "Events"])]
+
+
 def test_command_completion_uses_the_same_policy_and_declared_destination(tmp_path: Path) -> None:
     """A JSON response advances only through its policy's permitted continuation."""
     issue_dir = tmp_path / ".cafe" / "issues" / "demo"

--- a/tests/unit/test_ui_human_tasks.py
+++ b/tests/unit/test_ui_human_tasks.py
@@ -5,8 +5,13 @@ from __future__ import annotations
 from pathlib import Path
 
 from cafe.core.blackboard import BlackboardStore, HandoffIntent, HandoffOwner
+from cafe.core.human_tasks import HumanTaskPolicy
 from cafe.skills.loader import SkillLoader
-from cafe.ui.human_tasks import apply_human_task_payload, resolve_step_human_task
+from cafe.ui.human_tasks import (
+    apply_human_task_payload,
+    collect_human_task_payload,
+    resolve_step_human_task,
+)
 
 
 def test_custom_step_resolves_its_skill_owned_human_task(tmp_path: Path) -> None:
@@ -57,6 +62,97 @@ workflow:
 
     assert policy.prompt == "Approve this editorial brief"
     assert binding.outcomes == {"approve": "draft"}
+
+
+def test_iteration_mapped_step_uses_the_selected_iteration_skill(tmp_path: Path) -> None:
+    """Iteration-specific policies must match the skill that executed the step."""
+    builtin_root = tmp_path / "builtin"
+    for skill_name, decision_id in (("first-brief", "approve"), ("revised-brief", "revise")):
+        skill_dir = builtin_root / "skills" / skill_name
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            f"""---
+name: {skill_name}
+description: test skill
+workflow:
+  human_tasks:
+    - id: review-brief
+      pattern: confirm_output
+      prompt: Review the brief
+      input_schema: decision
+      decisions:
+        - id: {decision_id}
+          label: {decision_id.title()}
+---
+""",
+            encoding="utf-8",
+        )
+    loader = SkillLoader(
+        project_root=tmp_path / "project",
+        global_root=tmp_path / "global",
+        builtin_root=builtin_root,
+    )
+
+    policy, _binding = resolve_step_human_task(
+        playbook_data={
+            "steps": {
+                "brief": {
+                    "skill": {"1": "first-brief", "default": "revised-brief"},
+                    "human_tasks": [
+                        {
+                            "trigger": "confirm_output",
+                            "task_id": "review-brief",
+                            "outcomes": {"approve": "draft"},
+                        }
+                    ],
+                }
+            }
+        },
+        step_name="brief",
+        trigger="confirm_output",
+        skill_loader=loader,
+        iteration=1,
+    )
+
+    assert [decision.id for decision in policy.decisions] == ["approve"]
+
+
+def test_inline_multiple_choice_uses_checkbox_answers(monkeypatch) -> None:
+    """Interactive inline multi-select responses retain every selected option."""
+    calls: list[tuple[str, list[str]]] = []
+
+    def collect_checkbox(message: str, choices: list[str], default=None) -> list[str]:
+        calls.append((message, choices))
+        return ["Email", "Events"]
+
+    monkeypatch.setattr("cafe.ui.inquirer_prompts.prompt_checkbox", collect_checkbox)
+    monkeypatch.setattr(
+        "cafe.ui.inquirer_prompts.prompt_multiline", lambda *_args, **_kwargs: "Email"
+    )
+    policy = HumanTaskPolicy.model_validate(
+        {
+            "id": "channels",
+            "pattern": "answer_questions",
+            "prompt": "Select channels",
+            "input_schema": "answers",
+            "questions": [
+                {
+                    "id": "channel",
+                    "prompt": "Choose all channels",
+                    "options": ["Email", "Events"],
+                    "multiple": True,
+                }
+            ],
+        }
+    )
+
+    payload = collect_human_task_payload(policy)
+
+    assert payload == {
+        "task": "channels",
+        "answers": {"channel": ["Email", "Events"]},
+    }
+    assert calls == [("Choose all channels", ["Email", "Events"])]
 
 
 def test_command_completion_uses_the_same_policy_and_declared_destination(tmp_path: Path) -> None:

--- a/tests/unit/test_ui_human_tasks.py
+++ b/tests/unit/test_ui_human_tasks.py
@@ -1,0 +1,161 @@
+"""Tests for policy-backed human-task UI coordination."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from cafe.core.blackboard import BlackboardStore, HandoffIntent, HandoffOwner
+from cafe.skills.loader import SkillLoader
+from cafe.ui.human_tasks import apply_human_task_payload, resolve_step_human_task
+
+
+def test_custom_step_resolves_its_skill_owned_human_task(tmp_path: Path) -> None:
+    """Resolution uses declared metadata and never infers a development step name."""
+    skill_dir = tmp_path / "builtin" / "skills" / "editorial-review"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        """---
+name: editorial-review
+description: editorial review
+workflow:
+  human_tasks:
+    - id: editorial-approval
+      pattern: confirm_output
+      prompt: Approve this editorial brief
+      input_schema: decision
+      decisions:
+        - id: approve
+          label: Approve
+---
+""",
+        encoding="utf-8",
+    )
+    loader = SkillLoader(
+        project_root=tmp_path / "project",
+        global_root=tmp_path / "global",
+        builtin_root=tmp_path / "builtin",
+    )
+    policy, binding = resolve_step_human_task(
+        playbook_data={
+            "steps": {
+                "brief": {
+                    "skill": "editorial-review",
+                    "human_tasks": [
+                        {
+                            "trigger": "confirm_output",
+                            "task_id": "editorial-approval",
+                            "outcomes": {"approve": "draft"},
+                        }
+                    ],
+                }
+            }
+        },
+        step_name="brief",
+        trigger="confirm_output",
+        skill_loader=loader,
+    )
+
+    assert policy.prompt == "Approve this editorial brief"
+    assert binding.outcomes == {"approve": "draft"}
+
+
+def test_command_completion_uses_the_same_policy_and_declared_destination(tmp_path: Path) -> None:
+    """A JSON response advances only through its policy's permitted continuation."""
+    issue_dir = tmp_path / ".cafe" / "issues" / "demo"
+    store = BlackboardStore(issue_dir)
+    blackboard = store.load_or_create("spec", playbook_id="default")
+    store.update_handoff_contract(
+        blackboard,
+        from_step="spec",
+        to_owner=HandoffOwner.USER,
+        to_step="user",
+        intent=HandoffIntent.CONFIRM_OUTPUT,
+        source="test",
+    )
+    playbook = {
+        "steps": {
+            "spec": {
+                "skill": "cafe-spec",
+                "human_tasks": [
+                    {
+                        "trigger": "confirm_output",
+                        "task_id": "output-review",
+                        "outcomes": {"confirm": "plan", "revise": "spec"},
+                    }
+                ],
+            },
+            "plan": {"skill": "cafe-plan"},
+        }
+    }
+
+    result = apply_human_task_payload(
+        issue_dir=issue_dir,
+        playbook_data=playbook,
+        blackboard=blackboard,
+        from_step="spec",
+        trigger="confirm_output",
+        raw_payload='{"task":"output-review","decision":"confirm"}',
+        source="command",
+    )
+
+    assert result.target == "plan"
+    reloaded = store.load_or_create("spec", playbook_id="default")
+    assert reloaded.current_step == "plan"
+    assert reloaded.handoff_contract.to_owner == HandoffOwner.AGENT
+    assert reloaded.handoff_contract.to_step == "plan"
+
+
+def test_dynamic_xml_questions_reject_incomplete_command_answers(tmp_path: Path) -> None:
+    """Command validation reads the same current XML question set as the UI."""
+    issue_dir = tmp_path / ".cafe" / "issues" / "dynamic-questions"
+    iteration_dir = issue_dir / "spec" / "iteration_001"
+    iteration_dir.mkdir(parents=True)
+    (iteration_dir / "questions.xml").write_text(
+        (
+            "<questions>\n"
+            "  <question id=\"scope\"><title>Scope?</title><options><option>Small</option>"
+            "</options></question>\n"
+            "  <question id=\"compatibility\"><title>Compatibility?</title><options>"
+            "<option>Yes</option></options></question>\n"
+            "</questions>"
+        ),
+        encoding="utf-8",
+    )
+    store = BlackboardStore(issue_dir)
+    blackboard = store.load_or_create("spec", playbook_id="default")
+    store.set_current_step(blackboard, "user")
+    store.update_handoff_contract(
+        blackboard,
+        from_step="spec",
+        to_owner=HandoffOwner.USER,
+        to_step="user",
+        intent=HandoffIntent.NEED_CLARIFICATION,
+        source="test",
+    )
+    playbook = {
+        "steps": {
+            "spec": {
+                "skill": "cafe-spec",
+                "human_tasks": [
+                    {
+                        "trigger": "need_clarification",
+                        "task_id": "clarification-answers",
+                        "outcomes": {"submit": "spec"},
+                    }
+                ],
+            }
+        }
+    }
+
+    result = apply_human_task_payload(
+        issue_dir=issue_dir,
+        playbook_data=playbook,
+        blackboard=blackboard,
+        from_step="spec",
+        trigger="need_clarification",
+        raw_payload={"task": "clarification-answers", "answers": {"scope": "Small"}},
+        source="command",
+    )
+
+    assert result.rejection is not None
+    assert store.load_or_create("spec").current_step == "user"

--- a/tests/unit/test_workflow_skill_guardrails.py
+++ b/tests/unit/test_workflow_skill_guardrails.py
@@ -23,7 +23,7 @@ def test_packaged_develop_skill_has_read_only_budget() -> None:
     builtin_root = PROJECT_ROOT / "src" / "cafe" / "data" / "skills"
     text = _skill_text(builtin_root, "cafe-develop")
 
-    assert "version: 1.3.0" in text
+    assert "version: 1.4.0" in text
     assert "唯讀工具呼叫" in text
     assert "20 次" in text
     assert "failing test" in text


### PR DESCRIPTION
## Summary

Implements a reusable, declarative human-task contract layer for workflow handoffs, replacing step-specific human-interaction branches with policy-driven behavior and preserving default workflow UX while allowing non-development playbooks to define their own wording and outcomes.

## Changes

- References the requirement: *Move user handoff policies into declarative human-task contracts* and aligns with the confirmed implementation plan.
- Introduces typed policy and workflow model changes:
  - `src/cafe/core/human_tasks.py`
  - `src/cafe/skills/contracts.py`
  - `src/cafe/core/playbook.py`
- Removes step-specific user-input behavior from generic hooks and maps handoffs through declared tasks:
  - `src/cafe/core/hooks/native.py`
  - `src/cafe/phases/generic_workflow_step.py`
- Unifies interactive and command-driven responses under one completion validator path:
  - `src/cafe/ui/human_tasks.py`
  - `src/cafe/ui/cli_shared.py`
  - `src/cafe/ui/interactive_qa.py`
  - `src/cafe/ui/commands/workflow.py`
- Completes policy-driven built-in declarations and preserves existing wording/flow outcomes:
  - `src/cafe/data/playbooks/default.yaml`
  - `src/cafe/data/playbooks/tdd.yaml`
  - `src/cafe/data/skills/write-cafe-playbook/references/playbook-spec.md`
  - `src/cafe/data/skills/write-cafe-phase/references/skill-spec.md`
- Adds test coverage for contract validation, generic flow handling, and integration behavior.
- Major commits included:
  - `fe20e2f` workflow: define declarative human-task contracts
  - `c56cffb` workflow: unify human task handoffs
  - `394c2f1` workflow: declare builtin human-task policies
  - `90256ed` test: cover human-task journeys
  - `9ed45b5` test: update develop skill guardrail
  - `410e714` fix: address human task review feedback
  - `a5f95a0` fix: preserve tdd human task behavior

## Test Plan

- Run focused unit/integration suites for human-task policy resolution, completion validation, and CLI behavior (as added during this issue).
- Confirm full suite health:
  - `pytest -q` (reported 2,449 passed, 1 skipped, 1 xfailed)
  - `cafe audit`
  - `ruff check` for touched modules