### PR TITLE
Ignore strategic actions inside hyphenated descriptors

### DIFF
--- a/src/cafe/core/alignment.py
+++ b/src/cafe/core/alignment.py
@@ -605,6 +605,13 @@ def _matches_actionable_change_intent(
     target_patterns: Sequence[re.Pattern[str]],
 ) -> bool:
     for action in _STRATEGIC_CHANGE_ACTION_RE.finditer(text):
+        if (
+            action.start() > 0
+            and text[action.start() - 1] == "-"
+            or action.end() < len(text)
+            and text[action.end()] == "-"
+        ):
+            continue
         clause_start, clause_end = _clause_bounds(text, action.start())
         line_prefix = text[clause_start : action.start()].rstrip()
         nearby_prefix = line_prefix[-32:]

--- a/tests/unit/test_alignment_policy.py
+++ b/tests/unit/test_alignment_policy.py
@@ -565,6 +565,26 @@ def test_negated_requirement_does_not_escalate_trusted_boundary_change(
     assert not any(rule.rule_id == "trusted_capability_boundary" for rule in result.triggered_rules)
 
 
+def test_hyphenated_descriptor_is_not_a_strategic_change_action(
+    tmp_path: Path,
+) -> None:
+    plan_text = """
+    This supports the roadmap principle of evolving the repo-defined contract
+    without expanding runtime or host capabilities.
+    """
+
+    result = evaluate_alignment_policy(
+        AlignmentPolicyInput(step_name="develop", artifacts={"plan": plan_text}),
+        strategic_context=_context_with_confirmed_strategy(tmp_path),
+    )
+
+    assert result.level == AlignmentDecisionLevel.NO_ALIGNMENT
+    assert not any(
+        rule.rule_id in {"mandate_escalation:product_scope", "product_or_governance_impact"}
+        for rule in result.triggered_rules
+    )
+
+
 def test_medium_risk_records_note_only(tmp_path: Path) -> None:
     result = evaluate_alignment_policy(
         AlignmentPolicyInput(


### PR DESCRIPTION
## Summary
- prevent the alignment detector from treating action words inside hyphenated descriptors as strategic change intent
- cover the exact `repo-defined contract` false-positive found while running #350

## Validation
- `pytest tests/unit/test_alignment_policy.py` (30 passed)
- full pre-commit suite (2450 passed, 1 skipped, 1 xfailed)
- full pre-push suite (2450 passed, 1 skipped, 1 xfailed)