### PR TITLE
feat: declarative prepare field-driven workflow

### DIFF
--- a/docs/prepare_fields.md
+++ b/docs/prepare_fields.md
@@ -1,6 +1,6 @@
 # Declarative Prepare Fields
 
-This document describes the declarative prepare field contract for playbook and skill assets. When a playbook declares `fields` or `fields_ref`, interactive `cafe prepare` renders prompts from those definitions. Playbooks without declarative fields keep the legacy `commands.prepare` interactive path.
+This document describes the declarative prepare field contract for playbook and skill assets. A playbook that offers interactive preparation declares exactly one of `fields` or `fields_ref`; `cafe prepare` then renders and persists only those definitions. Bundled playbooks must use this contract. Older project/global playbooks without fields temporarily use the legacy adapter and receive a migration warning on every interactive prepare run.
 
 ## PrepareField schema
 
@@ -11,9 +11,13 @@ Each prepare question is declared as one field object:
 | `id` | yes | Stable identifier (for example `input_method`, `quick_rigor`) |
 | `type` | yes | `enum`, `boolean`, `template`, `text`, or `setup_mode` |
 | `label` | yes | User-facing label |
-| `write` | yes* | Issue config target (`spec.rigor`, `plan.template`, `pr.auto_create`, or `<step>.template`) |
+| `write` | yes* | Issue config target (`<step>.<config-key>`) |
 | `help` | no | Optional help text |
 | `default` | no | Default value when applicable |
+| `non_interactive_default` | no | Default used only by `--no-interactive`; otherwise `default` is used |
+| `non_interactive` | no | Whether the default participates in non-interactive setup (default `true`) |
+| `required` | no | Reject a missing non-interactive value when no default is declared |
+| `normalize` | no | Boundary normalizer; currently `github_issue` is valid only for `spec.issue_id` |
 | `choices` | yes for `enum` / `setup_mode` | `{ value, label, description? }` entries |
 | `show_when` | no | Simple visibility conditions |
 | `group` | no | Logical grouping (`input`, `setup`, `quick_defaults`, `custom`) |
@@ -23,9 +27,13 @@ Allowed `write` targets:
 - `spec.rigor`, `spec.template`, `spec.sync_github`, `spec.input_method`, `spec.issue_id`
 - `plan.template`, `plan.sync_github`
 - `pr.auto_create`, `pr.post_todo_list`
-- `<step>.template` for a playbook step whose selected skill declares an `output_templates` catalog
+- `<declared-step>.<config-key>` for any step declared in the same playbook
 
 `setup_mode` fields describe the setup-mode chooser and must not declare `write`.
+
+Template fields targeting a custom step still require that step's selected skill to
+declare an output-template catalog. Non-template workflow-owned fields do not need
+development-specific `spec`, `plan`, or `pr` configuration.
 
 Optional document metadata:
 
@@ -63,7 +71,7 @@ commands:
 
 `fields` and `fields_ref` are mutually exclusive.
 
-When a playbook keeps legacy `commands.prepare` blocks **and** declares `fields` / `fields_ref`, `cafe playbook validate` checks semantic parity between the legacy metadata and the declarative fields.
+When a migration playbook keeps legacy `commands.prepare` blocks **and** declares `fields` / `fields_ref`, `cafe playbook validate` checks their semantic parity. New field-driven playbooks should keep all prompt copy, choices, conditions, and defaults in the field document instead.
 
 ## `fields_ref` sources
 
@@ -118,7 +126,7 @@ The built-in default playbook references:
 
 `src/cafe/data/skills/cafe-spec/assets/prepare/default_prepare_fields.yaml`
 
-That asset fully describes the current default prepare flow, including setup mode selection, quick/custom branches, GitHub-only prompts, and sync/PR defaults. Legacy `commands.prepare` remains on `src/cafe/data/playbooks/default.yaml` for runtime behavior and parity validation.
+That asset fully describes the current default prepare flow, including setup mode selection, quick/custom branches, GitHub-only prompts, and interactive/non-interactive defaults. `default.yaml` contains only the reference, so there is no parallel prompt definition.
 
 ## Validation entry points
 
@@ -126,7 +134,34 @@ That asset fully describes the current default prepare flow, including setup mod
 - `load_playbook_file()` / `PlaybookLoader.load_model()`
 - `PrepareProfile.resolved_prepare_fields()` (read-only contract access; does not drive UI)
 
-Omitting both `fields` and `fields_ref` preserves backward-compatible behavior.
+Bundled playbooks with interactive prepare are rejected when they omit both `fields`
+and `fields_ref`. A bundled playbook with no interactive setup must explicitly set
+`commands.prepare.prompt_for_spec_plan_config: false`. Project/global playbooks may
+temporarily omit both sources, but interactive use emits a migration warning; migrate
+them by adding an inline `fields` document or `fields_ref`.
+
+## Workflow-owned fields
+
+A non-development workflow can own its setup without declaring unrelated development
+settings:
+
+```yaml
+commands:
+  prepare:
+    fields:
+      - id: audience
+        type: enum
+        label: Audience
+        write: synthesize.audience
+        default: internal
+        choices:
+          - {value: internal, label: Internal}
+          - {value: public, label: Public}
+```
+
+Both interactive and non-interactive preparation persist only
+`synthesize.audience`; no `--input-method`, `spec`, `plan`, or `pr` block is
+introduced.
 
 ## Custom step template fields
 

--- a/examples/non_software/editorial/.cafe/playbooks/editorial.yaml
+++ b/examples/non_software/editorial/.cafe/playbooks/editorial.yaml
@@ -63,4 +63,8 @@ steps:
     "on":
       await_agent: _done
 
+commands:
+  prepare:
+    prompt_for_spec_plan_config: false
+
 entry_point: brief

--- a/src/cafe/core/playbook.py
+++ b/src/cafe/core/playbook.py
@@ -488,6 +488,8 @@ def validate_playbook(
         model,
         skill_loader=skill_loader,
         playbook_path=path,
+        source=source,
+        warnings=warnings,
     )
 
     if warnings and strict:
@@ -500,54 +502,75 @@ def _validate_prepare_metadata(
     *,
     skill_loader: SkillLoader,
     playbook_path: Path,
+    source: str,
+    warnings: List[str],
 ) -> None:
     """Validate prepare metadata templates, rigor constraints, and declarative fields."""
     prepare = resolve_prepare_config(model)
+    declared_prepare = model.commands.prepare if model.commands else None
     spec_manager = TemplateManager(template_type="spec")
     plan_manager = TemplateManager(template_type="plan")
     template_managers = declared_template_managers(model, skill_loader)
-
-    _validate_prepare_template(
-        spec_manager,
-        prepare.quick_setup.spec.template,
-        "commands.prepare.quick_setup.spec.template",
-    )
-    _validate_prepare_template(
-        plan_manager,
-        prepare.quick_setup.plan.template,
-        "commands.prepare.quick_setup.plan.template",
-    )
-    _validate_prepare_template(
-        spec_manager,
-        prepare.non_interactive_defaults.spec_template,
-        "commands.prepare.non_interactive_defaults.spec_template",
-    )
-    _validate_prepare_template(
-        plan_manager,
-        prepare.non_interactive_defaults.plan_template,
-        "commands.prepare.non_interactive_defaults.plan_template",
-    )
-
-    allowed_rigor = set(prepare.constraints.rigor)
-    if prepare.quick_setup.spec.rigor not in allowed_rigor:
-        raise ValueError(
-            "commands.prepare.quick_setup.spec.rigor "
-            f"{prepare.quick_setup.spec.rigor!r} is not listed in "
-            f"commands.prepare.constraints.rigor"
-        )
-    if prepare.non_interactive_defaults.rigor not in allowed_rigor:
-        raise ValueError(
-            "commands.prepare.non_interactive_defaults.rigor "
-            f"{prepare.non_interactive_defaults.rigor!r} is not listed in "
-            f"commands.prepare.constraints.rigor"
-        )
 
     parsed_fields = resolve_prepare_fields(
         prepare,
         playbook_path=playbook_path,
         skill_loader=skill_loader,
     )
+
     if parsed_fields is None:
