### PR TITLE
Declare playbook-scoped workflow and chat skill environments

### DIFF
--- a/examples/non_software/editorial/.cafe/playbooks/editorial.yaml
+++ b/examples/non_software/editorial/.cafe/playbooks/editorial.yaml
@@ -2,6 +2,12 @@ playbook:
   id: editorial
   name: "Editorial Workflow"
 
+skills:
+  workflow:
+    shared: [cafe-workflow-common, cafe-github_sync]
+  chat:
+    shared: [cafe-common-chat-handoff, cafe-chat-develop-change, cafe-chat-spec-revision, cafe-chat-plan-revision, cafe-chat-alignment-decision]
+
 roles:
   editor:
     description: "Content Editor"

--- a/src/cafe/audit/tooling_audit.py
+++ b/src/cafe/audit/tooling_audit.py
@@ -11,7 +11,7 @@ from typing import Dict, List, Sequence, Tuple, Union
 import cafe
 from cafe.core.blackboard import HandoffIntent
 from cafe.core.hooks import BUILTIN_HOOKS
-from cafe.core.playbook import load_playbook_file
+from cafe.core.playbook import iter_declared_playbook_skills, load_playbook_file
 from cafe.core.status_codes import PLAYBOOK_INTENT_KEYS
 from cafe.skills.loader import SkillLoader, read_skill_frontmatter
 
@@ -132,6 +132,7 @@ def run_builtin_tooling_audit() -> List[AuditLine]:
     skill_loader.discover(strict=True)
 
     playbook_skill_refs: Dict[str, List[Tuple[str, str, str, str]]] = {}
+    support_skill_refs: set[str] = set()
     skill_needs_output: Dict[str, bool] = {}
 
     if not playbooks_dir.is_dir():
@@ -154,6 +155,9 @@ def run_builtin_tooling_audit() -> List[AuditLine]:
         lines.append(AuditLine(True, f"Playbook {pb_id!r} loads (strict) with no warnings"))
         model = loaded.model
         roles = model.roles
+        support_skill_refs.update(
+            skill_name for _, skill_name in iter_declared_playbook_skills(model)
+        )
 
         for step_name, step in model.steps.items():
             role = step.role
@@ -252,7 +256,7 @@ def run_builtin_tooling_audit() -> List[AuditLine]:
         if fm_ok:
             lines.append(AuditLine(True, f"Skill {sdir.name}: SKILL.md frontmatter is valid"))
 
-    referenced = set(playbook_skill_refs.keys())
+    referenced = set(playbook_skill_refs.keys()) | support_skill_refs
     all_skill_names = {p.name for p in skill_dirs}
 
     orphan = sorted(all_skill_names - referenced)
@@ -276,23 +280,24 @@ def run_builtin_tooling_audit() -> List[AuditLine]:
     for skill_name in sorted(referenced):
         sdir = skills_root / skill_name
         bundle = _skill_markdown_bundle(sdir)
