### PR TITLE
Generalize workflow entry-step initial input providers

### DIFF
--- a/docs/prepare_fields.md
+++ b/docs/prepare_fields.md
@@ -17,7 +17,7 @@ Each prepare question is declared as one field object:
 | `non_interactive_default` | no | Default used only by `--no-interactive`; otherwise `default` is used |
 | `non_interactive` | no | Whether the default participates in non-interactive setup (default `true`) |
 | `required` | no | Reject a missing non-interactive value when no default is declared |
-| `normalize` | no | Boundary normalizer; currently `github_issue` is valid only for `spec.issue_id` |
+| `normalize` | no | Boundary normalizer; `github_issue` marks the issue-reference field for the stable `github_issue_id` input field |
 | `choices` | yes for `enum` / `setup_mode` | `{ value, label, description? }` entries |
 | `show_when` | no | Simple visibility conditions |
 | `group` | no | Logical grouping (`input`, `setup`, `quick_defaults`, `custom`) |
@@ -162,6 +162,47 @@ commands:
 Both interactive and non-interactive preparation persist only
 `synthesize.audience`; no `--input-method`, `spec`, `plan`, or `pr` block is
 introduced.
+
+## Initial-input providers
+
+An entry step can declare the trusted host-side input providers it accepts and
+the locations that may receive the resolved content:
+
+```yaml
+entry_point: intake
+steps:
+  intake:
+    skill: cafe-intake
+    role: researcher
+    output_artifact: intake_brief
+    initial_input:
+      providers: [manual_text, github_issue]
+      bind:
+        artifact: intake_brief
+        prompt_context: user_input
+    hooks:
+      prepare_input: [InitialInputProviderResolver]
+    "on": {await_agent: _done}
+```
+
+- `initial_input` is valid only on `entry_point` and each provider may appear
+  once. The built-in providers are `manual_text` and `github_issue`.
+- `bind` must contain at least one destination. `artifact` must equal the
+  entry step's `output_artifact`; the only prompt context allowed in this
+  release is `user_input`.
+- `cafe prepare --input-method=manual|github --issue-id=…` writes the canonical
+  `initial_input.provider` / `initial_input.issue_id` selection to `issue.yaml`.
+  Existing default/simple/TDD prepare fields continue also to write legacy
+  `spec.input_method` / `spec.issue_id` values for compatibility.
+- Input fields are identified by the stable IDs `input_method` and
+  `github_issue_id`, not by a `spec.*` write target. A custom entry step may
+  therefore write its UI answers to `intake.input_method` and
+  `intake.issue_id` while the resolver consumes only the canonical block.
+
+Provider resolution runs only for a new first iteration and never overwrites a
+non-empty declared artifact. Manual text prefers invocation input; GitHub
+content is fetched only by the trusted host-side boundary. Playbooks cannot
+register arbitrary provider scripts or give agents credentials.
 
 ## Custom step template fields
 

--- a/docs/prepare_fields.md
+++ b/docs/prepare_fields.md
@@ -198,6 +198,10 @@ steps:
   `github_issue_id`, not by a `spec.*` write target. A custom entry step may
   therefore write its UI answers to `intake.input_method` and
   `intake.issue_id` while the resolver consumes only the canonical block.
+- `legacy_presentation: true` is reserved for bundled development playbooks.
+  It preserves their existing requirements heading and guided manual/GitHub
+  interaction while continuing to use `InitialInputProviderResolver`; custom
+  playbooks should omit it and receive the declared content unchanged.
 
 Provider resolution runs only for a new first iteration and never overwrites a
 non-empty declared artifact. Manual text prefers invocation input; GitHub