+        if (
+            source == "builtin"
+            and declared_prepare is not None
+            and prepare.prompt_for_spec_plan_config
+        ):
+            raise ValueError(
+                "bundled interactive prepare requires commands.prepare.fields or "
+                "commands.prepare.fields_ref"
+            )
+        if source in {"project", "global"} and (
+            declared_prepare is None or prepare.prompt_for_spec_plan_config
+        ):
+            warnings.append(
+                "Legacy interactive prepare is deprecated; migrate to "
+                "commands.prepare.fields or commands.prepare.fields_ref."
+            )
+
+    if parsed_fields is None:
+        _validate_prepare_template(
+            spec_manager,
+            prepare.quick_setup.spec.template,
+            "commands.prepare.quick_setup.spec.template",
+        )
+        _validate_prepare_template(
+            plan_manager,
+            prepare.quick_setup.plan.template,
+            "commands.prepare.quick_setup.plan.template",
+        )
+        _validate_prepare_template(
+            spec_manager,
+            prepare.non_interactive_defaults.spec_template,
+            "commands.prepare.non_interactive_defaults.spec_template",
+        )
+        _validate_prepare_template(
+            plan_manager,
+            prepare.non_interactive_defaults.plan_template,
+            "commands.prepare.non_interactive_defaults.plan_template",
+        )
+
+        allowed_rigor = set(prepare.constraints.rigor)
+        if prepare.quick_setup.spec.rigor not in allowed_rigor:
+            raise ValueError(
+                "commands.prepare.quick_setup.spec.rigor "
+                f"{prepare.quick_setup.spec.rigor!r} is not listed in "
+                f"commands.prepare.constraints.rigor"
+            )
+        if prepare.non_interactive_defaults.rigor not in allowed_rigor:
+            raise ValueError(
+                "commands.prepare.non_interactive_defaults.rigor "
+                f"{prepare.non_interactive_defaults.rigor!r} is not listed in "
+                f"commands.prepare.constraints.rigor"
+            )
         return
 
     has_explicit_legacy_prepare_metadata = bool(
@@ -559,6 +582,7 @@ def _validate_prepare_metadata(
         spec_manager=spec_manager,
         plan_manager=plan_manager,
         template_managers=template_managers,
+        step_names=set(model.steps),
         enforce_legacy_setup_modes=has_explicit_legacy_prepare_metadata,
     )
 

--- a/src/cafe/core/playbook.py
+++ b/src/cafe/core/playbook.py
@@ -519,11 +519,7 @@ def _validate_prepare_metadata(
     )
 
     if parsed_fields is None:
-        if (
-            source == "builtin"
-            and declared_prepare is not None
-            and prepare.prompt_for_spec_plan_config
-        ):
+        if source == "builtin" and prepare.prompt_for_spec_plan_config:
             raise ValueError(
                 "bundled interactive prepare requires commands.prepare.fields or "
                 "commands.prepare.fields_ref"

--- a/src/cafe/core/prepare_fields.py
+++ b/src/cafe/core/prepare_fields.py
@@ -34,7 +34,7 @@ ALLOWED_FIELD_TYPES = frozenset({"enum", "boolean", "template", "text", "setup_m
 ALLOWED_SHOW_WHEN_KEYS = frozenset({"github_repo", "issue_id_present", "setup_mode"})
 ALLOWED_SETUP_MODES = frozenset({"quick", "custom"})
 ALLOWED_STATIC_SUFFIXES = frozenset({".yaml", ".yml", ".json"})
-STEP_TEMPLATE_WRITE_PATTERN = re.compile(r"^[a-z][a-z0-9_-]*\.template$")
+WRITE_TARGET_PATTERN = re.compile(r"^[a-z][a-z0-9_-]*\.[a-z][a-z0-9_-]*$")
 
 SKILL_FIELDS_REF_PATTERN = re.compile(r"^skill://([^/]+)/assets/(.+)$")
 
@@ -79,6 +79,10 @@ class PrepareField(BaseModel):
     write: Optional[str] = None
     help: Optional[str] = None
     default: Optional[Any] = None
+    non_interactive_default: Optional[Any] = None
+    non_interactive: bool = True
+    required: bool = False
+    normalize: Optional[Literal["github_issue"]] = None
     choices: List[PrepareFieldChoice] = Field(default_factory=list)
     show_when: Optional[ShowWhen] = None
     group: Optional[str] = None
@@ -95,11 +99,8 @@ class PrepareField(BaseModel):
     def _validate_write(cls, value: Optional[str]) -> Optional[str]:
         if value is None:
             return value
-        if value not in ALLOWED_WRITE_TARGETS and not STEP_TEMPLATE_WRITE_PATTERN.fullmatch(value):
-            raise ValueError(
-                f"unknown write target {value!r}; "
-                f"must be one of {sorted(ALLOWED_WRITE_TARGETS)}"
-            )
+        if not WRITE_TARGET_PATTERN.fullmatch(value):
+            raise ValueError(f"invalid write target {value!r}; expected '<step>.<config-key>'")
         return value
 
     @model_validator(mode="after")
@@ -110,6 +111,25 @@ class PrepareField(BaseModel):
             raise ValueError(f"setup_mode field {self.id!r} must not declare write target")
         if self.type != "setup_mode" and self.write is None:
             raise ValueError(f"field {self.id!r} requires write target")
+        if self.type == "boolean":
+            for name, value in (
+                ("default", self.default),
+                ("non_interactive_default", self.non_interactive_default),
+            ):
+                if value is not None and not isinstance(value, bool):
+                    raise ValueError(f"field {self.id!r} {name} must be a boolean")
+        if self.type == "enum":
+            values = {choice.value for choice in self.choices}
+            for name, value in (
+                ("default", self.default),
+                ("non_interactive_default", self.non_interactive_default),
+            ):
+                if value is not None and value not in values:
+                    raise ValueError(
+                        f"field {self.id!r} {name} {value!r} is not one of its choices"
+                    )
+        if self.normalize == "github_issue" and self.write != "spec.issue_id":
+            raise ValueError(f"field {self.id!r} github_issue normalization requires spec.issue_id")
         return self
 
 
@@ -175,9 +195,7 @@ def _validate_relative_path(path: str, *, field_name: str) -> Path:
         raise ValueError(f"{field_name} must not reference scripts/")
     suffix = candidate.suffix.lower()
     if suffix not in ALLOWED_STATIC_SUFFIXES:
-        raise ValueError(
-            f"{field_name} must use one of {sorted(ALLOWED_STATIC_SUFFIXES)}"
-        )
+        raise ValueError(f"{field_name} must use one of {sorted(ALLOWED_STATIC_SUFFIXES)}")
     return candidate
 
 
@@ -282,6 +300,7 @@ def validate_field_semantics(
     spec_manager: TemplateManager,
     plan_manager: TemplateManager,
     template_managers: Optional[Dict[str, TemplateManager]] = None,
+    step_names: Optional[set[str]] = None,
     enforce_legacy_setup_modes: bool = True,
 ) -> None:
     """Apply semantic validation to loaded prepare fields."""
@@ -293,6 +312,11 @@ def validate_field_semantics(
             raise ValueError(f"duplicate prepare field id {field.id!r}")
         seen_ids.add(field.id)
         validate_show_when(field.show_when, field_id=field.id)
+
+        if field.write is not None:
+            section, _key = field.write.split(".", 1)
+            if field.write not in ALLOWED_WRITE_TARGETS and section not in (step_names or set()):
+                raise ValueError(f"field {field.id!r} targets undeclared workflow step {section!r}")
 
         if field.type == "template" and field.default is not None:
             step_name = field.write.split(".", 1)[0] if field.write else "plan"
@@ -338,9 +362,7 @@ def _validate_template_default(
     if template_name == "auto":
         return
     if not manager.template_exists(template_name):
-        raise ValueError(
-            f"field {field.id!r} references unknown template {template_name!r}"
-        )
+        raise ValueError(f"field {field.id!r} references unknown template {template_name!r}")
 
 
 def _validate_rigor_value(
@@ -370,7 +392,9 @@ def _show_when_tuple(show_when: Optional[ShowWhen]) -> tuple[tuple[str, Any], ..
     return tuple(sorted(items, key=lambda item: item[0]))
 
 
-def _legacy_field_defaults(prepare: Any) -> Dict[tuple[Optional[str], tuple[tuple[str, Any], ...]], Any]:
+def _legacy_field_defaults(
+    prepare: Any,
+) -> Dict[tuple[Optional[str], tuple[tuple[str, Any], ...]], Any]:
     quick = prepare.quick_setup
     defaults: Dict[tuple[Optional[str], tuple[tuple[str, Any], ...]], Any] = {
         ("spec.rigor", (("setup_mode", "quick"),)): quick.spec.rigor,
@@ -410,7 +434,9 @@ def _legacy_field_defaults(prepare: Any) -> Dict[tuple[Optional[str], tuple[tupl
     return defaults
 
 
-def _fields_default_map(fields: List[PrepareField]) -> Dict[tuple[Optional[str], tuple[tuple[str, Any], ...]], Any]:
+def _fields_default_map(
+    fields: List[PrepareField],
+) -> Dict[tuple[Optional[str], tuple[tuple[str, Any], ...]], Any]:
     mapping: Dict[tuple[Optional[str], tuple[tuple[str, Any], ...]], Any] = {}
     for field in fields:
         if field.type == "setup_mode" or field.write is None:
@@ -487,9 +513,7 @@ def assert_prepare_semantics_match(
         "constraints",
     ):
         if legacy_semantics[key] != fields_semantics[key]:
-            raise ValueError(
-                f"commands.prepare.fields disagree with legacy metadata for {key!r}"
-            )
+            raise ValueError(f"commands.prepare.fields disagree with legacy metadata for {key!r}")
 
     for key, expected in legacy_semantics["defaults"].items():
         actual = fields_semantics["defaults"].get(key)

--- a/src/cafe/data/playbooks/default.yaml
+++ b/src/cafe/data/playbooks/default.yaml
@@ -19,35 +19,6 @@ roles:
 
 commands:
   prepare:
-    prompt_for_spec_plan_config: true
-    setup_modes:
-      quick:
-        enabled: true
-        label: "Quick setup (use recommended defaults)"
-      custom:
-        enabled: true
-        label: "Custom configuration"
-    quick_setup:
-      spec:
-        rigor: medium
-        template: auto
-      plan:
-        template: auto
-      sync_github:
-        when_issue_id_present: true
-        when_manual_input: false
-      pr:
-        auto_create_on_github_repo: true
-        post_todo_list_when_auto_create: true
-    non_interactive_defaults:
-      rigor: medium
-      spec_template: auto
-      plan_template: default
-    input_method:
-      prompt_on_github_repo: true
-      non_github_default: manual
-    constraints:
-      rigor: [low, medium, high]
     fields_ref: skill://cafe-spec/assets/prepare/default_prepare_fields.yaml
 
 steps:

--- a/src/cafe/data/playbooks/editorial.yaml
+++ b/src/cafe/data/playbooks/editorial.yaml
@@ -13,6 +13,10 @@ roles:
     default_agent: "David"
     default_cli: "claude"
 
+commands:
+  prepare:
+    prompt_for_spec_plan_config: false
+
 steps:
   brief:
     type: skill

--- a/src/cafe/data/playbooks/incident.yaml
+++ b/src/cafe/data/playbooks/incident.yaml
@@ -9,6 +9,10 @@ roles:
     default_agent: "Casey"
     default_cli: "claude"
 
+commands:
+  prepare:
+    prompt_for_spec_plan_config: false
+
 steps:
   detect:
     type: skill

--- a/src/cafe/data/playbooks/research.yaml
+++ b/src/cafe/data/playbooks/research.yaml
@@ -9,6 +9,10 @@ roles:
     default_agent: "Morgan"
     default_cli: "claude"
 
+commands:
+  prepare:
+    prompt_for_spec_plan_config: false
+
 steps:
   question:
     type: skill

--- a/src/cafe/data/playbooks/simple.yaml
+++ b/src/cafe/data/playbooks/simple.yaml
@@ -15,35 +15,7 @@ roles:
 
 commands:
   prepare:
-    prompt_for_spec_plan_config: true
-    setup_modes:
-      quick:
-        enabled: true
-        label: "Quick setup (use recommended defaults)"
-      custom:
-        enabled: true
-        label: "Custom configuration"
-    quick_setup:
-      spec:
-        rigor: medium
-        template: auto
-      plan:
-        template: auto
-      sync_github:
-        when_issue_id_present: true
-        when_manual_input: false
-      pr:
-        auto_create_on_github_repo: true
-        post_todo_list_when_auto_create: true
-    non_interactive_defaults:
-      rigor: medium
-      spec_template: auto
-      plan_template: default
-    input_method:
-      prompt_on_github_repo: true
-      non_github_default: manual
-    constraints:
-      rigor: [low, medium, high]
+    fields_ref: skill://cafe-spec/assets/prepare/default_prepare_fields.yaml
 
 steps:
   spec:

--- a/src/cafe/data/playbooks/tdd.yaml
+++ b/src/cafe/data/playbooks/tdd.yaml
@@ -19,35 +19,7 @@ roles:
 
 commands:
   prepare:
-    prompt_for_spec_plan_config: true
-    setup_modes:
-      quick:
-        enabled: true
-        label: "Quick setup (use recommended defaults)"
-      custom:
-        enabled: true
-        label: "Custom configuration"
-    quick_setup:
-      spec:
-        rigor: medium
-        template: auto
-      plan:
-        template: auto
-      sync_github:
-        when_issue_id_present: true
-        when_manual_input: false
-      pr:
-        auto_create_on_github_repo: true
-        post_todo_list_when_auto_create: true
-    non_interactive_defaults:
-      rigor: medium
-      spec_template: auto
-      plan_template: default
-    input_method:
-      prompt_on_github_repo: true
-      non_github_default: manual
-    constraints:
-      rigor: [low, medium, high]
+    fields_ref: skill://cafe-spec/assets/prepare/default_prepare_fields.yaml
 
 steps:
   spec:

--- a/src/cafe/data/skills/cafe-spec/assets/prepare/default_prepare_fields.yaml
+++ b/src/cafe/data/skills/cafe-spec/assets/prepare/default_prepare_fields.yaml
@@ -7,6 +7,8 @@ fields:
     label: "Input method"
     help: "Choose how issue requirements are provided."
     write: spec.input_method
+    default: manual
+    required: true
     show_when:
       github_repo: true
     choices:
@@ -14,6 +16,14 @@ fields:
         label: "Manual input"
       - value: github
         label: "GitHub issue"
+
+  - id: github_issue_id
+    type: text
+    label: "GitHub issue ID or URL"
+    write: spec.issue_id
+    normalize: github_issue
+    show_when:
+      issue_id_present: true
 
   - id: setup_mode
     type: setup_mode
@@ -55,6 +65,7 @@ fields:
     label: "Plan template"
     write: plan.template
     default: auto
+    non_interactive_default: default
     group: quick_defaults
     show_when:
       setup_mode: quick
@@ -64,6 +75,7 @@ fields:
     label: "Sync spec to GitHub when issue id is present"
     write: spec.sync_github
     default: true
+    non_interactive: false
     group: quick_defaults
     show_when:
       setup_mode: quick
@@ -74,6 +86,7 @@ fields:
     label: "Sync spec to GitHub for manual input"
     write: spec.sync_github
     default: false
+    non_interactive: false
     group: quick_defaults
     show_when:
       setup_mode: quick
@@ -84,6 +97,7 @@ fields:
     label: "Sync plan to GitHub when issue id is present"
     write: plan.sync_github
     default: true
+    non_interactive: false
     group: quick_defaults
     show_when:
       setup_mode: quick
@@ -94,6 +108,7 @@ fields:
     label: "Sync plan to GitHub for manual input"
     write: plan.sync_github
     default: false
+    non_interactive: false
     group: quick_defaults
     show_when:
       setup_mode: quick
@@ -104,6 +119,7 @@ fields:
     label: "Auto create pull request"
     write: pr.auto_create
     default: true
+    non_interactive: false
     group: quick_defaults
     show_when:
       setup_mode: quick
@@ -114,6 +130,7 @@ fields:
     label: "Post PR todo list"
     write: pr.post_todo_list
     default: true
+    non_interactive: false
     group: quick_defaults
     show_when:
       setup_mode: quick
@@ -124,6 +141,7 @@ fields:
     label: "Sync spec to GitHub issue when confirmed?"
     write: spec.sync_github
     default: true
+    non_interactive: false
     group: custom
     show_when:
       setup_mode: custom
@@ -134,6 +152,7 @@ fields:
     label: "Sync plan to GitHub issue when confirmed?"
     write: plan.sync_github
     default: true
+    non_interactive: false
     group: custom
     show_when:
       setup_mode: custom
@@ -175,6 +194,7 @@ fields:
     label: "Auto create pull request"
     write: pr.auto_create
     group: custom
+    non_interactive: false
     show_when:
       setup_mode: custom
       github_repo: true
@@ -184,6 +204,7 @@ fields:
     label: "Post organized PR comments as todo list to PR?"
     write: pr.post_todo_list
     default: true
+    non_interactive: false
     group: custom
     show_when:
       setup_mode: custom

--- a/src/cafe/data/skills/write-cafe-playbook/SKILL.md
+++ b/src/cafe/data/skills/write-cafe-playbook/SKILL.md
@@ -63,7 +63,7 @@ version: 1.3.0
 - Represent optional work with a confirmed or `not_required` plan and an explicit forward skip. Do not add routine backward cycles merely to rewrite a checklist.
 - Reserve `allowed_goto` for deliberate conditional or exceptional routes. Keep the normal path in `"on"` so static simulation can explain it.
 - Quote the YAML key `"on"`. Avoid custom status tokens; use CAFE's supported intents and mappings from the reference.
-- For non-development workflows, explicitly decide `commands.prepare`; normally disable spec/plan setup prompts instead of inheriting irrelevant defaults.
+- For a workflow with interactive setup, declare `commands.prepare.fields` or `fields_ref`; own all prompt copy and defaults there. For a workflow without setup, explicitly set `commands.prepare.prompt_for_spec_plan_config: false`.
 
 ## Writing Process
 1. Inventory the conversation locale, skills, expected outputs, user gates,

--- a/src/cafe/data/skills/write-cafe-playbook/references/playbook-spec.md
+++ b/src/cafe/data/skills/write-cafe-playbook/references/playbook-spec.md
@@ -236,11 +236,13 @@ Prefer an explicit forward skip:
 - `UserInputCollector` belongs on phases that pause and resume with user feedback.
 - `PermissionRetryHandler` belongs on execution phases that may hit permission boundaries.
 - Use specialized hooks only when their implementation exists and their lifecycle stage is valid.
-- Non-software playbooks should normally set `commands.prepare.prompt_for_spec_plan_config: false`; otherwise they inherit development-oriented preparation prompts.
-- Declarative prepare fields support the fixed legacy targets plus
-  `<step>.template` when that step skill declares `workflow.output_templates`.
-  The selected value persists in the same named step block in `issue.yaml`.
-  Do not invent other domain write targets in YAML.
+- A playbook with interactive prepare must declare `commands.prepare.fields` or
+  `fields_ref`; bundled playbooks are rejected otherwise. A promptless workflow must
+  set `commands.prepare.prompt_for_spec_plan_config: false`.
+- Declarative fields may write `<declared-step>.<config-key>` and persist that value
+  in the matching `issue.yaml` block. A `template` field still requires the target
+  skill to declare `workflow.output_templates`; other workflow-owned settings need
+  no development-stage or PR metadata.
 
 ## 9. Validation Sequence
 

--- a/src/cafe/ui/commands/lifecycle.py
+++ b/src/cafe/ui/commands/lifecycle.py
@@ -183,7 +183,9 @@ def _run_legacy_prepare_prompts(
     else:
         console.print()
         console.print("[yellow]⚠️  No plan templates found. Using default template.[/yellow]")
-        console.print("[dim]    Tip: Use 'cafe template add <source> <name>' to add templates.[/dim]")
+        console.print(
+            "[dim]    Tip: Use 'cafe template add <source> <name>' to add templates.[/dim]"
+        )
 
     if profile.supports_pr_config():
         config_file = Path(".cafe") / "issues" / issue_name / "issue.yaml"
@@ -339,22 +341,30 @@ def prepare(
 
         # 1.1. Sync agents and templates at the beginning of prepare
         from cafe.ui.init_helpers import sync_agents, sync_templates
+
         cafe_dir = Path(".cafe")
         agent_success, agent_failed = sync_agents(cafe_dir)
         template_success, template_failed = sync_templates(cafe_dir)
 
         # Display sync summary
         if agent_success > 0 or template_success > 0:
-            console.print(f"  [green]✓[/green] Updated .cafe directory with {agent_success} agent(s) and {template_success} template(s)")
+            console.print(
+                f"  [green]✓[/green] Updated .cafe directory with {agent_success} agent(s) and {template_success} template(s)"
+            )
         if agent_failed > 0 or template_failed > 0:
-            console.print(f"  [yellow]⚠[/yellow] Warning: Failed to copy {agent_failed + template_failed} file(s)")
+            console.print(
+                f"  [yellow]⚠[/yellow] Warning: Failed to copy {agent_failed + template_failed} file(s)"
+            )
 
         # 1.2. Apply preset if specified
         if preset:
             from cafe.utils.preset import PresetManager, PresetNotFoundError
+
             try:
                 PresetManager().apply(preset, cafe_dir=cafe_dir)
-                console.print(f"  [green]✓[/green] Applied preset '[cyan]{preset}[/cyan]' as crew.yaml")
+                console.print(
+                    f"  [green]✓[/green] Applied preset '[cyan]{preset}[/cyan]' as crew.yaml"
+                )
             except PresetNotFoundError as e:
                 console.print(f"[red]Error: {e}[/red]")
                 raise typer.Exit(1)
@@ -395,26 +405,7 @@ def prepare(
                 console.print("[red]Error: Issue name is required in non-interactive mode.[/red]")
                 raise typer.Exit(1)
 
-        # 4. Validate non-interactive mode parameters (only when user explicitly passed --no-interactive)
-        if not interactive:
-            from cafe.ui.prepare_field_renderer import (
-                NonInteractiveCliAnswers,
-                PrepareNonInteractiveRequiredFieldError,
-                validate_non_interactive_required,
-            )
-
-            try:
-                validate_non_interactive_required(
-                    NonInteractiveCliAnswers(
-                        input_method=input_method,
-                        issue_id=issue_id,
-                    )
-                )
-            except PrepareNonInteractiveRequiredFieldError as exc:
-                console.print(f"[red]Error: {exc}[/red]")
-                raise typer.Exit(1)
-
-        # 5. Initialize Git operations
+        # 4. Initialize Git operations
         try:
             git_ops = GitOperations()
         except Exception as e:
@@ -450,8 +441,12 @@ def prepare(
             )
             console.print()
             console.print("[dim]To fix this, either:[/dim]")
-            console.print(f"[dim]  1. Switch to the base branch first: git checkout main && cafe prepare {issue_name}[/dim]")
-            console.print(f"[dim]  2. Specify the base branch explicitly: cafe prepare {issue_name} --base main[/dim]")
+            console.print(
+                f"[dim]  1. Switch to the base branch first: git checkout main && cafe prepare {issue_name}[/dim]"
+            )
+            console.print(
+                f"[dim]  2. Specify the base branch explicitly: cafe prepare {issue_name} --base main[/dim]"
+            )
             raise typer.Exit(1)
 
         # 8. Determine worktree mode (interactive or from parameter)
@@ -514,6 +509,10 @@ def prepare(
             )
             issue_id: Optional[int] = None
             if parsed_fields is None:
+                console.print(
+                    "[yellow]Deprecated: this playbook uses legacy interactive prepare "
+                    "metadata. Migrate to commands.prepare.fields or fields_ref.[/yellow]"
+                )
                 spec_config, plan_config, pr_config, issue_id = _run_legacy_prepare_prompts(
                     profile,
                     display=display,
@@ -580,12 +579,16 @@ def prepare(
                 console.print(f"[red]Error: {exc}[/red]")
                 raise typer.Exit(1)
             except PrepareNonInteractiveTemplateError as exc:
-                console.print(f"[red]Error: {exc.template_kind} template '{exc.template_name}' not found[/red]")
+                console.print(
+                    f"[red]Error: {exc.template_kind} template '{exc.template_name}' not found[/red]"
+                )
                 console.print()
                 console.print(f"[yellow]Available {exc.template_kind.lower()} templates:[/yellow]")
                 if exc.available:
                     for name, source_type in exc.available:
-                        source_label = " (system default)" if source_type == "system" else " (custom)"
+                        source_label = (
+                            " (system default)" if source_type == "system" else " (custom)"
+                        )
                         console.print(f"  - {name}{source_label}")
                 else:
                     console.print("  (none)")
@@ -649,11 +652,15 @@ def prepare(
                 # Check if branch already exists
                 if git_ops.branch_exists(feature_branch):
                     # Branch exists but worktree doesn't - create worktree with existing branch
-                    console.print(f"[dim]Branch '{feature_branch}' exists, creating worktree...[/dim]")
+                    console.print(
+                        f"[dim]Branch '{feature_branch}' exists, creating worktree...[/dim]"
+                    )
                     git_ops.run_git("worktree", "add", worktree_path, feature_branch)
                 else:
                     # Neither branch nor worktree exists - create both
-                    console.print(f"[dim]Creating worktree at '{worktree_path}' with new branch...[/dim]")
+                    console.print(
+                        f"[dim]Creating worktree at '{worktree_path}' with new branch...[/dim]"
+                    )
                     git_ops.create_worktree(worktree_path, feature_branch, base_branch)
 
             # Create actual .cafe directory in worktree instead of symlink
@@ -1294,9 +1301,7 @@ def close(
         raise typer.Exit(1)
 
 
-def restore(
-    issue_name: str = typer.Argument(..., help="Issue name to restore")
-) -> None:
+def restore(issue_name: str = typer.Argument(..., help="Issue name to restore")) -> None:
     """Restore archived issue from backup.
 
     This command restores an archived issue from ~/.cafe/projects/<project-path>/archived/<issue-name>/
@@ -1378,16 +1383,22 @@ def restore(
                 except Exception as e:
                     # If branch already exists, try without -b flag
                     if "already exists" in str(e):
-                        console.print(f"[yellow]ℹ️  Branch '{feature_branch}' already exists, creating worktree[/yellow]")
+                        console.print(
+                            f"[yellow]ℹ️  Branch '{feature_branch}' already exists, creating worktree[/yellow]"
+                        )
                         try:
                             git_ops.run_git("worktree", "add", worktree_path, feature_branch)
                             console.print(f"[green]✓ Created worktree at: {worktree_path}[/green]")
                             current_branch = feature_branch
                         except Exception as e2:
                             if "already used by worktree" in str(e2):
-                                console.print(f"[yellow]ℹ️  Branch '{feature_branch}' is already in another worktree[/yellow]")
+                                console.print(
+                                    f"[yellow]ℹ️  Branch '{feature_branch}' is already in another worktree[/yellow]"
+                                )
                             else:
-                                console.print(f"[red]❌ Error: Failed to create worktree: {e2}[/red]")
+                                console.print(
+                                    f"[red]❌ Error: Failed to create worktree: {e2}[/red]"
+                                )
                                 raise typer.Exit(1)
                     else:
                         console.print(f"[red]❌ Error: Failed to create worktree: {e}[/red]")
@@ -1404,7 +1415,9 @@ def restore(
                 git_ops.checkout_branch(feature_branch)
                 console.print(f"[green]✓ Checked out branch: {feature_branch}[/green]")
             except Exception as e:
-                console.print(f"[red]❌ Error: Failed to checkout branch {feature_branch}: {e}[/red]")
+                console.print(
+                    f"[red]❌ Error: Failed to checkout branch {feature_branch}: {e}[/red]"
+                )
                 raise typer.Exit(1)
 
         # 7. Remember main repo root before potentially changing directory
@@ -1432,18 +1445,27 @@ def restore(
                         is_in_worktree = False
 
                 if not is_in_worktree:
-                    console.print(f"[yellow]ℹ️  Navigating to worktree directory: {worktree_path}[/yellow]")
+                    console.print(
+                        f"[yellow]ℹ️  Navigating to worktree directory: {worktree_path}[/yellow]"
+                    )
                     try:
                         import os
+
                         os.chdir(worktree_path)
                         console.print(f"[green]✓ Changed directory to: {worktree_path}[/green]")
                     except Exception as e:
-                        console.print(f"[red]❌ Error: Failed to change directory to {worktree_path}: {e}[/red]")
+                        console.print(
+                            f"[red]❌ Error: Failed to change directory to {worktree_path}: {e}[/red]"
+                        )
                         raise typer.Exit(1)
 
         # 8. Prompt user for confirmation
         console.print("[yellow]⚠️  Warning: This will restore the issue from backup.[/yellow]")
-        console.print("[yellow]   Any current changes in .cafe/issues/{} will be overwritten.[/yellow]".format(issue_name))
+        console.print(
+            "[yellow]   Any current changes in .cafe/issues/{} will be overwritten.[/yellow]".format(
+                issue_name
+            )
+        )
         console.print()
 
         # Use typer.confirm for confirmation
@@ -1489,12 +1511,13 @@ def restore(
 def reset(
     phase: Optional[str] = typer.Argument(
         None,
-        help="Phase name (spec, plan, develop, review, pr). If not provided, resets the last phase with iterations"
+        help="Phase name (spec, plan, develop, review, pr). If not provided, resets the last phase with iterations",
     ),
     iteration: int = typer.Option(
         0,
-        "--iteration", "-i",
-        help="Iteration number to keep (positive, 0=remove latest only, negative=relative)"
+        "--iteration",
+        "-i",
+        help="Iteration number to keep (positive, 0=remove latest only, negative=relative)",
     ),
 ) -> None:
     """Remove iterations from a phase when agent behaves unexpectedly.
@@ -1662,7 +1685,9 @@ def reset(
                 if iter_dir.exists():
                     shutil.rmtree(iter_dir)
 
-            console.print(f"[green]✓ Removed iterations: {', '.join([f'iteration_{i:03d}' for i in sorted(to_remove)])}[/green]")
+            console.print(
+                f"[green]✓ Removed iterations: {', '.join([f'iteration_{i:03d}' for i in sorted(to_remove)])}[/green]"
+            )
         except Exception as e:
             console.print(f"[red]❌ Failed to remove iterations: {e}[/red]")
             console.print()
@@ -1700,14 +1725,20 @@ def reset(
                     "status_code": target_status_code,
                     "timestamp": target_timestamp or datetime.now().astimezone().isoformat(),
                     "iteration": target_iteration,
-                    "message": f"Phase completed with {target_status_code}" if target_status_code else "Phase reset to this iteration",
-                    "end_time": target_end_time or target_timestamp or datetime.now().astimezone().isoformat(),
+                    "message": f"Phase completed with {target_status_code}"
+                    if target_status_code
+                    else "Phase reset to this iteration",
+                    "end_time": target_end_time
+                    or target_timestamp
+                    or datetime.now().astimezone().isoformat(),
                 }
 
                 with open(status_file, "w", encoding="utf-8") as f:
                     json.dump(status_data, f, indent=2, ensure_ascii=False)
 
-                console.print(f"[green]✓ Updated {phase} phase status to iteration_{target_iteration:03d}[/green]")
+                console.print(
+                    f"[green]✓ Updated {phase} phase status to iteration_{target_iteration:03d}[/green]"
+                )
 
                 # Update iterations.jsonl to remove deleted iterations
                 if iterations_file.exists():
@@ -1718,7 +1749,11 @@ def reset(
                             if line.strip():
                                 iterations_data.append(json.loads(line))
 
-                    kept_iterations = [rec for rec in iterations_data if rec.get("iteration", 0) <= target_iteration]
+                    kept_iterations = [
+                        rec
+                        for rec in iterations_data
+                        if rec.get("iteration", 0) <= target_iteration
+                    ]
                     with open(iterations_file, "w", encoding="utf-8") as f:
                         for record in kept_iterations:
                             f.write(json.dumps(record, ensure_ascii=False) + "\n")
@@ -1730,7 +1765,9 @@ def reset(
                     status_file.unlink()
                 if iterations_file.exists():
                     iterations_file.unlink()
-                console.print(f"[green]✓ Phase restarted (status.json and iterations.jsonl removed)[/green]")
+                console.print(
+                    f"[green]✓ Phase restarted (status.json and iterations.jsonl removed)[/green]"
+                )
 
             console.print("[green]✓ Status saved[/green]")
         except Exception as e:

--- a/src/cafe/ui/phase_prompts.py
+++ b/src/cafe/ui/phase_prompts.py
@@ -20,6 +20,7 @@ def prompt_for_input_method(
     github_ops: GitHubOps,
     *,
     field: Optional[PrepareField] = None,
+    issue_field: Optional[PrepareField] = None,
 ) -> tuple[str, Optional[int]]:
     """Ask user to select input method (manual vs GitHub Issue)
 
@@ -70,14 +71,18 @@ def prompt_for_input_method(
 
     # Ask for Issue ID or URL, with error retry handling
     while True:
-        issue_input = prompt_text(
-            message="Please enter GitHub Issue ID or URL:",
-            default="",
-        )
+        issue_message = "Please enter GitHub Issue ID or URL:"
+        if issue_field is not None:
+            issue_message = issue_field.label
+            if issue_field.help:
+                issue_message = f"{issue_field.label}\n{issue_field.help}"
+        issue_input = prompt_text(message=issue_message, default="")
 
         try:
-            # Use GitHubOps to extract issue number
-            issue_id_str = github_ops.extract_issue_number(issue_input)
+            if issue_field is None or issue_field.normalize == "github_issue":
+                issue_id_str = github_ops.extract_issue_number(issue_input)
+            else:
+                issue_id_str = issue_input
             issue_id = int(issue_id_str)
 
             print()
@@ -108,11 +113,7 @@ def prompt_for_rigor(display: Display, allowed: Optional[List[str]] = None) -> s
     }
     allowed_values = allowed or ["low", "medium", "high"]
     choices = [choice_by_value[value] for value in allowed_values if value in choice_by_value]
-    default_choice = (
-        choice_by_value["medium"]
-        if "medium" in allowed_values
-        else choices[0]
-    )
+    default_choice = choice_by_value["medium"] if "medium" in allowed_values else choices[0]
 
     choice = prompt_list(
         message="Please select specification rigor level:",
@@ -204,7 +205,7 @@ def prompt_and_save_auto_create(config_file: Path, config_key: str) -> bool:
     # Save the choice to issue config
     try:
         if config_file.exists():
-            with open(config_file, 'r', encoding='utf-8') as f:
+            with open(config_file, "r", encoding="utf-8") as f:
                 config_data = yaml.safe_load(f) or {}
         else:
             config_data = {}
@@ -212,8 +213,8 @@ def prompt_and_save_auto_create(config_file: Path, config_key: str) -> bool:
         config_data = {}
 
     # Support dot notation for nested keys (e.g., "pr.auto_create")
-    if '.' in config_key:
-        keys = config_key.split('.')
+    if "." in config_key:
+        keys = config_key.split(".")
         current = config_data
         for key in keys[:-1]:
             if key not in current:
@@ -225,7 +226,7 @@ def prompt_and_save_auto_create(config_file: Path, config_key: str) -> bool:
 
     # Write back to config file
     config_file.parent.mkdir(parents=True, exist_ok=True)
-    with open(config_file, 'w', encoding='utf-8') as f:
+    with open(config_file, "w", encoding="utf-8") as f:
         yaml.dump(config_data, f, default_flow_style=False, allow_unicode=True)
 
     return auto_create

--- a/src/cafe/ui/prepare_field_renderer.py
+++ b/src/cafe/ui/prepare_field_renderer.py
@@ -131,7 +131,7 @@ def field_is_visible_for_non_interactive(
     ctx: PrepareNonInteractiveContext,
 ) -> bool:
     """Return whether one field applies in non-interactive mode."""
-    if field.type == "setup_mode" or field.id == "input_method":
+    if field.type == "setup_mode" or not field.non_interactive:
         return False
     show_when = field.show_when
     if show_when is None:
@@ -160,9 +160,7 @@ def validate_non_interactive_required(answers: NonInteractiveCliAnswers) -> None
             "--input-method is required in non-interactive mode"
         )
     if answers.input_method not in _ALLOWED_INPUT_METHODS:
-        raise PrepareNonInteractiveRequiredFieldError(
-            "--input-method must be 'manual' or 'github'"
-        )
+        raise PrepareNonInteractiveRequiredFieldError("--input-method must be 'manual' or 'github'")
     if answers.input_method == "github" and answers.issue_id is None:
         raise PrepareNonInteractiveRequiredFieldError(
             "--issue-id is required when using --input-method=github"
@@ -196,9 +194,7 @@ def _validate_field_enum_value(
     if field.write == "spec.rigor":
         allowed &= set(profile.allowed_rigor_values())
     if value not in allowed:
-        raise PrepareNonInteractiveError(
-            f"invalid value {value!r} for prepare field {field.id!r}"
-        )
+        raise PrepareNonInteractiveError(f"invalid value {value!r} for prepare field {field.id!r}")
 
 
 def validate_non_interactive_config(
@@ -241,6 +237,72 @@ def validate_non_interactive_config(
     _validate_template_name(deps.plan_template_manager, "Plan", plan_template)
 
 
+def _cli_value_for_field(
+    field: PrepareField,
+    answers: NonInteractiveCliAnswers,
+) -> tuple[bool, Any]:
+    """Return an explicitly supplied CLI value for one declared field."""
+    values = {
+        "spec.input_method": answers.input_method,
+        "spec.issue_id": answers.issue_id,
+        "spec.rigor": answers.rigor,
+        "spec.template": answers.spec_template,
+        "plan.template": answers.plan_template,
+        "spec.sync_github": answers.sync_spec_github,
+        "plan.sync_github": answers.sync_plan_github,
+        "pr.post_todo_list": answers.post_pr_todo_list,
+    }
+    if field.write == "pr.auto_create":
+        return answers.auto_create_pr, answers.auto_create_pr
+    value = values.get(field.write)
+    return value is not None, value
+
+
+def _field_default_for_non_interactive(field: PrepareField) -> Any:
+    """Return the authoritative default for a declared field."""
+    if field.non_interactive_default is not None:
+        return field.non_interactive_default
+    return field.default
+
+
+def _template_manager_for_field(
+    field: PrepareField,
+    deps: NonInteractiveResolverDeps,
+) -> TemplateManager:
+    """Resolve the template catalog declared by a template field's destination."""
+    section = field.write.split(".", 1)[0] if field.write else "plan"
+    if section == "spec":
+        return deps.spec_template_manager
+    if section == "plan":
+        return deps.plan_template_manager
+    manager = deps.template_managers.get(section)
+    if manager is None:
+        raise PrepareNonInteractiveError(
+            f"prepare field {field.id!r} targets undeclared template step {section!r}"
+        )
+    return manager
+
+
+def _validate_declared_non_interactive_input(
+    parsed_fields: ParsedPrepareFields,
+    answers: NonInteractiveCliAnswers,
+) -> None:
+    """Require input flags only when a declared input field asks for them."""
+    input_fields = [field for field in parsed_fields.fields if field.write == "spec.input_method"]
+    if not input_fields:
+        return
+    if answers.input_method is not None and answers.input_method not in _ALLOWED_INPUT_METHODS:
+        raise PrepareNonInteractiveRequiredFieldError("--input-method must be 'manual' or 'github'")
+    if any(field.required for field in input_fields) and answers.input_method is None:
+        raise PrepareNonInteractiveRequiredFieldError(
+            "--input-method is required by the declared prepare field"
+        )
+    if answers.input_method == "github" and answers.issue_id is None:
+        raise PrepareNonInteractiveRequiredFieldError(
+            "--issue-id is required when using --input-method=github"
+        )
+
+
 def resolve_non_interactive_issue_config(
     profile: PrepareProfile,
     answers: NonInteractiveCliAnswers,
@@ -249,102 +311,91 @@ def resolve_non_interactive_issue_config(
     deps: NonInteractiveResolverDeps,
 ) -> PrepareIssueConfig:
     """Resolve and validate non-interactive prepare config for issue.yaml."""
-    validate_non_interactive_required(answers)
-
-    defaults = profile.non_interactive_defaults()
-    explicit_legacy_defaults = "non_interactive_defaults" in profile.prepare.model_fields_set
-    field_defaults: dict[str, Any] = {}
-    ctx: Optional[PrepareNonInteractiveContext] = None
-    if parsed_fields is not None:
-        ctx = PrepareNonInteractiveContext(
-            is_github_repo=profile.is_github_repo,
-            issue_id=answers.issue_id if answers.input_method == "github" else None,
-            profile=profile,
+    if parsed_fields is None:
+        validate_non_interactive_required(answers)
+        defaults = profile.non_interactive_defaults()
+        rigor = answers.rigor if answers.rigor is not None else defaults.rigor
+        spec_template = (
+            answers.spec_template if answers.spec_template is not None else defaults.spec_template
         )
-        for field in visible_fields_for_non_interactive(parsed_fields, ctx):
-            if (
-                field.default is not None
-                and field.write is not None
-                and field.write not in field_defaults
-            ):
-                field_defaults[field.write] = field.default
+        plan_template = (
+            answers.plan_template if answers.plan_template is not None else defaults.plan_template
+        )
+        validate_non_interactive_config(
+            profile,
+            answers,
+            rigor=rigor,
+            spec_template=spec_template,
+            plan_template=plan_template,
+            parsed_fields=None,
+            deps=deps,
+        )
+        config = empty_issue_config()
+        set_write_value(config, "spec.input_method", answers.input_method)
+        if answers.input_method == "github" and answers.issue_id is not None:
+            set_write_value(config, "spec.issue_id", str(answers.issue_id))
+        set_write_value(config, "spec.rigor", rigor)
+        if spec_template:
+            set_write_value(config, "spec.template", spec_template)
+        if plan_template:
+            set_write_value(config, "plan.template", plan_template)
+        if answers.sync_spec_github is not None:
+            set_write_value(config, "spec.sync_github", answers.sync_spec_github)
+        if answers.sync_plan_github is not None:
+            set_write_value(config, "plan.sync_github", answers.sync_plan_github)
+        if not profile.supports_pr_config() and (
+            answers.auto_create_pr or answers.post_pr_todo_list is not None
+        ):
+            raise PrepareNonInteractiveError(
+                "--auto-create-pr and --post-pr-todo-list require a playbook with a "
+                "pr step or explicit pr.* prepare fields"
+            )
+        if profile.supports_pr_config() and profile.is_github_repo and answers.auto_create_pr:
+            set_write_value(config, "pr.auto_create", True)
+        if profile.supports_pr_config() and answers.post_pr_todo_list is not None:
+            set_write_value(config, "pr.post_todo_list", answers.post_pr_todo_list)
+        return config
 
-    default_rigor = (
-        defaults.rigor
-        if explicit_legacy_defaults
-        else field_defaults.get("spec.rigor", defaults.rigor)
+    _validate_declared_non_interactive_input(parsed_fields, answers)
+    ctx = PrepareNonInteractiveContext(
+        is_github_repo=profile.is_github_repo,
+        issue_id=answers.issue_id if answers.input_method == "github" else None,
+        profile=profile,
     )
-    default_spec_template = (
-        defaults.spec_template
-        if explicit_legacy_defaults
-        else field_defaults.get("spec.template", defaults.spec_template)
-    )
-    default_plan_template = (
-        defaults.plan_template
-        if explicit_legacy_defaults
-        else field_defaults.get("plan.template", defaults.plan_template)
-    )
-    rigor = answers.rigor if answers.rigor is not None else default_rigor
-    spec_template = answers.spec_template if answers.spec_template is not None else default_spec_template
-    plan_template = answers.plan_template if answers.plan_template is not None else default_plan_template
-
-    validate_non_interactive_config(
-        profile,
-        answers,
-        rigor=rigor,
-        spec_template=spec_template,
-        plan_template=plan_template,
-        parsed_fields=parsed_fields,
-        deps=deps,
-    )
-
     config = empty_issue_config()
-    set_write_value(config, "spec.input_method", answers.input_method)
-    if answers.input_method == "github" and answers.issue_id is not None:
-        set_write_value(config, "spec.issue_id", str(answers.issue_id))
-    set_write_value(config, "spec.rigor", rigor)
-    if spec_template:
-        set_write_value(config, "spec.template", spec_template)
-    if answers.sync_spec_github is not None:
-        set_write_value(config, "spec.sync_github", answers.sync_spec_github)
-
-    if plan_template:
-        set_write_value(config, "plan.template", plan_template)
-    if answers.sync_plan_github is not None:
-        set_write_value(config, "plan.sync_github", answers.sync_plan_github)
-
-    if parsed_fields is not None:
-        assert ctx is not None
-        for field in visible_fields_for_non_interactive(parsed_fields, ctx):
-            if field.type != "template" or field.write is None:
-                continue
-            section, _key = field.write.split(".", 1)
-            if section in {"spec", "plan"}:
-                continue
-            template_name = field_defaults.get(field.write)
-            if template_name is None:
-                continue
-            manager = deps.template_managers.get(section)
-            if manager is None:
-                raise PrepareNonInteractiveError(
-                    f"prepare field {field.id!r} targets undeclared template step {section!r}"
+    for field in parsed_fields.fields:
+        if field.type == "setup_mode" or field.write is None:
+            continue
+        is_explicit, value = _cli_value_for_field(field, answers)
+        if not field_is_visible_for_non_interactive(field, ctx) and not is_explicit:
+            continue
+        if not is_explicit:
+            value = _field_default_for_non_interactive(field)
+        if value is None:
+            if field.required:
+                raise PrepareNonInteractiveRequiredFieldError(
+                    f"prepare field {field.id!r} requires a value in non-interactive mode"
                 )
-            _validate_template_name(manager, field.label, str(template_name))
-            set_write_value(config, field.write, template_name)
+            continue
+        if field.write == "spec.issue_id":
+            value = str(value)
+        _validate_field_enum_value(field, value, profile=profile)
+        if field.type == "template":
+            _validate_template_name(
+                _template_manager_for_field(field, deps), field.label, str(value)
+            )
+        section, key = field.write.split(".", 1)
+        if key in config.section(section) and not is_explicit:
+            continue
+        set_write_value(config, field.write, value)
 
-    supports_pr_config = profile.supports_pr_config(parsed_fields)
-    if not supports_pr_config and (
+    if not profile.supports_pr_config(parsed_fields) and (
         answers.auto_create_pr or answers.post_pr_todo_list is not None
     ):
         raise PrepareNonInteractiveError(
             "--auto-create-pr and --post-pr-todo-list require a playbook with a "
             "pr step or explicit pr.* prepare fields"
         )
-    if supports_pr_config and profile.is_github_repo and answers.auto_create_pr:
-        set_write_value(config, "pr.auto_create", True)
-    if supports_pr_config and answers.post_pr_todo_list is not None:
-        set_write_value(config, "pr.post_todo_list", answers.post_pr_todo_list)
-
     return config
 
 
@@ -397,7 +448,11 @@ def apply_quick_defaults(
             continue
         set_write_value(config, field.write, field.default)
 
-    if ctx.profile.supports_pr_config(parsed) and ctx.is_github_repo and "auto_create" not in config.pr:
+    if (
+        ctx.profile.supports_pr_config(parsed)
+        and ctx.is_github_repo
+        and "auto_create" not in config.pr
+    ):
         auto_field = next(
             (field for field in parsed.fields if field.write == "pr.auto_create"),
             None,
@@ -465,9 +520,7 @@ def prompt_setup_mode(field: PrepareField, deps: RendererDeps) -> SetupMode:
 def _prompt_enum_field(field: PrepareField, ctx: PreparePromptContext, deps: RendererDeps) -> str:
     allowed = set(ctx.profile.allowed_rigor_values())
     choices = [
-        choice
-        for choice in field.choices
-        if field.write != "spec.rigor" or choice.value in allowed
+        choice for choice in field.choices if field.write != "spec.rigor" or choice.value in allowed
     ]
     if not choices:
         raise PrepareRigorError("no rigor choices available for this playbook")
@@ -495,9 +548,7 @@ def _prompt_template_field(field: PrepareField, deps: RendererDeps) -> Optional[
     if not template_names:
         if deps.console is not None:
             deps.console.print()
-            deps.console.print(
-                "[yellow]⚠️  No templates found. Using default template.[/yellow]"
-            )
+            deps.console.print("[yellow]⚠️  No templates found. Using default template.[/yellow]")
         return str(field.default) if field.default is not None else None
     if deps.console is not None:
         deps.console.print()
@@ -517,13 +568,13 @@ def prompt_custom_fields(
     custom_ctx = PreparePromptContext(
         is_github_repo=ctx.is_github_repo,
         issue_id=ctx.issue_id,
-        setup_mode="custom",
+        setup_mode=ctx.setup_mode,
         profile=ctx.profile,
         pr_auto_create=ctx.pr_auto_create,
     )
     config = empty_issue_config()
     for field in parsed.fields:
-        if field.type == "setup_mode" or field.id == "input_method":
+        if field.type == "setup_mode" or field.write in {"spec.input_method", "spec.issue_id"}:
             continue
         if field.write is None:
             continue
@@ -539,6 +590,10 @@ def prompt_custom_fields(
             value = _prompt_template_field(field, deps)
             if value is None:
                 continue
+        elif field.type == "text":
+            value = deps.prompt_text(field.label, default=str(field.default or ""))
+            if not value and field.required:
+                raise ValueError(f"prepare field {field.id!r} requires a value")
         else:
             continue
 
@@ -564,7 +619,10 @@ def run_field_driven_prepare_flow(
     spec_config = empty_issue_config()
     issue_id: Optional[int] = None
 
-    input_field = _find_field(parsed, "input_method")
+    input_field = next(
+        (field for field in parsed.fields if field.write == "spec.input_method"),
+        None,
+    )
     if input_field is not None and field_is_visible(
         input_field,
         PreparePromptContext(
@@ -582,19 +640,18 @@ def run_field_driven_prepare_flow(
         spec_config.spec["input_method"] = input_method
         if issue_id is not None:
             spec_config.spec["issue_id"] = str(issue_id)
-    elif profile.should_prompt_input_method():
-        input_method, issue_id = deps.prompt_for_input_method(deps.display, deps.github_ops)
-        spec_config.spec["input_method"] = input_method
-        if issue_id is not None:
-            spec_config.spec["issue_id"] = str(issue_id)
-    else:
-        spec_config.spec["input_method"] = profile.default_input_method()
-
+    elif input_field is not None and input_field.default is not None:
+        set_write_value(spec_config, input_field.write, input_field.default)
     ctx.issue_id = issue_id
 
-    setup_field = _find_field(parsed, "setup_mode")
+    setup_field = next((field for field in parsed.fields if field.type == "setup_mode"), None)
     if setup_field is None:
-        raise ValueError("prepare fields document must declare setup_mode")
+        custom_config = prompt_custom_fields(parsed, ctx, deps=deps)
+        spec_config.spec.update(custom_config.spec)
+        spec_config.plan.update(custom_config.plan)
+        spec_config.pr.update(custom_config.pr)
+        spec_config.steps.update(custom_config.steps)
+        return spec_config, issue_id
     if deps.console is not None:
         deps.console.print()
     setup_mode = prompt_setup_mode(setup_field, deps)
@@ -612,6 +669,10 @@ def run_field_driven_prepare_flow(
             for line in format_quick_summary(spec_config, parsed, ctx):
                 deps.console.print(f"  • {line}")
             deps.console.print()
+        if not profile.is_github_repo and any(
+            field.write == "pr.auto_create" for field in parsed.fields
+        ):
+            spec_config.pr["auto_create"] = False
         return spec_config, issue_id
 
     custom_config = prompt_custom_fields(parsed, ctx, deps=deps)
@@ -619,6 +680,8 @@ def run_field_driven_prepare_flow(
     spec_config.plan.update(custom_config.plan)
     spec_config.pr.update(custom_config.pr)
     spec_config.steps.update(custom_config.steps)
-    if not profile.is_github_repo:
+    if not profile.is_github_repo and any(
+        field.write == "pr.auto_create" for field in parsed.fields
+    ):
         spec_config.pr.setdefault("auto_create", False)
     return spec_config, issue_id

--- a/src/cafe/ui/prepare_field_renderer.py
+++ b/src/cafe/ui/prepare_field_renderer.py
@@ -312,6 +312,15 @@ def resolve_non_interactive_issue_config(
 ) -> PrepareIssueConfig:
     """Resolve and validate non-interactive prepare config for issue.yaml."""
     if parsed_fields is None:
+        if not profile.prepare.prompt_for_spec_plan_config and profile.prepare.model_fields_set == {
+            "prompt_for_spec_plan_config"
+        }:
+            if answers.auto_create_pr or answers.post_pr_todo_list is not None:
+                raise PrepareNonInteractiveError(
+                    "--auto-create-pr and --post-pr-todo-list require a playbook with a "
+                    "pr step or explicit pr.* prepare fields"
+                )
+            return empty_issue_config()
         validate_non_interactive_required(answers)
         defaults = profile.non_interactive_defaults()
         rigor = answers.rigor if answers.rigor is not None else defaults.rigor
@@ -623,6 +632,10 @@ def run_field_driven_prepare_flow(
         (field for field in parsed.fields if field.write == "spec.input_method"),
         None,
     )
+    issue_field = next(
+        (field for field in parsed.fields if field.write == "spec.issue_id"),
+        None,
+    )
     if input_field is not None and field_is_visible(
         input_field,
         PreparePromptContext(
@@ -636,6 +649,7 @@ def run_field_driven_prepare_flow(
             deps.display,
             deps.github_ops,
             field=input_field,
+            issue_field=issue_field,
         )
         spec_config.spec["input_method"] = input_method
         if issue_id is not None:

--- a/tests/integration/test_prepare_field_driven.py
+++ b/tests/integration/test_prepare_field_driven.py
@@ -236,6 +236,26 @@ commands:
         assert config["synthesize"] == {"audience": "internal"}
         assert not {"spec", "plan", "pr"}.intersection(config)
 
+    @pytest.mark.parametrize("playbook_id", ["research", "editorial", "incident"])
+    def test_promptless_builtin_prepare_creates_no_development_config(
+        self, playbook_id, temp_repo_dir, mock_git_ops
+    ):
+        """I4 — promptless bundled workflows need no development CLI flags."""
+        _write_config_with_playbook(temp_repo_dir, playbook_id)
+
+        result = runner.invoke(
+            app,
+            ["prepare", f"{playbook_id}-default", "--no-interactive"],
+        )
+
+        assert result.exit_code == 0
+        config = yaml.safe_load(
+            (
+                temp_repo_dir / ".cafe" / "issues" / f"{playbook_id}-default" / "issue.yaml"
+            ).read_text(encoding="utf-8")
+        )
+        assert not {"spec", "plan", "pr"}.intersection(config)
+
     @patch("cafe.ui.cli.prompt_confirm")
     @patch("cafe.ui.cli.prompt_list")
     @patch("cafe.ui.cli.prompt_text")

--- a/tests/integration/test_prepare_field_driven.py
+++ b/tests/integration/test_prepare_field_driven.py
@@ -28,11 +28,11 @@ def change_test_dir(tmp_path, monkeypatch):
 
 @pytest.fixture
 def mock_git_ops():
-    with patch("cafe.ui.cli.GitOperations") as MockGitOperations, patch(
-        "cafe.utils.git_utils.is_github_repo"
-    ) as mock_is_github_repo, patch(
-        "cafe.ui.phase_prompts.is_github_repo"
-    ) as mock_is_github_repo_phase:
+    with (
+        patch("cafe.ui.cli.GitOperations") as MockGitOperations,
+        patch("cafe.utils.git_utils.is_github_repo") as mock_is_github_repo,
+        patch("cafe.ui.phase_prompts.is_github_repo") as mock_is_github_repo_phase,
+    ):
         mock_git = MagicMock()
         MockGitOperations.return_value = mock_git
         mock_git.get_current_branch.return_value = "main"
@@ -67,6 +67,39 @@ steps:
 {prepare_block}
 """
     (playbooks_dir / f"{name}.yaml").write_text(content, encoding="utf-8")
+
+
+def _write_workflow_owned_fields_playbook(base_dir: Path, name: str) -> None:
+    """Create a non-development workflow with only workflow-owned setup."""
+    playbooks_dir = base_dir / ".cafe" / "playbooks"
+    playbooks_dir.mkdir(parents=True, exist_ok=True)
+    (playbooks_dir / f"{name}.yaml").write_text(
+        f"""
+playbook:
+  id: {name}
+steps:
+  synthesize:
+    type: skill
+    skill: cafe-spec
+    role: pm
+    "on":
+      await_agent: _done
+commands:
+  prepare:
+    fields:
+      - id: audience
+        type: enum
+        label: Audience
+        write: synthesize.audience
+        default: internal
+        choices:
+          - value: internal
+            label: Internal
+          - value: public
+            label: Public
+""",
+        encoding="utf-8",
+    )
 
 
 class TestPrepareFieldDriven:
@@ -180,6 +213,57 @@ commands:
         assert result.exit_code == 0
         mock_legacy.assert_called_once()
         mock_field.assert_not_called()
+        assert "Deprecated" in result.stdout
+
+    def test_non_development_fields_supply_non_interactive_defaults(
+        self, temp_repo_dir, mock_git_ops
+    ):
+        """I4 — workflow-owned defaults need no development CLI flags."""
+        _write_workflow_owned_fields_playbook(temp_repo_dir, "audience-workflow")
+        _write_config_with_playbook(temp_repo_dir, "audience-workflow")
+
+        result = runner.invoke(
+            app,
+            ["prepare", "audience-default", "--no-interactive"],
+        )
+
+        assert result.exit_code == 0
+        config = yaml.safe_load(
+            (temp_repo_dir / ".cafe" / "issues" / "audience-default" / "issue.yaml").read_text(
+                encoding="utf-8"
+            )
+        )
+        assert config["synthesize"] == {"audience": "internal"}
+        assert not {"spec", "plan", "pr"}.intersection(config)
+
+    @patch("cafe.ui.cli.prompt_confirm")
+    @patch("cafe.ui.cli.prompt_list")
+    @patch("cafe.ui.cli.prompt_text")
+    def test_non_development_fields_own_interactive_prompts(
+        self,
+        mock_prompt_text,
+        mock_prompt_list,
+        mock_prompt_confirm,
+        temp_repo_dir,
+        mock_git_ops,
+    ):
+        """I3 — interactive setup renders only the workflow's declared prompt."""
+        _write_workflow_owned_fields_playbook(temp_repo_dir, "audience-workflow")
+        _write_config_with_playbook(temp_repo_dir, "audience-workflow")
+        mock_prompt_text.return_value = "audience-interactive"
+        mock_prompt_confirm.return_value = False
+        mock_prompt_list.return_value = "Public"
+
+        result = runner.invoke(app, ["prepare"])
+
+        assert result.exit_code == 0
+        config = yaml.safe_load(
+            (temp_repo_dir / ".cafe" / "issues" / "audience-interactive" / "issue.yaml").read_text(
+                encoding="utf-8"
+            )
+        )
+        assert config["synthesize"] == {"audience": "public"}
+        assert [call.kwargs["message"] for call in mock_prompt_list.call_args_list] == ["Audience"]
 
 
 def test_field_driven_prepare_passes_declared_custom_template_managers() -> None:
@@ -203,6 +287,4 @@ def test_field_driven_prepare_passes_declared_custom_template_managers() -> None
             template_managers={"synthesis": custom_manager},
         )
 
-    assert run_flow.call_args.kwargs["deps"].template_managers == {
-        "synthesis": custom_manager
-    }
+    assert run_flow.call_args.kwargs["deps"].template_managers == {"synthesis": custom_manager}

--- a/tests/integration/test_prepare_playbook_driven.py
+++ b/tests/integration/test_prepare_playbook_driven.py
@@ -27,11 +27,11 @@ def change_test_dir(tmp_path, monkeypatch):
 
 @pytest.fixture
 def mock_git_ops():
-    with patch("cafe.ui.cli.GitOperations") as MockGitOperations, patch(
-        "cafe.utils.git_utils.is_github_repo"
-    ) as mock_is_github_repo, patch(
-        "cafe.ui.phase_prompts.is_github_repo"
-    ) as mock_is_github_repo_phase:
+    with (
+        patch("cafe.ui.cli.GitOperations") as MockGitOperations,
+        patch("cafe.utils.git_utils.is_github_repo") as mock_is_github_repo,
+        patch("cafe.ui.phase_prompts.is_github_repo") as mock_is_github_repo_phase,
+    ):
         mock_git = MagicMock()
         MockGitOperations.return_value = mock_git
         mock_git.get_current_branch.return_value = "main"
@@ -121,9 +121,7 @@ class TestPreparePlaybookDriven:
         assert config_data["spec"]["sync_github"] is True
         assert config_data["pr"]["auto_create"] is True
 
-    def test_default_playbook_non_interactive_manual_input(
-        self, temp_repo_dir, mock_git_ops
-    ):
+    def test_default_playbook_non_interactive_manual_input(self, temp_repo_dir, mock_git_ops):
         """Integration #2 — default playbook non-interactive parity."""
         result = runner.invoke(
             app,
@@ -138,9 +136,7 @@ class TestPreparePlaybookDriven:
         assert config_data["spec"]["template"] == "auto"
         assert config_data["plan"]["template"] == "default"
 
-    def test_no_pr_playbook_rejects_non_interactive_pr_flags(
-        self, temp_repo_dir, mock_git_ops
-    ):
+    def test_no_pr_playbook_rejects_non_interactive_pr_flags(self, temp_repo_dir, mock_git_ops):
         """A playbook without a pr step must reject legacy PR config flags."""
         prepare_block = """
 commands:
@@ -168,10 +164,10 @@ commands:
         config_file = temp_repo_dir / ".cafe" / "issues" / "no-pr-issue" / "issue.yaml"
         assert not config_file.exists()
 
-    def test_no_pr_playbook_without_pr_flags_omits_pr_config(
+    def test_promptless_playbook_ignores_legacy_development_flags(
         self, temp_repo_dir, mock_git_ops
     ):
-        """A playbook without a pr step can prepare without PR config."""
+        """A promptless workflow does not persist undeclared development config."""
         prepare_block = """
 commands:
   prepare:
@@ -194,8 +190,7 @@ commands:
         assert result.exit_code == 0
         config_file = temp_repo_dir / ".cafe" / "issues" / "no-pr-issue" / "issue.yaml"
         config_data = yaml.safe_load(config_file.read_text(encoding="utf-8"))
-        assert config_data["spec"]["input_method"] == "github"
-        assert "pr" not in config_data
+        assert not {"spec", "plan", "pr"}.intersection(config_data)
 
     @patch("cafe.ui.cli.prompt_confirm")
     @patch("cafe.ui.cli.prompt_text")
@@ -322,9 +317,7 @@ commands:
         config_data = yaml.safe_load(config_file.read_text(encoding="utf-8"))
         assert config_data["spec"]["rigor"] == "high"
 
-    def test_invalid_playbook_exits_with_actionable_error(
-        self, temp_repo_dir, mock_git_ops
-    ):
+    def test_invalid_playbook_exits_with_actionable_error(self, temp_repo_dir, mock_git_ops):
         """DoD — unloadable playbook fails gracefully."""
         _write_config_with_playbook(temp_repo_dir, "does-not-exist")
 
@@ -354,9 +347,7 @@ commands:
         assert config_data["spec"]["template"] == "auto"
         assert config_data["plan"]["template"] == "default"
 
-    def test_invalid_rigor_exits_before_polluted_issue_yaml(
-        self, temp_repo_dir, mock_git_ops
-    ):
+    def test_invalid_rigor_exits_before_polluted_issue_yaml(self, temp_repo_dir, mock_git_ops):
         """Integration — invalid rigor fails before writing polluted issue.yaml."""
         prepare_block = """
 commands:

--- a/tests/unit/test_phase_prompts.py
+++ b/tests/unit/test_phase_prompts.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, patch, MagicMock
 from cafe.ui.phase_prompts import prompt_for_input_method, prompt_for_rigor, fetch_github_issue
 from cafe.ui.display import Display
 from cafe.utils.github import GitHubOps, GitHubError
+from cafe.core.prepare_fields import PrepareField
 
 
 class TestPromptForInputMethod:
@@ -55,6 +56,33 @@ class TestPromptForInputMethod:
         github_ops.extract_issue_number.assert_called_once_with(
             "https://github.com/user/repo/issues/456"
         )
+
+    @patch("cafe.ui.phase_prompts.prompt_text")
+    @patch("cafe.ui.phase_prompts.prompt_list")
+    def test_GitHub_Issue欄位使用宣告的標籤(self, mock_prompt_list, mock_prompt_text):
+        """U5 — the declared issue field controls the GitHub prompt wording."""
+        mock_prompt_list.return_value = "2. GitHub"
+        mock_prompt_text.return_value = "350"
+        github_ops = Mock(spec=GitHubOps)
+        github_ops.extract_issue_number.return_value = "350"
+        issue_field = PrepareField.model_validate(
+            {
+                "id": "issue_reference",
+                "type": "text",
+                "label": "Tracked issue reference",
+                "write": "spec.issue_id",
+                "normalize": "github_issue",
+            }
+        )
+
+        method, issue_id = prompt_for_input_method(
+            Display(),
+            github_ops,
+            issue_field=issue_field,
+        )
+
+        assert (method, issue_id) == ("github", 350)
+        assert mock_prompt_text.call_args.kwargs["message"] == "Tracked issue reference"
 
     @patch("cafe.ui.phase_prompts.prompt_text")
     @patch("cafe.ui.phase_prompts.prompt_list")

--- a/tests/unit/test_playbook_loader.py
+++ b/tests/unit/test_playbook_loader.py
@@ -149,6 +149,9 @@ steps:
     skill: spec_first
     on:
       await_agent: _done
+commands:
+  prepare:
+    prompt_for_spec_plan_config: false
 """,
     )
     _write_playbook(
@@ -162,6 +165,9 @@ steps:
     skill: spec_first
     on:
       await_agent: _done
+commands:
+  prepare:
+    prompt_for_spec_plan_config: false
 """,
     )
     loader = PlaybookLoader(
@@ -248,6 +254,9 @@ steps:
     valid_intents: [confirmed]
     on:
       await_agent: _done
+commands:
+  prepare:
+    prompt_for_spec_plan_config: false
 """,
     )
 
@@ -291,6 +300,9 @@ steps:
     valid_intents: [confirmed]
     on:
       await_agent: _done
+commands:
+  prepare:
+    prompt_for_spec_plan_config: false
 """,
     )
 
@@ -327,6 +339,9 @@ steps:
     on:
       await_agent: _done
       alignment_checkpoint: develop
+commands:
+  prepare:
+    prompt_for_spec_plan_config: false
 """,
     )
 
@@ -358,6 +373,9 @@ steps:
     capability_requests: [cafe.pr.publish]
     on:
       await_agent: _done
+commands:
+  prepare:
+    prompt_for_spec_plan_config: false
 """,
     )
 
@@ -495,6 +513,9 @@ steps:
     on:
       confirm_output: plan
       await_agent: _done
+commands:
+  prepare:
+    prompt_for_spec_plan_config: false
 """,
     )
 
@@ -751,6 +772,9 @@ steps:
     skill: spec_first
     on:
       await_agent: _done
+commands:
+  prepare:
+    prompt_for_spec_plan_config: false
 """,
     )
 

--- a/tests/unit/test_playbook_prepare_metadata.py
+++ b/tests/unit/test_playbook_prepare_metadata.py
@@ -91,7 +91,7 @@ def _loader(tmp_path: Path) -> PlaybookLoader:
 def test_prepare_schema_parses_valid_block(tmp_path: Path) -> None:
     loader = _loader(tmp_path)
     _write_playbook(
-        loader._roots()[0],
+        loader._roots()[-1],
         "test",
         _minimal_playbook_yaml(prepare_block=STANDARD_PREPARE_YAML),
     )
@@ -106,7 +106,7 @@ def test_prepare_schema_parses_valid_block(tmp_path: Path) -> None:
 
 def test_omitted_prepare_section_resolves_defaults(tmp_path: Path) -> None:
     loader = _loader(tmp_path)
-    _write_playbook(loader._roots()[0], "test", _minimal_playbook_yaml())
+    _write_playbook(loader._roots()[-1], "test", _minimal_playbook_yaml())
 
     result = loader.load_model("test")
     resolved = resolve_prepare_config(result.model)
@@ -133,7 +133,7 @@ def test_required_skill_inputs_must_be_declared_by_the_playbook_step(tmp_path: P
         encoding="utf-8",
     )
     _write_playbook(
-        loader._roots()[0],
+        loader._roots()[-1],
         "missing-input",
         """
 playbook: {id: missing-input}
@@ -207,7 +207,7 @@ commands:
 def test_unknown_template_rejected_at_load_time(tmp_path: Path) -> None:
     loader = _loader(tmp_path)
     _write_playbook(
-        loader._roots()[0],
+        loader._roots()[-1],
         "test",
         _minimal_playbook_yaml(
             prepare_block="""
@@ -239,7 +239,7 @@ commands:
     non_interactive_defaults:
       plan_template: missing-template-name
 """
-    path = loader._roots()[0] / "bad.yaml"
+    path = loader._roots()[-1] / "bad.yaml"
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(content, encoding="utf-8")
 
@@ -250,9 +250,9 @@ commands:
     )
 
     with pytest.raises(ValueError, match="non_interactive_defaults.plan_template"):
-        load_playbook_file(path, source="builtin", skill_loader=skill_loader)
+        load_playbook_file(path, source="project", skill_loader=skill_loader)
 
-    _write_playbook(loader._roots()[0], "bad", content)
+    _write_playbook(loader._roots()[-1], "bad", content)
     with pytest.raises(ValueError, match="non_interactive_defaults.plan_template"):
         loader.load_model("bad")
 
@@ -260,7 +260,7 @@ commands:
 def test_legacy_playbook_without_prepare_section_loads(tmp_path: Path) -> None:
     loader = _loader(tmp_path)
     _write_playbook(
-        loader._roots()[0],
+        loader._roots()[-1],
         "legacy",
         """
 playbook: {id: legacy}
@@ -277,6 +277,7 @@ steps:
 
     assert result.model.commands is None
     assert resolve_prepare_config(result.model) == default_prepare_config()
+    assert any("Legacy interactive prepare is deprecated" in warning for warning in result.warnings)
 
 
 def test_builtin_interactive_prepare_requires_declared_fields(tmp_path: Path) -> None:
@@ -339,7 +340,23 @@ def test_builtin_non_prepare_playbooks_still_load_without_prepare_section() -> N
 
     for name in ("research", "editorial", "incident"):
         model = loader.load_model(name).model
-        assert model.commands is None or model.commands.prepare is None
+        assert model.commands is not None
+        assert model.commands.prepare is not None
+        assert model.commands.prepare.prompt_for_spec_plan_config is False
+
+
+def test_every_builtin_prepare_is_declarative_or_explicitly_promptless() -> None:
+    """U9 — bundled playbooks cannot reach the legacy interactive adapter."""
+    loader = PlaybookLoader()
+
+    for name in ("default", "simple", "tdd", "hotfix", "research", "editorial", "incident"):
+        model = loader.load_model(name).model
+        prepare = model.commands.prepare if model.commands else None
+        assert (
+            prepare is None
+            or not prepare.prompt_for_spec_plan_config
+            or (prepare.fields is not None or prepare.fields_ref is not None)
+        )
 
 
 def test_prepare_fields_and_fields_ref_are_mutually_exclusive() -> None:
@@ -366,7 +383,7 @@ commands:
 
 def test_invalid_prepare_field_write_target_fails_validate(tmp_path: Path) -> None:
     loader = _loader(tmp_path)
-    playbook_dir = loader._roots()[0]
+    playbook_dir = loader._roots()[-1]
     playbook_dir.mkdir(parents=True, exist_ok=True)
     asset = playbook_dir / "bad_fields.yaml"
     asset.write_text(
@@ -377,7 +394,7 @@ def test_invalid_prepare_field_write_target_fails_validate(tmp_path: Path) -> No
                         "id": "bad",
                         "type": "boolean",
                         "label": "Bad",
-                        "write": "spec.unknown",
+                        "write": "undeclared.unknown",
                         "default": True,
                     }
                 ]
@@ -398,13 +415,13 @@ commands:
         ),
     )
 
-    with pytest.raises((ValueError, ValidationError), match="unknown write target"):
+    with pytest.raises((ValueError, ValidationError), match="undeclared workflow step"):
         loader.load_model("bad")
 
 
 def test_prepare_fields_semantic_mismatch_fails_validate(tmp_path: Path) -> None:
     loader = _loader(tmp_path)
-    playbook_dir = loader._roots()[0]
+    playbook_dir = loader._roots()[-1]
     playbook_dir.mkdir(parents=True, exist_ok=True)
     asset = playbook_dir / "mismatch_fields.yaml"
     asset.write_text(
@@ -460,7 +477,7 @@ commands:
 
 def test_prepare_fields_without_legacy_metadata_skips_parity_validate(tmp_path: Path) -> None:
     loader = _loader(tmp_path)
-    playbook_dir = loader._roots()[0]
+    playbook_dir = loader._roots()[-1]
     playbook_dir.mkdir(parents=True, exist_ok=True)
     asset = playbook_dir / "declarative_only_fields.yaml"
     asset.write_text(

--- a/tests/unit/test_playbook_prepare_metadata.py
+++ b/tests/unit/test_playbook_prepare_metadata.py
@@ -104,15 +104,13 @@ def test_prepare_schema_parses_valid_block(tmp_path: Path) -> None:
     assert result.model.commands.prepare.quick_setup.spec.rigor == "medium"
 
 
-def test_omitted_prepare_section_resolves_defaults(tmp_path: Path) -> None:
+def test_builtin_missing_prepare_section_is_rejected(tmp_path: Path) -> None:
+    """U1 — built-ins cannot inherit implicit interactive legacy prompts."""
     loader = _loader(tmp_path)
-    _write_playbook(loader._roots()[-1], "test", _minimal_playbook_yaml())
+    _write_playbook(loader._roots()[0], "test", _minimal_playbook_yaml())
 
-    result = loader.load_model("test")
-    resolved = resolve_prepare_config(result.model)
-    expected = default_prepare_config()
-
-    assert resolved.model_dump() == expected.model_dump()
+    with pytest.raises(ValueError, match="fields.*fields_ref"):
+        loader.load_model("test")
 
 
 def test_required_skill_inputs_must_be_declared_by_the_playbook_step(tmp_path: Path) -> None:

--- a/tests/unit/test_playbook_prepare_metadata.py
+++ b/tests/unit/test_playbook_prepare_metadata.py
@@ -279,6 +279,22 @@ steps:
     assert resolve_prepare_config(result.model) == default_prepare_config()
 
 
+def test_builtin_interactive_prepare_requires_declared_fields(tmp_path: Path) -> None:
+    """Bundled interactive setup must not fall back to hidden legacy prompts."""
+    loader = _loader(tmp_path)
+    _write_playbook(
+        loader._roots()[0],
+        "missing-fields",
+        _minimal_playbook_yaml(
+            playbook_id="missing-fields",
+            prepare_block=STANDARD_PREPARE_YAML,
+        ),
+    )
+
+    with pytest.raises(ValueError, match="fields.*fields_ref"):
+        loader.load_model("missing-fields")
+
+
 def _expected_standard_prepare() -> dict:
     return _legacy_prepare_dump(default_prepare_config())
 

--- a/tests/unit/test_prepare_field_renderer.py
+++ b/tests/unit/test_prepare_field_renderer.py
@@ -34,6 +34,7 @@ from cafe.ui.prepare_field_renderer import (
     prompt_setup_mode,
     prompt_custom_fields,
     resolve_non_interactive_issue_config,
+    run_field_driven_prepare_flow,
     set_write_value,
     validate_non_interactive_required,
     visible_fields,
@@ -73,6 +74,60 @@ def _default_fields():
         playbook_path=loaded.path,
         skill_loader=SkillLoader(),
     )
+
+
+def test_input_method_flow_passes_the_declared_issue_field_to_its_boundary() -> None:
+    """U4 — GitHub input uses the field document's issue-field metadata."""
+    input_field = PrepareField.model_validate(
+        {
+            "id": "input_method",
+            "type": "enum",
+            "label": "Requirement source",
+            "write": "spec.input_method",
+            "choices": [
+                {"value": "manual", "label": "Manual"},
+                {"value": "github", "label": "GitHub"},
+            ],
+        }
+    )
+    issue_field = PrepareField.model_validate(
+        {
+            "id": "issue_reference",
+            "type": "text",
+            "label": "Tracked issue reference",
+            "write": "spec.issue_id",
+            "normalize": "github_issue",
+        }
+    )
+    prompt_input = MagicMock(return_value=("github", 350))
+    deps = RendererDeps(
+        prompt_list=MagicMock(),
+        prompt_confirm=MagicMock(),
+        prompt_text=MagicMock(),
+        prompt_for_input_method=prompt_input,
+        select_template=MagicMock(),
+        spec_template_manager=MagicMock(),
+        plan_template_manager=MagicMock(),
+        display=MagicMock(),
+        github_ops=MagicMock(),
+    )
+    profile = PrepareProfile(
+        prepare=PrepareConfig.model_validate(
+            {"fields": [input_field.model_dump(), issue_field.model_dump()]}
+        ),
+        is_github_repo=True,
+        step_names=frozenset({"spec"}),
+    )
+
+    config, issue_id = run_field_driven_prepare_flow(
+        ParsedPrepareFields(fields=[input_field, issue_field]),
+        profile,
+        deps=deps,
+    )
+
+    assert issue_id == 350
+    assert config.spec == {"input_method": "github", "issue_id": "350"}
+    assert prompt_input.call_args.kwargs["issue_field"] == issue_field
 
 
 class TestShowWhenVisibility:
@@ -333,9 +388,7 @@ class TestNonInteractiveContext:
 
     def test_github_mode_requires_issue_id(self) -> None:
         with pytest.raises(PrepareNonInteractiveRequiredFieldError):
-            validate_non_interactive_required(
-                NonInteractiveCliAnswers(input_method="github")
-            )
+            validate_non_interactive_required(NonInteractiveCliAnswers(input_method="github"))
 
 
 class TestNonInteractiveVisibility:
@@ -372,6 +425,26 @@ class TestNonInteractiveVisibility:
 
 
 class TestNonInteractiveResolver:
+    def test_promptless_playbook_creates_no_legacy_development_config(self) -> None:
+        """U6 — promptless workflows do not inherit the legacy resolver."""
+        profile = PrepareProfile(
+            prepare=PrepareConfig.model_validate({"prompt_for_spec_plan_config": False}),
+            is_github_repo=True,
+            step_names=frozenset({"research"}),
+        )
+
+        config = resolve_non_interactive_issue_config(
+            profile,
+            NonInteractiveCliAnswers(),
+            parsed_fields=None,
+            deps=_resolver_deps(),
+        )
+
+        assert config.spec == {}
+        assert config.plan == {}
+        assert config.pr == {}
+        assert config.steps == {}
+
     def test_default_playbook_manual_defaults(self) -> None:
         parsed = _default_fields()
         profile = _profile()

--- a/tests/unit/test_prepare_fields_loader.py
+++ b/tests/unit/test_prepare_fields_loader.py
@@ -37,8 +37,8 @@ def test_prepare_field_schema_parses_valid_definition() -> None:
     assert fields[0].write == "spec.rigor"
 
 
-def test_prepare_field_schema_rejects_unknown_write_target() -> None:
-    invalid = dict(MINIMAL_FIELD, write="spec.unknown")
+def test_prepare_field_schema_rejects_malformed_write_target() -> None:
+    invalid = dict(MINIMAL_FIELD, write="spec")
     with pytest.raises(ValidationError):
         parse_prepare_fields([invalid])
 
@@ -62,6 +62,16 @@ def test_prepare_field_schema_accepts_declared_custom_step_template_target() -> 
     parsed = parse_prepare_fields([field])
 
     assert parsed[0].write == "synthesis.template"
+
+
+def test_prepare_field_schema_rejects_invalid_declared_defaults_and_normalizer() -> None:
+    invalid_enum_default = dict(MINIMAL_FIELD, default="unexpected")
+    invalid_normalizer = dict(MINIMAL_FIELD, normalize="github_issue")
+
+    with pytest.raises(ValidationError):
+        parse_prepare_fields([invalid_enum_default])
+    with pytest.raises(ValidationError):
+        parse_prepare_fields([invalid_normalizer])
 
 
 def _write_skill(root: Path, name: str) -> None:
@@ -175,7 +185,9 @@ def test_skill_loader_precedence_for_fields_ref(tmp_path: Path) -> None:
         encoding="utf-8",
     )
 
-    project_asset = project_root / ".cafe" / "skills" / "cafe-spec" / "assets" / "prepare" / "fields.yaml"
+    project_asset = (
+        project_root / ".cafe" / "skills" / "cafe-spec" / "assets" / "prepare" / "fields.yaml"
+    )
     project_asset.parent.mkdir(parents=True)
     project_asset.write_text(
         yaml.safe_dump({"fields": [dict(MINIMAL_FIELD, default="high")]}),

--- a/tests/unit/test_prepare_profile.py
+++ b/tests/unit/test_prepare_profile.py
@@ -55,9 +55,11 @@ def _loader(tmp_path: Path) -> PlaybookLoader:
     )
 
 
-def _profile_from_yaml(tmp_path: Path, prepare_yaml: str, *, is_github_repo: bool) -> PrepareProfile:
+def _profile_from_yaml(
+    tmp_path: Path, prepare_yaml: str, *, is_github_repo: bool
+) -> PrepareProfile:
     loader = _loader(tmp_path)
-    playbook_dir = loader._roots()[0]
+    playbook_dir = loader._roots()[-1]
     playbook_dir.mkdir(parents=True, exist_ok=True)
     (playbook_dir / "test.yaml").write_text(
         _minimal_playbook_yaml(prepare_block=prepare_yaml),
@@ -70,9 +72,7 @@ def _profile_from_yaml(tmp_path: Path, prepare_yaml: str, *, is_github_repo: boo
 class TestPrepareProfilePromptGating:
     """Test List unit #1 — profile gates spec/plan prompts."""
 
-    def test_disables_spec_plan_prompts_when_playbook_metadata_false(
-        self, tmp_path: Path
-    ) -> None:
+    def test_disables_spec_plan_prompts_when_playbook_metadata_false(self, tmp_path: Path) -> None:
         profile = _profile_from_yaml(
             tmp_path,
             "commands:\n  prepare:\n    prompt_for_spec_plan_config: false\n",
@@ -82,9 +82,7 @@ class TestPrepareProfilePromptGating:
 
     def test_respects_base_flag_when_metadata_allows(self) -> None:
         profile = PrepareProfile.from_playbook(
-            PlaybookDefinition.model_validate(
-                yaml.safe_load(_minimal_playbook_yaml())
-            ),
+            PlaybookDefinition.model_validate(yaml.safe_load(_minimal_playbook_yaml())),
             is_github_repo=True,
         )
         assert profile.should_prompt_spec_plan_config(True) is True
@@ -251,7 +249,7 @@ commands:
 class TestPrepareProfileResolvedFields:
     """Test List unit #14 — resolved prepare field contract."""
 
-    def test_returns_none_when_fields_not_declared(self) -> None:
+    def test_simple_playbook_resolves_declared_fields(self) -> None:
         loader = PlaybookLoader()
         loaded = loader.load_model("simple")
         profile = PrepareProfile.from_playbook(loaded.model, is_github_repo=True)
@@ -260,7 +258,7 @@ class TestPrepareProfileResolvedFields:
                 playbook_path=loaded.path,
                 skill_loader=SkillLoader(),
             )
-            is None
+            is not None
         )
 
     def test_returns_fields_for_default_playbook(self) -> None:


### PR DESCRIPTION
## Summary

Migrate prepare interaction to declared field documents for bundled playbooks while preserving a compatibility path for existing non-declarative project/global playbooks.

## Changes

- Refactored prepare execution to use `prepare` field documents as the authoritative source of prompt labels, options, defaults, visibility, and destinations.
- Enforced that bundled interactive playbooks define a field source (`commands.prepare.fields` or `fields_ref`); non-interactive bundled workflows without prompts are now explicit.
- Preserved legacy adapter behavior only for older custom playbooks, with migration guidance when legacy prompts are used.
- Moved default-workflow prepare wording and behavior into `default_prepare_fields.yaml` and aligned runtime behavior for interactive and non-interactive flows.
- Added/updated schema, renderer, and profile validation to support declared field targets, generic resolution, and non-interactive defaults without hidden development assumptions.
- Expanded unit/integration/CLI coverage to prove default parity, custom workflow ownership, and legacy warning behavior.
- Updated authoring docs and migration guidance to make the declarative path explicit.
- Commits in scope include:
  - `2ab1375` — test: require fields for bundled prepare
  - `778bbda` — refactor: drive prepare from declared fields
  - `3bb39bb` — docs: explain declarative prepare migration
  - `78cc021` — fix: disable prepare prompts in editorial example
  - `add08ba` — fix: honor promptless prepare workflows
  - `30bf81d` — test: mark loader fixtures promptless

## Test Plan

- Run full suite: `uv run pytest -q` (2461 passed, 1 skipped, 1 xfailed).
- Run focused verification suites from implementation plan:
  - `pytest tests/unit/test_prepare_fields_loader.py tests/unit/test_playbook_prepare_metadata.py tests/unit/test_prepare_profile.py tests/unit/test_prepare_field_renderer.py tests/unit/test_phase_prompts.py`
  - `pytest tests/integration/test_prepare_field_driven.py tests/integration/test_prepare_playbook_driven.py tests/unit/test_cli_prepare.py`
- Run strict playbook validation for bundled playbooks (default, simple, tdd, hotfix, editorial, research, incident):
  - `cafe playbook validate <playbook> --strict`
- Run `cafe audit`.