### PR TITLE
Fix resumed-step scope grounding using declared input artifacts

### DIFF
--- a/src/cafe/phases/generic_phase.py
+++ b/src/cafe/phases/generic_phase.py
@@ -220,7 +220,11 @@ class GenericPhase:
                 )
         if context and context.get("resume_input_artifacts"):
             runtime_context.extend(
-                ["Current step input artifacts:", context["resume_input_artifacts"]]
+                [
+                    "Current resume scope (declared step inputs):",
+                    "Read every listed current source before selecting work.",
+                    context["resume_input_artifacts"],
+                ]
             )
         if context and context.get("delta_packet"):
             runtime_context.extend(

--- a/src/cafe/phases/generic_workflow_step.py
+++ b/src/cafe/phases/generic_workflow_step.py
@@ -27,7 +27,6 @@ from cafe.core.git import GitOperations
 from cafe.core.phase import Phase
 from cafe.core.playbook import resolve_playbook_skills
 from cafe.core.resume_user_input import (
-    is_followup_iteration,
     is_interrupted_iteration,
     load_prior_run_context,
     prior_cli_and_session,
@@ -547,22 +546,30 @@ class GenericWorkflowStepExecutor(Phase):
         else:
             updated.pop("user_input", None)
 
-        # On follow-up, surface current input artifact paths so the agent
-        # re-grounds on the current scope instead of inferring from prior work.
+        # On an interrupted run, surface only the current step's declared
+        # Blackboard artifact paths so the agent re-grounds on the current scope.
         previous_data = self._load_previous_iteration_data()
         current_data = self._load_current_iteration_data()
-        if is_followup_iteration(
+        step_def = self.playbook.get("steps", {}).get(step_name, {})
+        declared_artifacts = (
+            step_def.get("input_artifacts") if isinstance(step_def, dict) else None
+        )
+        if (
+            blackboard_state is not None
+            and isinstance(declared_artifacts, list)
+            and is_interrupted_iteration(
             iteration=self.iteration,
             previous_iteration_data=previous_data,
             current_iteration_data=current_data,
+            )
         ):
             artifact_lines = []
-            declared = self._declared_prompt_input_placeholders(step_name)
-            fallback_keys = ("develop_file", "spec_file", "plan_file", "feedback_file")
-            keys = list(dict.fromkeys(declared + fallback_keys))
-            for key in keys:
-                if updated.get(key):
-                    artifact_lines.append(f"- {key}: {updated[key]}")
+            for artifact_name in declared_artifacts:
+                name = str(artifact_name)
+                artifact = blackboard_state.artifacts.get(name)
+                path = artifact.path if artifact is not None else None
+                if isinstance(path, str) and path.strip():
+                    artifact_lines.append(f"- {name}: {path}")
             if artifact_lines:
                 updated["resume_input_artifacts"] = "\n".join(artifact_lines)
 
@@ -702,16 +709,6 @@ class GenericWorkflowStepExecutor(Phase):
             packet,
             expected_sha256=expected_sha256,
         )
-
-    def _declared_prompt_input_placeholders(self, step_name: str) -> tuple[str, ...]:
-        """Return declared prompt-input keys for the current step in contract order."""
-        steps = self.playbook.get("steps", {})
-        step_def = steps.get(step_name) if isinstance(steps, dict) else None
-        if not isinstance(step_def, dict):
-            return ()
-        skill_name = self._resolve_skill_name(step_def, self.iteration)
-        contract = self._get_skill_loader().get_workflow_contract(skill_name)
-        return tuple(mapping.placeholder for mapping in contract.prompt_inputs)
 
     def _detect_written_output_files(self) -> List[Path]:
         if self._current_output_file and self._current_output_file.exists():

--- a/tests/integration/test_declarative_skill_workflow.py
+++ b/tests/integration/test_declarative_skill_workflow.py
@@ -296,8 +296,10 @@ def test_interrupted_custom_step_uses_replaced_declared_batch_scope(
 
     prompt = manager.prompts[0]
     assert "Current resume scope (declared step inputs):" in prompt
-    assert str(replacement) in prompt
-    assert str(historical) not in prompt
+    scope = prompt.split("Current resume scope (declared step inputs):", maxsplit=1)[1]
+    scope = scope.split("Current user input for this iteration:", maxsplit=1)[0]
+    assert str(replacement) in scope
+    assert str(historical) not in scope
     assert "CURRENT_BATCH_CONTENT" not in prompt
     assert "Process batch 1 again." in prompt
     assert "[system] Resume from where you left off." in prompt

--- a/tests/integration/test_declarative_skill_workflow.py
+++ b/tests/integration/test_declarative_skill_workflow.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -228,3 +229,144 @@ def test_workflow_replace_removes_stale_native_skills(tmp_path: Path, monkeypatc
     assert not (native_skills / "stale-support").exists()
     assert (native_skills / "replacement-support" / "SKILL.md").is_file()
     assert (native_skills / "phase" / "SKILL.md").is_file()
+
+
+def test_interrupted_custom_step_uses_replaced_declared_batch_scope(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """I1 — a resumed custom step receives only its latest declared batch source."""
+    monkeypatch.chdir(tmp_path)
+    builtin_root = tmp_path / "builtin"
+    _write_skill(builtin_root / "skills", "synthesis")
+    loader = SkillLoader(
+        project_root=tmp_path,
+        global_root=tmp_path / "global",
+        builtin_root=builtin_root,
+    )
+    loader.discover()
+    generic_phase = GenericPhase(
+        loader,
+        skill_bridge=NativeSkillBridge(loader, project_root=tmp_path, home_dir=tmp_path / "home"),
+    )
+    issue_dir = tmp_path / ".cafe" / "issues" / "resumed-custom-batch"
+    iteration_dir = issue_dir / "synthesis" / "iteration_001"
+    iteration_dir.mkdir(parents=True)
+    (iteration_dir / "iteration.json").write_text(
+        json.dumps({"cli": "codex", "session_id": "interrupted-session"}),
+        encoding="utf-8",
+    )
+    replacement = issue_dir / "batches" / "batch-2.md"
+    replacement.parent.mkdir(parents=True)
+    replacement.write_text("CURRENT_BATCH_CONTENT", encoding="utf-8")
+    historical = issue_dir / "history" / "batch-1.md"
+    historical.parent.mkdir(parents=True)
+    historical.write_text("HISTORICAL_BATCH_CONTENT", encoding="utf-8")
+    store = BlackboardStore(issue_dir)
+    state = store.load_or_create("synthesis")
+    state.handoff_summary = "Process batch 1 again."
+    store.set_artifact(state, "batch_scope", str(replacement))
+    store.set_artifact(state, "historical_output", str(historical))
+    step = {
+        "skill": "synthesis",
+        "role": "researcher",
+        "input_artifacts": ["batch_scope"],
+        "output_artifact": "report",
+        "allowed_tools": ["Read"],
+        "valid_intents": ["confirmed"],
+        "on": {"await_agent": "_done"},
+    }
+    manager = _AgentManager()
+    executor = GenericWorkflowStepExecutor(
+        issue_dir=issue_dir,
+        issue_name="resumed-custom-batch",
+        playbook={
+            "playbook": {"id": "synthesis"},
+            "roles": {"researcher": {"default_agent": "David"}},
+            "skills": {"workflow": {"shared": []}, "chat": {"shared": []}},
+            "steps": {"synthesis": step},
+        },
+        generic_phase=generic_phase,
+        agent_manager=manager,
+        git_ops=_GitOps(),
+        role_agent_map={"researcher": "David"},
+    )
+    executor.step_user_inputs["synthesis"] = "[system] Resume from where you left off."
+
+    executor.execute_step("synthesis", step, state)
+
+    prompt = manager.prompts[0]
+    assert "Current resume scope (declared step inputs):" in prompt
+    assert str(replacement) in prompt
+    assert str(historical) not in prompt
+    assert "CURRENT_BATCH_CONTENT" not in prompt
+    assert "Process batch 1 again." in prompt
+    assert "[system] Resume from where you left off." in prompt
+
+
+def test_execution_without_declared_scope_does_not_invent_resume_scope(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """I2 — fresh and resumed custom steps omit grounding without declared inputs."""
+    monkeypatch.chdir(tmp_path)
+    builtin_root = tmp_path / "builtin"
+    _write_skill(builtin_root / "skills", "synthesis")
+    loader = SkillLoader(
+        project_root=tmp_path,
+        global_root=tmp_path / "global",
+        builtin_root=builtin_root,
+    )
+    loader.discover()
+    generic_phase = GenericPhase(
+        loader,
+        skill_bridge=NativeSkillBridge(loader, project_root=tmp_path, home_dir=tmp_path / "home"),
+    )
+    step = {
+        "skill": "synthesis",
+        "role": "researcher",
+        "input_artifacts": [],
+        "output_artifact": "report",
+        "allowed_tools": ["Read"],
+        "valid_intents": ["confirmed"],
+        "on": {"await_agent": "_done"},
+    }
+
+    def execute(issue_name: str, *, interrupted: bool) -> str:
+        issue_dir = tmp_path / ".cafe" / "issues" / issue_name
+        if interrupted:
+            iteration_dir = issue_dir / "synthesis" / "iteration_001"
+            iteration_dir.mkdir(parents=True)
+            (iteration_dir / "iteration.json").write_text(
+                json.dumps({"cli": "codex", "session_id": "interrupted-session"}),
+                encoding="utf-8",
+            )
+        store = BlackboardStore(issue_dir)
+        state = store.load_or_create("synthesis")
+        historical = issue_dir / "history" / "prior-output.md"
+        historical.parent.mkdir(parents=True)
+        historical.write_text("HISTORICAL_OUTPUT", encoding="utf-8")
+        store.set_artifact(state, "historical_output", str(historical))
+        manager = _AgentManager()
+        executor = GenericWorkflowStepExecutor(
+            issue_dir=issue_dir,
+            issue_name=issue_name,
+            playbook={
+                "playbook": {"id": "synthesis"},
+                "roles": {"researcher": {"default_agent": "David"}},
+                "skills": {"workflow": {"shared": []}, "chat": {"shared": []}},
+                "steps": {"synthesis": step},
+            },
+            generic_phase=generic_phase,
+            agent_manager=manager,
+            git_ops=_GitOps(),
+            role_agent_map={"researcher": "David"},
+        )
+        executor.execute_step("synthesis", step, state)
+        return manager.prompts[0]
+
+    fresh_prompt = execute("fresh-custom-step", interrupted=False)
+    resumed_prompt = execute("resumed-custom-step", interrupted=True)
+
+    assert "Current resume scope (declared step inputs):" not in fresh_prompt
+    assert "Current resume scope (declared step inputs):" not in resumed_prompt
+    assert "HISTORICAL_OUTPUT" not in fresh_prompt
+    assert "HISTORICAL_OUTPUT" not in resumed_prompt

--- a/tests/unit/test_generic_phase.py
+++ b/tests/unit/test_generic_phase.py
@@ -164,7 +164,7 @@ def test_build_prompt_includes_user_input_when_set(tmp_path: Path) -> None:
     assert "Please prioritize the auth module." in prompt
 
 
-def test_build_prompt_includes_resume_input_artifacts_when_set(tmp_path: Path) -> None:
+def test_build_prompt_renders_actionable_current_resume_scope(tmp_path: Path) -> None:
     phase = GenericPhase(_setup_loader(tmp_path))
     prompt = phase.build_prompt(
         skill_name="cafe-develop",
@@ -173,14 +173,19 @@ def test_build_prompt_includes_resume_input_artifacts_when_set(tmp_path: Path) -
         context={
             "blackboard_path": ".cafe/issues/demo/blackboard.json",
             "next_step_path": ".cafe/issues/demo/next_step.txt",
-            "resume_input_artifacts": "- develop_file: .cafe/issues/demo/develop/output.md",
+            "handoff_summary": "Continue the previous batch.",
+            "user_input": "[system] Resume from where you left off.",
+            "resume_input_artifacts": "- batch_scope: .cafe/issues/demo/batches/current.md",
         },
         output_file=Path("out.md"),
         checklist_file=Path("checklist.md"),
     )
 
-    assert "Current step input artifacts:" in prompt
-    assert "- develop_file: .cafe/issues/demo/develop/output.md" in prompt
+    assert "Current resume scope (declared step inputs):" in prompt
+    assert "Read every listed current source before selecting work." in prompt
+    assert "- batch_scope: .cafe/issues/demo/batches/current.md" in prompt
+    assert "Latest workflow handoff from blackboard:" in prompt
+    assert "Current user input for this iteration:" in prompt
 
 
 def test_build_prompt_omits_resume_input_artifacts_when_unset(tmp_path: Path) -> None:

--- a/tests/unit/test_generic_workflow_step.py
+++ b/tests/unit/test_generic_workflow_step.py
@@ -3412,35 +3412,33 @@ def test_apply_resume_to_runtime_context_keeps_real_input(tmp_path: Path) -> Non
     )
 
 
-def test_apply_resume_to_runtime_context_adds_resume_input_artifacts(tmp_path: Path) -> None:
+def test_apply_resume_to_runtime_context_projects_declared_scope_for_interrupted_run(
+    tmp_path: Path,
+) -> None:
     issue_dir = tmp_path / ".cafe" / "issues" / "issue-resume-input"
     spec_dir = issue_dir / "spec"
-    prev_iter = spec_dir / "iteration_001"
-    prev_iter.mkdir(parents=True)
-    (prev_iter / "iteration.json").write_text(
-        json.dumps(
-            {
-                "cli": "codex",
-                "session_id": "session-1",
-                "end_time": "2026-05-23T00:00:00+08:00",
-            }
-        ),
-        encoding="utf-8",
+    current_iter = spec_dir / "iteration_001"
+    current_iter.mkdir(parents=True)
+    (current_iter / "iteration.json").write_text(
+        json.dumps({"cli": "codex", "session_id": "session-1"}), encoding="utf-8"
     )
 
     executor = _minimal_spec_executor(tmp_path, agent_manager=FakeAgentManager("confirmed"))
     executor.phase_dir = spec_dir
-    executor.iteration = 2
+    executor.iteration = 1
     executor._step_agent_name = "Roger"
+    executor.playbook["steps"]["spec"]["input_artifacts"] = ["batch_scope"]
+    state = BlackboardStore(issue_dir).load_or_create("spec")
+    replacement = issue_dir / "inputs" / "batch-2.md"
+    BlackboardStore(issue_dir).set_artifact(state, "batch_scope", str(replacement))
 
     updated = executor._apply_resume_to_runtime_context(
         {"develop_file": ".cafe/issues/demo/develop/output.md"},
         "spec",
+        state,
     )
 
-    assert (
-        updated["resume_input_artifacts"] == "- develop_file: .cafe/issues/demo/develop/output.md"
-    )
+    assert updated["resume_input_artifacts"] == f"- batch_scope: {replacement}"
 
 
 def test_apply_resume_to_runtime_context_omits_artifacts_on_fresh_run(tmp_path: Path) -> None:
@@ -3458,26 +3456,28 @@ def test_apply_resume_to_runtime_context_omits_artifacts_on_fresh_run(tmp_path: 
     assert "resume_input_artifacts" not in updated
 
 
-def test_apply_resume_to_runtime_context_lists_all_present_artifacts(tmp_path: Path) -> None:
+def test_apply_resume_to_runtime_context_excludes_undeclared_and_fallback_scope(
+    tmp_path: Path,
+) -> None:
     issue_dir = tmp_path / ".cafe" / "issues" / "issue-resume-input"
     spec_dir = issue_dir / "spec"
-    prev_iter = spec_dir / "iteration_001"
-    prev_iter.mkdir(parents=True)
-    (prev_iter / "iteration.json").write_text(
-        json.dumps(
-            {
-                "cli": "codex",
-                "session_id": "session-1",
-                "end_time": "2026-05-23T00:00:00+08:00",
-            }
-        ),
-        encoding="utf-8",
+    current_iter = spec_dir / "iteration_001"
+    current_iter.mkdir(parents=True)
+    (current_iter / "iteration.json").write_text(
+        json.dumps({"cli": "codex", "session_id": "session-1"}), encoding="utf-8"
     )
 
     executor = _minimal_spec_executor(tmp_path, agent_manager=FakeAgentManager("confirmed"))
     executor.phase_dir = spec_dir
-    executor.iteration = 2
+    executor.iteration = 1
     executor._step_agent_name = "Roger"
+    executor.playbook["steps"]["spec"]["input_artifacts"] = ["batch_scope"]
+    state = BlackboardStore(issue_dir).load_or_create("spec")
+    current_scope = issue_dir / "inputs" / "current.md"
+    historical = issue_dir / "history" / "old.md"
+    store = BlackboardStore(issue_dir)
+    store.set_artifact(state, "batch_scope", str(current_scope))
+    store.set_artifact(state, "historical_output", str(historical))
 
     updated = executor._apply_resume_to_runtime_context(
         {
@@ -3487,43 +3487,77 @@ def test_apply_resume_to_runtime_context_lists_all_present_artifacts(tmp_path: P
             "spec_file": "spec.md",
         },
         "spec",
+        state,
     )
 
-    assert updated["resume_input_artifacts"] == "\n".join(
-        [
-            "- develop_file: develop.md",
-            "- spec_file: spec.md",
-            "- plan_file: plan.md",
-            "- feedback_file: review.md",
-        ]
-    )
+    assert updated["resume_input_artifacts"] == f"- batch_scope: {current_scope}"
+    assert "historical_output" not in updated["resume_input_artifacts"]
+    assert "develop_file" not in updated["resume_input_artifacts"]
 
 
-def test_apply_resume_to_runtime_context_lists_declared_custom_artifacts(tmp_path: Path) -> None:
-    """Resume context preserves a custom skill's declared placeholder name."""
+def test_apply_resume_to_runtime_context_uses_latest_declared_artifact_path(tmp_path: Path) -> None:
+    """U3 — interrupted runs read the current Blackboard path, not stale prompt data."""
     issue_dir = tmp_path / ".cafe" / "issues" / "issue-resume-custom-artifacts"
     phase_dir = issue_dir / "synthesize"
-    previous = phase_dir / "iteration_001"
-    previous.mkdir(parents=True)
-    (previous / "iteration.json").write_text(
-        json.dumps({"cli": "codex", "session_id": "session-1"}), encoding="utf-8"
-    )
-    current = phase_dir / "iteration_002"
-    current.mkdir()
+    current = phase_dir / "iteration_001"
+    current.mkdir(parents=True)
     (current / "iteration.json").write_text(
         json.dumps({"cli": "codex", "session_id": "session-1"}), encoding="utf-8"
     )
     executor = _minimal_spec_executor(tmp_path, agent_manager=FakeAgentManager("confirmed"))
-    executor.playbook = {"steps": {"synthesize": {"skill": "synthesis", "role": "developer"}}}
+    executor.playbook = {
+        "steps": {
+            "synthesize": {
+                "skill": "synthesis",
+                "role": "developer",
+                "input_artifacts": ["batch_scope"],
+            }
+        }
+    }
     executor.phase_dir = phase_dir
-    executor.iteration = 2
+    executor.iteration = 1
     executor._step_agent_name = "David"
+    state = BlackboardStore(issue_dir).load_or_create("synthesize")
+    replacement = issue_dir / "inputs" / "batch-2.md"
+    BlackboardStore(issue_dir).set_artifact(state, "batch_scope", str(replacement))
 
     updated = executor._apply_resume_to_runtime_context(
-        {"evidence_file": "research-notes.md"}, "synthesize"
+        {"evidence_file": "batch-1.md"}, "synthesize", state
     )
 
-    assert updated["resume_input_artifacts"] == "- evidence_file: research-notes.md"
+    assert updated["resume_input_artifacts"] == f"- batch_scope: {replacement}"
+
+
+def test_apply_resume_to_runtime_context_omits_scope_for_completed_correction_iteration(
+    tmp_path: Path,
+) -> None:
+    issue_dir = tmp_path / ".cafe" / "issues" / "issue-resume-input"
+    spec_dir = issue_dir / "spec"
+    previous = spec_dir / "iteration_001"
+    previous.mkdir(parents=True)
+    (previous / "iteration.json").write_text(
+        json.dumps(
+            {
+                "cli": "codex",
+                "session_id": "session-1",
+                "end_time": "2026-05-23T00:00:00+08:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+    executor = _minimal_spec_executor(tmp_path, agent_manager=FakeAgentManager("confirmed"))
+    executor.phase_dir = spec_dir
+    executor.iteration = 2
+    executor._step_agent_name = "Roger"
+    executor.playbook["steps"]["spec"]["input_artifacts"] = []
+    state = BlackboardStore(issue_dir).load_or_create("spec")
+
+    updated = executor._apply_resume_to_runtime_context(
+        {"user_input": "Apply review feedback."}, "spec", state
+    )
+
+    assert "resume_input_artifacts" not in updated
+    assert updated["user_input"] == "Apply review feedback."
 
 
 def test_execute_step_same_session_resume_keeps_real_input_in_prompt_and_user_input_md(
@@ -3592,39 +3626,31 @@ def test_execute_step_same_session_resume_keeps_real_input_in_prompt_and_user_in
     )
 
 
-def test_execute_step_resume_includes_current_input_artifacts_in_prompt(
+def test_execute_step_interrupted_fresh_session_surfaces_declared_current_scope(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
     monkeypatch.chdir(tmp_path)
     issue_dir = tmp_path / ".cafe" / "issues" / "issue-resume-artifacts"
     develop_dir = issue_dir / "develop"
-    prev_iter = develop_dir / "iteration_001"
-    prev_iter.mkdir(parents=True)
-    (prev_iter / "iteration.json").write_text(
-        json.dumps(
-            {
-                "cli": "codex",
-                "session_id": "session-1",
-                "end_time": "2026-05-23T00:00:00+08:00",
-            }
-        ),
+    current_iter = develop_dir / "iteration_001"
+    current_iter.mkdir(parents=True)
+    (current_iter / "iteration.json").write_text(
+        json.dumps({"cli": "codex", "session_id": "interrupted-session"}),
         encoding="utf-8",
     )
 
-    code_file = issue_dir / "develop" / "iteration_001" / "output.md"
-    code_file.write_text("Batch 2 scoped work", encoding="utf-8")
-    spec_file = issue_dir / "spec" / "iteration_001" / "output.md"
-    plan_file = issue_dir / "plan" / "iteration_001" / "output.md"
-    spec_file.parent.mkdir(parents=True, exist_ok=True)
-    plan_file.parent.mkdir(parents=True, exist_ok=True)
-    spec_file.write_text("# Spec\n", encoding="utf-8")
-    plan_file.write_text("# Plan\n", encoding="utf-8")
+    replacement = issue_dir / "inputs" / "batch-2.md"
+    replacement.parent.mkdir(parents=True)
+    replacement.write_text("current batch", encoding="utf-8")
+    historical = issue_dir / "history" / "batch-1.md"
+    historical.parent.mkdir(parents=True)
+    historical.write_text("already completed", encoding="utf-8")
     store = BlackboardStore(issue_dir)
     state = store.load_or_create("develop")
-    store.set_artifact(state, "spec", str(spec_file))
-    store.set_artifact(state, "plan", str(plan_file))
-    store.set_artifact(state, "code", str(code_file))
+    state.handoff_summary = "Continue the old batch."
+    store.set_artifact(state, "batch_scope", str(replacement))
+    store.set_artifact(state, "historical_output", str(historical))
 
     playbook = {
         "playbook": {"id": "default"},
@@ -3633,7 +3659,7 @@ def test_execute_step_resume_includes_current_input_artifacts_in_prompt(
             "develop": {
                 "skill": "cafe-develop",
                 "role": "developer",
-                "input_artifacts": ["code"],
+                "input_artifacts": ["batch_scope"],
                 "output_artifact": "code",
                 "allowed_tools": ["Read"],
                 "valid_intents": ["confirmed"],
@@ -3654,17 +3680,14 @@ def test_execute_step_resume_includes_current_input_artifacts_in_prompt(
         git_ops=FakeGitOperations(),
         role_agent_map={"developer": "David"},
     )
-    executor.iteration = 2
 
     executor.execute_step("develop", playbook["steps"]["develop"], state)
 
     assert manager.prompts
     prompt = manager.prompts[0]
-    assert "Current step input artifacts:" in prompt
-    assert (
-        "- develop_file: ./.cafe/issues/issue-resume-artifacts/develop/iteration_001/output.md"
-        in prompt
-    )
+    assert "Current resume scope (declared step inputs):" in prompt
+    assert str(replacement) in prompt
+    assert str(historical) not in prompt
 
 
 def _make_alignment_executor(tmp_path: Path, issue_name: str, step_def: dict, user_input: str):

--- a/tests/unit/test_generic_workflow_step.py
+++ b/tests/unit/test_generic_workflow_step.py
@@ -3686,8 +3686,10 @@ def test_execute_step_interrupted_fresh_session_surfaces_declared_current_scope(
     assert manager.prompts
     prompt = manager.prompts[0]
     assert "Current resume scope (declared step inputs):" in prompt
-    assert str(replacement) in prompt
-    assert str(historical) not in prompt
+    scope = prompt.split("Current resume scope (declared step inputs):", maxsplit=1)[1]
+    scope = scope.split("Current user input for this iteration:", maxsplit=1)[0]
+    assert str(replacement) in scope
+    assert str(historical) not in scope
 
 
 def _make_alignment_executor(tmp_path: Path, issue_name: str, step_def: dict, user_input: str):


### PR DESCRIPTION
## Summary

Implemented issue #366 by ensuring resumed agent steps ground on the latest declared scope inputs for the current step, so stale handoff context no longer overrides an updated batch/file declaration.

## Changes

- Aligned resume grounding with `input_artifacts` declared in the current step and the latest Blackboard artifact paths in `src/cafe/phases/generic_workflow_step.py`.
- Removed fixed placeholder fallback inference (`develop_file`, `spec_file`, `plan_file`, `feedback_file`) and preserved existing continuation/handoff/delta behavior.
- Added explicit prompt grounding section `Current resume scope (declared step inputs)` with a read-before-selection instruction in `src/cafe/phases/generic_phase.py`.
- Added/updated unit tests for declared-scope projection, replacement-path behavior, and compatibility cases in `tests/unit/test_generic_workflow_step.py` and `tests/unit/test_generic_phase.py`.
- Added/updated integration coverage for stale handoff with replaced batch scope and no-scope resumed compatibility in `tests/integration/test_declarative_skill_workflow.py`.
- Reflected the above in the final implementation summary in PR artifact.

## Test Plan

- `pytest -q tests/unit/test_resume_user_input.py tests/unit/test_generic_phase.py tests/unit/test_generic_workflow_step.py tests/integration/test_declarative_skill_workflow.py`
- `pytest`
- `./scripts/test-coverage.sh`

## References

- Requirements: `.cafe/issues/issue366/spec/iteration_002/output.md`
- Plan: `.cafe/issues/issue366/plan/iteration_001/output.md`
- Related commits:
  - `e553877` fix: label resume scope prompts
  - `c704137` fix: project declared resume scope
  - `ded0c06` test: cover custom resume scope
  - `f52b8b3` test: cover resume scope grounding