--- a/src/cafe/core/hooks/__init__.py
+++ b/src/cafe/core/hooks/__init__.py
@@ -69,6 +69,7 @@ class PRLinkOpener(NoOpHook):
 from cafe.core.hooks.native import (
     GitHubIssueFetcher,
     GitHubPRCreator,
+    InitialInputProviderResolver,
     LocalPRReviewer,
     NoChangesNeededHandler,
     PRCommentPoster,
@@ -82,6 +83,7 @@ BUILTIN_HOOKS = {
     hook.name: hook
     for hook in [
         GitHubIssueFetcher,
+        InitialInputProviderResolver,
         UserInputCollector,
         NoChangesNeededHandler,
         InteractiveQAHandler,

--- a/src/cafe/core/hooks/native.py
+++ b/src/cafe/core/hooks/native.py
@@ -12,6 +12,12 @@ from typing import Any, Optional
 
 from cafe.core.blackboard import BlackboardState, HandoffContract, HandoffIntent, HandoffOwner
 from cafe.core.hooks import HookResult, NoOpHook
+from cafe.core.initial_input import (
+    GITHUB_ISSUE_PROVIDER,
+    MANUAL_TEXT_PROVIDER,
+    InitialInputResult,
+    load_initial_input_selection,
+)
 from cafe.core.questions_schema import parse_questions_xml, validate_questions_xml
 from cafe.core.status_codes import PhaseStatusCode, step_on_declares
 from cafe.skills.loader import SkillLoader
@@ -576,97 +582,275 @@ def _declares_no_changes_task(step_def: Any) -> bool:
     )
 
 
-class GitHubIssueFetcher(NoOpHook):
-    """Collect initial requirements for spec iteration 1.
+class InitialInputProviderResolver(NoOpHook):
+    """Resolve declared entry-step input through trusted host-side providers."""
 
-    Reads issue.yaml to determine the input method (manual / github).
-    When no config exists, prompts the user to choose.  Writes the
-    initial requirements into the output file so the agent has content
-    to analyze.
-    """
+    name = "InitialInputProviderResolver"
+
+    def run(self, **kwargs: Any) -> HookResult:
+        if kwargs.get("stage") != "prepare_input":
+            return HookResult()
+
+        phase = kwargs.get("phase")
+        step_name = str(kwargs.get("step_name") or "")
+        step_def = kwargs.get("step_def")
+        if phase is None or not isinstance(step_def, dict):
+            return HookResult()
+        if getattr(phase, "iteration", 0) != 1:
+            return HookResult()
+
+        declaration = step_def.get("initial_input")
+        if not isinstance(declaration, dict):
+            return HookResult()
+        providers = declaration.get("providers")
+        binding = declaration.get("bind")
+        if not isinstance(providers, list) or not isinstance(binding, dict):
+            raise ValueError(f"initial_input declaration for step {step_name!r} is invalid")
+
+        output_file: Optional[Path] = kwargs.get("output_file")
+        artifact = binding.get("artifact")
+        if artifact is not None:
+            if output_file is None:
+                raise ValueError(
+                    f"initial_input.bind.artifact for step {step_name!r} requires output_file"
+                )
+            if output_file.exists() and output_file.read_text(encoding="utf-8").strip():
+                return HookResult()
+
+        result = self._resolve(
+            phase=phase,
+            step_name=step_name,
+            providers=providers,
+            context=kwargs.get("context"),
+            prompt_input_method=kwargs.get("initial_input_prompt_input_method"),
+            prompt_manual_input=kwargs.get("initial_input_prompt_manual_input"),
+            fetch_github_issue=kwargs.get("initial_input_fetch_github_issue"),
+        )
+        if artifact is not None:
+            assert output_file is not None
+            output_file.parent.mkdir(parents=True, exist_ok=True)
+            output_file.write_text(
+                f"# Initial Requirements\n\n{result.content}\n", encoding="utf-8"
+            )
+
+        context_updates = (
+            {"user_input": result.content}
+            if binding.get("prompt_context") == "user_input"
+            else {}
+        )
+        return HookResult(
+            context_updates=context_updates,
+            events=[
+                {
+                    "type": "initial_input_resolved",
+                    "step": step_name,
+                    "provider": result.provider,
+                }
+            ],
+        )
+
+    def _resolve(
+        self,
+        *,
+        phase: Any,
+        step_name: str,
+        providers: list[Any],
+        context: Any,
+        prompt_input_method: Any,
+        prompt_manual_input: Any,
+        fetch_github_issue: Any,
+    ) -> InitialInputResult:
+        declared = {str(provider) for provider in providers}
+        prefilled = GitHubIssueFetcher._resolve_prefilled_input(
+            phase=phase,
+            step_name=step_name,
+            context=context,
+        )
+        if prefilled is not None:
+            self._require_declared(MANUAL_TEXT_PROVIDER, declared, step_name)
+            return InitialInputResult(
+                content=prefilled,
+                provider=MANUAL_TEXT_PROVIDER,
+                source="workflow_user_input",
+            )
+
+        config = self._load_issue_config(phase)
+        provider, issue_id = load_initial_input_selection(config)
+        if provider is None:
+            provider, issue_id = self._select_provider(
+                phase=phase,
+                providers=declared,
+                prompt_input_method=prompt_input_method,
+            )
+            self._save_selection(phase, provider, issue_id)
+        self._require_declared(provider, declared, step_name)
+
+        if provider == GITHUB_ISSUE_PROVIDER:
+            if issue_id is None:
+                raise ValueError("initial_input.provider 'github_issue' requires issue_id")
+            fetch = fetch_github_issue or GitHubIssueFetcher._fetch_github_issue
+            try:
+                content = str(fetch(issue_id)).strip()
+            except Exception as exc:
+                raise ValueError(
+                    f"initial_input.provider 'github_issue' could not fetch issue {issue_id}"
+                ) from exc
+            if not content:
+                raise ValueError(f"GitHub issue {issue_id} produced no initial input")
+            return InitialInputResult(content=content, provider=provider, source="github_issue")
+
+        if not getattr(phase, "interactive", False):
+            raise ValueError(
+                "initial_input.provider 'manual_text' requires non-empty invocation input "
+                "when running non-interactively"
+            )
+        prompt = prompt_manual_input or GitHubIssueFetcher._prompt_manual_input
+        content = str(prompt()).strip()
+        if not content:
+            raise ValueError("initial_input.provider 'manual_text' received empty input")
+        return InitialInputResult(content=content, provider=provider, source="manual_text")
+
+    @staticmethod
+    def _require_declared(provider: str, declared: set[str], step_name: str) -> None:
+        if provider not in declared:
+            raise ValueError(
+                f"initial_input.provider {provider!r} is not declared for entry step {step_name!r}"
+            )
+
+    @staticmethod
+    def _load_issue_config(phase: Any) -> dict[str, Any]:
+        config_file = getattr(phase, "issue_dir", None)
+        if not isinstance(config_file, Path):
+            return {}
+        config_file = config_file / "issue.yaml"
+        if not config_file.exists():
+            return {}
+        try:
+            import yaml
+
+            data = yaml.safe_load(config_file.read_text(encoding="utf-8")) or {}
+        except Exception:
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    @staticmethod
+    def _save_selection(phase: Any, provider: str, issue_id: Optional[int]) -> None:
+        issue_dir = getattr(phase, "issue_dir", None)
+        if not isinstance(issue_dir, Path):
+            return
+        config_file = issue_dir / "issue.yaml"
+        data = InitialInputProviderResolver._load_issue_config(phase)
+        data["initial_input"] = {"provider": provider}
+        if issue_id is not None:
+            data["initial_input"]["issue_id"] = issue_id
+        import yaml
+
+        config_file.parent.mkdir(parents=True, exist_ok=True)
+        config_file.write_text(
+            yaml.dump(data, allow_unicode=True, default_flow_style=False), encoding="utf-8"
+        )
+
+    @staticmethod
+    def _select_provider(
+        *,
+        phase: Any,
+        providers: set[str],
+        prompt_input_method: Any,
+    ) -> tuple[str, Optional[int]]:
+        if len(providers) == 1:
+            return next(iter(providers)), None
+        if not getattr(phase, "interactive", False):
+            raise ValueError(
+                "initial_input.provider must be selected before non-interactive execution"
+            )
+        prompt = prompt_input_method or GitHubIssueFetcher._prompt_input_method
+        provider, issue_id = prompt()
+        normalized = {"manual": MANUAL_TEXT_PROVIDER, "github": GITHUB_ISSUE_PROVIDER}.get(
+            provider, provider
+        )
+        return normalized, issue_id
+
+
+class GitHubIssueFetcher(NoOpHook):
+    """Compatibility adapter for legacy ``spec`` initial-input hooks."""
 
     name = "GitHubIssueFetcher"
 
     def run(self, **kwargs: Any) -> HookResult:
-        stage = kwargs.get("stage")
-        if stage != "prepare_input":
+        if kwargs.get("stage") != "prepare_input":
             return HookResult()
-
         phase = kwargs.get("phase")
-        if phase is None:
-            return HookResult()
-
-        if getattr(phase, "iteration", 0) > 1:
-            return HookResult()
-
         step_name = str(kwargs.get("step_name") or "")
-        if step_name != "spec":
-            return HookResult()
-
         output_file: Optional[Path] = kwargs.get("output_file")
-        if output_file is None:
+        if phase is None or step_name != "spec" or output_file is None:
             return HookResult()
-
+        if getattr(phase, "iteration", 0) != 1:
+            return HookResult()
         if output_file.exists() and output_file.read_text(encoding="utf-8").strip():
             return HookResult()
 
-        content = self._resolve_prefilled_input(
+        prefilled = self._resolve_prefilled_input(
             phase=phase,
             step_name=step_name,
             context=kwargs.get("context"),
         )
-        if content is not None:
+        config = InitialInputProviderResolver._load_issue_config(phase)
+        configured_provider, _issue_id = load_initial_input_selection(config)
+        if prefilled is None and not getattr(phase, "interactive", False):
             output_file.parent.mkdir(parents=True, exist_ok=True)
-            output_file.write_text(f"# Initial Requirements\n\n{content}\n", encoding="utf-8")
+            output_file.write_text("# Initial Requirements\n\n\n", encoding="utf-8")
             return HookResult(
-                context_updates={"user_input": content},
+                context_updates={"user_input": ""},
                 events=[
                     {
                         "type": "user_input_collected",
                         "step": step_name,
-                        "source": "workflow_user_input",
+                        "source": (
+                            "github"
+                            if configured_provider == GITHUB_ISSUE_PROVIDER
+                            else "non_interactive_no_input"
+                        ),
                     }
                 ],
             )
 
-        config_file = phase.issue_dir / "issue.yaml"
-        input_method, issue_id = self._load_input_config(config_file)
-
-        if input_method is None:
-            if not getattr(phase, "interactive", False):
-                return HookResult(
-                    context_updates={"user_input": ""},
-                    events=[
-                        {
-                            "type": "user_input_collected",
-                            "step": step_name,
-                            "source": "non_interactive_no_input",
-                        }
-                    ],
-                )
-            input_method, issue_id = self._prompt_input_method()
-            self._save_input_config(config_file, input_method, issue_id)
-
-        if input_method == "github" and issue_id is not None:
-            content = self._fetch_github_issue(issue_id)
-        elif getattr(phase, "interactive", False):
-            content = self._prompt_manual_input()
-        else:
-            content = ""
-
-        output_file.parent.mkdir(parents=True, exist_ok=True)
-        output_file.write_text(f"# Initial Requirements\n\n{content}\n", encoding="utf-8")
-
-        return HookResult(
-            context_updates={"user_input": content},
-            events=[
-                {
-                    "type": "user_input_collected",
-                    "step": step_name,
-                    "source": "github" if input_method == "github" else "manual",
-                }
-            ],
+        legacy_step_def = dict(kwargs.get("step_def") or {})
+        legacy_step_def["initial_input"] = {
+            "providers": [MANUAL_TEXT_PROVIDER, GITHUB_ISSUE_PROVIDER],
+            "bind": {"artifact": "spec", "prompt_context": "user_input"},
+        }
+        resolver_kwargs = dict(kwargs)
+        resolver_kwargs.update(
+            {
+                "step_def": legacy_step_def,
+                "initial_input_prompt_input_method": self._prompt_and_save_input_method(phase),
+                "initial_input_prompt_manual_input": self._prompt_manual_input,
+                "initial_input_fetch_github_issue": self._fetch_github_issue,
+            }
         )
+        result = InitialInputProviderResolver().run(**resolver_kwargs)
+        provider = result.events[0]["provider"] if result.events else MANUAL_TEXT_PROVIDER
+        source = (
+            "workflow_user_input"
+            if prefilled is not None
+            else "github" if provider == GITHUB_ISSUE_PROVIDER else "manual"
+        )
+        return HookResult(
+            continue_pipeline=result.continue_pipeline,
+            retry_requested=result.retry_requested,
+            artifact_ready=result.artifact_ready,
+            override_status_code=result.override_status_code,
+            context_updates=result.context_updates,
+            events=[{"type": "user_input_collected", "step": step_name, "source": source}],
+        )
+
+    def _prompt_and_save_input_method(self, phase: Any) -> Any:
+        def prompt() -> tuple[str, Optional[int]]:
+            method, issue_id = self._prompt_input_method()
+            self._save_input_config(phase.issue_dir / "issue.yaml", method, issue_id)
+            return method, issue_id
+
+        return prompt
 
     @staticmethod
     def _resolve_prefilled_input(

--- a/src/cafe/core/hooks/native.py
+++ b/src/cafe/core/hooks/native.py
@@ -602,6 +602,7 @@ class InitialInputProviderResolver(NoOpHook):
         declaration = step_def.get("initial_input")
         if not isinstance(declaration, dict):
             return HookResult()
+        legacy_presentation = declaration.get("legacy_presentation") is True
         providers = declaration.get("providers")
         binding = declaration.get("bind")
         if not isinstance(providers, list) or not isinstance(binding, dict):
@@ -617,19 +618,37 @@ class InitialInputProviderResolver(NoOpHook):
             if output_file.exists() and output_file.read_text(encoding="utf-8").strip():
                 return HookResult()
 
+        legacy_adapter = GitHubIssueFetcher() if legacy_presentation else None
         result = self._resolve(
             phase=phase,
             step_name=step_name,
             providers=providers,
             context=kwargs.get("context"),
-            prompt_input_method=kwargs.get("initial_input_prompt_input_method"),
-            prompt_manual_input=kwargs.get("initial_input_prompt_manual_input"),
-            fetch_github_issue=kwargs.get("initial_input_fetch_github_issue"),
+            prompt_input_method=(
+                kwargs.get("initial_input_prompt_input_method")
+                or (
+                    legacy_adapter._prompt_and_save_input_method(phase)
+                    if legacy_adapter is not None
+                    else None
+                )
+            ),
+            prompt_manual_input=(
+                kwargs.get("initial_input_prompt_manual_input")
+                or (legacy_adapter._prompt_manual_input if legacy_adapter is not None else None)
+            ),
+            fetch_github_issue=(
+                kwargs.get("initial_input_fetch_github_issue")
+                or (legacy_adapter._fetch_github_issue if legacy_adapter is not None else None)
+            ),
         )
         if artifact is not None:
             assert output_file is not None
             output_file.parent.mkdir(parents=True, exist_ok=True)
-            formatter = kwargs.get("initial_input_output_formatter")
+            formatter = kwargs.get("initial_input_output_formatter") or (
+                legacy_adapter._format_initial_requirements
+                if legacy_adapter is not None
+                else None
+            )
             content = formatter(result.content) if callable(formatter) else result.content
             output_file.write_text(f"{content.rstrip()}\n", encoding="utf-8")
 
@@ -696,7 +715,7 @@ class InitialInputProviderResolver(NoOpHook):
                 content = str(fetch(issue_id)).strip()
             except Exception as exc:
                 raise ValueError(
-                    f"initial_input.provider 'github_issue' could not fetch issue {issue_id}"
+                    f"initial_input.provider 'github_issue' could not fetch issue {issue_id}: {exc}"
                 ) from exc
             if not content:
                 raise ValueError(f"GitHub issue {issue_id} produced no initial input")

--- a/src/cafe/core/hooks/native.py
+++ b/src/cafe/core/hooks/native.py
@@ -619,28 +619,42 @@ class InitialInputProviderResolver(NoOpHook):
                 return HookResult()
 
         legacy_adapter = GitHubIssueFetcher() if legacy_presentation else None
-        result = self._resolve(
+        legacy_empty_seed = self._should_seed_empty_legacy_requirements(
             phase=phase,
             step_name=step_name,
             providers=providers,
             context=kwargs.get("context"),
-            prompt_input_method=(
-                kwargs.get("initial_input_prompt_input_method")
-                or (
-                    legacy_adapter._prompt_and_save_input_method(phase)
-                    if legacy_adapter is not None
-                    else None
-                )
-            ),
-            prompt_manual_input=(
-                kwargs.get("initial_input_prompt_manual_input")
-                or (legacy_adapter._prompt_manual_input if legacy_adapter is not None else None)
-            ),
-            fetch_github_issue=(
-                kwargs.get("initial_input_fetch_github_issue")
-                or (legacy_adapter._fetch_github_issue if legacy_adapter is not None else None)
-            ),
+            legacy_presentation=legacy_presentation,
         )
+        if legacy_empty_seed:
+            result = InitialInputResult(
+                content="",
+                provider=MANUAL_TEXT_PROVIDER,
+                source="non_interactive_no_input",
+            )
+        else:
+            result = self._resolve(
+                phase=phase,
+                step_name=step_name,
+                providers=providers,
+                context=kwargs.get("context"),
+                prompt_input_method=(
+                    kwargs.get("initial_input_prompt_input_method")
+                    or (
+                        legacy_adapter._prompt_and_save_input_method(phase)
+                        if legacy_adapter is not None
+                        else None
+                    )
+                ),
+                prompt_manual_input=(
+                    kwargs.get("initial_input_prompt_manual_input")
+                    or (legacy_adapter._prompt_manual_input if legacy_adapter is not None else None)
+                ),
+                fetch_github_issue=(
+                    kwargs.get("initial_input_fetch_github_issue")
+                    or (legacy_adapter._fetch_github_issue if legacy_adapter is not None else None)
+                ),
+            )
         if artifact is not None:
             assert output_file is not None
             output_file.parent.mkdir(parents=True, exist_ok=True)
@@ -650,7 +664,10 @@ class InitialInputProviderResolver(NoOpHook):
                 else None
             )
             content = formatter(result.content) if callable(formatter) else result.content
-            output_file.write_text(f"{content.rstrip()}\n", encoding="utf-8")
+            if legacy_empty_seed:
+                output_file.write_text(f"{content}\n", encoding="utf-8")
+            else:
+                output_file.write_text(f"{content.rstrip()}\n", encoding="utf-8")
 
         context_updates = (
             {"user_input": result.content}
@@ -667,6 +684,31 @@ class InitialInputProviderResolver(NoOpHook):
                 }
             ],
         )
+
+    def _should_seed_empty_legacy_requirements(
+        self,
+        *,
+        phase: Any,
+        step_name: str,
+        providers: list[Any],
+        context: Any,
+        legacy_presentation: bool,
+    ) -> bool:
+        """Keep built-in manual workflows compatible with their empty initial seed."""
+        if not legacy_presentation or getattr(phase, "interactive", False):
+            return False
+        if MANUAL_TEXT_PROVIDER not in {str(provider) for provider in providers}:
+            return False
+        if self._resolve_prefilled_input(
+            phase=phase,
+            step_name=step_name,
+            context=context,
+        ) is not None:
+            return False
+        configured_provider, _issue_id = load_initial_input_selection(
+            self._load_issue_config(phase)
+        )
+        return configured_provider in (None, MANUAL_TEXT_PROVIDER)
 
     def _resolve(
         self,

--- a/src/cafe/core/hooks/native.py
+++ b/src/cafe/core/hooks/native.py
@@ -21,7 +21,7 @@ from cafe.core.initial_input import (
 from cafe.core.questions_schema import parse_questions_xml, validate_questions_xml
 from cafe.core.status_codes import PhaseStatusCode, step_on_declares
 from cafe.skills.loader import SkillLoader
-from cafe.ui.inquirer_prompts import prompt_multiline
+from cafe.ui.inquirer_prompts import prompt_list, prompt_multiline, prompt_text
 from cafe.ui.interactive_qa import interactive_qa_flow
 from cafe.utils.github import (
     GitHubError,
@@ -629,9 +629,9 @@ class InitialInputProviderResolver(NoOpHook):
         if artifact is not None:
             assert output_file is not None
             output_file.parent.mkdir(parents=True, exist_ok=True)
-            output_file.write_text(
-                f"# Initial Requirements\n\n{result.content}\n", encoding="utf-8"
-            )
+            formatter = kwargs.get("initial_input_output_formatter")
+            content = formatter(result.content) if callable(formatter) else result.content
+            output_file.write_text(f"{content.rstrip()}\n", encoding="utf-8")
 
         context_updates = (
             {"user_input": result.content}
@@ -660,14 +660,15 @@ class InitialInputProviderResolver(NoOpHook):
         prompt_manual_input: Any,
         fetch_github_issue: Any,
     ) -> InitialInputResult:
-        declared = {str(provider) for provider in providers}
-        prefilled = GitHubIssueFetcher._resolve_prefilled_input(
+        declared = [str(provider) for provider in providers]
+        declared_set = set(declared)
+        prefilled = self._resolve_prefilled_input(
             phase=phase,
             step_name=step_name,
             context=context,
         )
         if prefilled is not None:
-            self._require_declared(MANUAL_TEXT_PROVIDER, declared, step_name)
+            self._require_declared(MANUAL_TEXT_PROVIDER, declared_set, step_name)
             return InitialInputResult(
                 content=prefilled,
                 provider=MANUAL_TEXT_PROVIDER,
@@ -682,13 +683,15 @@ class InitialInputProviderResolver(NoOpHook):
                 providers=declared,
                 prompt_input_method=prompt_input_method,
             )
+            self._require_declared(provider, declared_set, step_name)
             self._save_selection(phase, provider, issue_id)
-        self._require_declared(provider, declared, step_name)
+        else:
+            self._require_declared(provider, declared_set, step_name)
 
         if provider == GITHUB_ISSUE_PROVIDER:
             if issue_id is None:
                 raise ValueError("initial_input.provider 'github_issue' requires issue_id")
-            fetch = fetch_github_issue or GitHubIssueFetcher._fetch_github_issue
+            fetch = fetch_github_issue or self._fetch_github_issue
             try:
                 content = str(fetch(issue_id)).strip()
             except Exception as exc:
@@ -704,7 +707,7 @@ class InitialInputProviderResolver(NoOpHook):
                 "initial_input.provider 'manual_text' requires non-empty invocation input "
                 "when running non-interactively"
             )
-        prompt = prompt_manual_input or GitHubIssueFetcher._prompt_manual_input
+        prompt = prompt_manual_input or self._prompt_manual_input
         content = str(prompt()).strip()
         if not content:
             raise ValueError("initial_input.provider 'manual_text' received empty input")
@@ -754,29 +757,91 @@ class InitialInputProviderResolver(NoOpHook):
     def _select_provider(
         *,
         phase: Any,
-        providers: set[str],
+        providers: list[str],
         prompt_input_method: Any,
     ) -> tuple[str, Optional[int]]:
         if len(providers) == 1:
-            provider = next(iter(providers))
+            provider = providers[0]
             if provider != GITHUB_ISSUE_PROVIDER or not getattr(phase, "interactive", False):
                 return provider, None
-            prompt = prompt_input_method or GitHubIssueFetcher._prompt_input_method
-            selected_provider, issue_id = prompt()
-            normalized = {"manual": MANUAL_TEXT_PROVIDER, "github": GITHUB_ISSUE_PROVIDER}.get(
-                selected_provider, selected_provider
-            )
-            return normalized, issue_id
+            prompt = prompt_input_method or InitialInputProviderResolver._prompt_github_issue
+            return InitialInputProviderResolver._normalize_provider_selection(prompt())
         if not getattr(phase, "interactive", False):
             raise ValueError(
                 "initial_input.provider must be selected before non-interactive execution"
             )
-        prompt = prompt_input_method or GitHubIssueFetcher._prompt_input_method
-        provider, issue_id = prompt()
+        prompt = prompt_input_method or (
+            lambda: InitialInputProviderResolver._prompt_declared_provider(providers)
+        )
+        return InitialInputProviderResolver._normalize_provider_selection(prompt())
+
+    @staticmethod
+    def _normalize_provider_selection(
+        selection: tuple[str, Optional[int]],
+    ) -> tuple[str, Optional[int]]:
+        provider, issue_id = selection
         normalized = {"manual": MANUAL_TEXT_PROVIDER, "github": GITHUB_ISSUE_PROVIDER}.get(
             provider, provider
         )
         return normalized, issue_id
+
+    @staticmethod
+    def _resolve_prefilled_input(
+        *,
+        phase: Any,
+        step_name: str,
+        context: Any,
+    ) -> Optional[str]:
+        if hasattr(phase, "step_user_inputs"):
+            step_user_inputs = getattr(phase, "step_user_inputs")
+            if isinstance(step_user_inputs, dict):
+                raw_user_input = step_user_inputs.get(step_name)
+                if isinstance(raw_user_input, str) and raw_user_input.strip():
+                    return raw_user_input.strip()
+
+        if isinstance(context, dict):
+            raw_user_input = context.get("user_input")
+            if isinstance(raw_user_input, str) and raw_user_input.strip():
+                return raw_user_input.strip()
+
+        return None
+
+    @staticmethod
+    def _prompt_declared_provider(providers: list[str]) -> tuple[str, Optional[int]]:
+        provider = prompt_list("Select initial input provider:", choices=providers)
+        if provider == GITHUB_ISSUE_PROVIDER:
+            return InitialInputProviderResolver._prompt_github_issue()
+        return provider, None
+
+    @staticmethod
+    def _prompt_github_issue() -> tuple[str, Optional[int]]:
+        while True:
+            issue_input = prompt_text(message="GitHub Issue ID or URL:", default="")
+            try:
+                issue_id = int(GitHubOps().extract_issue_number(issue_input))
+            except (ValueError, GitHubError) as exc:
+                print(f"Invalid GitHub Issue ID or URL: {exc}")
+                continue
+            return GITHUB_ISSUE_PROVIDER, issue_id
+
+    @staticmethod
+    def _prompt_manual_input() -> str:
+        content = prompt_multiline("Provide the initial input").strip()
+        if not content:
+            raise ValueError("initial_input.provider 'manual_text' received empty input")
+        return content
+
+    @staticmethod
+    def _fetch_github_issue(issue_id: int) -> str:
+        from cafe.ui.phase_prompts import fetch_github_issue
+
+        fetched_content, _image_urls = fetch_github_issue(GitHubOps(), issue_id)
+        lines = fetched_content.split("\n", 1)
+        if lines[0].startswith("# "):
+            title = lines[0][2:].strip()
+            body = lines[1].strip() if len(lines) > 1 else ""
+            return f"**Issue Title:** {title}\n\n{body}" if body else f"**Issue Title:** {title}"
+        return fetched_content
 
 
 class GitHubIssueFetcher(NoOpHook):
@@ -835,6 +900,7 @@ class GitHubIssueFetcher(NoOpHook):
         resolver_kwargs.update(
             {
                 "step_def": legacy_step_def,
+                "initial_input_output_formatter": self._format_initial_requirements,
                 "initial_input_prompt_input_method": self._prompt_and_save_input_method(phase),
                 "initial_input_prompt_manual_input": self._prompt_manual_input,
                 "initial_input_fetch_github_issue": self._fetch_github_issue,
@@ -871,19 +937,15 @@ class GitHubIssueFetcher(NoOpHook):
         step_name: str,
         context: Any,
     ) -> Optional[str]:
-        if hasattr(phase, "step_user_inputs"):
-            step_user_inputs = getattr(phase, "step_user_inputs")
-            if isinstance(step_user_inputs, dict):
-                raw_user_input = step_user_inputs.get(step_name)
-                if isinstance(raw_user_input, str) and raw_user_input.strip():
-                    return raw_user_input.strip()
+        return InitialInputProviderResolver._resolve_prefilled_input(
+            phase=phase,
+            step_name=step_name,
+            context=context,
+        )
 
-        if isinstance(context, dict):
-            raw_user_input = context.get("user_input")
-            if isinstance(raw_user_input, str) and raw_user_input.strip():
-                return raw_user_input.strip()
-
-        return None
+    @staticmethod
+    def _format_initial_requirements(content: str) -> str:
+        return f"# Initial Requirements\n\n{content}"
 
     @staticmethod
     def _load_input_config(config_file: Path) -> tuple[Optional[str], Optional[int]]:

--- a/src/cafe/core/hooks/native.py
+++ b/src/cafe/core/hooks/native.py
@@ -758,7 +758,15 @@ class InitialInputProviderResolver(NoOpHook):
         prompt_input_method: Any,
     ) -> tuple[str, Optional[int]]:
         if len(providers) == 1:
-            return next(iter(providers)), None
+            provider = next(iter(providers))
+            if provider != GITHUB_ISSUE_PROVIDER or not getattr(phase, "interactive", False):
+                return provider, None
+            prompt = prompt_input_method or GitHubIssueFetcher._prompt_input_method
+            selected_provider, issue_id = prompt()
+            normalized = {"manual": MANUAL_TEXT_PROVIDER, "github": GITHUB_ISSUE_PROVIDER}.get(
+                selected_provider, selected_provider
+            )
+            return normalized, issue_id
         if not getattr(phase, "interactive", False):
             raise ValueError(
                 "initial_input.provider must be selected before non-interactive execution"
@@ -796,7 +804,11 @@ class GitHubIssueFetcher(NoOpHook):
         )
         config = InitialInputProviderResolver._load_issue_config(phase)
         configured_provider, _issue_id = load_initial_input_selection(config)
-        if prefilled is None and not getattr(phase, "interactive", False):
+        if (
+            prefilled is None
+            and not getattr(phase, "interactive", False)
+            and configured_provider != GITHUB_ISSUE_PROVIDER
+        ):
             output_file.parent.mkdir(parents=True, exist_ok=True)
             output_file.write_text("# Initial Requirements\n\n\n", encoding="utf-8")
             return HookResult(

--- a/src/cafe/core/initial_input.py
+++ b/src/cafe/core/initial_input.py
@@ -1,0 +1,62 @@
+"""Trusted initial-input provider declarations and resolution primitives."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+MANUAL_TEXT_PROVIDER = "manual_text"
+GITHUB_ISSUE_PROVIDER = "github_issue"
+SUPPORTED_INITIAL_INPUT_PROVIDERS = frozenset(
+    {MANUAL_TEXT_PROVIDER, GITHUB_ISSUE_PROVIDER}
+)
+
+
+@dataclass(frozen=True)
+class InitialInputResult:
+    """Content resolved by a trusted host-side provider."""
+
+    content: str
+    provider: str
+    source: str
+
+
+def registered_initial_input_providers() -> frozenset[str]:
+    """Return names implemented by the trusted host provider registry.
+
+    Provider execution is registered by the native hook. Keeping this small,
+    explicit registry fail-closes authoring validation without loading plugins
+    or granting playbooks arbitrary host execution.
+    """
+    return SUPPORTED_INITIAL_INPUT_PROVIDERS
+
+
+def normalize_initial_input_provider(value: Optional[str]) -> Optional[str]:
+    """Normalize legacy prepare values to the provider contract names."""
+    if value is None:
+        return None
+    normalized = value.strip().lower()
+    return {"manual": MANUAL_TEXT_PROVIDER, "github": GITHUB_ISSUE_PROVIDER}.get(
+        normalized, normalized
+    )
+
+
+def load_initial_input_selection(
+    issue_config: dict[str, Any],
+) -> tuple[Optional[str], Optional[int]]:
+    """Read canonical selection first, then preserve legacy spec configuration."""
+    canonical = issue_config.get("initial_input")
+    if isinstance(canonical, dict):
+        provider = normalize_initial_input_provider(canonical.get("provider"))
+        raw_issue_id = canonical.get("issue_id")
+    else:
+        legacy_spec = issue_config.get("spec")
+        legacy_spec = legacy_spec if isinstance(legacy_spec, dict) else {}
+        provider = normalize_initial_input_provider(legacy_spec.get("input_method"))
+        raw_issue_id = legacy_spec.get("issue_id")
+
+    try:
+        issue_id = int(raw_issue_id) if raw_issue_id not in (None, "") else None
+    except (TypeError, ValueError):
+        issue_id = None
+    return provider, issue_id

--- a/src/cafe/core/playbook.py
+++ b/src/cafe/core/playbook.py
@@ -573,6 +573,11 @@ def _validate_initial_input_declarations(model: PlaybookDefinition) -> None:
                 f"{field_path}.bind.artifact {artifact!r} must match output_artifact "
                 f"{step.output_artifact!r}"
             )
+        if "InitialInputProviderResolver" not in step.hooks.prepare_input:
+            raise ValueError(
+                f"{field_path} requires hooks.prepare_input to include "
+                "'InitialInputProviderResolver'"
+            )
 
 
 def _validate_prepare_metadata(

--- a/src/cafe/core/playbook.py
+++ b/src/cafe/core/playbook.py
@@ -11,6 +11,10 @@ import yaml
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from cafe.core.human_tasks import HumanTaskBinding
+from cafe.core.initial_input import (
+    SUPPORTED_INITIAL_INPUT_PROVIDERS,
+    registered_initial_input_providers,
+)
 from cafe.core.prepare_fields import (
     PrepareField,
     assert_prepare_semantics_match,
@@ -103,6 +107,50 @@ class StepAlignmentConfig(BaseModel):
         return list(dict.fromkeys(cleaned))
 
 
+class InitialInputBinding(BaseModel):
+    """Declared destinations for an entry step's trusted initial input."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    artifact: Optional[str] = None
+    prompt_context: Optional[Literal["user_input"]] = None
+
+    @model_validator(mode="after")
+    def _require_a_target(self) -> "InitialInputBinding":
+        if self.artifact is None and self.prompt_context is None:
+            raise ValueError("initial_input.bind must declare artifact or prompt_context")
+        return self
+
+
+class InitialInputDeclaration(BaseModel):
+    """Trusted providers permitted for an entry step's first iteration."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    providers: List[str]
+    bind: InitialInputBinding
+
+    @field_validator("providers")
+    @classmethod
+    def _validate_providers(cls, value: List[str]) -> List[str]:
+        providers = [provider.strip() for provider in value if provider.strip()]
+        if not providers:
+            raise ValueError("initial_input.providers must include at least one provider")
+        if len(providers) != len(set(providers)):
+            raise ValueError("initial_input.providers must not contain duplicates")
+        unsupported = [
+            provider
+            for provider in providers
+            if provider not in SUPPORTED_INITIAL_INPUT_PROVIDERS
+        ]
+        if unsupported:
+            raise ValueError(
+                "initial_input.providers contains unsupported provider "
+                f"{unsupported[0]!r}"
+            )
+        return providers
+
+
 class StepConfig(BaseModel):
     """One playbook step."""
 
@@ -117,6 +165,7 @@ class StepConfig(BaseModel):
     # remains the opt-in isolated scope.
     input_artifacts: Optional[List[str]] = None
     output_artifact: Optional[str] = None
+    initial_input: Optional[InitialInputDeclaration] = None
     template: Optional[str] = None
     allowed_tools: List[str] = Field(default_factory=list)
     capability_requests: List[str] = Field(default_factory=list)
@@ -462,6 +511,8 @@ def validate_playbook(
     if entry is not None and entry not in steps:
         raise ValueError(f"entry_point {entry!r} is not a defined step")
 
+    _validate_initial_input_declarations(model)
+
     _report_structural_issue(
         playbook_id=model.playbook.id,
         filename=path.stem,
@@ -496,6 +547,32 @@ def validate_playbook(
     if warnings and strict:
         raise ValueError("\n".join(warnings))
     return warnings
+
+
+def _validate_initial_input_declarations(model: PlaybookDefinition) -> None:
+    """Fail closed on invalid initial-input declarations before execution."""
+    registered = registered_initial_input_providers()
+    for step_name, step in model.steps.items():
+        declaration = step.initial_input
+        if declaration is None:
+            continue
+        field_path = f"steps.{step_name}.initial_input"
+        if step_name != model.entry_point:
+            raise ValueError(
+                f"{field_path} is only allowed on entry_point {model.entry_point!r}"
+            )
+        missing = [provider for provider in declaration.providers if provider not in registered]
+        if missing:
+            raise ValueError(
+                f"{field_path}.providers declares {missing[0]!r}, which has no trusted "
+                "host implementation"
+            )
+        artifact = declaration.bind.artifact
+        if artifact is not None and artifact != step.output_artifact:
+            raise ValueError(
+                f"{field_path}.bind.artifact {artifact!r} must match output_artifact "
+                f"{step.output_artifact!r}"
+            )
 
 
 def _validate_prepare_metadata(

--- a/src/cafe/core/playbook.py
+++ b/src/cafe/core/playbook.py
@@ -129,6 +129,7 @@ class InitialInputDeclaration(BaseModel):
 
     providers: List[str]
     bind: InitialInputBinding
+    legacy_presentation: bool = False
 
     @field_validator("providers")
     @classmethod

--- a/src/cafe/core/playbook.py
+++ b/src/cafe/core/playbook.py
@@ -115,6 +115,13 @@ class InitialInputBinding(BaseModel):
     artifact: Optional[str] = None
     prompt_context: Optional[Literal["user_input"]] = None
 
+    @field_validator("artifact")
+    @classmethod
+    def _validate_artifact(cls, value: Optional[str]) -> Optional[str]:
+        if value is not None and not value.strip():
+            raise ValueError("initial_input.bind.artifact must not be empty")
+        return value
+
     @model_validator(mode="after")
     def _require_a_target(self) -> "InitialInputBinding":
         if self.artifact is None and self.prompt_context is None:

--- a/src/cafe/core/playbook.py
+++ b/src/cafe/core/playbook.py
@@ -512,7 +512,7 @@ def validate_playbook(
     if entry is not None and entry not in steps:
         raise ValueError(f"entry_point {entry!r} is not a defined step")
 
-    _validate_initial_input_declarations(model)
+    _validate_initial_input_declarations(model, source=source)
 
     _report_structural_issue(
         playbook_id=model.playbook.id,
@@ -550,7 +550,9 @@ def validate_playbook(
     return warnings
 
 
-def _validate_initial_input_declarations(model: PlaybookDefinition) -> None:
+def _validate_initial_input_declarations(
+    model: PlaybookDefinition, *, source: str
+) -> None:
     """Fail closed on invalid initial-input declarations before execution."""
     registered = registered_initial_input_providers()
     for step_name, step in model.steps.items():
@@ -561,6 +563,12 @@ def _validate_initial_input_declarations(model: PlaybookDefinition) -> None:
         if step_name != model.entry_point:
             raise ValueError(
                 f"{field_path} is only allowed on entry_point {model.entry_point!r}"
+            )
+        if declaration.legacy_presentation and (
+            source != "builtin" or model.playbook.id not in {"default", "simple", "tdd"}
+        ):
+            raise ValueError(
+                f"{field_path}.legacy_presentation is reserved for bundled development playbooks"
             )
         missing = [provider for provider in declaration.providers if provider not in registered]
         if missing:

--- a/src/cafe/core/prepare_fields.py
+++ b/src/cafe/core/prepare_fields.py
@@ -128,8 +128,8 @@ class PrepareField(BaseModel):
                     raise ValueError(
                         f"field {self.id!r} {name} {value!r} is not one of its choices"
                     )
-        if self.normalize == "github_issue" and self.write != "spec.issue_id":
-            raise ValueError(f"field {self.id!r} github_issue normalization requires spec.issue_id")
+        if self.normalize == "github_issue" and self.type != "text":
+            raise ValueError(f"field {self.id!r} github_issue normalization requires a text field")
         return self
 
 

--- a/src/cafe/core/prepare_profile.py
+++ b/src/cafe/core/prepare_profile.py
@@ -23,6 +23,7 @@ class PrepareIssueConfig:
     plan: Dict[str, Any]
     pr: Dict[str, Any]
     steps: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+    initial_input: Dict[str, Any] = field(default_factory=dict)
 
     def section(self, step_name: str) -> Dict[str, Any]:
         """Return a mutable issue-config section, retaining legacy views."""

--- a/src/cafe/data/playbooks/default.yaml
+++ b/src/cafe/data/playbooks/default.yaml
@@ -31,6 +31,11 @@ steps:
     assignee_type: agent
     input_artifacts: []
     output_artifact: spec
+    initial_input:
+      providers: [manual_text, github_issue]
+      bind:
+        artifact: spec
+        prompt_context: user_input
     human_tasks:
       - trigger: confirm_output
         task_id: output-review
@@ -40,7 +45,7 @@ steps:
         outcomes: {submit: spec}
     allowed_tools: [Read, Grep, Glob, WebFetch, WebSearch]
     hooks:
-      prepare_input: [GitHubIssueFetcher, UserInputCollector]
+      prepare_input: [InitialInputProviderResolver, UserInputCollector]
       after_execute: [InteractiveQAHandler]
     "on":
       confirm_output: spec

--- a/src/cafe/data/playbooks/default.yaml
+++ b/src/cafe/data/playbooks/default.yaml
@@ -36,6 +36,7 @@ steps:
       bind:
         artifact: spec
         prompt_context: user_input
+      legacy_presentation: true
     human_tasks:
       - trigger: confirm_output
         task_id: output-review

--- a/src/cafe/data/playbooks/simple.yaml
+++ b/src/cafe/data/playbooks/simple.yaml
@@ -30,6 +30,7 @@ steps:
       bind:
         artifact: spec
         prompt_context: user_input
+      legacy_presentation: true
     human_tasks:
       - trigger: confirm_output
         task_id: output-review

--- a/src/cafe/data/playbooks/simple.yaml
+++ b/src/cafe/data/playbooks/simple.yaml
@@ -25,6 +25,11 @@ steps:
     assignee_type: agent
     input_artifacts: []
     output_artifact: spec
+    initial_input:
+      providers: [manual_text, github_issue]
+      bind:
+        artifact: spec
+        prompt_context: user_input
     human_tasks:
       - trigger: confirm_output
         task_id: output-review
@@ -34,7 +39,7 @@ steps:
         outcomes: {submit: spec}
     allowed_tools: [Read, Grep, Glob, WebFetch, WebSearch]
     hooks:
-      prepare_input: [GitHubIssueFetcher, UserInputCollector]
+      prepare_input: [InitialInputProviderResolver, UserInputCollector]
       after_execute: [InteractiveQAHandler]
     "on":
       confirm_output: spec

--- a/src/cafe/data/playbooks/tdd.yaml
+++ b/src/cafe/data/playbooks/tdd.yaml
@@ -31,6 +31,11 @@ steps:
     assignee_type: agent
     input_artifacts: []
     output_artifact: spec
+    initial_input:
+      providers: [manual_text, github_issue]
+      bind:
+        artifact: spec
+        prompt_context: user_input
     human_tasks:
       - trigger: confirm_output
         task_id: output-review
@@ -40,7 +45,7 @@ steps:
         outcomes: {submit: spec}
     allowed_tools: [Read, Grep, Glob, WebFetch, WebSearch]
     hooks:
-      prepare_input: [GitHubIssueFetcher, UserInputCollector]
+      prepare_input: [InitialInputProviderResolver, UserInputCollector]
       after_execute: [InteractiveQAHandler]
     "on":
       confirm_output: spec

--- a/src/cafe/data/playbooks/tdd.yaml
+++ b/src/cafe/data/playbooks/tdd.yaml
@@ -36,6 +36,7 @@ steps:
       bind:
         artifact: spec
         prompt_context: user_input
+      legacy_presentation: true
     human_tasks:
       - trigger: confirm_output
         task_id: output-review

--- a/src/cafe/data/skills/write-cafe-playbook/references/playbook-spec.md
+++ b/src/cafe/data/skills/write-cafe-playbook/references/playbook-spec.md
@@ -282,6 +282,11 @@ their legacy `spec.input_method` / `spec.issue_id` keys. The provider resolver i
 host-side only, runs on first iteration without overwriting existing output, and
 does not grant agent credentials or arbitrary host execution.
 
+`legacy_presentation: true` is reserved for bundled development playbooks. It
+keeps their established requirements heading and guided manual/GitHub interaction
+while they use `InitialInputProviderResolver`; custom playbooks should omit it so
+the resolver writes only the declared input content.
+
 ## 9. Validation Sequence
 
 Run all applicable checks from the target repo:

--- a/src/cafe/data/skills/write-cafe-playbook/references/playbook-spec.md
+++ b/src/cafe/data/skills/write-cafe-playbook/references/playbook-spec.md
@@ -98,6 +98,7 @@ artifacts.
 | `assignee_type` | Use `agent`; other values are currently reserved and warn |
 | `input_artifacts` | Artifact keys already produced by earlier or conditional paths |
 | `output_artifact` | The key registered when `{output_file}` exists |
+| `initial_input` | Entry-step-only trusted input providers and explicit artifact/prompt bindings |
 | `template` | Optional default selected from the step skill's declared output-template catalog |
 | `valid_intents` | Supported `PhaseStatusCode` tokens the phase may return |
 | `allowed_tools` | Least broad set that still allows the skill to complete |
@@ -243,6 +244,43 @@ Prefer an explicit forward skip:
   in the matching `issue.yaml` block. A `template` field still requires the target
   skill to declare `workflow.output_templates`; other workflow-owned settings need
   no development-stage or PR metadata.
+
+### Initial input for a custom entry step
+
+Use this contract when an entry step needs operator text or a GitHub issue before
+the agent executes:
+
+```yaml
+entry_point: intake
+steps:
+  intake:
+    type: skill
+    skill: cafe-intake
+    role: researcher
+    output_artifact: intake_brief
+    initial_input:
+      providers: [manual_text, github_issue]
+      bind:
+        artifact: intake_brief
+        prompt_context: user_input
+    hooks:
+      prepare_input: [InitialInputProviderResolver]
+    "on": {await_agent: _done}
+```
+
+`initial_input` is permitted only on `entry_point`. Providers must be unique and
+implemented by CAFE's trusted host registry; this release supplies only
+`manual_text` and `github_issue`. `bind` must name an artifact equal to this
+step's `output_artifact`, `user_input` prompt context, or both. Validation fails
+before agent execution for unsupported providers, non-entry declarations, missing
+bindings, or invalid destinations.
+
+Prepare persists a canonical `initial_input` block in `issue.yaml` using the
+stable field IDs `input_method` and `github_issue_id`; those fields may write to
+the entry step's own config section. Built-in development playbooks also retain
+their legacy `spec.input_method` / `spec.issue_id` keys. The provider resolver is
+host-side only, runs on first iteration without overwriting existing output, and
+does not grant agent credentials or arbitrary host execution.
 
 ## 9. Validation Sequence
 

--- a/src/cafe/ui/commands/lifecycle.py
+++ b/src/cafe/ui/commands/lifecycle.py
@@ -393,6 +393,7 @@ def prepare(
             raise typer.Exit(1)
 
         profile = PrepareProfile.from_playbook(loaded_playbook.model, is_github_repo())
+        entry_step_name = str(loaded_playbook.model.entry_point)
 
         # 2. Determine interactive mode and config prompt behavior
         # should_prompt_for_config: Should we show config prompts?
@@ -720,7 +721,7 @@ def prepare(
             # Create issues directory structure in worktree
             worktree_issues_dir = worktree_cafe_dir / "issues" / issue_name
             worktree_issues_dir.mkdir(parents=True, exist_ok=True)
-            (worktree_issues_dir / "spec").mkdir(exist_ok=True)
+            (worktree_issues_dir / entry_step_name).mkdir(exist_ok=True)
             (worktree_issues_dir / "sessions").mkdir(exist_ok=True)
 
             # Initialize default templates and agents in worktree .cafe
@@ -732,10 +733,10 @@ def prepare(
             # Normal branch mode
             # First create issue directory structure
             issue_dir = Path(f".cafe/issues/{issue_name}")
-            spec_dir = issue_dir / "spec"
+            entry_step_dir = issue_dir / entry_step_name
             sessions_dir = issue_dir / "sessions"
 
-            spec_dir.mkdir(parents=True, exist_ok=True)
+            entry_step_dir.mkdir(parents=True, exist_ok=True)
             sessions_dir.mkdir(parents=True, exist_ok=True)
 
             # Then perform git operations

--- a/src/cafe/ui/commands/lifecycle.py
+++ b/src/cafe/ui/commands/lifecycle.py
@@ -212,6 +212,7 @@ def _run_field_driven_prepare_prompts(
     dict[str, Any],
     dict[str, Any],
     dict[str, dict[str, Any]],
+    dict[str, Any],
     Optional[int],
 ]:
     """Run interactive prepare prompts from declarative PrepareField definitions."""
@@ -231,7 +232,14 @@ def _run_field_driven_prepare_prompts(
         github_ops=github_ops,
     )
     config, issue_id = run_field_driven_prepare_flow(parsed, profile, deps=deps)
-    return config.spec, config.plan, config.pr, config.steps, issue_id
+    return (
+        config.spec,
+        config.plan,
+        config.pr,
+        config.steps,
+        getattr(config, "initial_input", {}),
+        issue_id,
+    )
 
 
 def prepare(
@@ -488,6 +496,7 @@ def prepare(
         plan_config = {}
         pr_config = {}
         step_configs: dict[str, dict[str, Any]] = {}
+        initial_input_config: dict[str, Any] = {}
 
         if profile.should_prompt_spec_plan_config(should_prompt_for_config):
             console.print()
@@ -532,8 +541,25 @@ def prepare(
                 )
                 if len(field_result) == 4:
                     spec_config, plan_config, pr_config, issue_id = field_result
-                else:
+                elif len(field_result) == 5:
                     spec_config, plan_config, pr_config, step_configs, issue_id = field_result
+                else:
+                    (
+                        spec_config,
+                        plan_config,
+                        pr_config,
+                        step_configs,
+                        initial_input_config,
+                        issue_id,
+                    ) = field_result
+                if not initial_input_config:
+                    from cafe.core.initial_input import normalize_initial_input_provider
+
+                    provider = normalize_initial_input_provider(spec_config.get("input_method"))
+                    if provider is not None:
+                        initial_input_config = {"provider": provider}
+                        if provider == "github_issue" and issue_id is not None:
+                            initial_input_config["issue_id"] = issue_id
         elif not interactive:
             from cafe.core.playbook import declared_template_managers
             from cafe.skills.loader import SkillLoader
@@ -601,6 +627,7 @@ def prepare(
             plan_config = resolved_config.plan
             pr_config = resolved_config.pr
             step_configs = resolved_config.steps
+            initial_input_config = resolved_config.initial_input
         # else: issue_name was provided as argument but not --no-interactive
         #       Don't save any config (old behavior for backward compatibility)
 
@@ -633,6 +660,9 @@ def prepare(
         # Add pr config if present
         if pr_config:
             config_data["pr"] = pr_config
+
+        if initial_input_config:
+            config_data["initial_input"] = initial_input_config
 
         for step_name, step_config in step_configs.items():
             if step_config:

--- a/src/cafe/ui/prepare_field_renderer.py
+++ b/src/cafe/ui/prepare_field_renderer.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Callable, List, Literal, Optional, Tuple
 
+from cafe.core.initial_input import normalize_initial_input_provider
 from cafe.core.prepare_fields import ParsedPrepareFields, PrepareField, PrepareFieldChoice
 from cafe.core.prepare_profile import PrepareIssueConfig, PrepareProfile, PrepareRigorError
 from cafe.templates.manager import TemplateManager
@@ -242,6 +243,10 @@ def _cli_value_for_field(
     answers: NonInteractiveCliAnswers,
 ) -> tuple[bool, Any]:
     """Return an explicitly supplied CLI value for one declared field."""
+    if field.id == "input_method":
+        return answers.input_method is not None, answers.input_method
+    if field.id == "github_issue_id" or field.normalize == "github_issue":
+        return answers.issue_id is not None, answers.issue_id
     values = {
         "spec.input_method": answers.input_method,
         "spec.issue_id": answers.issue_id,
@@ -288,7 +293,7 @@ def _validate_declared_non_interactive_input(
     answers: NonInteractiveCliAnswers,
 ) -> None:
     """Require input flags only when a declared input field asks for them."""
-    input_fields = [field for field in parsed_fields.fields if field.write == "spec.input_method"]
+    input_fields = [field for field in parsed_fields.fields if field.id == "input_method"]
     if not input_fields:
         return
     if answers.input_method is not None and answers.input_method not in _ALLOWED_INPUT_METHODS:
@@ -386,7 +391,7 @@ def resolve_non_interactive_issue_config(
                     f"prepare field {field.id!r} requires a value in non-interactive mode"
                 )
             continue
-        if field.write == "spec.issue_id":
+        if field.id == "github_issue_id" or field.normalize == "github_issue":
             value = str(value)
         _validate_field_enum_value(field, value, profile=profile)
         if field.type == "template":
@@ -397,6 +402,13 @@ def resolve_non_interactive_issue_config(
         if key in config.section(section) and not is_explicit:
             continue
         set_write_value(config, field.write, value)
+
+    if answers.input_method is not None:
+        provider = normalize_initial_input_provider(answers.input_method)
+        if provider is not None:
+            config.initial_input["provider"] = provider
+            if provider == "github_issue" and answers.issue_id is not None:
+                config.initial_input["issue_id"] = answers.issue_id
 
     if not profile.supports_pr_config(parsed_fields) and (
         answers.auto_create_pr or answers.post_pr_todo_list is not None
@@ -583,7 +595,11 @@ def prompt_custom_fields(
     )
     config = empty_issue_config()
     for field in parsed.fields:
-        if field.type == "setup_mode" or field.write in {"spec.input_method", "spec.issue_id"}:
+        if (
+            field.type == "setup_mode"
+            or field.id == "input_method"
+            or field.normalize == "github_issue"
+        ):
             continue
         if field.write is None:
             continue
@@ -629,11 +645,14 @@ def run_field_driven_prepare_flow(
     issue_id: Optional[int] = None
 
     input_field = next(
-        (field for field in parsed.fields if field.write == "spec.input_method"),
-        None,
+        (field for field in parsed.fields if field.id == "input_method"), None
     )
     issue_field = next(
-        (field for field in parsed.fields if field.write == "spec.issue_id"),
+        (
+            field
+            for field in parsed.fields
+            if field.id == "github_issue_id" or field.normalize == "github_issue"
+        ),
         None,
     )
     if input_field is not None and field_is_visible(
@@ -651,11 +670,23 @@ def run_field_driven_prepare_flow(
             field=input_field,
             issue_field=issue_field,
         )
-        spec_config.spec["input_method"] = input_method
+        set_write_value(spec_config, input_field.write, input_method)
         if issue_id is not None:
-            spec_config.spec["issue_id"] = str(issue_id)
+            if issue_field is None or issue_field.write is None:
+                raise ValueError(
+                    "input_method field requires a github_issue field for GitHub input"
+                )
+            set_write_value(spec_config, issue_field.write, str(issue_id))
     elif input_field is not None and input_field.default is not None:
         set_write_value(spec_config, input_field.write, input_field.default)
+        input_method = str(input_field.default)
+    else:
+        input_method = None
+    provider = normalize_initial_input_provider(input_method)
+    if provider is not None:
+        spec_config.initial_input["provider"] = provider
+        if provider == "github_issue" and issue_id is not None:
+            spec_config.initial_input["issue_id"] = issue_id
     ctx.issue_id = issue_id
 
     setup_field = next((field for field in parsed.fields if field.type == "setup_mode"), None)

--- a/tests/integration/test_initial_input_providers.py
+++ b/tests/integration/test_initial_input_providers.py
@@ -1,0 +1,143 @@
+"""Integration journeys for declared initial-input providers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from cafe.core.blackboard import BlackboardStore
+from cafe.core.types import AgentCLI, TokenUsage
+from cafe.phases.generic_phase import GenericPhase
+from cafe.phases.generic_workflow_step import GenericWorkflowStepExecutor
+from cafe.skills.loader import SkillLoader
+from cafe.skills.native_bridge import NativeSkillBridge
+
+
+class _AgentManager:
+    def __init__(self) -> None:
+        self.prompts: list[str] = []
+        self.agent = SimpleNamespace(
+            config=SimpleNamespace(cli=AgentCLI.CODEX, session_id=None, model=None)
+        )
+
+    def get_agent(self, _name: str):
+        return self.agent
+
+    def execute(self, _name: str, prompt: str, **_kwargs):
+        self.prompts.append(prompt)
+        return "confirmed", TokenUsage(), [], [], [], None
+
+
+class _GitOps:
+    def get_default_base_branch(self) -> str:
+        return "main"
+
+    def get_commits_between(self, *, base: str, head: str) -> str:
+        return ""
+
+
+def _write_skill(root: Path, name: str) -> None:
+    directory = root / name
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: {name}\n---\n", encoding="utf-8"
+    )
+
+
+def _intake_executor(
+    tmp_path: Path,
+    *,
+    initial_input: dict[str, object],
+    step_user_inputs: dict[str, str] | None = None,
+) -> tuple[GenericWorkflowStepExecutor, _AgentManager, Path, dict[str, object]]:
+    builtin_root = tmp_path / "builtin"
+    for name in ("cafe-workflow-common", "cafe-github_sync"):
+        _write_skill(builtin_root / "skills", name)
+    _write_skill(tmp_path / ".cafe" / "skills", "intake")
+    loader = SkillLoader(
+        project_root=tmp_path,
+        global_root=tmp_path / "global",
+        builtin_root=builtin_root,
+    )
+    loader.discover()
+    generic_phase = GenericPhase(
+        loader,
+        skill_bridge=NativeSkillBridge(loader, project_root=tmp_path, home_dir=tmp_path / "home"),
+    )
+    issue_dir = tmp_path / ".cafe" / "issues" / "intake-journey"
+    issue_dir.mkdir(parents=True)
+    step: dict[str, object] = {
+        "skill": "intake",
+        "role": "researcher",
+        "input_artifacts": [],
+        "output_artifact": "intake_brief",
+        "initial_input": {
+            "providers": ["manual_text", "github_issue"],
+            "bind": {"artifact": "intake_brief", "prompt_context": "user_input"},
+        },
+        "hooks": {"prepare_input": ["InitialInputProviderResolver"]},
+        "valid_intents": ["confirmed"],
+        "on": {"await_agent": "_done"},
+    }
+    (issue_dir / "issue.yaml").write_text(
+        "initial_input:\n"
+        + "\n".join(f"  {key}: {value}" for key, value in initial_input.items())
+        + "\n",
+        encoding="utf-8",
+    )
+    manager = _AgentManager()
+    executor = GenericWorkflowStepExecutor(
+        issue_dir=issue_dir,
+        issue_name="intake-journey",
+        playbook={
+            "playbook": {"id": "intake"},
+            "roles": {"researcher": {"default_agent": "David"}},
+            "entry_point": "intake",
+            "steps": {"intake": step},
+        },
+        generic_phase=generic_phase,
+        agent_manager=manager,
+        git_ops=_GitOps(),
+        role_agent_map={"researcher": "David"},
+        step_user_inputs=step_user_inputs,
+    )
+    return executor, manager, issue_dir, step
+
+
+def test_custom_manual_intake_delivers_one_input_to_artifact_and_agent(tmp_path: Path) -> None:
+    """I1 — a non-development entry step receives declared manual input."""
+    content = "Collect the customer's incident timeline."
+    executor, manager, issue_dir, step = _intake_executor(
+        tmp_path,
+        initial_input={"provider": "manual_text"},
+        step_user_inputs={"intake": content},
+    )
+    state = BlackboardStore(issue_dir).load_or_create("intake")
+
+    executor.execute_step("intake", step, state)
+
+    output = issue_dir / "intake" / "iteration_001" / "output.md"
+    assert content in output.read_text(encoding="utf-8")
+    assert "Current user input for this iteration:\n" + content in manager.prompts[0]
+    assert not (issue_dir / "spec").exists()
+
+
+def test_custom_github_intake_uses_trusted_host_boundary_once(tmp_path: Path) -> None:
+    """I2 — a non-development entry step receives host-resolved GitHub input."""
+    content = "**Issue Title:** Intake request\n\nCollect source material."
+    executor, manager, issue_dir, step = _intake_executor(
+        tmp_path,
+        initial_input={"provider": "github_issue", "issue_id": 346},
+    )
+    state = BlackboardStore(issue_dir).load_or_create("intake")
+
+    with patch(
+        "cafe.core.hooks.native.GitHubIssueFetcher._fetch_github_issue", return_value=content
+    ) as fetch:
+        executor.execute_step("intake", step, state)
+
+    fetch.assert_called_once_with(346)
+    output = issue_dir / "intake" / "iteration_001" / "output.md"
+    assert content in output.read_text(encoding="utf-8")
+    assert "Current user input for this iteration:\n" + content in manager.prompts[0]

--- a/tests/integration/test_initial_input_providers.py
+++ b/tests/integration/test_initial_input_providers.py
@@ -213,7 +213,8 @@ def test_custom_github_intake_uses_trusted_host_boundary_once(tmp_path: Path, mo
     state = BlackboardStore(issue_dir).load_or_create("intake")
 
     with patch(
-        "cafe.core.hooks.native.GitHubIssueFetcher._fetch_github_issue", return_value=content
+        "cafe.core.hooks.native.InitialInputProviderResolver._fetch_github_issue",
+        return_value=content,
     ) as fetch:
         executor.execute_step("intake", step, state)
 

--- a/tests/integration/test_initial_input_providers.py
+++ b/tests/integration/test_initial_input_providers.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
 import yaml
 from typer.testing import CliRunner
 
@@ -180,6 +181,57 @@ def _prepare_intake_issue(
     return executor, manager, issue_dir, step
 
 
+def _prepare_builtin_issue(
+    tmp_path: Path, *, playbook_id: str
+) -> tuple[GenericWorkflowStepExecutor, _AgentManager, Path, dict[str, object]]:
+    """Prepare one built-in workflow for its first-step compatibility journey."""
+    from tests.conftest import create_minimal_config
+
+    create_minimal_config(tmp_path)
+    config_path = tmp_path / ".cafe" / "config.yaml"
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    config["playbook"] = playbook_id
+    config_path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
+
+    mock_git = MagicMock()
+    mock_git.get_current_branch.return_value = "main"
+    mock_git.has_uncommitted_changes.return_value = False
+    mock_git.branch_exists.return_value = False
+    mock_git.worktree_exists.return_value = False
+    issue_name = f"{playbook_id}-legacy-input"
+    with (
+        patch("cafe.ui.cli.GitOperations", return_value=mock_git),
+        patch("cafe.utils.git_utils.is_github_repo", return_value=True),
+        patch("cafe.ui.phase_prompts.is_github_repo", return_value=True),
+    ):
+        result = runner.invoke(
+            app,
+            ["prepare", issue_name, "--no-interactive", "--input-method=manual"],
+        )
+    assert result.exit_code == 0, result.stdout
+
+    issue_dir = tmp_path / ".cafe" / "issues" / issue_name
+    playbook = PlaybookLoader(project_root=tmp_path).load(playbook_id)
+    step = playbook["steps"]["spec"]
+    manager = _AgentManager()
+    loader = SkillLoader(project_root=tmp_path)
+    loader.discover()
+    generic_phase = GenericPhase(
+        loader,
+        skill_bridge=NativeSkillBridge(loader, project_root=tmp_path, home_dir=tmp_path / "home"),
+    )
+    executor = GenericWorkflowStepExecutor(
+        issue_dir=issue_dir,
+        issue_name=issue_name,
+        playbook=playbook,
+        generic_phase=generic_phase,
+        agent_manager=manager,
+        git_ops=_GitOps(),
+        role_agent_map={"pm": "Roger"},
+    )
+    return executor, manager, issue_dir, step
+
+
 def test_custom_manual_intake_delivers_one_input_to_artifact_and_agent(
     tmp_path: Path, monkeypatch
 ) -> None:
@@ -222,3 +274,64 @@ def test_custom_github_intake_uses_trusted_host_boundary_once(tmp_path: Path, mo
     output = issue_dir / "intake" / "iteration_001" / "output.md"
     assert content in output.read_text(encoding="utf-8")
     assert "Current user input for this iteration:\n" + content in manager.prompts[0]
+
+
+@pytest.mark.parametrize("playbook_id", ("default", "simple", "tdd"))
+def test_builtin_workflows_prepare_and_seed_their_first_spec_step(
+    tmp_path: Path, monkeypatch, playbook_id: str
+) -> None:
+    """I3 — built-ins preserve manual prepare config and first-step seeding."""
+    monkeypatch.chdir(tmp_path)
+    executor, manager, issue_dir, step = _prepare_builtin_issue(
+        tmp_path, playbook_id=playbook_id
+    )
+    config = yaml.safe_load((issue_dir / "issue.yaml").read_text(encoding="utf-8"))
+    assert config["spec"]["input_method"] == "manual"
+    assert config["initial_input"] == {"provider": "manual_text"}
+
+    state = BlackboardStore(issue_dir).load_or_create("spec")
+    result = executor.execute_step("spec", step, state)
+
+    output = issue_dir / "spec" / "iteration_001" / "output.md"
+    assert result.artifacts["spec"] == str(output)
+    assert output.read_text(encoding="utf-8").strip()
+    assert len(manager.prompts) == 1
+
+
+def test_invalid_initial_input_declaration_stops_at_cli_validation_boundary(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """I4 — invalid declarations fail before agent or GitHub-provider execution."""
+    monkeypatch.chdir(tmp_path)
+    _write_skill(tmp_path / ".cafe" / "skills", "intake")
+    playbooks_dir = tmp_path / ".cafe" / "playbooks"
+    playbooks_dir.mkdir(parents=True, exist_ok=True)
+    (playbooks_dir / "invalid-intake.yaml").write_text(
+        """
+playbook: {id: invalid-intake}
+entry_point: intake
+steps:
+  intake:
+    role: researcher
+    skill: intake
+    output_artifact: intake_brief
+    initial_input:
+      providers: [github_issue]
+      bind: {artifact: ""}
+    hooks:
+      prepare_input: [InitialInputProviderResolver]
+    "on": {await_agent: _done}
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    with (
+        patch("cafe.core.hooks.native.InitialInputProviderResolver._fetch_github_issue") as fetch,
+        patch("cafe.ui.cli.AgentManager") as agents,
+    ):
+        result = runner.invoke(app, ["playbook", "validate", "invalid-intake"])
+
+    assert result.exit_code == 1
+    assert "bind.artifact" in result.stdout
+    fetch.assert_not_called()
+    agents.assert_not_called()

--- a/tests/integration/test_initial_input_providers.py
+++ b/tests/integration/test_initial_input_providers.py
@@ -4,14 +4,21 @@ from __future__ import annotations
 
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
+
+import yaml
+from typer.testing import CliRunner
 
 from cafe.core.blackboard import BlackboardStore
 from cafe.core.types import AgentCLI, TokenUsage
 from cafe.phases.generic_phase import GenericPhase
 from cafe.phases.generic_workflow_step import GenericWorkflowStepExecutor
+from cafe.playbooks.loader import PlaybookLoader
 from cafe.skills.loader import SkillLoader
 from cafe.skills.native_bridge import NativeSkillBridge
+from cafe.ui.cli import app
+
+runner = CliRunner()
 
 
 class _AgentManager:
@@ -45,16 +52,97 @@ def _write_skill(root: Path, name: str) -> None:
     )
 
 
-def _intake_executor(
+def _write_intake_playbook(tmp_path: Path) -> None:
+    playbooks_dir = tmp_path / ".cafe" / "playbooks"
+    playbooks_dir.mkdir(parents=True, exist_ok=True)
+    (playbooks_dir / "intake.yaml").write_text(
+        """
+playbook:
+  id: intake
+roles:
+  researcher:
+    default_agent: David
+entry_point: intake
+steps:
+  intake:
+    type: skill
+    skill: intake
+    role: researcher
+    input_artifacts: []
+    output_artifact: intake_brief
+    initial_input:
+      providers: [manual_text, github_issue]
+      bind:
+        artifact: intake_brief
+        prompt_context: user_input
+    hooks:
+      prepare_input: [InitialInputProviderResolver]
+    valid_intents: [confirmed]
+    "on": {await_agent: _done}
+commands:
+  prepare:
+    fields:
+      - id: input_method
+        type: enum
+        label: Input method
+        write: intake.input_method
+        required: true
+        choices:
+          - value: manual
+            label: Manual input
+          - value: github
+            label: GitHub issue
+      - id: github_issue_id
+        type: text
+        label: GitHub issue ID
+        write: intake.issue_id
+        normalize: github_issue
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+
+def _prepare_intake_issue(
     tmp_path: Path,
     *,
-    initial_input: dict[str, object],
+    input_method: str,
+    issue_id: int | None = None,
     step_user_inputs: dict[str, str] | None = None,
 ) -> tuple[GenericWorkflowStepExecutor, _AgentManager, Path, dict[str, object]]:
+    from tests.conftest import create_minimal_config
+
+    create_minimal_config(tmp_path)
+    _write_skill(tmp_path / ".cafe" / "skills", "intake")
+    _write_intake_playbook(tmp_path)
+    config_path = tmp_path / ".cafe" / "config.yaml"
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    config["playbook"] = "intake"
+    config_path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
+
+    mock_git = MagicMock()
+    mock_git.get_current_branch.return_value = "main"
+    mock_git.has_uncommitted_changes.return_value = False
+    mock_git.branch_exists.return_value = False
+    mock_git.worktree_exists.return_value = False
+    command = [
+        "prepare",
+        "intake-journey",
+        "--no-interactive",
+        f"--input-method={input_method}",
+    ]
+    if issue_id is not None:
+        command.append(f"--issue-id={issue_id}")
+    with (
+        patch("cafe.ui.cli.GitOperations", return_value=mock_git),
+        patch("cafe.utils.git_utils.is_github_repo", return_value=True),
+        patch("cafe.ui.phase_prompts.is_github_repo", return_value=True),
+    ):
+        result = runner.invoke(app, command)
+    assert result.exit_code == 0, result.stdout
+
     builtin_root = tmp_path / "builtin"
     for name in ("cafe-workflow-common", "cafe-github_sync"):
         _write_skill(builtin_root / "skills", name)
-    _write_skill(tmp_path / ".cafe" / "skills", "intake")
     loader = SkillLoader(
         project_root=tmp_path,
         global_root=tmp_path / "global",
@@ -66,36 +154,23 @@ def _intake_executor(
         skill_bridge=NativeSkillBridge(loader, project_root=tmp_path, home_dir=tmp_path / "home"),
     )
     issue_dir = tmp_path / ".cafe" / "issues" / "intake-journey"
-    issue_dir.mkdir(parents=True)
-    step: dict[str, object] = {
-        "skill": "intake",
-        "role": "researcher",
-        "input_artifacts": [],
-        "output_artifact": "intake_brief",
-        "initial_input": {
-            "providers": ["manual_text", "github_issue"],
-            "bind": {"artifact": "intake_brief", "prompt_context": "user_input"},
-        },
-        "hooks": {"prepare_input": ["InitialInputProviderResolver"]},
-        "valid_intents": ["confirmed"],
-        "on": {"await_agent": "_done"},
-    }
-    (issue_dir / "issue.yaml").write_text(
-        "initial_input:\n"
-        + "\n".join(f"  {key}: {value}" for key, value in initial_input.items())
-        + "\n",
-        encoding="utf-8",
+    playbook = PlaybookLoader(
+        project_root=tmp_path,
+        global_root=tmp_path / "global",
+        builtin_root=tmp_path / "builtin",
+    ).load("intake")
+    step = playbook["steps"]["intake"]
+    assert (issue_dir / "intake").is_dir()
+    assert not (issue_dir / "spec").exists()
+    prepared_config = yaml.safe_load((issue_dir / "issue.yaml").read_text(encoding="utf-8"))
+    assert prepared_config["initial_input"]["provider"] == (
+        "github_issue" if input_method == "github" else "manual_text"
     )
     manager = _AgentManager()
     executor = GenericWorkflowStepExecutor(
         issue_dir=issue_dir,
         issue_name="intake-journey",
-        playbook={
-            "playbook": {"id": "intake"},
-            "roles": {"researcher": {"default_agent": "David"}},
-            "entry_point": "intake",
-            "steps": {"intake": step},
-        },
+        playbook=playbook,
         generic_phase=generic_phase,
         agent_manager=manager,
         git_ops=_GitOps(),
@@ -105,12 +180,15 @@ def _intake_executor(
     return executor, manager, issue_dir, step
 
 
-def test_custom_manual_intake_delivers_one_input_to_artifact_and_agent(tmp_path: Path) -> None:
-    """I1 — a non-development entry step receives declared manual input."""
+def test_custom_manual_intake_delivers_one_input_to_artifact_and_agent(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """I1 — custom prepare and loader deliver manual input to an intake entry step."""
+    monkeypatch.chdir(tmp_path)
     content = "Collect the customer's incident timeline."
-    executor, manager, issue_dir, step = _intake_executor(
+    executor, manager, issue_dir, step = _prepare_intake_issue(
         tmp_path,
-        initial_input={"provider": "manual_text"},
+        input_method="manual",
         step_user_inputs={"intake": content},
     )
     state = BlackboardStore(issue_dir).load_or_create("intake")
@@ -123,12 +201,14 @@ def test_custom_manual_intake_delivers_one_input_to_artifact_and_agent(tmp_path:
     assert not (issue_dir / "spec").exists()
 
 
-def test_custom_github_intake_uses_trusted_host_boundary_once(tmp_path: Path) -> None:
-    """I2 — a non-development entry step receives host-resolved GitHub input."""
+def test_custom_github_intake_uses_trusted_host_boundary_once(tmp_path: Path, monkeypatch) -> None:
+    """I2 — custom prepare and loader deliver trusted GitHub input to intake."""
+    monkeypatch.chdir(tmp_path)
     content = "**Issue Title:** Intake request\n\nCollect source material."
-    executor, manager, issue_dir, step = _intake_executor(
+    executor, manager, issue_dir, step = _prepare_intake_issue(
         tmp_path,
-        initial_input={"provider": "github_issue", "issue_id": 346},
+        input_method="github",
+        issue_id=346,
     )
     state = BlackboardStore(issue_dir).load_or_create("intake")
 

--- a/tests/integration/test_prepare_playbook_driven.py
+++ b/tests/integration/test_prepare_playbook_driven.py
@@ -132,6 +132,7 @@ class TestPreparePlaybookDriven:
         config_file = temp_repo_dir / ".cafe" / "issues" / "parity-ni" / "issue.yaml"
         config_data = yaml.safe_load(config_file.read_text(encoding="utf-8"))
         assert config_data["spec"]["input_method"] == "manual"
+        assert config_data["initial_input"] == {"provider": "manual_text"}
         assert config_data["spec"]["rigor"] == "medium"
         assert config_data["spec"]["template"] == "auto"
         assert config_data["plan"]["template"] == "default"

--- a/tests/unit/test_initial_input_providers.py
+++ b/tests/unit/test_initial_input_providers.py
@@ -1,0 +1,37 @@
+"""Unit tests for initial-input provider selection primitives."""
+
+from cafe.core.initial_input import (
+    GITHUB_ISSUE_PROVIDER,
+    MANUAL_TEXT_PROVIDER,
+    load_initial_input_selection,
+    normalize_initial_input_provider,
+)
+
+
+def test_provider_selection_normalizes_legacy_aliases_without_step_names() -> None:
+    """U7/U8 — provider aliases remain independent of a ``spec`` destination."""
+    assert normalize_initial_input_provider("manual") == MANUAL_TEXT_PROVIDER
+    assert normalize_initial_input_provider("github") == GITHUB_ISSUE_PROVIDER
+
+
+def test_canonical_provider_selection_precedes_legacy_spec_configuration() -> None:
+    """U8 — new config wins while old development configuration remains readable."""
+    provider, issue_id = load_initial_input_selection(
+        {
+            "initial_input": {"provider": "github_issue", "issue_id": "346"},
+            "spec": {"input_method": "manual"},
+        }
+    )
+
+    assert provider == GITHUB_ISSUE_PROVIDER
+    assert issue_id == 346
+
+
+def test_legacy_spec_selection_remains_available_when_canonical_config_is_absent() -> None:
+    """U8 — legacy issue config still resolves through the generic selection helper."""
+    provider, issue_id = load_initial_input_selection(
+        {"spec": {"input_method": "github", "issue_id": "350"}}
+    )
+
+    assert provider == GITHUB_ISSUE_PROVIDER
+    assert issue_id == 350

--- a/tests/unit/test_native_user_input_hook.py
+++ b/tests/unit/test_native_user_input_hook.py
@@ -657,6 +657,108 @@ def test_initial_input_provider_skips_resume_and_existing_artifact(tmp_path: Pat
     assert output.read_text(encoding="utf-8") == "existing artifact"
 
 
+@pytest.mark.parametrize("playbook_name", ["default", "simple", "tdd"])
+def test_builtin_initial_input_preserves_legacy_requirements_seed(
+    tmp_path: Path, playbook_name: str
+) -> None:
+    """I3 — built-in first steps retain the legacy initial-input experience."""
+    import yaml
+
+    playbook_file = (
+        Path(__file__).parents[2] / "src" / "cafe" / "data" / "playbooks" / f"{playbook_name}.yaml"
+    )
+    playbook = yaml.safe_load(playbook_file.read_text(encoding="utf-8"))
+    step_def = playbook["steps"]["spec"]
+    assert step_def["hooks"]["prepare_input"][0] == "InitialInputProviderResolver"
+
+    phase = _FakePhase(phase_dir=tmp_path / "spec", iteration=1)
+    output_file = phase._get_iteration_dir(1) / "output.md"
+
+    result = InitialInputProviderResolver().run(
+        stage="prepare_input",
+        phase=phase,
+        step_name="spec",
+        step_def=step_def,
+        output_file=output_file,
+        context={"user_input": "Preserve the established workflow kickoff."},
+    )
+
+    assert output_file.read_text(encoding="utf-8") == (
+        "# Initial Requirements\n\nPreserve the established workflow kickoff.\n"
+    )
+    assert result.context_updates == {
+        "user_input": "Preserve the established workflow kickoff."
+    }
+
+
+def test_builtin_initial_input_reuses_legacy_github_ui_and_formatter(tmp_path: Path) -> None:
+    """I3 — generic built-in resolution keeps the established GitHub interaction."""
+    import yaml
+
+    playbook_file = Path(__file__).parents[2] / "src/cafe/data/playbooks/default.yaml"
+    step_def = yaml.safe_load(playbook_file.read_text(encoding="utf-8"))["steps"]["spec"]
+    phase = _FakePhase(phase_dir=tmp_path / "spec", iteration=1)
+    output_file = phase._get_iteration_dir(1) / "output.md"
+    prompt = MagicMock(return_value=("github_issue", 346))
+
+    with (
+        patch.object(
+            GitHubIssueFetcher,
+            "_prompt_and_save_input_method",
+            return_value=prompt,
+        ) as select_provider,
+        patch.object(
+            GitHubIssueFetcher,
+            "_fetch_github_issue",
+            return_value="**Issue Title:** Restore compatibility",
+        ) as fetch_issue,
+    ):
+        result = InitialInputProviderResolver().run(
+            stage="prepare_input",
+            phase=phase,
+            step_name="spec",
+            step_def=step_def,
+            output_file=output_file,
+        )
+
+    select_provider.assert_called_once_with(phase)
+    prompt.assert_called_once_with()
+    fetch_issue.assert_called_once_with(346)
+    assert output_file.read_text(encoding="utf-8") == (
+        "# Initial Requirements\n\n**Issue Title:** Restore compatibility\n"
+    )
+    assert result.context_updates == {"user_input": "**Issue Title:** Restore compatibility"}
+
+
+def test_initial_input_provider_preserves_github_fetch_failure_guidance(tmp_path: Path) -> None:
+    """U5 — operator-facing provider errors retain the host boundary's remedy."""
+    phase = _FakePhase(phase_dir=tmp_path / "intake", iteration=1)
+    phase.interactive = False
+    phase.issue_dir.mkdir(parents=True, exist_ok=True)
+    (phase.issue_dir / "issue.yaml").write_text(
+        "initial_input:\n  provider: github_issue\n  issue_id: 346\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="gh auth login"):
+        InitialInputProviderResolver().run(
+            stage="prepare_input",
+            phase=phase,
+            step_name="intake",
+            step_def={
+                "output_artifact": "intake_brief",
+                "initial_input": {
+                    "providers": ["github_issue"],
+                    "bind": {"artifact": "intake_brief"},
+                },
+            },
+            output_file=phase._get_iteration_dir(1) / "output.md",
+            initial_input_fetch_github_issue=MagicMock(
+                side_effect=RuntimeError("GitHub CLI unavailable; run gh auth login")
+            ),
+        )
+
+
 def test_github_issue_fetcher_uses_phase_step_user_input_without_prompting(tmp_path: Path) -> None:
     phase_dir = tmp_path / "spec"
     phase = _FakePhase(phase_dir=phase_dir, iteration=1)

--- a/tests/unit/test_native_user_input_hook.py
+++ b/tests/unit/test_native_user_input_hook.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 from cafe.core.hooks.native import (
     GitHubIssueFetcher,
     GitHubPRCreator,
+    InitialInputProviderResolver,
     LocalPRReviewer,
     PRCommentPoster,
     PRLinkOpener,
@@ -481,6 +482,79 @@ def test_github_issue_fetcher_uses_context_user_input_without_prompting(tmp_path
     mock_prompt_method.assert_not_called()
     mock_prompt_manual.assert_not_called()
     mock_fetch_issue.assert_not_called()
+
+
+def test_initial_input_provider_delivers_prefilled_manual_text_to_custom_entry_step(
+    tmp_path: Path,
+) -> None:
+    """U4/U6 — declared custom entry bindings receive invocation input once."""
+    phase_dir = tmp_path / "intake"
+    phase = _FakePhase(phase_dir=phase_dir, iteration=1)
+    output_file = phase._get_iteration_dir(1) / "output.md"
+    hook = InitialInputProviderResolver()
+
+    result = hook.run(
+        stage="prepare_input",
+        phase=phase,
+        step_name="intake",
+        step_def={
+            "output_artifact": "intake_brief",
+            "initial_input": {
+                "providers": ["manual_text", "github_issue"],
+                "bind": {"artifact": "intake_brief", "prompt_context": "user_input"},
+            },
+        },
+        output_file=output_file,
+        context={"user_input": "Summarize the incoming customer report."},
+    )
+
+    assert output_file.read_text(encoding="utf-8") == (
+        "# Initial Requirements\n\nSummarize the incoming customer report.\n"
+    )
+    assert result.context_updates == {"user_input": "Summarize the incoming customer report."}
+    assert result.events == [
+        {"type": "initial_input_resolved", "step": "intake", "provider": "manual_text"}
+    ]
+
+
+def test_initial_input_provider_skips_resume_and_existing_artifact(tmp_path: Path) -> None:
+    """U9 — providers cannot overwrite resumed or already seeded entry output."""
+    hook = InitialInputProviderResolver()
+    step_def = {
+        "output_artifact": "intake_brief",
+        "initial_input": {
+            "providers": ["manual_text"],
+            "bind": {"artifact": "intake_brief", "prompt_context": "user_input"},
+        },
+    }
+    resumed_phase = _FakePhase(phase_dir=tmp_path / "intake", iteration=2)
+    resumed_output = resumed_phase._get_iteration_dir(2) / "output.md"
+
+    resumed = hook.run(
+        stage="prepare_input",
+        phase=resumed_phase,
+        step_name="intake",
+        step_def=step_def,
+        output_file=resumed_output,
+        context={"user_input": "new content"},
+    )
+
+    phase = _FakePhase(phase_dir=tmp_path / "existing", iteration=1)
+    output = phase._get_iteration_dir(1) / "output.md"
+    output.parent.mkdir(parents=True)
+    output.write_text("existing artifact", encoding="utf-8")
+    existing = hook.run(
+        stage="prepare_input",
+        phase=phase,
+        step_name="intake",
+        step_def=step_def,
+        output_file=output,
+        context={"user_input": "new content"},
+    )
+
+    assert resumed.events == []
+    assert existing.events == []
+    assert output.read_text(encoding="utf-8") == "existing artifact"
 
 
 def test_github_issue_fetcher_uses_phase_step_user_input_without_prompting(tmp_path: Path) -> None:

--- a/tests/unit/test_native_user_input_hook.py
+++ b/tests/unit/test_native_user_input_hook.py
@@ -484,6 +484,74 @@ def test_github_issue_fetcher_uses_context_user_input_without_prompting(tmp_path
     mock_fetch_issue.assert_not_called()
 
 
+def test_github_issue_fetcher_fetches_configured_issue_noninteractively(tmp_path: Path) -> None:
+    """U8 — legacy GitHub config remains usable without an interactive prompt."""
+    phase_dir = tmp_path / "spec"
+    phase = _FakePhase(phase_dir=phase_dir, iteration=1)
+    phase.interactive = False
+    phase.issue_dir.mkdir(parents=True, exist_ok=True)
+    (phase.issue_dir / "issue.yaml").write_text(
+        "spec:\n  input_method: github\n  issue_id: 346\n", encoding="utf-8"
+    )
+    output_file = phase._get_iteration_dir(1) / "output.md"
+    hook = GitHubIssueFetcher()
+
+    with (
+        patch.object(hook, "_prompt_input_method") as mock_prompt_method,
+        patch.object(hook, "_prompt_manual_input") as mock_prompt_manual,
+        patch.object(
+            hook,
+            "_fetch_github_issue",
+            return_value="**Issue Title:** Restore legacy input",
+        ) as mock_fetch_issue,
+    ):
+        result = hook.run(
+            stage="prepare_input",
+            phase=phase,
+            step_name="spec",
+            output_file=output_file,
+        )
+
+    assert "Restore legacy input" in output_file.read_text(encoding="utf-8")
+    assert result.context_updates == {"user_input": "**Issue Title:** Restore legacy input"}
+    assert result.events == [
+        {"type": "user_input_collected", "step": "spec", "source": "github"}
+    ]
+    mock_prompt_method.assert_not_called()
+    mock_prompt_manual.assert_not_called()
+    mock_fetch_issue.assert_called_once_with(346)
+
+
+def test_github_only_provider_prompts_for_issue_id_interactively(tmp_path: Path) -> None:
+    """U5 — a GitHub-only declaration obtains its issue ID at the trusted UI boundary."""
+    phase = _FakePhase(phase_dir=tmp_path / "intake", iteration=1)
+    output_file = phase._get_iteration_dir(1) / "output.md"
+    hook = InitialInputProviderResolver()
+
+    prompt = MagicMock(return_value=("github", 346))
+    fetch = MagicMock(return_value="**Issue Title:** Gather requirements")
+    result = hook.run(
+        stage="prepare_input",
+        phase=phase,
+        step_name="intake",
+        step_def={
+            "output_artifact": "intake_brief",
+            "initial_input": {
+                "providers": ["github_issue"],
+                "bind": {"artifact": "intake_brief", "prompt_context": "user_input"},
+            },
+        },
+        output_file=output_file,
+        initial_input_prompt_input_method=prompt,
+        initial_input_fetch_github_issue=fetch,
+    )
+
+    assert "Gather requirements" in output_file.read_text(encoding="utf-8")
+    assert result.context_updates == {"user_input": "**Issue Title:** Gather requirements"}
+    prompt.assert_called_once_with()
+    fetch.assert_called_once_with(346)
+
+
 def test_initial_input_provider_delivers_prefilled_manual_text_to_custom_entry_step(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_native_user_input_hook.py
+++ b/tests/unit/test_native_user_input_hook.py
@@ -4,6 +4,8 @@ import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from cafe.core.hooks.native import (
     GitHubIssueFetcher,
     GitHubPRCreator,
@@ -546,10 +548,40 @@ def test_github_only_provider_prompts_for_issue_id_interactively(tmp_path: Path)
         initial_input_fetch_github_issue=fetch,
     )
 
-    assert "Gather requirements" in output_file.read_text(encoding="utf-8")
+    assert output_file.read_text(encoding="utf-8") == (
+        "**Issue Title:** Gather requirements\n"
+    )
     assert result.context_updates == {"user_input": "**Issue Title:** Gather requirements"}
     prompt.assert_called_once_with()
     fetch.assert_called_once_with(346)
+
+
+def test_github_only_provider_rejects_undeclared_prompt_selection_without_persisting(
+    tmp_path: Path,
+) -> None:
+    """U5 — an unavailable interactive choice cannot poison a later retry."""
+    phase = _FakePhase(phase_dir=tmp_path / "intake", iteration=1)
+    output_file = phase._get_iteration_dir(1) / "output.md"
+    hook = InitialInputProviderResolver()
+
+    with pytest.raises(ValueError, match="not declared"):
+        hook.run(
+            stage="prepare_input",
+            phase=phase,
+            step_name="intake",
+            step_def={
+                "output_artifact": "intake_brief",
+                "initial_input": {
+                    "providers": ["github_issue"],
+                    "bind": {"artifact": "intake_brief"},
+                },
+            },
+            output_file=output_file,
+            initial_input_prompt_input_method=MagicMock(return_value=("manual", None)),
+        )
+
+    assert not (phase.issue_dir / "issue.yaml").exists()
+    assert not output_file.exists()
 
 
 def test_initial_input_provider_delivers_prefilled_manual_text_to_custom_entry_step(
@@ -577,7 +609,7 @@ def test_initial_input_provider_delivers_prefilled_manual_text_to_custom_entry_s
     )
 
     assert output_file.read_text(encoding="utf-8") == (
-        "# Initial Requirements\n\nSummarize the incoming customer report.\n"
+        "Summarize the incoming customer report.\n"
     )
     assert result.context_updates == {"user_input": "Summarize the incoming customer report."}
     assert result.events == [

--- a/tests/unit/test_native_user_input_hook.py
+++ b/tests/unit/test_native_user_input_hook.py
@@ -691,6 +691,40 @@ def test_builtin_initial_input_preserves_legacy_requirements_seed(
     }
 
 
+@pytest.mark.parametrize("playbook_name", ["default", "simple", "tdd"])
+def test_builtin_initial_input_seeds_empty_legacy_requirements_non_interactively(
+    tmp_path: Path, playbook_name: str
+) -> None:
+    """I3 — prepared manual built-ins retain the empty legacy requirements seed."""
+    import yaml
+
+    playbook_file = (
+        Path(__file__).parents[2] / "src" / "cafe" / "data" / "playbooks" / f"{playbook_name}.yaml"
+    )
+    step_def = yaml.safe_load(playbook_file.read_text(encoding="utf-8"))["steps"]["spec"]
+    phase = _FakePhase(phase_dir=tmp_path / "spec", iteration=1)
+    phase.interactive = False
+    phase.issue_dir.mkdir(parents=True, exist_ok=True)
+    (phase.issue_dir / "issue.yaml").write_text(
+        "initial_input:\n  provider: manual_text\n", encoding="utf-8"
+    )
+    output_file = phase._get_iteration_dir(1) / "output.md"
+
+    result = InitialInputProviderResolver().run(
+        stage="prepare_input",
+        phase=phase,
+        step_name="spec",
+        step_def=step_def,
+        output_file=output_file,
+    )
+
+    assert output_file.read_text(encoding="utf-8") == "# Initial Requirements\n\n\n"
+    assert result.context_updates == {"user_input": ""}
+    assert result.events == [
+        {"type": "initial_input_resolved", "step": "spec", "provider": "manual_text"}
+    ]
+
+
 def test_builtin_initial_input_reuses_legacy_github_ui_and_formatter(tmp_path: Path) -> None:
     """I3 — generic built-in resolution keeps the established GitHub interaction."""
     import yaml

--- a/tests/unit/test_playbook_loader.py
+++ b/tests/unit/test_playbook_loader.py
@@ -307,6 +307,7 @@ def test_builtin_entry_steps_use_declared_initial_input_resolver(playbook_name: 
 
     assert entry.initial_input.providers == ["manual_text", "github_issue"]
     assert entry.initial_input.bind.artifact == entry.output_artifact
+    assert entry.initial_input.legacy_presentation is True
     assert "InitialInputProviderResolver" in entry.hooks.prepare_input
     assert "GitHubIssueFetcher" not in entry.hooks.prepare_input
 

--- a/tests/unit/test_playbook_loader.py
+++ b/tests/unit/test_playbook_loader.py
@@ -143,6 +143,9 @@ def test_entry_step_initial_input_accepts_declared_providers_and_bindings(tmp_pa
         """
 playbook: {id: intake-flow}
 entry_point: intake
+commands:
+  prepare:
+    prompt_for_spec_plan_config: false
 steps:
   intake:
     role: pm
@@ -153,10 +156,9 @@ steps:
       bind:
         artifact: intake_brief
         prompt_context: user_input
+    hooks:
+      prepare_input: [InitialInputProviderResolver]
     on: {await_agent: _done}
-commands:
-  prepare:
-    prompt_for_spec_plan_config: false
 """,
     )
 
@@ -307,6 +309,36 @@ def test_builtin_entry_steps_use_declared_initial_input_resolver(playbook_name: 
     assert entry.initial_input.bind.artifact == entry.output_artifact
     assert "InitialInputProviderResolver" in entry.hooks.prepare_input
     assert "GitHubIssueFetcher" not in entry.hooks.prepare_input
+
+
+def test_initial_input_declaration_requires_generic_resolver_hook(tmp_path: Path) -> None:
+    """I4 — a declared provider cannot silently bypass trusted delivery."""
+    builtin_root = tmp_path / "builtin"
+    _write_skill(builtin_root / "skills", "intake")
+    _write_playbook(
+        builtin_root / "playbooks",
+        "missing-resolver",
+        """
+playbook: {id: missing-resolver}
+entry_point: intake
+commands:
+  prepare:
+    prompt_for_spec_plan_config: false
+steps:
+  intake:
+    role: pm
+    skill: intake
+    output_artifact: intake_brief
+    initial_input:
+      providers: [manual_text]
+      bind: {artifact: intake_brief}
+    on: {await_agent: _done}
+""",
+    )
+    loader = PlaybookLoader(builtin_root=builtin_root)
+
+    with pytest.raises(ValueError, match="InitialInputProviderResolver"):
+        loader.load_model("missing-resolver")
 
 
 def test_playbook_conversation_locale_supports_bcp47_and_defaults_to_auto(

--- a/tests/unit/test_playbook_loader.py
+++ b/tests/unit/test_playbook_loader.py
@@ -299,6 +299,50 @@ steps:
         loader.load_model("unimplemented-provider")
 
 
+@pytest.mark.parametrize("source", ["project", "global"])
+def test_initial_input_rejects_legacy_presentation_outside_bundled_playbooks(
+    tmp_path: Path, source: str
+) -> None:
+    """U2/I4 — custom playbooks cannot opt into the built-in empty-input compatibility path."""
+    builtin_root = tmp_path / "builtin"
+    global_root = tmp_path / "global"
+    project_root = tmp_path / "project"
+    _write_skill(builtin_root / "skills", "intake")
+    playbook_root = (
+        project_root / ".cafe" / "playbooks"
+        if source == "project"
+        else global_root / "playbooks"
+    )
+    _write_playbook(
+        playbook_root,
+        "intake-flow",
+        """
+playbook: {id: intake-flow}
+entry_point: intake
+steps:
+  intake:
+    role: pm
+    skill: intake
+    output_artifact: intake_brief
+    initial_input:
+      providers: [manual_text]
+      bind: {artifact: intake_brief}
+      legacy_presentation: true
+    hooks:
+      prepare_input: [InitialInputProviderResolver]
+    on: {await_agent: _done}
+""",
+    )
+    loader = PlaybookLoader(
+        project_root=project_root,
+        global_root=global_root,
+        builtin_root=builtin_root,
+    )
+
+    with pytest.raises(ValueError, match="legacy_presentation"):
+        loader.load_model("intake-flow")
+
+
 @pytest.mark.parametrize("playbook_name", ["default", "simple", "tdd"])
 def test_builtin_entry_steps_use_declared_initial_input_resolver(playbook_name: str) -> None:
     """I3 — built-in development flows retain the provider contract."""

--- a/tests/unit/test_playbook_loader.py
+++ b/tests/unit/test_playbook_loader.py
@@ -237,6 +237,42 @@ commands:
         loader.load_model("invalid-input")
 
 
+def test_initial_input_rejects_empty_artifact_binding_before_execution(tmp_path: Path) -> None:
+    """U2 — an empty artifact binding remains invalid even with an empty output name."""
+    builtin_root = tmp_path / "builtin"
+    _write_skill(builtin_root / "skills", "intake")
+    _write_playbook(
+        builtin_root / "playbooks",
+        "empty-artifact",
+        """
+playbook: {id: empty-artifact}
+entry_point: intake
+steps:
+  intake:
+    role: pm
+    skill: intake
+    output_artifact: ""
+    initial_input:
+      providers: [manual_text]
+      bind: {artifact: ""}
+    hooks:
+      prepare_input: [InitialInputProviderResolver]
+    on: {await_agent: _done}
+commands:
+  prepare:
+    prompt_for_spec_plan_config: false
+""",
+    )
+    loader = PlaybookLoader(
+        project_root=tmp_path / "project",
+        global_root=tmp_path / "global",
+        builtin_root=builtin_root,
+    )
+
+    with pytest.raises(ValueError, match="initial_input.bind.artifact"):
+        loader.load_model("empty-artifact")
+
+
 def test_initial_input_rejects_non_entry_or_unimplemented_provider(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/test_playbook_loader.py
+++ b/tests/unit/test_playbook_loader.py
@@ -133,6 +133,182 @@ steps:
     assert result.model.steps["spec"].role == "reviewer"
 
 
+def test_entry_step_initial_input_accepts_declared_providers_and_bindings(tmp_path: Path) -> None:
+    """A non-development entry step owns its declared initial-input contract."""
+    builtin_root = tmp_path / "builtin"
+    _write_skill(builtin_root / "skills", "intake")
+    _write_playbook(
+        builtin_root / "playbooks",
+        "intake-flow",
+        """
+playbook: {id: intake-flow}
+entry_point: intake
+steps:
+  intake:
+    role: pm
+    skill: intake
+    output_artifact: intake_brief
+    initial_input:
+      providers: [manual_text, github_issue]
+      bind:
+        artifact: intake_brief
+        prompt_context: user_input
+    on: {await_agent: _done}
+commands:
+  prepare:
+    prompt_for_spec_plan_config: false
+""",
+    )
+
+    loader = PlaybookLoader(
+        project_root=tmp_path / "project",
+        global_root=tmp_path / "global",
+        builtin_root=builtin_root,
+    )
+
+    model = loader.load_model("intake-flow").model
+
+    assert model.steps["intake"].initial_input.providers == ["manual_text", "github_issue"]
+    assert model.steps["intake"].initial_input.bind.artifact == "intake_brief"
+    assert model.steps["intake"].initial_input.bind.prompt_context == "user_input"
+
+
+@pytest.mark.parametrize(
+    ("initial_input", "error_token"),
+    [
+        (
+            """
+    initial_input:
+      providers: [manual_text]
+      bind: {artifact: unrelated}
+""",
+            "bind.artifact",
+        ),
+        (
+            """
+    initial_input:
+      providers: [manual_text, manual_text]
+      bind: {artifact: intake_brief}
+""",
+            "duplicates",
+        ),
+        (
+            """
+    initial_input:
+      providers: [url]
+      bind: {artifact: intake_brief}
+""",
+            "unsupported provider",
+        ),
+    ],
+)
+def test_initial_input_rejects_invalid_provider_or_binding_before_execution(
+    tmp_path: Path, initial_input: str, error_token: str
+) -> None:
+    """U2 — invalid entry declarations fail with their actionable field token."""
+    builtin_root = tmp_path / "builtin"
+    _write_skill(builtin_root / "skills", "intake")
+    _write_playbook(
+        builtin_root / "playbooks",
+        "invalid-input",
+        f"""
+playbook: {{id: invalid-input}}
+entry_point: intake
+steps:
+  intake:
+    role: pm
+    skill: intake
+    output_artifact: intake_brief
+{initial_input}    on: {{await_agent: _done}}
+commands:
+  prepare:
+    prompt_for_spec_plan_config: false
+""",
+    )
+    loader = PlaybookLoader(
+        project_root=tmp_path / "project",
+        global_root=tmp_path / "global",
+        builtin_root=builtin_root,
+    )
+
+    with pytest.raises(ValueError, match=error_token):
+        loader.load_model("invalid-input")
+
+
+def test_initial_input_rejects_non_entry_or_unimplemented_provider(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """U3 — declarations are entry-only and must map to a host provider."""
+    builtin_root = tmp_path / "builtin"
+    _write_skill(builtin_root / "skills", "intake")
+    _write_playbook(
+        builtin_root / "playbooks",
+        "invalid-placement",
+        """
+playbook: {id: invalid-placement}
+entry_point: intake
+steps:
+  intake:
+    role: pm
+    skill: intake
+    output_artifact: intake_brief
+    on: {await_agent: _done}
+  refinement:
+    role: pm
+    skill: intake
+    output_artifact: refined_brief
+    initial_input:
+      providers: [manual_text]
+      bind: {artifact: refined_brief}
+    on: {await_agent: _done}
+""",
+    )
+    loader = PlaybookLoader(
+        project_root=tmp_path / "project",
+        global_root=tmp_path / "global",
+        builtin_root=builtin_root,
+    )
+
+    with pytest.raises(ValueError, match="only allowed on entry_point"):
+        loader.load_model("invalid-placement")
+
+    _write_playbook(
+        builtin_root / "playbooks",
+        "unimplemented-provider",
+        """
+playbook: {id: unimplemented-provider}
+entry_point: intake
+steps:
+  intake:
+    role: pm
+    skill: intake
+    output_artifact: intake_brief
+    initial_input:
+      providers: [github_issue]
+      bind: {artifact: intake_brief}
+    on: {await_agent: _done}
+""",
+    )
+    monkeypatch.setattr(
+        "cafe.core.playbook.registered_initial_input_providers", lambda: frozenset()
+    )
+
+    with pytest.raises(ValueError, match="no trusted host implementation"):
+        loader.load_model("unimplemented-provider")
+
+
+@pytest.mark.parametrize("playbook_name", ["default", "simple", "tdd"])
+def test_builtin_entry_steps_use_declared_initial_input_resolver(playbook_name: str) -> None:
+    """I3 — built-in development flows retain the provider contract."""
+    model = PlaybookLoader().load_model(playbook_name).model
+    entry = model.steps[model.entry_point]
+
+    assert entry.initial_input.providers == ["manual_text", "github_issue"]
+    assert entry.initial_input.bind.artifact == entry.output_artifact
+    assert "InitialInputProviderResolver" in entry.hooks.prepare_input
+    assert "GitHubIssueFetcher" not in entry.hooks.prepare_input
+
+
 def test_playbook_conversation_locale_supports_bcp47_and_defaults_to_auto(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_prepare_field_renderer.py
+++ b/tests/unit/test_prepare_field_renderer.py
@@ -130,6 +130,57 @@ def test_input_method_flow_passes_the_declared_issue_field_to_its_boundary() -> 
     assert prompt_input.call_args.kwargs["issue_field"] == issue_field
 
 
+def test_stable_input_field_ids_persist_selection_for_a_custom_entry_step() -> None:
+    """U7 — prepare field IDs do not require legacy ``spec.*`` targets."""
+    input_field = PrepareField.model_validate(
+        {
+            "id": "input_method",
+            "type": "enum",
+            "label": "Requirement source",
+            "write": "intake.input_method",
+            "choices": [
+                {"value": "manual", "label": "Manual"},
+                {"value": "github", "label": "GitHub"},
+            ],
+        }
+    )
+    issue_field = PrepareField.model_validate(
+        {
+            "id": "github_issue_id",
+            "type": "text",
+            "label": "Tracked issue reference",
+            "write": "intake.issue_id",
+            "normalize": "github_issue",
+        }
+    )
+    deps = RendererDeps(
+        prompt_list=MagicMock(),
+        prompt_confirm=MagicMock(),
+        prompt_text=MagicMock(),
+        prompt_for_input_method=MagicMock(return_value=("github", 346)),
+        select_template=MagicMock(),
+        spec_template_manager=MagicMock(),
+        plan_template_manager=MagicMock(),
+        display=MagicMock(),
+        github_ops=MagicMock(),
+    )
+    profile = PrepareProfile(
+        prepare=PrepareConfig.model_validate(
+            {"fields": [input_field.model_dump(), issue_field.model_dump()]}
+        ),
+        is_github_repo=True,
+        step_names=frozenset({"intake"}),
+    )
+
+    config, issue_id = run_field_driven_prepare_flow(
+        ParsedPrepareFields(fields=[input_field, issue_field]), profile, deps=deps
+    )
+
+    assert issue_id == 346
+    assert config.steps["intake"] == {"input_method": "github", "issue_id": "346"}
+    assert config.initial_input == {"provider": "github_issue", "issue_id": 346}
+
+
 class TestShowWhenVisibility:
     def test_github_repo_gate(self) -> None:
         field = PrepareField.model_validate(


### PR DESCRIPTION
## Summary

This PR implements Issue #346's planned provider contract so any workflow entry step can accept initial input through trusted providers without requiring a development-specific `spec` path.

## Changes

- Added a typed `initial_input` declaration model and early semantic validation for entry-step providers in `src/cafe/core/playbook.py`.
- Introduced generic trusted-provider resolution in `src/cafe/core/initial_input.py` with `manual_text` and `github_issue` providers.
- Normalized prepare-field flow to write canonical `initial_input` selection while preserving legacy `spec.*` compatibility.
- Added a generic initial-input runtime hook in `src/cafe/core/hooks/native.py` and wired hook registration for entry-step binding delivery.
- Reduced `GitHubIssueFetcher` to a thin legacy adapter and migrated built-in playbooks to the generic input contract.
- Added test coverage for schema validation, provider resolution, native hook behavior, and custom non-development journey integration.
- Kept manual/GitHub legacy and default/simple/TDD startup behavior unchanged, with invalid declarations failing before execution.
- Commits included in this sequence:
  - 17748b2 feat: add initial input providers
  - 80e8c16 fix: complete initial input provider handling
  - aa4bcd8 fix: preserve legacy initial input behavior
  - c888359 fix: harden initial input providers
  - 32d51ef fix: seed empty legacy requirements
  - eec27f0 fix: restrict legacy input presentation
  - 2b91b9d fix: validate initial input bindings

## Test Plan

- Unit tests in `tests/unit/test_playbook_loader.py`, `tests/unit/test_initial_input_providers.py`, `tests/unit/test_prepare_field_renderer.py`, and `tests/unit/test_native_user_input_hook.py`.
- Integration test suites in `tests/integration/test_initial_input_providers.py` and targeted CLI journeys for prepare/audit/validation.
- Verification recorded in review output: targeted, Ruff, and project integration checks all passed and no open review blockers remain.