-        if "{agent_file}" not in bundle:
-            lines.append(
-                AuditLine(
-                    False,
-                    f"Skill {skill_name}: markdown bundle must mention placeholder {{agent_file}} "
-                    "(playbook-bound)",
+        if skill_name in playbook_skill_refs:
+            if "{agent_file}" not in bundle:
+                lines.append(
+                    AuditLine(
+                        False,
+                        f"Skill {skill_name}: markdown bundle must mention placeholder {{agent_file}} "
+                        "(playbook-bound)",
+                    )
                 )
-            )
-        else:
-            lines.append(
-                AuditLine(
-                    True,
-                    f"Skill {skill_name}: bundle documents {{agent_file}}",
+            else:
+                lines.append(
+                    AuditLine(
+                        True,
+                        f"Skill {skill_name}: bundle documents {{agent_file}}",
+                    )
                 )
-            )
 
-        if skill_needs_output.get(skill_name):
+        if skill_name in playbook_skill_refs and skill_needs_output.get(skill_name):
             if "{output_file}" not in bundle:
                 lines.append(
                     AuditLine(

--- a/src/cafe/core/playbook.py
+++ b/src/cafe/core/playbook.py
@@ -67,6 +67,56 @@ class PlaybookRole(BaseModel):
     default_cli: Optional[str] = None
 
 
+SkillEnvironmentMode = Literal["extend", "replace"]
+
+
+class SkillEnvironmentOverlay(BaseModel):
+    """One role or step addition to a declared skill environment."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    mode: SkillEnvironmentMode
+    skills: List[str]
+
+    @field_validator("skills")
+    @classmethod
+    def _validate_skill_names(cls, value: List[str]) -> List[str]:
+        return _clean_declared_skill_names(value)
+
+
+class SkillEnvironmentChannel(BaseModel):
+    """Shared skills plus optional role and step overlays for one channel."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    shared: List[str]
+    roles: Dict[str, SkillEnvironmentOverlay] = Field(default_factory=dict)
+    steps: Dict[str, SkillEnvironmentOverlay] = Field(default_factory=dict)
+
+    @field_validator("shared")
+    @classmethod
+    def _validate_shared_skill_names(cls, value: List[str]) -> List[str]:
+        return _clean_declared_skill_names(value)
+
+
+class PlaybookSkillEnvironments(BaseModel):
+    """Workflow and chat skill declarations owned by a playbook."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    workflow: Optional[SkillEnvironmentChannel] = None
+    chat: Optional[SkillEnvironmentChannel] = None
+
+
+def _clean_declared_skill_names(value: List[str]) -> List[str]:
+    cleaned: List[str] = []
+    for item in value:
+        if not isinstance(item, str) or not item.strip():
+            raise ValueError("skill declarations must contain non-empty skill names")
+        cleaned.append(item.strip())
+    return cleaned
+
+
 class StepHooks(BaseModel):
     """Lifecycle hook configuration."""
 
@@ -439,6 +489,7 @@ class PlaybookDefinition(BaseModel):
 
     playbook: PlaybookMeta
     roles: Dict[str, PlaybookRole] = Field(default_factory=dict)
+    skills: Optional[PlaybookSkillEnvironments] = None
     steps: Dict[str, StepConfig]
     commands: Optional[CommandsConfig] = None
     entry_point: Optional[str] = None
@@ -448,6 +499,74 @@ class PlaybookDefinition(BaseModel):
         if self.entry_point is None:
             self.entry_point = next(iter(self.steps.keys()))
         return self
+
+
+def resolve_playbook_skills(
+    playbook: PlaybookDefinition | Dict[str, Any],
+    *,
+    channel: Literal["workflow", "chat"],
+    role: Optional[str],
+    step_name: Optional[str],
+) -> List[str]:
+    """Resolve one playbook-owned environment in shared → role → step order."""
+    if isinstance(playbook, PlaybookDefinition):
+        environments: Any = playbook.skills
+    else:
+        environments = playbook.get("skills")
+
+    if environments is None:
+        return []
+    environment = (
+        getattr(environments, channel, None)
+        if isinstance(environments, PlaybookSkillEnvironments)
+        else environments.get(channel)
+    )
+    if environment is None:
+        return []
+
+    if isinstance(environment, SkillEnvironmentChannel):
+        shared = environment.shared
+        role_overlay = environment.roles.get(role) if role else None
+        step_overlay = environment.steps.get(step_name) if step_name else None
+    else:
+        shared = environment.get("shared", [])
+        role_overlay = environment.get("roles", {}).get(role) if role else None
+        step_overlay = environment.get("steps", {}).get(step_name) if step_name else None
+
+    resolved = list(shared)
+    for overlay in (role_overlay, step_overlay):
+        if overlay is None:
+            continue
+        if isinstance(overlay, SkillEnvironmentOverlay):
+            mode, names = overlay.mode, overlay.skills
+        else:
+            mode, names = overlay["mode"], overlay["skills"]
+        resolved = list(names) if mode == "replace" else [*resolved, *names]
+    return list(dict.fromkeys(resolved))
+
+
+def iter_declared_playbook_skills(model: PlaybookDefinition) -> List[tuple[str, str]]:
+    """Return every declared support skill with its actionable YAML field path."""
+    if model.skills is None:
+        return []
+
+    references: List[tuple[str, str]] = []
+    for channel_name in ("workflow", "chat"):
+        environment = getattr(model.skills, channel_name)
+        if environment is None:
+            continue
+        for index, skill_name in enumerate(environment.shared):
+            references.append((f"skills.{channel_name}.shared[{index}]", skill_name))
+        for scope_name, overlays in (("roles", environment.roles), ("steps", environment.steps)):
+            for scope_key, overlay in overlays.items():
+                for index, skill_name in enumerate(overlay.skills):
+                    references.append(
+                        (
+                            f"skills.{channel_name}.{scope_name}.{scope_key}.skills[{index}]",
+                            skill_name,
+                        )
+                    )
+    return references
 
 
 @dataclass(frozen=True)
@@ -528,6 +647,7 @@ def validate_playbook(
         strict=strict,
         warnings=warnings,
     )
+    _validate_skill_environments(model, skill_loader=skill_loader, warnings=warnings)
 
     for step_name, step in steps.items():
         _validate_step_role(step_name, step, model.roles)
@@ -555,6 +675,46 @@ def validate_playbook(
     if warnings and strict:
         raise ValueError("\n".join(warnings))
     return warnings
+
+
+def _validate_skill_environments(
+    model: PlaybookDefinition,
+    *,
+    skill_loader: SkillLoader,
+    warnings: List[str],
+) -> None:
+    """Validate playbook-owned support skills before workflow or chat starts."""
+    environments = model.skills
+    for channel_name in ("workflow", "chat"):
+        environment = getattr(environments, channel_name) if environments is not None else None
+        if environment is None:
+            warnings.append(
+                f"skills.{channel_name} is missing; declare it explicitly, for example "
+                f"skills: {{{channel_name}: {{shared: []}}}}."
+            )
+            continue
+
+        for role_name in environment.roles:
+            if role_name not in model.roles:
+                raise ValueError(
+                    f"skills.{channel_name}.roles.{role_name} references an unknown playbook role; "
+                    "add the role or remove the overlay"
+                )
+        for step_name in environment.steps:
+            if step_name not in model.steps:
+                raise ValueError(
+                    f"skills.{channel_name}.steps.{step_name} references an unknown playbook step; "
+                    "add the step or remove the overlay"
+                )
+
+    for field_path, skill_name in iter_declared_playbook_skills(model):
+        try:
+            skill_loader.get_skill_dir(skill_name)
+        except (SkillDiscoveryError, FileNotFoundError) as exc:
+            raise ValueError(
+                f"{field_path} references unknown skill {skill_name!r}; "
+                "install it or correct the declaration"
+            ) from exc
 
 
 def _validate_initial_input_declarations(

--- a/src/cafe/data/playbooks/default.yaml
+++ b/src/cafe/data/playbooks/default.yaml
@@ -3,6 +3,12 @@ playbook:
   name: "Standard Development Workflow"
   conversation_locale: en-US
 
+skills:
+  workflow:
+    shared: [cafe-workflow-common, cafe-github_sync]
+  chat:
+    shared: [cafe-common-chat-handoff, cafe-chat-develop-change, cafe-chat-spec-revision, cafe-chat-plan-revision, cafe-chat-alignment-decision]
+
 roles:
   pm:
     description: "Product Manager"

--- a/src/cafe/data/playbooks/editorial.yaml
+++ b/src/cafe/data/playbooks/editorial.yaml
@@ -3,6 +3,12 @@ playbook:
   name: "Editorial Workflow（撰稿 → 審閱 → 發佈）"
   conversation_locale: en-US
 
+skills:
+  workflow:
+    shared: [cafe-workflow-common, cafe-github_sync]
+  chat:
+    shared: [cafe-common-chat-handoff, cafe-chat-develop-change, cafe-chat-spec-revision, cafe-chat-plan-revision, cafe-chat-alignment-decision]
+
 roles:
   editor:
     description: "內容編輯／審閱"

--- a/src/cafe/data/playbooks/hotfix.yaml
+++ b/src/cafe/data/playbooks/hotfix.yaml
@@ -3,6 +3,12 @@ playbook:
   name: "Hotfix Workflow"
   conversation_locale: en-US
 
+skills:
+  workflow:
+    shared: [cafe-workflow-common, cafe-github_sync]
+  chat:
+    shared: [cafe-common-chat-handoff, cafe-chat-develop-change, cafe-chat-spec-revision, cafe-chat-plan-revision, cafe-chat-alignment-decision]
+
 roles:
   developer:
     description: "Developer"

--- a/src/cafe/data/playbooks/incident.yaml
+++ b/src/cafe/data/playbooks/incident.yaml
@@ -3,6 +3,12 @@ playbook:
   name: "Incident Response Workflow（偵測 → 分類 → 緩解 → 事後檢討）"
   conversation_locale: en-US
 
+skills:
+  workflow:
+    shared: [cafe-workflow-common, cafe-github_sync]
+  chat:
+    shared: [cafe-common-chat-handoff, cafe-chat-develop-change, cafe-chat-spec-revision, cafe-chat-plan-revision, cafe-chat-alignment-decision]
+
 roles:
   ops:
     description: "值班／維運應變"

--- a/src/cafe/data/playbooks/research.yaml
+++ b/src/cafe/data/playbooks/research.yaml
@@ -3,6 +3,12 @@ playbook:
   name: "Research Workflow（問題 → 搜尋整理 → 綜合 → 報告）"
   conversation_locale: en-US
 
+skills:
+  workflow:
+    shared: [cafe-workflow-common, cafe-github_sync]
+  chat:
+    shared: [cafe-common-chat-handoff, cafe-chat-develop-change, cafe-chat-spec-revision, cafe-chat-plan-revision, cafe-chat-alignment-decision]
+
 roles:
   researcher:
     description: "研究／分析人員"

--- a/src/cafe/data/playbooks/simple.yaml
+++ b/src/cafe/data/playbooks/simple.yaml
@@ -3,6 +3,12 @@ playbook:
   name: "Simple Workflow"
   conversation_locale: en-US
 
+skills:
+  workflow:
+    shared: [cafe-workflow-common, cafe-github_sync]
+  chat:
+    shared: [cafe-common-chat-handoff, cafe-chat-develop-change, cafe-chat-spec-revision, cafe-chat-plan-revision, cafe-chat-alignment-decision]
+
 roles:
   pm:
     description: "Product Manager"

--- a/src/cafe/data/playbooks/tdd.yaml
+++ b/src/cafe/data/playbooks/tdd.yaml
@@ -3,6 +3,12 @@ playbook:
   name: "Test-Driven Development Workflow"
   conversation_locale: en-US
 
+skills:
+  workflow:
+    shared: [cafe-workflow-common, cafe-github_sync]
+  chat:
+    shared: [cafe-common-chat-handoff, cafe-chat-develop-change, cafe-chat-spec-revision, cafe-chat-plan-revision, cafe-chat-alignment-decision]
+
 roles:
   pm:
     description: "Product Manager"

--- a/src/cafe/data/skills/write-cafe-phase/references/skill-spec.md
+++ b/src/cafe/data/skills/write-cafe-phase/references/skill-spec.md
@@ -244,9 +244,10 @@ placeholder 名稱。不要依賴 artifact 名稱或新增 Python mapping；未�
 
   > 請依 shared skill「cafe-workflow-common」的 **<Section 名>**；本 skill 不重複敘述。
 
-- runtime 對每個 phase 自動附掛的 shared skills 定義在
-  `generic_workflow_step.SHARED_WORKFLOW_SKILLS`（目前為 `cafe-workflow-common`、`cafe-github_sync`）。
-  新的 shared skill 若要自動附掛，需同步修改該常數。
+- runtime 依 active playbook `skills.workflow` 宣告解析每個 phase 的 shared
+  skills；新增 shared skill 時，在 playbook 宣告，不要修改 Python 常數。
+- chat 的共用與修訂能力同樣由 playbook `skills.chat` 宣告。這只決定技能環境，
+  不改變 baton、HumanTask 或 alignment policy 的 owner。
 
 ## 8. Iteration 行為的兩種做法
 

--- a/src/cafe/data/skills/write-cafe-playbook/references/playbook-spec.md
+++ b/src/cafe/data/skills/write-cafe-playbook/references/playbook-spec.md
@@ -287,6 +287,37 @@ keeps their established requirements heading and guided manual/GitHub interactio
 while they use `InitialInputProviderResolver`; custom playbooks should omit it so
 the resolver writes only the declared input content.
 
+## 8.1 Skill environments
+
+Every playbook explicitly owns both `skills.workflow` and `skills.chat`. Each
+channel has a required `shared` list; an explicit empty list is the way to
+install no shared skills. Runtime resolves names in stable `shared → role → step`
+order and removes duplicates while keeping their first position.
+
+```yaml
+skills:
+  workflow:
+    shared: [cafe-workflow-common]
+    roles:
+      developer: {mode: extend, skills: [project-dev-common]}
+    steps:
+      review: {mode: replace, skills: [project-review-common]}
+  chat:
+    shared: []
+```
+
+Role and step overlays must name a declared role or step. `extend` retains the
+previous layer and appends its names; `replace` discards the previous layer.
+All referenced skills, including overlay-only skills, are validated through the
+normal project/global/builtin discovery order. A missing channel is a warning in
+non-strict custom-playbook loading and resolves to an empty environment; it is a
+failure for `cafe playbook validate <id> --strict`. Add the missing channel with
+`shared: []` to make isolation intentional.
+
+The phase `steps.<name>.skill` remains separate: it selects the phase behavior
+and is installed once, after resolved workflow support skills. Do not add
+development revision skills to `skills.chat` unless that playbook needs them.
+
 ## 9. Validation Sequence
 
 Run all applicable checks from the target repo:

--- a/src/cafe/phases/generic_workflow_step.py
+++ b/src/cafe/phases/generic_workflow_step.py
@@ -25,6 +25,7 @@ from cafe.core.delta_packet import (
 )
 from cafe.core.git import GitOperations
 from cafe.core.phase import Phase
+from cafe.core.playbook import resolve_playbook_skills
 from cafe.core.resume_user_input import (
     is_followup_iteration,
     is_interrupted_iteration,
@@ -105,7 +106,6 @@ def align_pr_baton_after_execution(
 class GenericWorkflowStepExecutor(Phase):
     """Execute one playbook step without shelling out to legacy CLI commands."""
 
-    SHARED_WORKFLOW_SKILLS = ["cafe-workflow-common", "cafe-github_sync"]
     BLACKBOARD_DIGEST_EVENT_LIMIT = 5
     BLACKBOARD_DIGEST_ARTIFACT_LIMIT = 20
     BLACKBOARD_DIGEST_TEXT_LIMIT = 240
@@ -238,7 +238,12 @@ class GenericWorkflowStepExecutor(Phase):
             contract=contract,
         )
         shared_skill_invocations = self.generic_phase.prepare_skills(
-            skill_names=self.SHARED_WORKFLOW_SKILLS,
+            skill_names=resolve_playbook_skills(
+                self.playbook,
+                channel="workflow",
+                role=step_def.get("role"),
+                step_name=step_name,
+            ),
             agent_cli=agent_cli,
             context=context,
         )

--- a/src/cafe/phases/generic_workflow_step.py
+++ b/src/cafe/phases/generic_workflow_step.py
@@ -237,13 +237,18 @@ class GenericWorkflowStepExecutor(Phase):
             skill_name=skill_name,
             contract=contract,
         )
+        workflow_skill_names = resolve_playbook_skills(
+            self.playbook,
+            channel="workflow",
+            role=step_def.get("role"),
+            step_name=step_name,
+        )
+        self.generic_phase.skill_bridge.synchronize_skills(
+            [*workflow_skill_names, skill_name],
+            agent_cli,
+        )
         shared_skill_invocations = self.generic_phase.prepare_skills(
-            skill_names=resolve_playbook_skills(
-                self.playbook,
-                channel="workflow",
-                role=step_def.get("role"),
-                step_name=step_name,
-            ),
+            skill_names=workflow_skill_names,
             agent_cli=agent_cli,
             context=context,
         )

--- a/src/cafe/phases/generic_workflow_step.py
+++ b/src/cafe/phases/generic_workflow_step.py
@@ -246,6 +246,7 @@ class GenericWorkflowStepExecutor(Phase):
         self.generic_phase.skill_bridge.synchronize_skills(
             [*workflow_skill_names, skill_name],
             agent_cli,
+            install=False,
         )
         shared_skill_invocations = self.generic_phase.prepare_skills(
             skill_names=workflow_skill_names,

--- a/src/cafe/skills/native_bridge.py
+++ b/src/cafe/skills/native_bridge.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -127,6 +129,8 @@ class NativeSkillBridge:
         names: list[str],
         cli: AgentCLI,
         context: dict[str, str] | None = None,
+        *,
+        install: bool = True,
     ) -> list[Path]:
         """Make the CLI-native CAFE skill directory match one resolved environment.
 
@@ -152,6 +156,8 @@ class NativeSkillBridge:
         for stale_name in managed - desired_names:
             self._remove_managed_skill(cli, stale_name)
         self._write_managed_skills(cli, desired_names)
+        if not install:
+            return []
         return [self.install_skill(name, cli, context=context) for name, _ in desired]
 
     def _managed_skills_manifest(self, cli: AgentCLI) -> Path:
@@ -164,15 +170,27 @@ class NativeSkillBridge:
         try:
             data = json.loads(manifest.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError):
-            return set()
+            return None
         if not isinstance(data, list):
-            return set()
+            return None
         return {name for name in data if isinstance(name, str) and Path(name).name == name}
 
     def _write_managed_skills(self, cli: AgentCLI, names: set[str]) -> None:
         manifest = self._managed_skills_manifest(cli)
         manifest.parent.mkdir(parents=True, exist_ok=True)
-        manifest.write_text(json.dumps(sorted(names)) + "\n", encoding="utf-8")
+        file_descriptor, temporary_name = tempfile.mkstemp(
+            dir=manifest.parent,
+            prefix=f".{manifest.name}.",
+            suffix=".tmp",
+        )
+        temporary_manifest = Path(temporary_name)
+        try:
+            with os.fdopen(file_descriptor, "w", encoding="utf-8") as temporary_file:
+                temporary_file.write(json.dumps(sorted(names)) + "\n")
+            temporary_manifest.replace(manifest)
+        finally:
+            if temporary_manifest.exists():
+                temporary_manifest.unlink()
 
     def _legacy_managed_skills(self, cli: AgentCLI) -> set[str]:
         """Recognize pre-manifest CAFE installs without claiming arbitrary skills."""

--- a/src/cafe/skills/native_bridge.py
+++ b/src/cafe/skills/native_bridge.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import shutil
 import subprocess
 from dataclasses import dataclass
@@ -28,6 +29,8 @@ class SkillValidationResult:
 
 class NativeSkillBridge:
     """Bridge resolved CAFE skills into each CLI's native skill directory."""
+
+    MANAGED_SKILLS_MANIFEST = ".cafe-managed-skills.json"
 
     CLI_PREFIXES = {
         AgentCLI.CODEX: "$",
@@ -69,6 +72,17 @@ class NativeSkillBridge:
         """Return the user-level native skills directory for one CLI."""
         return self.home_dir / self.GLOBAL_CLI_SKILL_DIRS[cli]
 
+    def _ensure_native_skills_dir(self, cli: AgentCLI) -> Path:
+        """Return a usable project-local native skill directory for one CLI."""
+        skills_root = self.get_native_skills_dir(cli)
+        if skills_root.is_symlink() and not skills_root.exists():
+            skills_root.unlink()
+        elif skills_root.exists() and not skills_root.is_dir():
+            skills_root.unlink()
+        skills_root.mkdir(parents=True, exist_ok=True)
+        self._ensure_cli_dir_git_excluded(cli)
+        return skills_root
+
     def get_installed_skill_name(self, name: str) -> str:
         """Return the installed skill folder/invocation name.
 
@@ -94,16 +108,7 @@ class NativeSkillBridge:
         multiple CAFE workflows install/update the same native skill in parallel.
         """
         source_dir = self.skill_loader.get_skill_dir(name)
-        target_dir = self.get_native_skills_dir(cli) / self.get_installed_skill_name(name)
-        skills_root = target_dir.parent
-        # Recover from invalid roots (regular file or dangling symlink), which can
-        # otherwise raise FileExistsError even with exist_ok=True.
-        if skills_root.is_symlink() and not skills_root.exists():
-            skills_root.unlink()
-        elif skills_root.exists() and not skills_root.is_dir():
-            skills_root.unlink()
-        skills_root.mkdir(parents=True, exist_ok=True)
-        self._ensure_cli_dir_git_excluded(cli)
+        target_dir = self._ensure_native_skills_dir(cli) / self.get_installed_skill_name(name)
 
         if target_dir.exists():
             shutil.rmtree(target_dir)
@@ -114,7 +119,92 @@ class NativeSkillBridge:
             for key, value in context.items():
                 rendered = rendered.replace(f"{{{key}}}", str(value))
             skill_file.write_text(rendered, encoding="utf-8")
+        self._record_managed_skill(cli, target_dir.name)
         return target_dir
+
+    def synchronize_skills(
+        self,
+        names: list[str],
+        cli: AgentCLI,
+        context: dict[str, str] | None = None,
+    ) -> list[Path]:
+        """Make the CLI-native CAFE skill directory match one resolved environment.
+
+        A workflow or chat environment is an exact set, not an additive install.
+        The manifest lets the bridge remove CAFE-managed entries without touching
+        unrelated native skills. On first use, existing catalog-backed entries
+        are treated as legacy CAFE installs so an upgrade also clears stale skills.
+        """
+        desired: list[tuple[str, str]] = []
+        seen: set[str] = set()
+        for name in names:
+            installed_name = self.skill_loader.get_skill_dir(name).name
+            if installed_name in seen:
+                continue
+            seen.add(installed_name)
+            desired.append((name, installed_name))
+
+        self._ensure_native_skills_dir(cli)
+        managed = self._read_managed_skills(cli)
+        if managed is None:
+            managed = self._legacy_managed_skills(cli)
+        desired_names = {installed_name for _, installed_name in desired}
+        for stale_name in managed - desired_names:
+            self._remove_managed_skill(cli, stale_name)
+        self._write_managed_skills(cli, desired_names)
+        return [self.install_skill(name, cli, context=context) for name, _ in desired]
+
+    def _managed_skills_manifest(self, cli: AgentCLI) -> Path:
+        return self.get_native_skills_dir(cli) / self.MANAGED_SKILLS_MANIFEST
+
+    def _read_managed_skills(self, cli: AgentCLI) -> set[str] | None:
+        manifest = self._managed_skills_manifest(cli)
+        if not manifest.is_file():
+            return None
+        try:
+            data = json.loads(manifest.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return set()
+        if not isinstance(data, list):
+            return set()
+        return {name for name in data if isinstance(name, str) and Path(name).name == name}
+
+    def _write_managed_skills(self, cli: AgentCLI, names: set[str]) -> None:
+        manifest = self._managed_skills_manifest(cli)
+        manifest.parent.mkdir(parents=True, exist_ok=True)
+        manifest.write_text(json.dumps(sorted(names)) + "\n", encoding="utf-8")
+
+    def _legacy_managed_skills(self, cli: AgentCLI) -> set[str]:
+        """Recognize pre-manifest CAFE installs without claiming arbitrary skills."""
+        skills_root = self.get_native_skills_dir(cli)
+        if not skills_root.is_dir():
+            return set()
+        managed: set[str] = set()
+        for candidate in skills_root.iterdir():
+            if not candidate.is_dir():
+                continue
+            try:
+                if self.skill_loader.get_skill_dir(candidate.name).name == candidate.name:
+                    managed.add(candidate.name)
+            except (SkillDiscoveryError, FileNotFoundError):
+                continue
+        return managed
+
+    def _remove_managed_skill(self, cli: AgentCLI, name: str) -> None:
+        if Path(name).name != name:
+            return
+        target = self.get_native_skills_dir(cli) / name
+        if target.is_symlink() or target.is_file():
+            target.unlink()
+        elif target.is_dir():
+            shutil.rmtree(target)
+
+    def _record_managed_skill(self, cli: AgentCLI, name: str) -> None:
+        managed = self._read_managed_skills(cli)
+        if managed is None:
+            managed = self._legacy_managed_skills(cli)
+        managed.add(name)
+        self._write_managed_skills(cli, managed)
 
     def _ensure_cli_dir_git_excluded(self, cli: AgentCLI) -> None:
         """Best-effort: add the CLI's top-level injection dir to git's local

--- a/src/cafe/ui/chat.py
+++ b/src/cafe/ui/chat.py
@@ -8,20 +8,13 @@ from typing import Optional
 
 from cafe.agents.manager import AgentManager
 from cafe.core.blackboard import BlackboardStore, HandoffIntent, HandoffOwner
+from cafe.core.playbook import resolve_playbook_skills
 from cafe.core.types import AgentCLI, AgentConfig
 from cafe.playbooks.loader import PlaybookLoader
 from cafe.skills.loader import SkillLoader
 from cafe.skills.native_bridge import NativeSkillBridge
 from cafe.utils.config import ConfigManager
 from cafe.utils.crew import CrewManager, normalize_role_config
-
-CHAT_SKILL_NAMES = [
-    "cafe-common-chat-handoff",
-    "cafe-chat-develop-change",
-    "cafe-chat-spec-revision",
-    "cafe-chat-plan-revision",
-    "cafe-chat-alignment-decision",
-]
 
 CURSOR_NATIVE_MODULE_HINT = "@anysphere/file-service-"
 
@@ -364,8 +357,11 @@ def _prepare_chat_handoff_state(issue_dir: Path) -> tuple[str, list[str], str]:
 def _prepare_chat_environment(
     *,
     agent_cli: AgentCLI | object,
+    playbook: dict,
+    role: str,
+    step_name: str,
 ) -> None:
-    """Install shared chat skills for the target CLI."""
+    """Install chat skills resolved from the active playbook."""
     if not isinstance(agent_cli, AgentCLI):
         return
 
@@ -373,7 +369,12 @@ def _prepare_chat_environment(
     loader.discover()
     bridge = NativeSkillBridge(loader)
 
-    for skill_name in CHAT_SKILL_NAMES:
+    for skill_name in resolve_playbook_skills(
+        playbook,
+        channel="chat",
+        role=role,
+        step_name=step_name,
+    ):
         bridge.install_skill(skill_name, agent_cli)
 
 
@@ -475,8 +476,15 @@ def launch_chat_session(
 
     _current_step, _valid_steps, _playbook_id = _prepare_chat_handoff_state(issue_dir)
 
+    try:
+        chat_playbook = PlaybookLoader(project_root=Path.cwd()).load(_playbook_id)
+    except Exception:
+        chat_playbook = {}
     _prepare_chat_environment(
         agent_cli=agent_cli,
+        playbook=chat_playbook,
+        role=role,
+        step_name=_current_step,
     )
     session_id: Optional[str] = executor.config.session_id
     codex_history_start_ts = int(time.time())

--- a/src/cafe/ui/chat.py
+++ b/src/cafe/ui/chat.py
@@ -369,13 +369,15 @@ def _prepare_chat_environment(
     loader.discover()
     bridge = NativeSkillBridge(loader)
 
-    for skill_name in resolve_playbook_skills(
-        playbook,
-        channel="chat",
-        role=role,
-        step_name=step_name,
-    ):
-        bridge.install_skill(skill_name, agent_cli)
+    bridge.synchronize_skills(
+        resolve_playbook_skills(
+            playbook,
+            channel="chat",
+            role=role,
+            step_name=step_name,
+        ),
+        agent_cli,
+    )
 
 
 def _format_cli_specific_error(agent_cli: AgentCLI, stderr: str, stdout: str) -> Optional[str]:
@@ -431,6 +433,17 @@ def launch_chat_session(
     """
     issue_dir = Path.cwd() / ".cafe" / "issues" / issue_name
 
+    playbook_id = "default"
+    try:
+        _current_step, _valid_steps, playbook_id = _load_chat_workflow_context(issue_dir)
+        chat_playbook = PlaybookLoader(project_root=Path.cwd()).load(playbook_id)
+    except Exception as exc:
+        print(
+            f"\n⚠️  Chat cannot start because playbook validation failed for "
+            f"'{playbook_id}': {exc}. Fix the declaration and retry.\n"
+        )
+        return 1
+
     # Load configuration
     config_manager = ConfigManager()
     agent_config = _load_chat_role_config(config_manager, role, issue_dir=issue_dir)
@@ -475,11 +488,6 @@ def launch_chat_session(
     cli_strategy = executor._get_cli_strategy()
 
     _current_step, _valid_steps, _playbook_id = _prepare_chat_handoff_state(issue_dir)
-
-    try:
-        chat_playbook = PlaybookLoader(project_root=Path.cwd()).load(_playbook_id)
-    except Exception:
-        chat_playbook = {}
     _prepare_chat_environment(
         agent_cli=agent_cli,
         playbook=chat_playbook,

--- a/tests/integration/test_declarative_skill_workflow.py
+++ b/tests/integration/test_declarative_skill_workflow.py
@@ -157,3 +157,74 @@ Read {evidence_file} and use {template_file}.
     activated = loader.activate("synthesis", context)
     assert "research/iteration_001/output.md" in activated
     assert "evidence.md" in activated
+
+
+def test_workflow_replace_removes_stale_native_skills(tmp_path: Path, monkeypatch) -> None:
+    """I2 — a replace declaration leaves only the current workflow environment."""
+    monkeypatch.chdir(tmp_path)
+    builtin_root = tmp_path / "builtin"
+    for name in ("phase", "stale-support", "replacement-support"):
+        _write_skill(builtin_root / "skills", name)
+
+    loader = SkillLoader(
+        project_root=tmp_path,
+        global_root=tmp_path / "global",
+        builtin_root=builtin_root,
+    )
+    loader.discover()
+    generic_phase = GenericPhase(
+        loader,
+        skill_bridge=NativeSkillBridge(loader, project_root=tmp_path, home_dir=tmp_path / "home"),
+    )
+    step = {
+        "skill": "phase",
+        "role": "operator",
+        "output_artifact": "report",
+        "allowed_tools": ["Read"],
+        "valid_intents": ["confirmed"],
+        "on": {"await_agent": "_done"},
+    }
+
+    def execute_with(playbook: dict) -> None:
+        issue_dir = tmp_path / ".cafe" / "issues" / playbook["playbook"]["id"]
+        state = BlackboardStore(issue_dir).load_or_create("run")
+        executor = GenericWorkflowStepExecutor(
+            issue_dir=issue_dir,
+            issue_name=playbook["playbook"]["id"],
+            playbook=playbook,
+            generic_phase=generic_phase,
+            agent_manager=_AgentManager(),
+            git_ops=_GitOps(),
+            role_agent_map={"operator": "David"},
+        )
+        executor.execute_step("run", step, state)
+
+    execute_with(
+        {
+            "playbook": {"id": "workflow-base"},
+            "roles": {"operator": {"default_agent": "David"}},
+            "skills": {"workflow": {"shared": ["stale-support"]}, "chat": {"shared": []}},
+            "steps": {"run": step},
+        }
+    )
+    assert (tmp_path / ".codex" / "skills" / "stale-support").is_dir()
+
+    execute_with(
+        {
+            "playbook": {"id": "workflow-replace"},
+            "roles": {"operator": {"default_agent": "David"}},
+            "skills": {
+                "workflow": {
+                    "shared": ["stale-support"],
+                    "steps": {"run": {"mode": "replace", "skills": ["replacement-support"]}},
+                },
+                "chat": {"shared": []},
+            },
+            "steps": {"run": step},
+        }
+    )
+
+    native_skills = tmp_path / ".codex" / "skills"
+    assert not (native_skills / "stale-support").exists()
+    assert (native_skills / "replacement-support" / "SKILL.md").is_file()
+    assert (native_skills / "phase" / "SKILL.md").is_file()

--- a/tests/integration/test_declarative_skill_workflow.py
+++ b/tests/integration/test_declarative_skill_workflow.py
@@ -130,6 +130,7 @@ Read {evidence_file} and use {template_file}.
         playbook={
             "playbook": {"id": "synthesis"},
             "roles": {"researcher": {"default_agent": "David"}},
+            "skills": {"workflow": {"shared": []}, "chat": {"shared": []}},
             "steps": {"synthesis": step},
         },
         generic_phase=generic_phase,

--- a/tests/unit/test_cafe_audit.py
+++ b/tests/unit/test_cafe_audit.py
@@ -24,6 +24,18 @@ def test_run_builtin_tooling_audit_all_pass() -> None:
     assert all(row.ok for row in lines), format_audit_markdown(lines)
 
 
+def test_builtin_audit_treats_declared_support_skills_as_referenced() -> None:
+    """I1 — support skills are audited for reachability, not phase placeholders."""
+    lines = run_builtin_tooling_audit()
+    messages = [row.message for row in lines]
+
+    assert any("cafe-workflow-common" in message for message in messages)
+    assert not any(
+        "Skill cafe-workflow-common: markdown bundle must mention placeholder" in message
+        for message in messages
+    )
+
+
 def test_format_audit_markdown_includes_checkbox() -> None:
     text = format_audit_markdown([AuditLine(True, "ok")])
     assert "[x]" in text

--- a/tests/unit/test_chat.py
+++ b/tests/unit/test_chat.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -9,6 +10,8 @@ import pytest
 from cafe.agents.cli import ClaudeCLI, CodexCLI, CopilotCLI, CursorCLI, GeminiCLI
 from cafe.core.blackboard import BlackboardStore, HandoffIntent, HandoffOwner
 from cafe.core.types import AgentCLI, AgentConfig
+from cafe.skills.loader import SkillLoader
+from cafe.skills.native_bridge import NativeSkillBridge
 from cafe.ui.chat import (
     _load_latest_role_iteration_cli,
     _prepare_chat_environment,
@@ -337,7 +340,7 @@ class TestLaunchChatSession:
 def test_prepare_chat_environment_installs_chat_skills_only() -> None:
     with (
         patch("cafe.ui.chat.SkillLoader.discover"),
-        patch("cafe.ui.chat.NativeSkillBridge.install_skill") as mock_install,
+        patch("cafe.ui.chat.NativeSkillBridge.synchronize_skills") as mock_synchronize,
     ):
         _prepare_chat_environment(
             agent_cli=AgentCLI.CODEX,
@@ -358,8 +361,92 @@ def test_prepare_chat_environment_installs_chat_skills_only() -> None:
             step_name="develop",
         )
 
-    installed = [call.args[0] for call in mock_install.call_args_list]
-    assert installed == ["chat-step"]
+    assert mock_synchronize.call_args.args == (["chat-step"], AgentCLI.CODEX)
+
+
+def test_prepare_chat_environment_removes_previously_installed_chat_skills(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """I3 — a chat replace environment is isolated in the native skill directory."""
+    monkeypatch.chdir(tmp_path)
+    builtin_root = tmp_path / "builtin"
+    for name in ("chat-stale", "chat-current"):
+        skill_dir = builtin_root / "skills" / name
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            f"---\nname: {name}\ndescription: {name}\n---\n", encoding="utf-8"
+        )
+    loader = SkillLoader(
+        project_root=tmp_path,
+        global_root=tmp_path / "global",
+        builtin_root=builtin_root,
+    )
+    loader.discover()
+    NativeSkillBridge(loader, project_root=tmp_path).install_skill("chat-stale", AgentCLI.CODEX)
+    monkeypatch.setattr("cafe.ui.chat.SkillLoader", lambda: loader)
+
+    _prepare_chat_environment(
+        agent_cli=AgentCLI.CODEX,
+        playbook={
+            "skills": {
+                "chat": {
+                    "shared": ["chat-stale"],
+                    "steps": {"question": {"mode": "replace", "skills": ["chat-current"]}},
+                }
+            }
+        },
+        role="researcher",
+        step_name="question",
+    )
+
+    native_skills = tmp_path / ".codex" / "skills"
+    assert not (native_skills / "chat-stale").exists()
+    assert (native_skills / "chat-current" / "SKILL.md").is_file()
+
+    _prepare_chat_environment(
+        agent_cli=AgentCLI.CODEX,
+        playbook={"skills": {"chat": {"shared": []}}},
+        role="researcher",
+        step_name="question",
+    )
+
+    assert not (native_skills / "chat-current").exists()
+
+
+def test_launch_chat_session_stops_before_cli_when_playbook_validation_fails(
+    tmp_path: Path, monkeypatch, mock_chat_environment
+) -> None:
+    """I4 — invalid declared chat skills fail before the interactive CLI starts."""
+    monkeypatch.chdir(tmp_path)
+    issue_dir = tmp_path / ".cafe" / "issues" / "invalid-chat"
+    issue_dir.mkdir(parents=True)
+    (issue_dir / "blackboard.json").write_text(
+        '{"schema_version":1,"playbook_id":"invalid","current_step":"develop",'
+        '"artifacts":{},"events":[],"decisions":[]}',
+        encoding="utf-8",
+    )
+
+    with (
+        patch("builtins.print") as mock_print,
+        patch("cafe.ui.chat.subprocess.run", return_value=MagicMock(returncode=0)) as mock_run,
+        patch("cafe.ui.chat.ConfigManager") as mock_config_manager_cls,
+        patch("cafe.ui.chat.AgentManager"),
+        patch("cafe.ui.chat.PlaybookLoader") as mock_loader_cls,
+    ):
+        mock_config = MagicMock()
+        mock_config.config_dir = str(tmp_path / ".cafe")
+        mock_config.get.return_value = {"name": "David", "cli": "claude"}
+        mock_config_manager_cls.return_value = mock_config
+        mock_loader_cls.return_value.load.side_effect = ValueError(
+            "skills.chat.shared references missing skill 'not-installed'"
+        )
+
+        result = launch_chat_session("developer", "invalid-chat")
+
+    assert result == 1
+    mock_run.assert_not_called()
+    printed = " ".join(str(call) for call in mock_print.call_args_list)
+    assert "not-installed" in printed
 
 
 def test_latest_role_iteration_cli_infers_codex_for_legacy_fallback_metadata(

--- a/tests/unit/test_chat.py
+++ b/tests/unit/test_chat.py
@@ -341,16 +341,25 @@ def test_prepare_chat_environment_installs_chat_skills_only() -> None:
     ):
         _prepare_chat_environment(
             agent_cli=AgentCLI.CODEX,
+            playbook={
+                "skills": {
+                    "chat": {
+                        "shared": ["chat-base"],
+                        "roles": {
+                            "developer": {"mode": "extend", "skills": ["chat-role"]}
+                        },
+                        "steps": {
+                            "develop": {"mode": "replace", "skills": ["chat-step"]}
+                        },
+                    }
+                }
+            },
+            role="developer",
+            step_name="develop",
         )
 
     installed = [call.args[0] for call in mock_install.call_args_list]
-    assert installed == [
-        "cafe-common-chat-handoff",
-        "cafe-chat-develop-change",
-        "cafe-chat-spec-revision",
-        "cafe-chat-plan-revision",
-        "cafe-chat-alignment-decision",
-    ]
+    assert installed == ["chat-step"]
 
 
 def test_latest_role_iteration_cli_infers_codex_for_legacy_fallback_metadata(

--- a/tests/unit/test_generic_workflow_step.py
+++ b/tests/unit/test_generic_workflow_step.py
@@ -906,6 +906,14 @@ def test_generic_workflow_step_executor_installs_workflow_common_and_phase_skill
     store.set_artifact(state, "spec", str(spec_file))
     store.set_artifact(state, "plan", str(plan_file))
     generic_phase = _build_loader(tmp_path)
+    installed_skill_names: list[str] = []
+    original_install_skill = generic_phase.skill_bridge.install_skill
+
+    def record_skill_install(name, cli, context=None):
+        installed_skill_names.append(name)
+        return original_install_skill(name, cli, context)
+
+    monkeypatch.setattr(generic_phase.skill_bridge, "install_skill", record_skill_install)
     agent_manager = FakeAgentManager("confirmed")
     executor = GenericWorkflowStepExecutor(
         issue_dir=issue_dir,
@@ -922,6 +930,7 @@ def test_generic_workflow_step_executor_installs_workflow_common_and_phase_skill
     assert (tmp_path / ".codex" / "skills" / "cafe-workflow-common" / "SKILL.md").exists()
     assert (tmp_path / ".codex" / "skills" / "cafe-github_sync" / "SKILL.md").exists()
     assert (tmp_path / ".codex" / "skills" / "cafe-review" / "SKILL.md").exists()
+    assert installed_skill_names == ["cafe-workflow-common", "cafe-github_sync", "review"]
     iteration_dir = issue_dir / "review" / "iteration_001"
     output_file = iteration_dir / "output.md"
     checklist_file = iteration_dir / "checklist.md"

--- a/tests/unit/test_generic_workflow_step.py
+++ b/tests/unit/test_generic_workflow_step.py
@@ -872,6 +872,18 @@ def test_generic_workflow_step_executor_installs_workflow_common_and_phase_skill
     playbook = {
         "playbook": {"id": "default"},
         "roles": {"reviewer": {"default_agent": "Richard"}},
+        "skills": {
+            "workflow": {
+                "shared": ["cafe-workflow-common", "cafe-github_sync"],
+                "roles": {
+                    "reviewer": {"mode": "extend", "skills": ["cafe-workflow-common"]},
+                },
+                "steps": {
+                    "review": {"mode": "extend", "skills": ["cafe-github_sync"]},
+                },
+            },
+            "chat": {"shared": []},
+        },
         "steps": {
             "review": {
                 "skill": "review",
@@ -941,6 +953,12 @@ def test_generic_workflow_step_prompt_includes_latest_blackboard_handoff(
     playbook = {
         "playbook": {"id": "default"},
         "roles": {"developer": {"default_agent": "David"}},
+        "skills": {
+            "workflow": {
+                "shared": ["cafe-workflow-common", "cafe-github_sync"],
+            },
+            "chat": {"shared": []},
+        },
         "steps": {
             "develop": {
                 "skill": "plan",
@@ -1012,6 +1030,12 @@ def test_generic_workflow_step_prompt_keeps_skill_invocations_only(
     playbook = {
         "playbook": {"id": "default"},
         "roles": {"developer": {"default_agent": "David"}},
+        "skills": {
+            "workflow": {
+                "shared": ["cafe-workflow-common", "cafe-github_sync"],
+            },
+            "chat": {"shared": []},
+        },
         "steps": {
             "pr": {
                 "skill": "pr",

--- a/tests/unit/test_playbook_loader.py
+++ b/tests/unit/test_playbook_loader.py
@@ -4,7 +4,9 @@ from pathlib import Path
 
 import pytest
 
+from cafe.core.playbook import PlaybookDefinition, resolve_playbook_skills
 from cafe.playbooks.loader import PlaybookLoader
+from cafe.skills.loader import SkillLoader
 from cafe.ui.human_tasks import resolve_step_human_task
 
 
@@ -20,6 +22,217 @@ def _write_skill(root: Path, name: str) -> None:
 def _write_playbook(root: Path, name: str, content: str) -> None:
     root.mkdir(parents=True, exist_ok=True)
     (root / f"{name}.yaml").write_text(content, encoding="utf-8")
+
+
+def test_declared_skill_environment_resolves_layers_with_stable_deduplication() -> None:
+    """U1/U2 — workflow skills resolve shared, role, and step layers predictably."""
+    model = PlaybookDefinition.model_validate(
+        {
+            "playbook": {"id": "layered"},
+            "roles": {"developer": {}},
+            "skills": {
+                "workflow": {
+                    "shared": ["base", "shared"],
+                    "roles": {
+                        "developer": {"mode": "extend", "skills": ["shared", "role"]}
+                    },
+                    "steps": {
+                        "build": {"mode": "replace", "skills": ["step", "role", "step"]}
+                    },
+                },
+                "chat": {"shared": []},
+            },
+            "steps": {
+                "build": {"role": "developer", "skill": "phase", "on": {"await_agent": "_done"}}
+            },
+        }
+    )
+
+    assert resolve_playbook_skills(
+        model, channel="workflow", role="developer", step_name="build"
+    ) == ["step", "role"]
+    assert resolve_playbook_skills(
+        model, channel="chat", role="developer", step_name="build"
+    ) == []
+
+
+def test_skill_environment_reports_missing_channel_and_missing_skill_before_execution(
+    tmp_path: Path,
+) -> None:
+    """U3/U4 — declarations identify absent channels and unresolved support skills."""
+    builtin_root = tmp_path / "builtin"
+    project_root = tmp_path / "project"
+    _write_skill(builtin_root / "skills", "phase")
+    _write_playbook(
+        project_root / ".cafe" / "playbooks",
+        "custom",
+        """
+playbook: {id: custom}
+commands: {prepare: {prompt_for_spec_plan_config: false}}
+steps:
+  run:
+    role: operator
+    skill: phase
+    on: {await_agent: _done}
+""",
+    )
+    loader = PlaybookLoader(
+        project_root=project_root,
+        global_root=tmp_path / "global",
+        builtin_root=builtin_root,
+    )
+
+    loaded = loader.load_model("custom")
+    assert any("skills.workflow" in warning for warning in loaded.warnings)
+    assert any("skills.chat" in warning for warning in loaded.warnings)
+    with pytest.raises(ValueError, match="skills.workflow"):
+        loader.load_model("custom", strict=True)
+
+    _write_playbook(
+        project_root / ".cafe" / "playbooks",
+        "custom",
+        """
+playbook: {id: custom}
+commands: {prepare: {prompt_for_spec_plan_config: false}}
+skills:
+  workflow: {shared: [missing-support]}
+  chat: {shared: []}
+steps:
+  run:
+    role: operator
+    skill: phase
+    on: {await_agent: _done}
+""",
+    )
+    with pytest.raises(ValueError, match="skills.workflow.shared\\[0\\]"):
+        loader.load_model("custom")
+
+
+def test_skill_environment_rejects_malformed_and_unknown_overlay_scopes(
+    tmp_path: Path,
+) -> None:
+    """U3 — malformed declarations identify the field that authors must repair."""
+    with pytest.raises(ValueError, match="skills.workflow.shared"):
+        PlaybookDefinition.model_validate(
+            {
+                "playbook": {"id": "invalid"},
+                "skills": {"workflow": {}, "chat": {"shared": []}},
+                "steps": {"run": {"role": "operator", "skill": "phase", "on": {"await_agent": "_done"}}},
+            }
+        )
+    with pytest.raises(ValueError, match="skills.workflow.roles.developer.mode"):
+        PlaybookDefinition.model_validate(
+            {
+                "playbook": {"id": "invalid"},
+                "roles": {"developer": {}},
+                "skills": {
+                    "workflow": {
+                        "shared": [],
+                        "roles": {"developer": {"mode": "merge", "skills": []}},
+                    },
+                    "chat": {"shared": []},
+                },
+                "steps": {
+                    "run": {"role": "developer", "skill": "phase", "on": {"await_agent": "_done"}}
+                },
+            }
+        )
+
+    builtin_root = tmp_path / "builtin"
+    project_root = tmp_path / "project"
+    _write_skill(builtin_root / "skills", "phase")
+    _write_playbook(
+        project_root / ".cafe" / "playbooks",
+        "invalid",
+        """
+playbook: {id: invalid}
+commands: {prepare: {prompt_for_spec_plan_config: false}}
+skills:
+  workflow:
+    shared: []
+    roles: {missing-role: {mode: extend, skills: []}}
+  chat: {shared: []}
+steps:
+  run: {role: operator, skill: phase, on: {await_agent: _done}}
+""",
+    )
+    loader = PlaybookLoader(
+        project_root=project_root,
+        global_root=tmp_path / "global",
+        builtin_root=builtin_root,
+    )
+
+    with pytest.raises(ValueError, match="skills.workflow.roles.missing-role"):
+        loader.load_model("invalid")
+
+
+def test_declared_skills_share_project_override_catalog_with_phase_skills(tmp_path: Path) -> None:
+    """U4/I2 — support declarations use the existing project-over-builtin catalog."""
+    builtin_root = tmp_path / "builtin"
+    project_root = tmp_path / "project"
+    _write_skill(builtin_root / "skills", "phase")
+    _write_skill(builtin_root / "skills", "support")
+    _write_skill(project_root / ".cafe" / "skills", "support")
+    _write_skill(project_root / ".cafe" / "skills", "project-extra")
+    _write_playbook(
+        project_root / ".cafe" / "playbooks",
+        "custom",
+        """
+playbook: {id: custom}
+roles: {operator: {}}
+commands: {prepare: {prompt_for_spec_plan_config: false}}
+skills:
+  workflow:
+    shared: [support]
+    roles: {operator: {mode: extend, skills: [project-extra]}}
+  chat: {shared: []}
+steps:
+  run: {role: operator, skill: phase, on: {await_agent: _done}}
+""",
+    )
+    loader = PlaybookLoader(
+        project_root=project_root,
+        global_root=tmp_path / "global",
+        builtin_root=builtin_root,
+    )
+
+    loaded = loader.load_model("custom", strict=True)
+    assert resolve_playbook_skills(
+        loaded.model, channel="workflow", role="operator", step_name="run"
+    ) == ["support", "project-extra"]
+    catalog = SkillLoader(
+        project_root=project_root,
+        global_root=tmp_path / "global",
+        builtin_root=builtin_root,
+    )
+    assert catalog.get_skill_dir("support") == project_root / ".cafe" / "skills" / "support"
+
+
+@pytest.mark.parametrize(
+    "playbook_id",
+    ["default", "simple", "tdd", "hotfix", "editorial", "incident", "research"],
+)
+def test_bundled_playbooks_preserve_declared_skill_environment_parity(
+    tmp_path: Path, playbook_id: str
+) -> None:
+    """I1 — each bundled playbook declares the historic support skill order."""
+    builtin_root = Path(__file__).resolve().parents[2] / "src" / "cafe" / "data"
+    model = PlaybookLoader(
+        project_root=tmp_path / "project",
+        global_root=tmp_path / "global",
+        builtin_root=builtin_root,
+    ).load_model(playbook_id, strict=True).model
+
+    assert resolve_playbook_skills(
+        model, channel="workflow", role=None, step_name=None
+    ) == ["cafe-workflow-common", "cafe-github_sync"]
+    assert resolve_playbook_skills(model, channel="chat", role=None, step_name=None) == [
+        "cafe-common-chat-handoff",
+        "cafe-chat-develop-change",
+        "cafe-chat-spec-revision",
+        "cafe-chat-plan-revision",
+        "cafe-chat-alignment-decision",
+    ]
 
 
 def test_playbook_rejects_human_task_outcome_outside_declared_steps(tmp_path: Path) -> None:

--- a/tests/unit/test_skill_loader.py
+++ b/tests/unit/test_skill_loader.py
@@ -1,6 +1,7 @@
 """Tests for skill loader."""
 
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -306,3 +307,58 @@ def test_install_skill_recovers_when_skills_root_is_broken_symlink(tmp_path: Pat
     installed = bridge.synchronize_skills(["cafe-plan"], AgentCLI.COPILOT)[0]
     assert installed.exists()
     assert bad_root.is_dir()
+
+
+@pytest.mark.parametrize("manifest_contents", ["{broken", "{}"])
+def test_synchronize_skills_recovers_stale_skills_from_a_corrupted_manifest(
+    tmp_path: Path, manifest_contents: str
+) -> None:
+    """A damaged manifest still permits replace-style native skill cleanup."""
+    global_root = tmp_path / "global" / "skills"
+    _write_skill(global_root, "cafe-plan")
+    _write_skill(global_root, "cafe-stale")
+    project_root = tmp_path / "project"
+    loader = SkillLoader(
+        project_root=project_root,
+        global_root=tmp_path / "global",
+        builtin_root=tmp_path / "builtin",
+    )
+    loader.discover()
+    bridge = NativeSkillBridge(loader, project_root=project_root, home_dir=tmp_path / "home")
+
+    bridge.synchronize_skills(["cafe-stale"], AgentCLI.COPILOT)
+    native_skills = project_root / ".copilot" / "skills"
+    (native_skills / bridge.MANAGED_SKILLS_MANIFEST).write_text(
+        manifest_contents, encoding="utf-8"
+    )
+
+    bridge.synchronize_skills(["cafe-plan"], AgentCLI.COPILOT)
+
+    assert not (native_skills / "cafe-stale").exists()
+    assert (native_skills / "cafe-plan" / "SKILL.md").is_file()
+
+
+def test_synchronize_skills_can_reconcile_without_reinstalling_desired_skills(
+    tmp_path: Path,
+) -> None:
+    """Workflow prompt preparation remains the single installation path."""
+    global_root = tmp_path / "global" / "skills"
+    _write_skill(global_root, "cafe-plan")
+    _write_skill(global_root, "cafe-stale")
+    project_root = tmp_path / "project"
+    loader = SkillLoader(
+        project_root=project_root,
+        global_root=tmp_path / "global",
+        builtin_root=tmp_path / "builtin",
+    )
+    loader.discover()
+    bridge = NativeSkillBridge(loader, project_root=project_root, home_dir=tmp_path / "home")
+
+    bridge.synchronize_skills(["cafe-stale"], AgentCLI.COPILOT)
+    with patch.object(bridge, "install_skill") as install_skill:
+        installed = bridge.synchronize_skills(["cafe-plan"], AgentCLI.COPILOT, install=False)
+
+    native_skills = project_root / ".copilot" / "skills"
+    assert installed == []
+    install_skill.assert_not_called()
+    assert not (native_skills / "cafe-stale").exists()

--- a/tests/unit/test_skill_loader.py
+++ b/tests/unit/test_skill_loader.py
@@ -140,6 +140,7 @@ def test_imported_project_skill_is_discovered_with_project_precedence(tmp_path: 
     assert any(item.name == "plan" and item.source == "project" for item in items)
     assert "Imported project body" in loader.activate("plan")
 
+
 def test_builtin_catalog_includes_chat_handoff_skills(tmp_path: Path) -> None:
     builtin_root = Path(__file__).resolve().parents[2] / "src" / "cafe" / "data"
     loader = SkillLoader(
@@ -236,7 +237,6 @@ def test_global_overrides_builtin_when_no_project_skill(tmp_path: Path) -> None:
     assert items[0].source == "global"
 
 
-
 def test_install_skill_uses_project_version_over_global(tmp_path: Path) -> None:
     """When a project skill overrides a global skill, install_skill uses the project version."""
     global_root = tmp_path / "global" / "skills"
@@ -282,7 +282,7 @@ def test_install_skill_recovers_when_skills_root_is_file(tmp_path: Path) -> None
     loader.discover()
     bridge = NativeSkillBridge(loader, project_root=project_root, home_dir=tmp_path / "home")
 
-    installed = bridge.install_skill("cafe-plan", AgentCLI.COPILOT)
+    installed = bridge.synchronize_skills(["cafe-plan"], AgentCLI.COPILOT)[0]
     assert installed.exists()
     assert bad_root.is_dir()
 
@@ -303,6 +303,6 @@ def test_install_skill_recovers_when_skills_root_is_broken_symlink(tmp_path: Pat
     loader.discover()
     bridge = NativeSkillBridge(loader, project_root=project_root, home_dir=tmp_path / "home")
 
-    installed = bridge.install_skill("cafe-plan", AgentCLI.COPILOT)
+    installed = bridge.synchronize_skills(["cafe-plan"], AgentCLI.COPILOT)[0]
     assert installed.exists()
     assert bad_root.is_dir()

--- a/tests/unit/test_write_cafe_phase_skill.py
+++ b/tests/unit/test_write_cafe_phase_skill.py
@@ -22,3 +22,5 @@ def test_write_cafe_phase_repairs_only_its_declarative_layer() -> None:
     assert "Driver diagnosis 與 declarative repair 邊界" in spec
     assert "不要建立隱含的 `write-cafe-driver` fallback" in normalized_spec
     assert "沒有 user 明確授權不得 自動 create、comment 或 close issue" in normalized_spec
+    assert "playbook `skills.workflow`" in spec
+    assert "playbook `skills.chat`" in spec

--- a/tests/unit/test_write_cafe_playbook_skill.py
+++ b/tests/unit/test_write_cafe_playbook_skill.py
@@ -38,6 +38,12 @@ def test_write_cafe_playbook_skill_preserves_core_contracts() -> None:
     assert "confirmation-gates" in skill
     assert "no unreachable steps" in reference
     assert "write-cafe-phase" in skill
+    assert "skills.workflow" in reference
+    assert "skills.chat" in reference
+    assert "extend" in reference
+    assert "replace" in reference
+    assert "explicit empty" in normalized_reference
+    assert "missing channel" in normalized_reference
 
 
 def test_write_cafe_playbook_repairs_only_its_declarative_layer() -> None:


### PR DESCRIPTION
## Summary

Issue #349 requires making workflow/chat skill environments explicitly declared in the playbook so custom playbooks can control required shared capabilities without relying on implicit core defaults. This PR implements that model while preserving default playbook behavior and avoiding scope creep outside skill environment handling.

## Changes

- Implemented declarative `skills.workflow` and `skills.chat` declarations in playbook schema:
  - shared, roles, and steps scopes
  - `extend`/`replace` overlays with stable ordering and dedup
  - explicit empty list support to express isolation.
- Centralized skill-resolution logic in playbook core (`src/cafe/core/playbook.py`) and reused it in runtime and chat.
- Updated `GenericWorkflowStepExecutor` to remove `SHARED_WORKFLOW_SKILLS`; workflow support skills now come from the active playbook resolution only.
- Updated chat bootstrap to remove `CHAT_SKILL_NAMES`; chat support skills now come from active playbook context (`role`/`step`) only.
- Added schema/loader validation for missing/malformed declarations and unknown mode/skill references, with actionable diagnostics for fixing inputs.
- Ensured all declared skills are validated through existing `SkillLoader` catalog resolution so custom overrides remain usable and precedence is preserved.
- Updated bundled playbook declarations to lock in parity with previous effective behavior for `default`, `simple`, `tdd`, `hotfix`, `editorial`, `incident`, and `research`.
- Extended audit logic to distinguish support/chat references from phase-skill placeholders and validate both under strict rules.
- Updated playbook/phase authoring docs and test fixtures for the new contract and strict/legacy validation behavior.
- Key commits included:
  - `4678789` `fix: recover native skill synchronization`
  - `4c1e7e9` `fix: isolate declared native skill environments`
  - `9c30120` `docs: document playbook skill environments`
  - `ebed674` `feat: declare bundled playbook skill stacks`
  - `000a543` `feat: scope chat skills by playbook`
  - `839d93a` `feat: resolve workflow skills from playbooks`
  - `b92edb2` `feat: declare playbook skill environments`

## Test Plan

- Full targeted verification from plan/develop/review iterations completed:
  - plan-targeted suites passed: `194` tests.
  - `pytest -q` full suite passed: `2540` passed, `1` skipped, `1` xfailed.
  - `./scripts/test-coverage.sh` passed with `78%` (gate `75%`).
  - `ruff check --ignore E501` on touched files passed.
  - `git diff --check` passed.
  - `cafe playbook validate` strict mode for all seven bundled playbooks passed.
  - `cafe audit` passed.