### PR TITLE
Add validated phase context packets and takeover recovery

### DIFF
--- a/src/cafe/agents/cli/codex.py
+++ b/src/cafe/agents/cli/codex.py
@@ -13,10 +13,8 @@ class CodexCLI(AbstractCLI):
     """Concrete implementation of Codex CLI tool."""
 
     def build_environment(self) -> dict[str, str]:
-        """Keep the CAFE process's Codex configuration out of child sessions."""
-        environment = super().build_environment()
-        environment.pop("CODEX_HOME", None)
-        return environment
+        """Build the child environment without changing provider configuration."""
+        return super().build_environment()
 
     @staticmethod
     def extract_turn_usages(output_lines: List[str]) -> List[Dict[str, Any]]:

--- a/src/cafe/agents/cli/codex.py
+++ b/src/cafe/agents/cli/codex.py
@@ -12,6 +12,12 @@ from cafe.utils.git_utils import get_git_dir
 class CodexCLI(AbstractCLI):
     """Concrete implementation of Codex CLI tool."""
 
+    def build_environment(self) -> dict[str, str]:
+        """Keep the CAFE process's Codex configuration out of child sessions."""
+        environment = super().build_environment()
+        environment.pop("CODEX_HOME", None)
+        return environment
+
     @staticmethod
     def extract_turn_usages(output_lines: List[str]) -> List[Dict[str, Any]]:
         """Extract per-turn token usage from Codex JSONL output."""

--- a/src/cafe/agents/diagnostics.py
+++ b/src/cafe/agents/diagnostics.py
@@ -19,7 +19,7 @@ _NON_TRANSIENT_CLI_UNAVAILABLE = re.compile(
 )
 _BEARER_CREDENTIAL = re.compile(r"\bbearer\s+[^\s,;]+", re.IGNORECASE)
 _KEY_VALUE_CREDENTIAL = re.compile(
-    r"\b(api[_-]?key|token|password|secret|authorization)\s*[:=]\s*[^\s,;]+",
+    r"\b(api[_-]?key|token|password|secret|credential|authorization)\s*[:=]\s*[^\s,;]+",
     re.IGNORECASE,
 )
 _URL_CREDENTIAL = re.compile(r"(https?://)[^\s:/@]+:[^\s@/]+@", re.IGNORECASE)

--- a/src/cafe/agents/manager.py
+++ b/src/cafe/agents/manager.py
@@ -710,6 +710,7 @@ class AgentManager:
         # Track tried CLIs to avoid duplicates
         tried_clis = {config.cli}
         failed_agents: List[str] = [f"{primary_cli_name} ({sanitize_error_excerpt(primary_error)})"]
+        takeover_error = primary_error
 
         for entry in fallback_entries:
             if entry.cli in tried_clis:
@@ -725,7 +726,7 @@ class AgentManager:
             backup_prompt = prompt
             if backup_context_callback is not None:
                 try:
-                    takeover_context = backup_context_callback(primary_error)
+                    takeover_context = backup_context_callback(takeover_error)
                 except Exception as exc:
                     failed_agents.append(
                         f"{entry.cli.value} (takeover context unavailable: {sanitize_error_excerpt(exc)})"
@@ -806,6 +807,7 @@ class AgentManager:
                             f"❌ {entry.cli.value} failed ({self._fallback_reason(backup_error)}), trying next agent..."
                         )
                         self._print_fallback_error_detail(backup_error)
+                        takeover_error = backup_error
                         break
                     raise
 

--- a/src/cafe/agents/manager.py
+++ b/src/cafe/agents/manager.py
@@ -4,7 +4,7 @@ import json
 import os
 import subprocess
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Callable, Dict, List, Optional, Tuple
 
 from cafe.agents.diagnostics import (
     build_failed_attempt,
@@ -43,6 +43,7 @@ class AgentManager:
         "edit only when the approved plan requires no new test). Use the context already in "
         "this session."
     )
+    SUPPORTS_COLD_TAKEOVER = True
 
     def __init__(
         self, session_manager: Optional[SessionManager] = None, issue_name: Optional[str] = None
@@ -416,6 +417,7 @@ class AgentManager:
         streaming_output_file: Optional[str] = None,
         phase_name: Optional[str] = None,
         continuation: Optional[SessionContinuation] = None,
+        backup_context_callback: Optional[Callable[[AgentExecutionError], str]] = None,
     ) -> Tuple[str, TokenUsage, List, Optional[List[str]], List[str], Optional[str]]:
         """Execute prompt with specified agent.
 
@@ -540,6 +542,7 @@ class AgentManager:
                         streaming_output_file=streaming_output_file,
                         phase_name=phase_name,
                         continuation=continuation,
+                        backup_context_callback=backup_context_callback,
                     )
                     break  # Backup succeeded, exit loop
                 else:
@@ -647,6 +650,7 @@ class AgentManager:
         streaming_output_file: Optional[str] = None,
         phase_name: Optional[str] = None,
         continuation: Optional[SessionContinuation] = None,
+        backup_context_callback: Optional[Callable[[AgentExecutionError], str]] = None,
     ) -> "AgentResponse":
         """Try backup agents in order until one succeeds or all fail.
 
@@ -715,6 +719,21 @@ class AgentManager:
             backup_model = entry.resolve_model(phase_name)
             print(f"Trying {entry.cli.value}...")
 
+            # Every different-provider attempt is a cold takeover. Refresh the
+            # durable runtime snapshot at this last responsible moment instead
+            # of carrying a provider session or an earlier in-memory summary.
+            backup_prompt = prompt
+            if backup_context_callback is not None:
+                try:
+                    takeover_context = backup_context_callback(primary_error)
+                except Exception:
+                    takeover_context = ""
+                if takeover_context:
+                    backup_prompt = (
+                        f"{prompt}\n\nCold backup takeover context (fresh, provider-neutral):\n"
+                        f"{takeover_context}"
+                    )
+
             # Explicit workflow policies never continue a different fallback
             # session. AUTO preserves legacy sticky-session behavior.
             fallback_session_id = None
@@ -742,7 +761,7 @@ class AgentManager:
                             self.DEVELOP_READ_ONLY_COMMAND_LIMIT
                         )
                     agent_response = backup_executor.execute(
-                        prompt,
+                        backup_prompt,
                         allowed_tools,
                         allowed_directories,
                         streaming_output_file,

--- a/src/cafe/agents/manager.py
+++ b/src/cafe/agents/manager.py
@@ -726,8 +726,14 @@ class AgentManager:
             if backup_context_callback is not None:
                 try:
                     takeover_context = backup_context_callback(primary_error)
-                except Exception:
-                    takeover_context = ""
+                except Exception as exc:
+                    failed_agents.append(
+                        f"{entry.cli.value} (takeover context unavailable: {sanitize_error_excerpt(exc)})"
+                    )
+                    print(
+                        f"❌ {entry.cli.value} takeover context unavailable; trying next agent..."
+                    )
+                    continue
                 if takeover_context:
                     backup_prompt = (
                         f"{prompt}\n\nCold backup takeover context (fresh, provider-neutral):\n"

--- a/src/cafe/core/blackboard.py
+++ b/src/cafe/core/blackboard.py
@@ -704,7 +704,9 @@ class BlackboardStore:
                 version=version,
                 updated_by=step,
                 path=str(path),
-                summary=f"long_running_operation:{artifact.state.value}",
+                summary=(
+                    f"long_running_operation:{artifact.operation_id}:{artifact.state.value}"
+                ),
             ),
         )
         self.record_event(

--- a/src/cafe/core/context_packet.py
+++ b/src/cafe/core/context_packet.py
@@ -7,7 +7,7 @@ from typing import Any, Mapping
 
 from cafe.core.downstream_contract import ContractValidationError, extract_downstream_contract
 from cafe.core.packet_io import (
-    atomic_write_bytes,
+    canonical_json,
     file_metadata,
     load_or_persist_json,
     sha256_bytes,
@@ -154,13 +154,12 @@ def resolve_context_packet(
             source_artifact_name=source_artifact_name,
             source_artifact_version=source_artifact_version,
         )
-        receipt_path = packet_path.with_suffix(f"{packet_path.suffix}.sha256")
-        expected_sha256 = _read_packet_receipt(receipt_path) if packet_path.exists() else None
+        # The deterministic packet derived from the current authority is the
+        # trust anchor.  A mutable adjacent receipt cannot approve altered bytes.
+        expected_sha256 = sha256_bytes(canonical_json(packet))
         persisted, metadata = persist_context_packet(
             packet_path, packet, expected_sha256=expected_sha256
         )
-        if expected_sha256 is None:
-            atomic_write_bytes(receipt_path, metadata["sha256"].encode("ascii") + b"\n")
         return {
             "mode": "packet",
             "path": packet_path.as_posix(),
@@ -175,13 +174,3 @@ def resolve_context_packet(
             else "Invalid or altered context packet"
         )
         return {"mode": "full_fallback", "path": Path(source_path).as_posix(), "reason": reason}
-
-
-def _read_packet_receipt(path: Path) -> str:
-    try:
-        receipt = path.read_text(encoding="ascii").strip()
-    except OSError as exc:
-        raise ValueError("Missing context packet receipt") from exc
-    if not _valid_sha256(receipt):
-        raise ValueError("Invalid context packet receipt")
-    return receipt

--- a/src/cafe/core/context_packet.py
+++ b/src/cafe/core/context_packet.py
@@ -1,0 +1,49 @@
+"""Immutable packet envelopes for validated source-owned contracts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping
+
+from cafe.core.downstream_contract import ContractValidationError, extract_downstream_contract
+from cafe.core.packet_io import file_metadata, load_or_persist_json, sha256_bytes
+
+CONTEXT_PACKET_SCHEMA_VERSION = 1
+
+
+def build_context_packet(*, source_path: str | Path, contract_kind: str, target_step: str, iteration: int, placeholders: tuple[str, ...]) -> dict[str, Any]:
+    source = Path(source_path)
+    contract = extract_downstream_contract(source, kind=contract_kind)
+    return {
+        "schema_version": CONTEXT_PACKET_SCHEMA_VERSION,
+        "packet_kind": "downstream_contract",
+        "target": {"step": target_step, "iteration": iteration, "placeholders": list(placeholders)},
+        "source": file_metadata(source),
+        "contract": {"kind": contract.kind, "version": contract.version, "sha256": contract.sha256, "bytes": contract.bytes.decode("utf-8")},
+    }
+
+
+def validate_context_packet(packet: Any) -> None:
+    if not isinstance(packet, dict) or packet.get("schema_version") != CONTEXT_PACKET_SCHEMA_VERSION or packet.get("packet_kind") != "downstream_contract":
+        raise ValueError("Invalid context packet schema")
+    if not isinstance(packet.get("target"), dict) or not isinstance(packet.get("source"), dict) or not isinstance(packet.get("contract"), dict):
+        raise ValueError("Invalid context packet envelope")
+    contract = packet["contract"]
+    if contract.get("kind") not in {"spec", "plan"} or contract.get("version") != 1 or not isinstance(contract.get("bytes"), str):
+        raise ValueError("Invalid context packet contract")
+    if sha256_bytes(contract["bytes"].encode("utf-8")) != contract.get("sha256"):
+        raise ValueError("Invalid context packet contract hash")
+
+
+def persist_context_packet(path: Path, packet: Mapping[str, Any], *, expected_sha256: str | None = None) -> tuple[dict[str, Any], dict[str, Any]]:
+    return load_or_persist_json(path, packet, validate=validate_context_packet, expected_sha256=expected_sha256, matches_identity=lambda old, new: old.get("target") == new.get("target") and old.get("source") == new.get("source") and old.get("contract") == new.get("contract"))
+
+
+def resolve_context_packet(*, source_path: str | Path, contract_kind: str, target_step: str, iteration: int, placeholders: tuple[str, ...], packet_path: Path) -> dict[str, Any]:
+    """Return packet metadata or a deliberate full-source fallback result."""
+    try:
+        packet = build_context_packet(source_path=source_path, contract_kind=contract_kind, target_step=target_step, iteration=iteration, placeholders=placeholders)
+        persisted, metadata = persist_context_packet(packet_path, packet)
+        return {"mode": "packet", "path": packet_path.as_posix(), "packet": persisted, "metadata": metadata}
+    except (ContractValidationError, ValueError) as exc:
+        return {"mode": "full_fallback", "path": Path(source_path).as_posix(), "reason": str(exc)}

--- a/src/cafe/core/context_packet.py
+++ b/src/cafe/core/context_packet.py
@@ -6,44 +6,182 @@ from pathlib import Path
 from typing import Any, Mapping
 
 from cafe.core.downstream_contract import ContractValidationError, extract_downstream_contract
-from cafe.core.packet_io import file_metadata, load_or_persist_json, sha256_bytes
+from cafe.core.packet_io import (
+    atomic_write_bytes,
+    file_metadata,
+    load_or_persist_json,
+    sha256_bytes,
+)
 
 CONTEXT_PACKET_SCHEMA_VERSION = 1
 
 
-def build_context_packet(*, source_path: str | Path, contract_kind: str, target_step: str, iteration: int, placeholders: tuple[str, ...]) -> dict[str, Any]:
+def build_context_packet(
+    *,
+    source_path: str | Path,
+    contract_kind: str,
+    target_step: str,
+    iteration: int,
+    placeholders: tuple[str, ...],
+    source_artifact_name: str | None = None,
+    source_artifact_version: int | None = None,
+) -> dict[str, Any]:
     source = Path(source_path)
     contract = extract_downstream_contract(source, kind=contract_kind)
+    source_metadata = file_metadata(source)
+    source_metadata.update(
+        {
+            "artifact_name": source_artifact_name or source.stem,
+            "artifact_version": source_artifact_version or 1,
+        }
+    )
     return {
         "schema_version": CONTEXT_PACKET_SCHEMA_VERSION,
         "packet_kind": "downstream_contract",
         "target": {"step": target_step, "iteration": iteration, "placeholders": list(placeholders)},
-        "source": file_metadata(source),
-        "contract": {"kind": contract.kind, "version": contract.version, "sha256": contract.sha256, "bytes": contract.bytes.decode("utf-8")},
+        "source": source_metadata,
+        "contract": {
+            "kind": contract.kind,
+            "version": contract.version,
+            "sha256": contract.sha256,
+            "bytes": contract.bytes.decode("utf-8"),
+        },
     }
 
 
 def validate_context_packet(packet: Any) -> None:
-    if not isinstance(packet, dict) or packet.get("schema_version") != CONTEXT_PACKET_SCHEMA_VERSION or packet.get("packet_kind") != "downstream_contract":
+    if not isinstance(packet, dict) or set(packet) != {
+        "schema_version",
+        "packet_kind",
+        "target",
+        "source",
+        "contract",
+    }:
+        raise ValueError("Invalid context packet envelope")
+    if (
+        packet.get("schema_version") != CONTEXT_PACKET_SCHEMA_VERSION
+        or packet.get("packet_kind") != "downstream_contract"
+    ):
         raise ValueError("Invalid context packet schema")
-    if not isinstance(packet.get("target"), dict) or not isinstance(packet.get("source"), dict) or not isinstance(packet.get("contract"), dict):
+    target = packet.get("target")
+    source = packet.get("source")
+    if (
+        not isinstance(target, dict)
+        or set(target) != {"step", "iteration", "placeholders"}
+        or not isinstance(target["step"], str)
+        or not isinstance(target["iteration"], int)
+        or isinstance(target["iteration"], bool)
+        or target["iteration"] < 1
+        or not isinstance(target["placeholders"], list)
+        or not target["placeholders"]
+        or any(not isinstance(item, str) or not item for item in target["placeholders"])
+        or len(set(target["placeholders"])) != len(target["placeholders"])
+    ):
+        raise ValueError("Invalid context packet target")
+    if (
+        not isinstance(source, dict)
+        or set(source) != {"artifact_name", "artifact_version", "path", "state", "bytes", "sha256"}
+        or source.get("state") != "file"
+        or not isinstance(source.get("artifact_name"), str)
+        or not source["artifact_name"]
+        or not isinstance(source.get("artifact_version"), int)
+        or isinstance(source["artifact_version"], bool)
+        or source["artifact_version"] < 1
+        or not isinstance(source.get("path"), str)
+        or not source["path"]
+        or not isinstance(source.get("bytes"), int)
+        or isinstance(source["bytes"], bool)
+        or source["bytes"] < 0
+        or not _valid_sha256(source.get("sha256"))
+    ):
+        raise ValueError("Invalid context packet source")
+    if not isinstance(packet.get("contract"), dict):
         raise ValueError("Invalid context packet envelope")
     contract = packet["contract"]
-    if contract.get("kind") not in {"spec", "plan"} or contract.get("version") != 1 or not isinstance(contract.get("bytes"), str):
+    if (
+        set(contract) != {"kind", "version", "sha256", "bytes"}
+        or contract.get("kind") not in {"spec", "plan"}
+        or contract.get("version") != 1
+        or not isinstance(contract.get("bytes"), str)
+        or not _valid_sha256(contract.get("sha256"))
+    ):
         raise ValueError("Invalid context packet contract")
     if sha256_bytes(contract["bytes"].encode("utf-8")) != contract.get("sha256"):
         raise ValueError("Invalid context packet contract hash")
 
 
-def persist_context_packet(path: Path, packet: Mapping[str, Any], *, expected_sha256: str | None = None) -> tuple[dict[str, Any], dict[str, Any]]:
-    return load_or_persist_json(path, packet, validate=validate_context_packet, expected_sha256=expected_sha256, matches_identity=lambda old, new: old.get("target") == new.get("target") and old.get("source") == new.get("source") and old.get("contract") == new.get("contract"))
+def _valid_sha256(value: Any) -> bool:
+    return (
+        isinstance(value, str)
+        and len(value) == 64
+        and all(char in "0123456789abcdef" for char in value)
+    )
 
 
-def resolve_context_packet(*, source_path: str | Path, contract_kind: str, target_step: str, iteration: int, placeholders: tuple[str, ...], packet_path: Path) -> dict[str, Any]:
+def persist_context_packet(
+    path: Path, packet: Mapping[str, Any], *, expected_sha256: str | None = None
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    return load_or_persist_json(
+        path,
+        packet,
+        validate=validate_context_packet,
+        expected_sha256=expected_sha256,
+        matches_identity=lambda old, new: old.get("target") == new.get("target")
+        and old.get("source") == new.get("source")
+        and old.get("contract") == new.get("contract"),
+    )
+
+
+def resolve_context_packet(
+    *,
+    source_path: str | Path,
+    contract_kind: str,
+    target_step: str,
+    iteration: int,
+    placeholders: tuple[str, ...],
+    packet_path: Path,
+    source_artifact_name: str | None = None,
+    source_artifact_version: int | None = None,
+) -> dict[str, Any]:
     """Return packet metadata or a deliberate full-source fallback result."""
     try:
-        packet = build_context_packet(source_path=source_path, contract_kind=contract_kind, target_step=target_step, iteration=iteration, placeholders=placeholders)
-        persisted, metadata = persist_context_packet(packet_path, packet)
-        return {"mode": "packet", "path": packet_path.as_posix(), "packet": persisted, "metadata": metadata}
-    except (ContractValidationError, ValueError) as exc:
-        return {"mode": "full_fallback", "path": Path(source_path).as_posix(), "reason": str(exc)}
+        packet = build_context_packet(
+            source_path=source_path,
+            contract_kind=contract_kind,
+            target_step=target_step,
+            iteration=iteration,
+            placeholders=placeholders,
+            source_artifact_name=source_artifact_name,
+            source_artifact_version=source_artifact_version,
+        )
+        receipt_path = packet_path.with_suffix(f"{packet_path.suffix}.sha256")
+        expected_sha256 = _read_packet_receipt(receipt_path) if packet_path.exists() else None
+        persisted, metadata = persist_context_packet(
+            packet_path, packet, expected_sha256=expected_sha256
+        )
+        if expected_sha256 is None:
+            atomic_write_bytes(receipt_path, metadata["sha256"].encode("ascii") + b"\n")
+        return {
+            "mode": "packet",
+            "path": packet_path.as_posix(),
+            "packet": persisted,
+            "metadata": metadata,
+            "source": dict(packet["source"]),
+        }
+    except (ContractValidationError, ValueError, OSError):
+        reason = (
+            "Unable to persist context packet"
+            if not packet_path.exists()
+            else "Invalid or altered context packet"
+        )
+        return {"mode": "full_fallback", "path": Path(source_path).as_posix(), "reason": reason}
+
+
+def _read_packet_receipt(path: Path) -> str:
+    try:
+        receipt = path.read_text(encoding="ascii").strip()
+    except OSError as exc:
+        raise ValueError("Missing context packet receipt") from exc
+    if not _valid_sha256(receipt):
+        raise ValueError("Invalid context packet receipt")
+    return receipt

--- a/src/cafe/core/delta_packet.py
+++ b/src/cafe/core/delta_packet.py
@@ -191,7 +191,12 @@ def persist_delta_packet(
             display_path=_display_path,
         )
     except ValueError as exc:
-        if "identity mismatch" in str(exc):
+        message = str(exc)
+        if "Invalid persisted packet" in message:
+            raise ValueError(f"Invalid persisted delta packet: {path}") from exc
+        if "Persisted packet hash mismatch" in message:
+            raise ValueError(f"Persisted delta packet hash mismatch: {path}") from exc
+        if "identity mismatch" in message:
             raise ValueError(f"Persisted delta packet identity mismatch: {path}") from exc
         raise
 

--- a/src/cafe/core/delta_packet.py
+++ b/src/cafe/core/delta_packet.py
@@ -2,14 +2,18 @@
 
 from __future__ import annotations
 
-import hashlib
-import json
-import os
-import tempfile
 from pathlib import Path
 from typing import Any, Mapping, Optional
 
 from cafe.core.blackboard import ArtifactEntry, BlackboardState
+from cafe.core.packet_io import (
+    atomic_write_bytes,
+    canonical_json,
+    compact_json,
+    file_metadata,
+    load_or_persist_json,
+    sha256_bytes,
+)
 from cafe.utils.git_utils import to_cwd_relative_path
 
 DELTA_PACKET_SCHEMA_VERSION = 1
@@ -23,33 +27,8 @@ def _display_path(path: Path) -> str:
         return path.as_posix()
 
 
-def _sha256_bytes(content: bytes) -> str:
-    return hashlib.sha256(content).hexdigest()
-
-
 def _file_record(path: str | Path) -> dict[str, Any]:
-    source = Path(path)
-    record: dict[str, Any] = {"path": _display_path(source)}
-    try:
-        if not source.exists():
-            record["state"] = "missing"
-            return record
-        if not source.is_file():
-            record["state"] = "not_file"
-            return record
-        content = source.read_bytes()
-    except OSError:
-        record["state"] = "unreadable"
-        return record
-
-    record.update(
-        {
-            "state": "file",
-            "bytes": len(content),
-            "sha256": _sha256_bytes(content),
-        }
-    )
-    return record
+    return file_metadata(path, display_path=_display_path)
 
 
 def _artifact_record(name: str, artifact: ArtifactEntry) -> dict[str, Any]:
@@ -101,7 +80,7 @@ def build_delta_packet(
         "user_input": {
             "path": _display_path(user_input_path),
             "bytes": len(user_input_bytes),
-            "sha256": _sha256_bytes(user_input_bytes),
+            "sha256": sha256_bytes(user_input_bytes),
         },
     }
     if git_snapshot:
@@ -111,36 +90,7 @@ def build_delta_packet(
 
 def serialize_delta_packet(packet: Mapping[str, Any]) -> bytes:
     """Return canonical UTF-8 JSON bytes."""
-    return (
-        json.dumps(
-            packet,
-            ensure_ascii=False,
-            indent=2,
-            sort_keys=True,
-        )
-        + "\n"
-    ).encode("utf-8")
-
-
-def _atomic_write_bytes(path: Path, content: bytes) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    temp_path: Optional[Path] = None
-    try:
-        with tempfile.NamedTemporaryFile(
-            mode="wb",
-            dir=path.parent,
-            prefix=f".{path.name}.",
-            suffix=".tmp",
-            delete=False,
-        ) as temp_file:
-            temp_path = Path(temp_file.name)
-            temp_file.write(content)
-            temp_file.flush()
-            os.fsync(temp_file.fileno())
-        os.replace(temp_path, path)
-    finally:
-        if temp_path is not None:
-            temp_path.unlink(missing_ok=True)
+    return canonical_json(packet)
 
 
 def persist_delta_input_snapshot(path: Path, user_input: str) -> str:
@@ -150,7 +100,7 @@ def persist_delta_input_snapshot(path: Path, user_input: str) -> str:
             return path.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError) as exc:
             raise ValueError(f"Invalid persisted delta input snapshot: {path}") from exc
-    _atomic_write_bytes(path, user_input.encode("utf-8"))
+    atomic_write_bytes(path, user_input.encode("utf-8"))
     return user_input
 
 
@@ -225,34 +175,25 @@ def persist_delta_packet(
     expected_sha256: Optional[str] = None,
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     """Persist once, or reuse and validate the immutable packet from an interrupted run."""
-    if path.exists():
-        try:
-            content = path.read_bytes()
-            persisted = json.loads(content.decode("utf-8"))
-        except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
-            raise ValueError(f"Invalid persisted delta packet: {path}") from exc
-        actual_sha256 = _sha256_bytes(content)
-        if expected_sha256 is not None and actual_sha256 != expected_sha256:
-            raise ValueError(f"Persisted delta packet hash mismatch: {path}")
-        validate_delta_packet(persisted)
-        for key in ("schema_version", "issue", "step", "iteration"):
-            if persisted.get(key) != packet.get(key):
-                raise ValueError(f"Persisted delta packet identity mismatch for {key}: {path}")
-        if persisted.get("user_input") != packet.get("user_input"):
-            raise ValueError(f"Persisted delta packet identity mismatch for user_input: {path}")
-        packet_data = persisted
-    else:
-        packet_data = dict(packet)
-        validate_delta_packet(packet_data)
-        content = serialize_delta_packet(packet_data)
-        _atomic_write_bytes(path, content)
 
-    metadata = {
-        "path": _display_path(path),
-        "bytes": len(content),
-        "sha256": _sha256_bytes(content),
-    }
-    return packet_data, metadata
+    def matches_identity(old: Mapping[str, Any], new: Mapping[str, Any]) -> bool:
+        return all(
+            old.get(key) == new.get(key) for key in ("schema_version", "issue", "step", "iteration")
+        ) and old.get("user_input") == new.get("user_input")
+
+    try:
+        return load_or_persist_json(
+            path,
+            packet,
+            validate=validate_delta_packet,
+            matches_identity=matches_identity,
+            expected_sha256=expected_sha256,
+            display_path=_display_path,
+        )
+    except ValueError as exc:
+        if "identity mismatch" in str(exc):
+            raise ValueError(f"Persisted delta packet identity mismatch: {path}") from exc
+        raise
 
 
 def inline_delta_packet(
@@ -260,12 +201,7 @@ def inline_delta_packet(
     metadata: Mapping[str, Any],
 ) -> str:
     """Inline the packet when bounded, otherwise inline a deterministic pointer."""
-    compact = json.dumps(
-        packet,
-        ensure_ascii=False,
-        separators=(",", ":"),
-        sort_keys=True,
-    )
+    compact = compact_json(packet)
     if len(compact.encode("utf-8")) <= DELTA_PACKET_INLINE_LIMIT_BYTES:
         return compact
 
@@ -278,9 +214,4 @@ def inline_delta_packet(
         "previous_output": packet.get("previous_output"),
         "packet": dict(metadata),
     }
-    return json.dumps(
-        pointer,
-        ensure_ascii=False,
-        separators=(",", ":"),
-        sort_keys=True,
-    )
+    return compact_json(pointer)

--- a/src/cafe/core/downstream_contract.py
+++ b/src/cafe/core/downstream_contract.py
@@ -50,7 +50,7 @@ def _rows(section: str, heading: str, columns: tuple[str, ...]) -> list[list[str
     if tuple(header) != columns:
         raise ContractValidationError(f"{heading} has invalid columns")
     result: list[list[str]] = []
-    for line in lines[tables[2]:]:
+    for line in lines[tables[2] :]:
         if not line.startswith("|"):
             break
         row = [item.strip() for item in line.strip().strip("|").split("|")]
@@ -87,7 +87,10 @@ def extract_downstream_contract(path: str | Path, *, kind: str) -> DownstreamCon
     end = start + 1 + following.start() if following else len(text)
     exact = text[start:end].encode("utf-8")
     contract = text[start:end]
-    match = re.match(r"## Downstream Contract\n\n- Contract-Version: `([0-9]+)`\n- Artifact-Kind: `([a-z]+)`\n", contract)
+    match = re.match(
+        r"## Downstream Contract\n\n- Contract-Version: `([0-9]+)`\n- Artifact-Kind: `([a-z]+)`\n",
+        contract,
+    )
     if match is None or match.group(1) != "1" or match.group(2) != kind:
         raise ContractValidationError("Unsupported or mismatched contract declaration")
     cursor = match.end()
@@ -95,6 +98,7 @@ def extract_downstream_contract(path: str | Path, *, kind: str) -> DownstreamCon
         cursor += 1
     ids: set[str] = set()
     task_states: dict[str, str] = {}
+    sections: dict[str, list[list[str]]] = {}
     for index, (heading, columns, prefix) in enumerate(_SCHEMAS[kind]):
         expected = f"### {heading}\n"
         if not contract[cursor:].startswith(expected):
@@ -102,10 +106,15 @@ def extract_downstream_contract(path: str | Path, *, kind: str) -> DownstreamCon
         next_cursor = contract.find("\n### ", cursor + len(expected))
         section_end = len(contract) if next_cursor == -1 else next_cursor + 1
         rows = _rows(contract[cursor:section_end], heading, columns)
+        sections[heading] = rows
         for row in rows:
             identifier = row[0]
             valid_prefixes = (prefix,) if isinstance(prefix, str) else prefix
-            if not _ID.fullmatch(identifier) or not identifier.startswith(valid_prefixes) or identifier in ids:
+            if (
+                not _ID.fullmatch(identifier)
+                or not identifier.startswith(valid_prefixes)
+                or identifier in ids
+            ):
                 raise ContractValidationError(f"Invalid or duplicate ID: {identifier}")
             ids.add(identifier)
             if heading == "Task Status" and row[1] not in {"pending", "completed"}:
@@ -115,16 +124,12 @@ def extract_downstream_contract(path: str | Path, *, kind: str) -> DownstreamCon
         cursor = section_end
     if contract[cursor:].strip():
         raise ContractValidationError("Unexpected contract content")
-    for heading, _columns, _prefix in _SCHEMAS[kind]:
-        # references are only meaningful in dependency columns; all references
-        # must resolve to a declared stable ID, except a plan task's own ID.
-        if heading in {"Test List", "Dependency ADR References", "Task Status"}:
-            position = contract.find(f"### {heading}")
-            end_position = contract.find("\n### ", position + 1)
-            for reference in _required_references(contract[position:end_position if end_position != -1 else len(contract)]):
-                if reference not in ids:
-                    raise ContractValidationError(f"Unresolved contract reference: {reference}")
-    body_ids = set(_ID.findall(text[:start]))
+    if kind == "plan":
+        _validate_plan_references(sections, ids)
+    body = text[:start] + text[end:]
+    body_ids = set(_ID.findall(body))
+    if not body_ids:
+        raise ContractValidationError("Source must declare stable IDs in its authoritative body")
     if body_ids - ids:
         raise ContractValidationError("Contract does not cover source stable IDs")
     if kind == "plan":
@@ -132,9 +137,35 @@ def extract_downstream_contract(path: str | Path, *, kind: str) -> DownstreamCon
             identifier: "completed" if marker.lower() == "x" else "pending"
             for marker, identifier in re.findall(
                 r"(?m)^-\s+\[([ xX])\]\s+\*\*(TASK-[0-9]{3,})\*\*",
-                text[:start],
+                body,
             )
         }
-        if body_task_states and body_task_states != task_states:
+        if not body_task_states:
+            raise ContractValidationError(
+                "Plan must declare top-level task state in its authoritative body"
+            )
+        if body_task_states != task_states:
             raise ContractValidationError("Plan task state disagrees with complete plan")
-    return DownstreamContract(kind=kind, version=1, bytes=exact, sha256=hashlib.sha256(exact).hexdigest(), ids=frozenset(ids))
+    return DownstreamContract(
+        kind=kind,
+        version=1,
+        bytes=exact,
+        sha256=hashlib.sha256(exact).hexdigest(),
+        ids=frozenset(ids),
+    )
+
+
+def _validate_plan_references(sections: dict[str, list[list[str]]], ids: set[str]) -> None:
+    """Validate reference columns against the kinds mandated by the schema."""
+    allowed = {
+        "Test List": (2, ("INV-",)),
+        "Dependency ADR References": (2, ("INV-",)),
+        "Task Status": (3, ("TASK-",)),
+    }
+    for section, (column, prefixes) in allowed.items():
+        for row in sections[section]:
+            for reference in _required_references(row[column]):
+                if reference not in ids or not reference.startswith(prefixes):
+                    raise ContractValidationError(
+                        f"{section} has an invalid reference: {reference}"
+                    )

--- a/src/cafe/core/downstream_contract.py
+++ b/src/cafe/core/downstream_contract.py
@@ -94,6 +94,7 @@ def extract_downstream_contract(path: str | Path, *, kind: str) -> DownstreamCon
     if contract[cursor:].startswith("\n"):
         cursor += 1
     ids: set[str] = set()
+    task_states: dict[str, str] = {}
     for index, (heading, columns, prefix) in enumerate(_SCHEMAS[kind]):
         expected = f"### {heading}\n"
         if not contract[cursor:].startswith(expected):
@@ -109,6 +110,8 @@ def extract_downstream_contract(path: str | Path, *, kind: str) -> DownstreamCon
             ids.add(identifier)
             if heading == "Task Status" and row[1] not in {"pending", "completed"}:
                 raise ContractValidationError("Task Status must be pending or completed")
+            if heading == "Task Status":
+                task_states[identifier] = row[1]
         cursor = section_end
     if contract[cursor:].strip():
         raise ContractValidationError("Unexpected contract content")
@@ -124,4 +127,14 @@ def extract_downstream_contract(path: str | Path, *, kind: str) -> DownstreamCon
     body_ids = set(_ID.findall(text[:start]))
     if body_ids - ids:
         raise ContractValidationError("Contract does not cover source stable IDs")
+    if kind == "plan":
+        body_task_states = {
+            identifier: "completed" if marker.lower() == "x" else "pending"
+            for marker, identifier in re.findall(
+                r"(?m)^-\s+\[([ xX])\]\s+\*\*(TASK-[0-9]{3,})\*\*",
+                text[:start],
+            )
+        }
+        if body_task_states and body_task_states != task_states:
+            raise ContractValidationError("Plan task state disagrees with complete plan")
     return DownstreamContract(kind=kind, version=1, bytes=exact, sha256=hashlib.sha256(exact).hexdigest(), ids=frozenset(ids))

--- a/src/cafe/core/downstream_contract.py
+++ b/src/cafe/core/downstream_contract.py
@@ -39,18 +39,26 @@ _SCHEMAS = {
     ),
 }
 _ID = re.compile(r"[A-Z][A-Z0-9_]*-[0-9]{3,}")
+_TABLE_SEPARATOR = re.compile(r":?-{3,}:?")
 
 
 def _rows(section: str, heading: str, columns: tuple[str, ...]) -> list[list[str]]:
     lines = section.splitlines()
-    tables = [index for index, line in enumerate(lines) if line.startswith("|")]
-    if len(tables) < 3:
+    table_start = next((index for index, line in enumerate(lines) if line.startswith("|")), None)
+    if table_start is None or table_start + 2 >= len(lines):
         raise ContractValidationError(f"{heading} requires a non-empty table")
-    header = [item.strip() for item in lines[tables[0]].strip().strip("|").split("|")]
+    header = [item.strip() for item in lines[table_start].strip().strip("|").split("|")]
     if tuple(header) != columns:
         raise ContractValidationError(f"{heading} has invalid columns")
+    separator = [
+        item.strip() for item in lines[table_start + 1].strip().strip("|").split("|")
+    ]
+    if len(separator) != len(columns) or not all(
+        _TABLE_SEPARATOR.fullmatch(cell) for cell in separator
+    ):
+        raise ContractValidationError(f"{heading} has an invalid table separator")
     result: list[list[str]] = []
-    for line in lines[tables[2] :]:
+    for line in lines[table_start + 2 :]:
         if not line.startswith("|"):
             break
         row = [item.strip() for item in line.strip().strip("|").split("|")]
@@ -58,7 +66,7 @@ def _rows(section: str, heading: str, columns: tuple[str, ...]) -> list[list[str
             raise ContractValidationError(f"{heading} has an invalid row")
         result.append(row)
     if not result:
-        raise ContractValidationError(f"{heading} requires rows")
+        raise ContractValidationError(f"{heading} requires a non-empty table")
     return result
 
 

--- a/src/cafe/core/downstream_contract.py
+++ b/src/cafe/core/downstream_contract.py
@@ -44,7 +44,7 @@ _ID = re.compile(r"[A-Z][A-Z0-9_]*-[0-9]{3,}")
 def _rows(section: str, heading: str, columns: tuple[str, ...]) -> list[list[str]]:
     lines = section.splitlines()
     tables = [index for index, line in enumerate(lines) if line.startswith("|")]
-    if len(tables) < 2:
+    if len(tables) < 3:
         raise ContractValidationError(f"{heading} requires a non-empty table")
     header = [item.strip() for item in lines[tables[0]].strip().strip("|").split("|")]
     if tuple(header) != columns:

--- a/src/cafe/core/downstream_contract.py
+++ b/src/cafe/core/downstream_contract.py
@@ -40,13 +40,18 @@ _SCHEMAS = {
 }
 _ID = re.compile(r"[A-Z][A-Z0-9_]*-[0-9]{3,}")
 _TABLE_SEPARATOR = re.compile(r":?-{3,}:?")
+_FENCE_MARKER = re.compile(r"^[ \t]{0,3}(`{3,}|~{3,})(.*)$")
 
 
 def _rows(section: str, heading: str, columns: tuple[str, ...]) -> list[list[str]]:
     lines = section.splitlines()
+    if lines and lines[0] == f"### {heading}":
+        lines = lines[1:]
     table_start = next((index for index, line in enumerate(lines) if line.startswith("|")), None)
     if table_start is None or table_start + 2 >= len(lines):
         raise ContractValidationError(f"{heading} requires a non-empty table")
+    if any(line.strip() for line in lines[:table_start]):
+        raise ContractValidationError(f"{heading} has unexpected content before its table")
     header = [item.strip() for item in lines[table_start].strip().strip("|").split("|")]
     if tuple(header) != columns:
         raise ContractValidationError(f"{heading} has invalid columns")
@@ -58,8 +63,11 @@ def _rows(section: str, heading: str, columns: tuple[str, ...]) -> list[list[str
     ):
         raise ContractValidationError(f"{heading} has an invalid table separator")
     result: list[list[str]] = []
-    for line in lines[table_start + 2 :]:
+    remaining = lines[table_start + 2 :]
+    for row_index, line in enumerate(remaining):
         if not line.startswith("|"):
+            if any(candidate.strip() for candidate in remaining[row_index:]):
+                raise ContractValidationError(f"{heading} has unexpected content after its table")
             break
         row = [item.strip() for item in line.strip().strip("|").split("|")]
         if len(row) != len(columns) or not all(row):
@@ -68,6 +76,23 @@ def _rows(section: str, heading: str, columns: tuple[str, ...]) -> list[list[str
     if not result:
         raise ContractValidationError(f"{heading} requires a non-empty table")
     return result
+
+
+def _update_fence(fence: str | None, line: str) -> str | None:
+    """Track CommonMark fences without treating a shorter marker as a closer."""
+    marker = _FENCE_MARKER.match(line.rstrip("\r\n"))
+    if marker is None:
+        return fence
+    token, trailing = marker.groups()
+    if fence is None:
+        return token
+    if (
+        token[0] == fence[0]
+        and len(token) >= len(fence)
+        and not trailing.strip()
+    ):
+        return None
+    return fence
 
 
 def _required_references(text: str) -> Iterable[str]:
@@ -80,14 +105,9 @@ def _markdown_heading_positions(text: str, pattern: re.Pattern[str]) -> list[int
     offset = 0
     fence: str | None = None
     for line in text.splitlines(keepends=True):
-        marker = re.match(r"^\s*(`{3,}|~{3,})", line)
-        if marker:
-            token = marker.group(1)[0]
-            if fence is None:
-                fence = token
-            elif fence == token:
-                fence = None
-        elif fence is None and pattern.fullmatch(line.rstrip("\r\n")):
+        was_visible = fence is None
+        fence = _update_fence(fence, line)
+        if was_visible and fence is None and pattern.fullmatch(line.rstrip("\r\n")):
             positions.append(offset)
         offset += len(line)
     return positions
@@ -98,14 +118,9 @@ def _visible_markdown(text: str) -> str:
     lines: list[str] = []
     fence: str | None = None
     for line in text.splitlines(keepends=True):
-        marker = re.match(r"^\s*(`{3,}|~{3,})", line)
-        if marker:
-            token = marker.group(1)[0]
-            if fence is None:
-                fence = token
-            elif fence == token:
-                fence = None
-        elif fence is None:
+        was_visible = fence is None
+        fence = _update_fence(fence, line)
+        if was_visible and fence is None:
             lines.append(line)
     return "".join(lines)
 

--- a/src/cafe/core/downstream_contract.py
+++ b/src/cafe/core/downstream_contract.py
@@ -66,6 +66,42 @@ def _required_references(text: str) -> Iterable[str]:
     return _ID.findall(text)
 
 
+def _markdown_heading_positions(text: str, pattern: re.Pattern[str]) -> list[int]:
+    """Return headings outside fenced examples, preserving source byte layout."""
+    positions: list[int] = []
+    offset = 0
+    fence: str | None = None
+    for line in text.splitlines(keepends=True):
+        marker = re.match(r"^\s*(`{3,}|~{3,})", line)
+        if marker:
+            token = marker.group(1)[0]
+            if fence is None:
+                fence = token
+            elif fence == token:
+                fence = None
+        elif fence is None and pattern.fullmatch(line.rstrip("\r\n")):
+            positions.append(offset)
+        offset += len(line)
+    return positions
+
+
+def _visible_markdown(text: str) -> str:
+    """Exclude fenced examples from authoritative-body ID validation."""
+    lines: list[str] = []
+    fence: str | None = None
+    for line in text.splitlines(keepends=True):
+        marker = re.match(r"^\s*(`{3,}|~{3,})", line)
+        if marker:
+            token = marker.group(1)[0]
+            if fence is None:
+                fence = token
+            elif fence == token:
+                fence = None
+        elif fence is None:
+            lines.append(line)
+    return "".join(lines)
+
+
 def extract_downstream_contract(path: str | Path, *, kind: str) -> DownstreamContract:
     """Return the exact contract bytes after validating the fixed schema.
 
@@ -79,12 +115,12 @@ def extract_downstream_contract(path: str | Path, *, kind: str) -> DownstreamCon
         text = source.decode("utf-8")
     except (OSError, UnicodeDecodeError) as exc:
         raise ContractValidationError("Unreadable contract source") from exc
-    starts = [match.start() for match in re.finditer(r"(?m)^## Downstream Contract\s*$", text)]
+    starts = _markdown_heading_positions(text, re.compile(r"## Downstream Contract\s*"))
     if len(starts) != 1:
         raise ContractValidationError("Source must contain exactly one Downstream Contract")
     start = starts[0]
-    following = re.search(r"(?m)^## (?!#)", text[start + 1 :])
-    end = start + 1 + following.start() if following else len(text)
+    headings = _markdown_heading_positions(text, re.compile(r"## (?!#).+"))
+    end = next((position for position in headings if position > start), len(text))
     exact = text[start:end].encode("utf-8")
     contract = text[start:end]
     match = re.match(
@@ -126,12 +162,7 @@ def extract_downstream_contract(path: str | Path, *, kind: str) -> DownstreamCon
         raise ContractValidationError("Unexpected contract content")
     if kind == "plan":
         _validate_plan_references(sections, ids)
-    body = text[:start] + text[end:]
-    body_ids = set(_ID.findall(body))
-    if not body_ids:
-        raise ContractValidationError("Source must declare stable IDs in its authoritative body")
-    if body_ids - ids:
-        raise ContractValidationError("Contract does not cover source stable IDs")
+    body = _visible_markdown(text[:start] + text[end:])
     if kind == "plan":
         body_task_states = {
             identifier: "completed" if marker.lower() == "x" else "pending"
@@ -146,6 +177,11 @@ def extract_downstream_contract(path: str | Path, *, kind: str) -> DownstreamCon
             )
         if body_task_states != task_states:
             raise ContractValidationError("Plan task state disagrees with complete plan")
+    body_ids = set(_ID.findall(body))
+    if not body_ids:
+        raise ContractValidationError("Source must declare stable IDs in its authoritative body")
+    if body_ids != ids:
+        raise ContractValidationError("Contract does not cover source stable IDs")
     return DownstreamContract(
         kind=kind,
         version=1,
@@ -164,7 +200,12 @@ def _validate_plan_references(sections: dict[str, list[list[str]]], ids: set[str
     }
     for section, (column, prefixes) in allowed.items():
         for row in sections[section]:
-            for reference in _required_references(row[column]):
+            references = list(_required_references(row[column]))
+            if not references:
+                if section == "Task Status" and row[column] == "—":
+                    continue
+                raise ContractValidationError(f"{section} requires a reference")
+            for reference in references:
                 if reference not in ids or not reference.startswith(prefixes):
                     raise ContractValidationError(
                         f"{section} has an invalid reference: {reference}"

--- a/src/cafe/core/downstream_contract.py
+++ b/src/cafe/core/downstream_contract.py
@@ -1,0 +1,127 @@
+"""Strict, source-owned downstream contract extraction."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+class ContractValidationError(ValueError):
+    """The complete authority must be used instead of an unsafe packet."""
+
+
+@dataclass(frozen=True)
+class DownstreamContract:
+    kind: str
+    version: int
+    bytes: bytes
+    sha256: str
+    ids: frozenset[str]
+
+
+_SCHEMAS = {
+    "spec": (
+        ("Goals", ("ID", "Statement"), "GOAL-"),
+        ("Non-Goals", ("ID", "Statement"), "NONGOAL-"),
+        ("Acceptance Criteria", ("ID", "Priority", "Statement"), "AC-"),
+        ("Invariants", ("ID", "Statement"), "INV-"),
+        ("Trust Boundaries", ("ID", "Statement"), "TRUST-"),
+    ),
+    "plan": (
+        ("Architecture Boundaries", ("ID", "Location", "Responsibility"), "ARCH-"),
+        ("Invariants", ("ID", "Statement"), "INV-"),
+        ("Test List", ("ID", "Type", "Covers"), ("UT-", "IT-")),
+        ("Dependency ADR References", ("ID", "Decision", "Requirement / invariant"), "ADR-"),
+        ("Task Status", ("ID", "Status", "Summary", "Depends On"), "TASK-"),
+    ),
+}
+_ID = re.compile(r"[A-Z][A-Z0-9_]*-[0-9]{3,}")
+
+
+def _rows(section: str, heading: str, columns: tuple[str, ...]) -> list[list[str]]:
+    lines = section.splitlines()
+    tables = [index for index, line in enumerate(lines) if line.startswith("|")]
+    if len(tables) < 2:
+        raise ContractValidationError(f"{heading} requires a non-empty table")
+    header = [item.strip() for item in lines[tables[0]].strip().strip("|").split("|")]
+    if tuple(header) != columns:
+        raise ContractValidationError(f"{heading} has invalid columns")
+    result: list[list[str]] = []
+    for line in lines[tables[2]:]:
+        if not line.startswith("|"):
+            break
+        row = [item.strip() for item in line.strip().strip("|").split("|")]
+        if len(row) != len(columns) or not all(row):
+            raise ContractValidationError(f"{heading} has an invalid row")
+        result.append(row)
+    if not result:
+        raise ContractValidationError(f"{heading} requires rows")
+    return result
+
+
+def _required_references(text: str) -> Iterable[str]:
+    return _ID.findall(text)
+
+
+def extract_downstream_contract(path: str | Path, *, kind: str) -> DownstreamContract:
+    """Return the exact contract bytes after validating the fixed schema.
+
+    Invalid or legacy sources raise ``ContractValidationError`` so callers can
+    expose the original complete file as a relationship-local fallback.
+    """
+    if kind not in _SCHEMAS:
+        raise ContractValidationError(f"Unsupported contract kind: {kind}")
+    try:
+        source = Path(path).read_bytes()
+        text = source.decode("utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        raise ContractValidationError("Unreadable contract source") from exc
+    starts = [match.start() for match in re.finditer(r"(?m)^## Downstream Contract\s*$", text)]
+    if len(starts) != 1:
+        raise ContractValidationError("Source must contain exactly one Downstream Contract")
+    start = starts[0]
+    following = re.search(r"(?m)^## (?!#)", text[start + 1 :])
+    end = start + 1 + following.start() if following else len(text)
+    exact = text[start:end].encode("utf-8")
+    contract = text[start:end]
+    match = re.match(r"## Downstream Contract\n\n- Contract-Version: `([0-9]+)`\n- Artifact-Kind: `([a-z]+)`\n", contract)
+    if match is None or match.group(1) != "1" or match.group(2) != kind:
+        raise ContractValidationError("Unsupported or mismatched contract declaration")
+    cursor = match.end()
+    if contract[cursor:].startswith("\n"):
+        cursor += 1
+    ids: set[str] = set()
+    for index, (heading, columns, prefix) in enumerate(_SCHEMAS[kind]):
+        expected = f"### {heading}\n"
+        if not contract[cursor:].startswith(expected):
+            raise ContractValidationError(f"Missing, duplicated, or reordered section: {heading}")
+        next_cursor = contract.find("\n### ", cursor + len(expected))
+        section_end = len(contract) if next_cursor == -1 else next_cursor + 1
+        rows = _rows(contract[cursor:section_end], heading, columns)
+        for row in rows:
+            identifier = row[0]
+            valid_prefixes = (prefix,) if isinstance(prefix, str) else prefix
+            if not _ID.fullmatch(identifier) or not identifier.startswith(valid_prefixes) or identifier in ids:
+                raise ContractValidationError(f"Invalid or duplicate ID: {identifier}")
+            ids.add(identifier)
+            if heading == "Task Status" and row[1] not in {"pending", "completed"}:
+                raise ContractValidationError("Task Status must be pending or completed")
+        cursor = section_end
+    if contract[cursor:].strip():
+        raise ContractValidationError("Unexpected contract content")
+    for heading, _columns, _prefix in _SCHEMAS[kind]:
+        # references are only meaningful in dependency columns; all references
+        # must resolve to a declared stable ID, except a plan task's own ID.
+        if heading in {"Test List", "Dependency ADR References", "Task Status"}:
+            position = contract.find(f"### {heading}")
+            end_position = contract.find("\n### ", position + 1)
+            for reference in _required_references(contract[position:end_position if end_position != -1 else len(contract)]):
+                if reference not in ids:
+                    raise ContractValidationError(f"Unresolved contract reference: {reference}")
+    body_ids = set(_ID.findall(text[:start]))
+    if body_ids - ids:
+        raise ContractValidationError("Contract does not cover source stable IDs")
+    return DownstreamContract(kind=kind, version=1, bytes=exact, sha256=hashlib.sha256(exact).hexdigest(), ids=frozenset(ids))

--- a/src/cafe/core/packet_io.py
+++ b/src/cafe/core/packet_io.py
@@ -18,17 +18,25 @@ def sha256_bytes(content: bytes) -> str:
     return hashlib.sha256(content).hexdigest()
 
 
-def file_metadata(path: str | Path) -> dict[str, Any]:
+def file_metadata(
+    path: str | Path, *, display_path: Callable[[Path], str] | None = None
+) -> dict[str, Any]:
     source = Path(path)
+    shown_path = display_path(source) if display_path is not None else source.as_posix()
     if not source.exists():
-        return {"path": source.as_posix(), "state": "missing"}
+        return {"path": shown_path, "state": "missing"}
     if not source.is_file():
-        return {"path": source.as_posix(), "state": "not_file"}
+        return {"path": shown_path, "state": "not_file"}
     try:
         content = source.read_bytes()
     except OSError:
-        return {"path": source.as_posix(), "state": "unreadable"}
-    return {"path": source.as_posix(), "state": "file", "bytes": len(content), "sha256": sha256_bytes(content)}
+        return {"path": shown_path, "state": "unreadable"}
+    return {
+        "path": shown_path,
+        "state": "file",
+        "bytes": len(content),
+        "sha256": sha256_bytes(content),
+    }
 
 
 def canonical_json(value: Mapping[str, Any]) -> bytes:
@@ -43,7 +51,9 @@ def atomic_write_bytes(path: Path, content: bytes) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     temporary: Path | None = None
     try:
-        with tempfile.NamedTemporaryFile("wb", dir=path.parent, prefix=f".{path.name}.", suffix=".tmp", delete=False) as handle:
+        with tempfile.NamedTemporaryFile(
+            "wb", dir=path.parent, prefix=f".{path.name}.", suffix=".tmp", delete=False
+        ) as handle:
             temporary = Path(handle.name)
             handle.write(content)
             handle.flush()
@@ -61,6 +71,7 @@ def load_or_persist_json(
     validate: Callable[[Any], None],
     matches_identity: Callable[[Mapping[str, Any], Mapping[str, Any]], bool],
     expected_sha256: str | None = None,
+    display_path: Callable[[Path], str] | None = None,
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     """Persist immutable JSON once, or return a validated matching prior copy."""
     if path.exists():
@@ -81,4 +92,5 @@ def load_or_persist_json(
         validate(packet)
         content = canonical_json(packet)
         atomic_write_bytes(path, content)
-    return packet, {"path": path.as_posix(), "bytes": len(content), "sha256": sha256_bytes(content)}
+    shown_path = display_path(path) if display_path is not None else path.as_posix()
+    return packet, {"path": shown_path, "bytes": len(content), "sha256": sha256_bytes(content)}

--- a/src/cafe/core/packet_io.py
+++ b/src/cafe/core/packet_io.py
@@ -1,0 +1,84 @@
+"""Schema-neutral durable packet persistence helpers.
+
+The helpers deliberately know nothing about delta or context packet fields.  Each
+caller supplies its own validation and identity checks before reusing bytes.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+
+def sha256_bytes(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def file_metadata(path: str | Path) -> dict[str, Any]:
+    source = Path(path)
+    if not source.exists():
+        return {"path": source.as_posix(), "state": "missing"}
+    if not source.is_file():
+        return {"path": source.as_posix(), "state": "not_file"}
+    try:
+        content = source.read_bytes()
+    except OSError:
+        return {"path": source.as_posix(), "state": "unreadable"}
+    return {"path": source.as_posix(), "state": "file", "bytes": len(content), "sha256": sha256_bytes(content)}
+
+
+def canonical_json(value: Mapping[str, Any]) -> bytes:
+    return (json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n").encode("utf-8")
+
+
+def compact_json(value: Mapping[str, Any]) -> str:
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+
+
+def atomic_write_bytes(path: Path, content: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile("wb", dir=path.parent, prefix=f".{path.name}.", suffix=".tmp", delete=False) as handle:
+            temporary = Path(handle.name)
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    finally:
+        if temporary is not None:
+            temporary.unlink(missing_ok=True)
+
+
+def load_or_persist_json(
+    path: Path,
+    value: Mapping[str, Any],
+    *,
+    validate: Callable[[Any], None],
+    matches_identity: Callable[[Mapping[str, Any], Mapping[str, Any]], bool],
+    expected_sha256: str | None = None,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Persist immutable JSON once, or return a validated matching prior copy."""
+    if path.exists():
+        try:
+            content = path.read_bytes()
+            persisted = json.loads(content.decode("utf-8"))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise ValueError(f"Invalid persisted packet: {path}") from exc
+        actual = sha256_bytes(content)
+        if expected_sha256 is not None and actual != expected_sha256:
+            raise ValueError(f"Persisted packet hash mismatch: {path}")
+        validate(persisted)
+        if not matches_identity(persisted, value):
+            raise ValueError(f"Persisted packet identity mismatch: {path}")
+        packet = dict(persisted)
+    else:
+        packet = dict(value)
+        validate(packet)
+        content = canonical_json(packet)
+        atomic_write_bytes(path, content)
+    return packet, {"path": path.as_posix(), "bytes": len(content), "sha256": sha256_bytes(content)}

--- a/src/cafe/core/phase.py
+++ b/src/cafe/core/phase.py
@@ -9,7 +9,7 @@ from abc import ABC, abstractmethod
 from copy import copy
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -24,7 +24,7 @@ from cafe.core.session_continuation import (
     SessionContinuation,
     SessionContinuationPolicy,
 )
-from cafe.agents.executor import AgentExecutor
+from cafe.agents.executor import AgentExecutor, AgentExecutionError
 
 # Backward-compat re-export for test imports
 from cafe.core.phase_state_mixin import ensure_agent_file_exists  # noqa: F401
@@ -810,6 +810,7 @@ class Phase(PhaseStateMixin, PhaseSandboxMixin, PhaseReviewMixin, PhaseChecklist
         allowed_tools: Optional[List[str]] = None,
         denied_tools: Optional[List[str]] = None,
         phase_specific_data: Optional[Dict[str, Any]] = None,
+        backup_context_callback: Optional[Callable[[AgentExecutionError], str]] = None,
     ) -> tuple[str, Optional[PhaseStatusCode]]:
         """Common agent execution flow that all phases can use.
 
@@ -1020,6 +1021,15 @@ class Phase(PhaseStateMixin, PhaseSandboxMixin, PhaseReviewMixin, PhaseChecklist
                 for param in execute_signature.parameters.values()
             ):
                 execute_kwargs["continuation"] = requested_continuation
+            if backup_context_callback is not None and getattr(
+                self.agent_manager, "SUPPORTS_COLD_TAKEOVER", False
+            ) and (
+                "backup_context_callback" in execute_signature.parameters or any(
+                    param.kind == inspect.Parameter.VAR_KEYWORD
+                    for param in execute_signature.parameters.values()
+                )
+            ):
+                execute_kwargs["backup_context_callback"] = backup_context_callback
 
             response, token_usage, permission_denials, cli_command_args, streaming_log, model = (
                 self.agent_manager.execute(

--- a/src/cafe/core/takeover.py
+++ b/src/cafe/core/takeover.py
@@ -2,18 +2,27 @@
 
 from __future__ import annotations
 
-import hashlib
 import re
 from pathlib import Path
 from typing import Any, Mapping
 
+from cafe.agents.diagnostics import sanitize_error_excerpt
 from cafe.core.packet_io import file_metadata
-
-_SECRET = re.compile(r"(?i)(token|password|secret|api[_-]?key)\s*[=:]\s*\S+")
 
 
 def sanitize_failure_reason(reason: object, *, limit: int = 400) -> str:
-    return _SECRET.sub(r"\1=[redacted]", str(reason).replace("\n", " "))[:limit]
+    return sanitize_error_excerpt(reason).replace("<redacted>", "[redacted]")[:limit]
+
+
+def _checklist_progress(path: str | Path) -> dict[str, int]:
+    try:
+        markers = re.findall(r"(?m)^\s*(?:[-*]\s+)?\[([ xX])\]", Path(path).read_text())
+    except (OSError, UnicodeDecodeError):
+        return {}
+    return {
+        "completed": sum(marker.lower() == "x" for marker in markers),
+        "pending": sum(marker == " " for marker in markers),
+    }
 
 
 def build_takeover_snapshot(
@@ -32,12 +41,15 @@ def build_takeover_snapshot(
     if operation:
         candidate = operation.get("state")
         status = str(candidate) if candidate in {"running", "terminal", "unknown"} else "unknown"
+    checklist = file_metadata(checklist_file)
+    if checklist.get("state") == "file":
+        checklist.update(_checklist_progress(checklist_file))
     return {
         "schema_version": 1,
         "reason": sanitize_failure_reason(reason),
         "target": {"step": step, "iteration": iteration},
         "resolved_inputs": {key: {"mode": value.get("mode", "full"), "path": value.get("path", "")} for key, value in sorted(resolved_inputs.items())},
         "workspace": dict(workspace or {}),
-        "partial": {"output": file_metadata(output_file), "checklist": file_metadata(checklist_file)},
+        "partial": {"output": file_metadata(output_file), "checklist": checklist},
         "operation": {"state": status, **({"id": str(operation.get("id", ""))} if operation and operation.get("id") else {})},
     }

--- a/src/cafe/core/takeover.py
+++ b/src/cafe/core/takeover.py
@@ -1,0 +1,43 @@
+"""Bounded, provider-neutral state for cold backup agents."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from pathlib import Path
+from typing import Any, Mapping
+
+from cafe.core.packet_io import file_metadata
+
+_SECRET = re.compile(r"(?i)(token|password|secret|api[_-]?key)\s*[=:]\s*\S+")
+
+
+def sanitize_failure_reason(reason: object, *, limit: int = 400) -> str:
+    return _SECRET.sub(r"\1=[redacted]", str(reason).replace("\n", " "))[:limit]
+
+
+def build_takeover_snapshot(
+    *,
+    reason: object,
+    step: str,
+    iteration: int,
+    resolved_inputs: Mapping[str, Mapping[str, str]],
+    output_file: str | Path,
+    checklist_file: str | Path,
+    operation: Mapping[str, Any] | None = None,
+    workspace: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Create durable metadata only; never read session logs or file bodies."""
+    status = "absent"
+    if operation:
+        candidate = operation.get("state")
+        status = str(candidate) if candidate in {"running", "terminal", "unknown"} else "unknown"
+    return {
+        "schema_version": 1,
+        "reason": sanitize_failure_reason(reason),
+        "target": {"step": step, "iteration": iteration},
+        "resolved_inputs": {key: {"mode": value.get("mode", "full"), "path": value.get("path", "")} for key, value in sorted(resolved_inputs.items())},
+        "workspace": dict(workspace or {}),
+        "partial": {"output": file_metadata(output_file), "checklist": file_metadata(checklist_file)},
+        "operation": {"state": status, **({"id": str(operation.get("id", ""))} if operation and operation.get("id") else {})},
+    }

--- a/src/cafe/core/workflow_runtime.py
+++ b/src/cafe/core/workflow_runtime.py
@@ -101,7 +101,10 @@ def operation_artifact_is_trusted(
     entry = blackboard_store.get_artifact(blackboard, f"{current_step}_operation")
     if entry is None:
         return False
-    if entry.summary != f"long_running_operation:{artifact.state.value}":
+    expected_summary = (
+        f"long_running_operation:{artifact.operation_id}:{artifact.state.value}"
+    )
+    if entry.summary != expected_summary:
         return False
     return Path(entry.path) == operation_artifact_path(iteration_dir)
 
@@ -1109,10 +1112,11 @@ class BlackboardWorkflowRuntime:
         sufficient evidence. ``BlackboardStore.write_operation_artifact`` is
         the only supported writer and always records a matching
         ``{step}_operation`` metadata artifact on the blackboard in the same
-        call; requiring that record to exist, match, and point at *this*
-        iteration's ``operation.json`` path keeps an agent-authored or
-        hand-edited file, or a stale metadata record left over from an
-        earlier iteration, from being accepted as trusted operation truth.
+        call; requiring that record to bind this artifact's operation ID and
+        state, and point at *this* iteration's ``operation.json`` path keeps
+        an agent-authored or hand-edited file, or a stale metadata record left
+        over from an earlier iteration, from being accepted as trusted
+        operation truth.
         """
         return operation_artifact_is_trusted(
             blackboard_store=self.blackboard_store,

--- a/src/cafe/core/workflow_runtime.py
+++ b/src/cafe/core/workflow_runtime.py
@@ -89,6 +89,48 @@ class RuntimePositionResolution:
     realignment_result: Optional[PlaybookRunResult] = None
 
 
+def operation_artifact_is_trusted(
+    *,
+    blackboard_store: BlackboardStore,
+    blackboard: Any,
+    current_step: str,
+    iteration_dir: Path,
+    artifact: LongRunningOperationArtifact,
+) -> bool:
+    """Return whether operation state has matching runtime-owned evidence."""
+    entry = blackboard_store.get_artifact(blackboard, f"{current_step}_operation")
+    if entry is None:
+        return False
+    if entry.summary != f"long_running_operation:{artifact.state.value}":
+        return False
+    return Path(entry.path) == operation_artifact_path(iteration_dir)
+
+
+def operation_receipt_is_trusted(
+    *,
+    blackboard_store: BlackboardStore,
+    blackboard: Any,
+    current_step: str,
+    iteration_dir: Path,
+    operation: LongRunningOperationArtifact,
+    receipt: LongRunningOperationArtifact,
+) -> bool:
+    """Return whether terminal receipt state has matching runtime-owned evidence."""
+    if receipt.state == LongRunningOperationState.RUNNING:
+        return False
+    if receipt.operation_id != operation.operation_id:
+        return False
+    entry = blackboard_store.get_artifact(blackboard, f"{current_step}_operation_receipt")
+    if entry is None:
+        return False
+    expected_summary = (
+        f"long_running_operation_receipt:{operation.operation_id}:{receipt.state.value}"
+    )
+    if entry.summary != expected_summary:
+        return False
+    return Path(entry.path) == operation_receipt_path(iteration_dir)
+
+
 class BlackboardWorkflowRuntime:
     """Workflow runtime that prefers blackboard/baton-driven transitions."""
 
@@ -1072,13 +1114,13 @@ class BlackboardWorkflowRuntime:
         hand-edited file, or a stale metadata record left over from an
         earlier iteration, from being accepted as trusted operation truth.
         """
-        entry = self.blackboard_store.get_artifact(self.blackboard, f"{current_step}_operation")
-        if entry is None:
-            return False
-        if entry.summary != f"long_running_operation:{artifact.state.value}":
-            return False
-        expected_path = operation_artifact_path(iteration_dir)
-        return Path(entry.path) == expected_path
+        return operation_artifact_is_trusted(
+            blackboard_store=self.blackboard_store,
+            blackboard=self.blackboard,
+            current_step=current_step,
+            iteration_dir=iteration_dir,
+            artifact=artifact,
+        )
 
     def _operation_receipt_trusted(
         self,
@@ -1089,22 +1131,14 @@ class BlackboardWorkflowRuntime:
         receipt: LongRunningOperationArtifact,
     ) -> bool:
         """Trust only terminal receipts written through the blackboard store."""
-        if receipt.state == LongRunningOperationState.RUNNING:
-            return False
-        if receipt.operation_id != operation.operation_id:
-            return False
-        entry = self.blackboard_store.get_artifact(
-            self.blackboard, f"{current_step}_operation_receipt"
+        return operation_receipt_is_trusted(
+            blackboard_store=self.blackboard_store,
+            blackboard=self.blackboard,
+            current_step=current_step,
+            iteration_dir=iteration_dir,
+            operation=operation,
+            receipt=receipt,
         )
-        if entry is None:
-            return False
-        expected_summary = (
-            f"long_running_operation_receipt:{operation.operation_id}:{receipt.state.value}"
-        )
-        if entry.summary != expected_summary:
-            return False
-        expected_path = operation_receipt_path(iteration_dir)
-        return Path(entry.path) == expected_path
 
     def _read_trusted_operation_receipt(
         self,

--- a/src/cafe/data/skills/cafe-develop/SKILL.md
+++ b/src/cafe/data/skills/cafe-develop/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cafe-develop
 description: "依計畫進行程式開發與測試"
-version: 1.6.0
+version: 1.5.0
 workflow:
   human_tasks:
     - id: no-change-decision

--- a/src/cafe/data/skills/cafe-develop/SKILL.md
+++ b/src/cafe/data/skills/cafe-develop/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cafe-develop
 description: "依計畫進行程式開發與測試"
-version: 1.5.0
+version: 1.6.0
 workflow:
   human_tasks:
     - id: no-change-decision
@@ -22,15 +22,31 @@ workflow:
     - artifacts: [spec]
       placeholder: spec_file
       required: false
+      load_policy:
+        - when: {feedback: true}
+          mode: packet
+          contract_kind: spec
     - artifacts: [spec]
       placeholder: spec_file_path
       required: false
+      load_policy:
+        - when: {feedback: true}
+          mode: packet
+          contract_kind: spec
     - artifacts: [plan]
       placeholder: plan_file
       required: false
+      load_policy:
+        - when: {feedback: true}
+          mode: packet
+          contract_kind: plan
     - artifacts: [plan]
       placeholder: plan_file_path
       required: false
+      load_policy:
+        - when: {feedback: true}
+          mode: packet
+          contract_kind: plan
     - artifacts: [review_feedback, pr_result]
       placeholder: feedback_file_path
       required: false

--- a/src/cafe/data/skills/cafe-plan/SKILL.md
+++ b/src/cafe/data/skills/cafe-plan/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cafe-plan
 description: "產出可執行的開發計畫"
-version: 1.0.1
+version: 1.1.0
 workflow:
   human_tasks:
     - id: development-guide
@@ -100,6 +100,10 @@ When the Dependency ADR proposes a **new major** of a package, note whether that
 
 ## Output
 Write plan to: {output_file}
+
+## Downstream Contract
+
+Keep exactly one versioned `## Downstream Contract` in every produced plan. Synchronize stable IDs and each top-level task's pending/completed state with the complete plan before user confirmation; legacy artifacts without this section deliberately remain full-source inputs.
 
 ## Handoff
 - 依照本輪結果更新 blackboard 與 next-step baton。

--- a/src/cafe/data/skills/cafe-plan/assets/templates/bug.md
+++ b/src/cafe/data/skills/cafe-plan/assets/templates/bug.md
@@ -74,6 +74,17 @@ Copy the DoD items from the spec's Acceptance Criteria section (lines marked wit
 - [ ] The reported bug no longer reproduces
 - [ ] No regressions in existing functionality
 
+## Authoritative Delivery IDs
+
+Keep these IDs on the matching architecture, test, ADR, and top-level task as
+the plan evolves; the downstream contract must contain the same IDs and task state.
+
+- **ARCH-001** — [Architecture boundary]
+- **INV-001** — [Stable invariant]
+- **UT-001** — [Planned unit test]
+- **ADR-001** — [Dependency decision]
+- [ ] **TASK-001** — [Top-level executable task]
+
 ## Downstream Contract
 
 - Contract-Version: `1`

--- a/src/cafe/data/skills/cafe-plan/assets/templates/bug.md
+++ b/src/cafe/data/skills/cafe-plan/assets/templates/bug.md
@@ -73,3 +73,29 @@ _(If N or M is 0, one sentence explains why.)_
 Copy the DoD items from the spec's Acceptance Criteria section (lines marked with `✅ **DoD:**`) and verify each one:
 - [ ] The reported bug no longer reproduces
 - [ ] No regressions in existing functionality
+
+## Downstream Contract
+
+- Contract-Version: `1`
+- Artifact-Kind: `plan`
+
+### Architecture Boundaries
+| ID | Location | Responsibility |
+| --- | --- | --- |
+| ARCH-001 | [Path] | [Boundary] |
+### Invariants
+| ID | Statement |
+| --- | --- |
+| INV-001 | [Stable invariant] |
+### Test List
+| ID | Type | Covers |
+| --- | --- | --- |
+| UT-001 | unit | INV-001 |
+### Dependency ADR References
+| ID | Decision | Requirement / invariant |
+| --- | --- | --- |
+| ADR-001 | [Decision] | INV-001 |
+### Task Status
+| ID | Status | Summary | Depends On |
+| --- | --- | --- | --- |
+| TASK-001 | pending | [Top-level task] | — |

--- a/src/cafe/data/skills/cafe-plan/assets/templates/default.md
+++ b/src/cafe/data/skills/cafe-plan/assets/templates/default.md
@@ -146,6 +146,17 @@ Copy the DoD items from the spec's Acceptance Criteria section (lines marked wit
 - [ ] **Dev 6.2**: All error handling returns proper error codes and messages
 - [ ] **Dev 6.3**: API response format is unchanged from before refactoring
 
+## Authoritative Delivery IDs
+
+Keep these IDs on the matching architecture, test, ADR, and top-level task as
+the plan evolves; the downstream contract must contain the same IDs and task state.
+
+- **ARCH-001** — [Architecture boundary]
+- **INV-001** — [Stable invariant]
+- **UT-001** — [Planned unit test]
+- **ADR-001** — [Dependency decision]
+- [ ] **TASK-001** — [Top-level executable task]
+
 ## Downstream Contract
 
 - Contract-Version: `1`

--- a/src/cafe/data/skills/cafe-plan/assets/templates/default.md
+++ b/src/cafe/data/skills/cafe-plan/assets/templates/default.md
@@ -145,3 +145,29 @@ Copy the DoD items from the spec's Acceptance Criteria section (lines marked wit
 - [ ] **Dev 6.1**: Login and registration work correctly through the new service layer
 - [ ] **Dev 6.2**: All error handling returns proper error codes and messages
 - [ ] **Dev 6.3**: API response format is unchanged from before refactoring
+
+## Downstream Contract
+
+- Contract-Version: `1`
+- Artifact-Kind: `plan`
+
+### Architecture Boundaries
+| ID | Location | Responsibility |
+| --- | --- | --- |
+| ARCH-001 | [Path] | [Boundary] |
+### Invariants
+| ID | Statement |
+| --- | --- |
+| INV-001 | [Stable invariant] |
+### Test List
+| ID | Type | Covers |
+| --- | --- | --- |
+| UT-001 | unit | INV-001 |
+### Dependency ADR References
+| ID | Decision | Requirement / invariant |
+| --- | --- | --- |
+| ADR-001 | [Decision] | INV-001 |
+### Task Status
+| ID | Status | Summary | Depends On |
+| --- | --- | --- | --- |
+| TASK-001 | pending | [Top-level task] | — |

--- a/src/cafe/data/skills/cafe-plan/assets/templates/simple.md
+++ b/src/cafe/data/skills/cafe-plan/assets/templates/simple.md
@@ -40,3 +40,29 @@ _(If N or M is 0, one sentence explains why.)_
 
 ## Notes
 Uses existing `utils/email.py` for sending emails.
+
+## Downstream Contract
+
+- Contract-Version: `1`
+- Artifact-Kind: `plan`
+
+### Architecture Boundaries
+| ID | Location | Responsibility |
+| --- | --- | --- |
+| ARCH-001 | [Path] | [Boundary] |
+### Invariants
+| ID | Statement |
+| --- | --- |
+| INV-001 | [Stable invariant] |
+### Test List
+| ID | Type | Covers |
+| --- | --- | --- |
+| UT-001 | unit | INV-001 |
+### Dependency ADR References
+| ID | Decision | Requirement / invariant |
+| --- | --- | --- |
+| ADR-001 | [Decision] | INV-001 |
+### Task Status
+| ID | Status | Summary | Depends On |
+| --- | --- | --- | --- |
+| TASK-001 | pending | [Top-level task] | — |

--- a/src/cafe/data/skills/cafe-plan/assets/templates/simple.md
+++ b/src/cafe/data/skills/cafe-plan/assets/templates/simple.md
@@ -41,6 +41,17 @@ _(If N or M is 0, one sentence explains why.)_
 ## Notes
 Uses existing `utils/email.py` for sending emails.
 
+## Authoritative Delivery IDs
+
+Keep these IDs on the matching architecture, test, ADR, and top-level task as
+the plan evolves; the downstream contract must contain the same IDs and task state.
+
+- **ARCH-001** — [Architecture boundary]
+- **INV-001** — [Stable invariant]
+- **UT-001** — [Planned unit test]
+- **ADR-001** — [Dependency decision]
+- [ ] **TASK-001** — [Top-level executable task]
+
 ## Downstream Contract
 
 - Contract-Version: `1`

--- a/src/cafe/data/skills/cafe-pr/SKILL.md
+++ b/src/cafe/data/skills/cafe-pr/SKILL.md
@@ -1,21 +1,33 @@
 ---
 name: cafe-pr
 description: "整理提交內容並產出 pull request 標題與描述"
-version: 1.0.1
+version: 1.1.0
 workflow:
   prompt_inputs:
     - artifacts: [spec]
       placeholder: spec_file
       required: false
+      load_policy:
+        - mode: packet
+          contract_kind: spec
     - artifacts: [spec]
       placeholder: spec_file_path
       required: false
+      load_policy:
+        - mode: packet
+          contract_kind: spec
     - artifacts: [plan]
       placeholder: plan_file
       required: false
+      load_policy:
+        - mode: packet
+          contract_kind: plan
     - artifacts: [plan]
       placeholder: plan_file_path
       required: false
+      load_policy:
+        - mode: packet
+          contract_kind: plan
     - artifacts: [code]
       placeholder: develop_file
       required: false

--- a/src/cafe/data/skills/cafe-review/SKILL.md
+++ b/src/cafe/data/skills/cafe-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cafe-review
 description: "審查程式碼品質與風險"
-version: 1.1.0
+version: 1.2.0
 workflow:
   required_tools:
     - "Bash(cafe verification check:*)"
@@ -14,15 +14,27 @@ workflow:
     - artifacts: [spec]
       placeholder: spec_file
       required: false
+      load_policy:
+        - mode: packet
+          contract_kind: spec
     - artifacts: [spec]
       placeholder: spec_file_path
       required: false
+      load_policy:
+        - mode: packet
+          contract_kind: spec
     - artifacts: [plan]
       placeholder: plan_file
       required: false
+      load_policy:
+        - mode: packet
+          contract_kind: plan
     - artifacts: [plan]
       placeholder: plan_file_path
       required: false
+      load_policy:
+        - mode: packet
+          contract_kind: plan
     - artifacts: [code]
       placeholder: develop_file
       required: false

--- a/src/cafe/data/skills/cafe-spec/SKILL.md
+++ b/src/cafe/data/skills/cafe-spec/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cafe-spec
 description: "收集、整理或修訂需求規格（依 iteration 切換行為）"
-version: 1.0.1
+version: 1.1.0
 workflow:
   human_tasks:
     - id: output-review
@@ -86,6 +86,10 @@ bash scripts/sync_github.sh --help
 
 ## Output
 Write spec to: {output_file}
+
+## Downstream Contract
+
+Keep exactly one versioned `## Downstream Contract` in every produced spec. Its stable IDs must cover the downstream requirements in the complete body; it is confirmed with the complete artifact and is copied byte-for-byte only by the runtime. Legacy artifacts without this section deliberately remain full-source inputs.
 
 ## Handoff
 - 依照本輪結果更新 blackboard 與 next-step baton。

--- a/src/cafe/data/skills/cafe-spec/assets/templates/default.md
+++ b/src/cafe/data/skills/cafe-spec/assets/templates/default.md
@@ -48,3 +48,29 @@
 - ✅ **DoD:** [User-selected completion criterion 1]
 - ✅ **DoD:** [User-selected completion criterion 2]
 - ✅ **DoD:** [Custom user-provided criterion if any]
+
+## Downstream Contract
+
+- Contract-Version: `1`
+- Artifact-Kind: `spec`
+
+### Goals
+| ID | Statement |
+| --- | --- |
+| GOAL-001 | [Stable goal] |
+### Non-Goals
+| ID | Statement |
+| --- | --- |
+| NONGOAL-001 | [Stable non-goal] |
+### Acceptance Criteria
+| ID | Priority | Statement |
+| --- | --- | --- |
+| AC-001 | must | [Stable acceptance criterion] |
+### Invariants
+| ID | Statement |
+| --- | --- |
+| INV-001 | [Stable invariant] |
+### Trust Boundaries
+| ID | Statement |
+| --- | --- |
+| TRUST-001 | [Stable trust boundary] |

--- a/src/cafe/data/skills/cafe-spec/assets/templates/default.md
+++ b/src/cafe/data/skills/cafe-spec/assets/templates/default.md
@@ -49,6 +49,17 @@
 - ✅ **DoD:** [User-selected completion criterion 2]
 - ✅ **DoD:** [Custom user-provided criterion if any]
 
+## Authoritative Requirement IDs
+
+Maintain these IDs beside the corresponding source requirements whenever this
+template is completed; the downstream contract must contain the same set.
+
+- **GOAL-001** — [Stable goal represented in the requirements above]
+- **NONGOAL-001** — [Stable non-goal represented in scope]
+- **AC-001** — [Stable acceptance criterion]
+- **INV-001** — [Stable invariant]
+- **TRUST-001** — [Stable trust boundary]
+
 ## Downstream Contract
 
 - Contract-Version: `1`

--- a/src/cafe/data/skills/cafe-spec/assets/templates/detailed.md
+++ b/src/cafe/data/skills/cafe-spec/assets/templates/detailed.md
@@ -95,6 +95,17 @@
 1. [Question 1]
 2. [Question 2]
 
+## Authoritative Requirement IDs
+
+Maintain these IDs beside the corresponding source requirements whenever this
+template is completed; the downstream contract must contain the same set.
+
+- **GOAL-001** — [Stable goal represented in the requirements above]
+- **NONGOAL-001** — [Stable non-goal represented in scope]
+- **AC-001** — [Stable acceptance criterion]
+- **INV-001** — [Stable invariant]
+- **TRUST-001** — [Stable trust boundary]
+
 ## Downstream Contract
 
 - Contract-Version: `1`

--- a/src/cafe/data/skills/cafe-spec/assets/templates/detailed.md
+++ b/src/cafe/data/skills/cafe-spec/assets/templates/detailed.md
@@ -94,3 +94,29 @@
 
 1. [Question 1]
 2. [Question 2]
+
+## Downstream Contract
+
+- Contract-Version: `1`
+- Artifact-Kind: `spec`
+
+### Goals
+| ID | Statement |
+| --- | --- |
+| GOAL-001 | [Stable goal] |
+### Non-Goals
+| ID | Statement |
+| --- | --- |
+| NONGOAL-001 | [Stable non-goal] |
+### Acceptance Criteria
+| ID | Priority | Statement |
+| --- | --- | --- |
+| AC-001 | must | [Stable acceptance criterion] |
+### Invariants
+| ID | Statement |
+| --- | --- |
+| INV-001 | [Stable invariant] |
+### Trust Boundaries
+| ID | Statement |
+| --- | --- |
+| TRUST-001 | [Stable trust boundary] |

--- a/src/cafe/data/skills/cafe-spec/assets/templates/simple.md
+++ b/src/cafe/data/skills/cafe-spec/assets/templates/simple.md
@@ -21,6 +21,17 @@
 
 [Any clarification questions if needed]
 
+## Authoritative Requirement IDs
+
+Maintain these IDs beside the corresponding source requirements whenever this
+template is completed; the downstream contract must contain the same set.
+
+- **GOAL-001** — [Stable goal represented in the requirements above]
+- **NONGOAL-001** — [Stable non-goal represented in scope]
+- **AC-001** — [Stable acceptance criterion]
+- **INV-001** — [Stable invariant]
+- **TRUST-001** — [Stable trust boundary]
+
 ## Downstream Contract
 
 - Contract-Version: `1`

--- a/src/cafe/data/skills/cafe-spec/assets/templates/simple.md
+++ b/src/cafe/data/skills/cafe-spec/assets/templates/simple.md
@@ -20,3 +20,29 @@
 ## Questions
 
 [Any clarification questions if needed]
+
+## Downstream Contract
+
+- Contract-Version: `1`
+- Artifact-Kind: `spec`
+
+### Goals
+| ID | Statement |
+| --- | --- |
+| GOAL-001 | [Stable goal] |
+### Non-Goals
+| ID | Statement |
+| --- | --- |
+| NONGOAL-001 | [Stable non-goal] |
+### Acceptance Criteria
+| ID | Priority | Statement |
+| --- | --- | --- |
+| AC-001 | must | [Stable acceptance criterion] |
+### Invariants
+| ID | Statement |
+| --- | --- |
+| INV-001 | [Stable invariant] |
+### Trust Boundaries
+| ID | Statement |
+| --- | --- |
+| TRUST-001 | [Stable trust boundary] |

--- a/src/cafe/phases/generic_phase.py
+++ b/src/cafe/phases/generic_phase.py
@@ -243,6 +243,14 @@ class GenericPhase:
                     context["resume_input_artifacts"],
                 ]
             )
+        if context and context.get("input_loading_modes"):
+            runtime_context.extend(
+                [
+                    "Declared input loading modes:",
+                    context["input_loading_modes"],
+                    "A packet is a validated exact Downstream Contract; full and full_fallback paths remain complete authoritative sources.",
+                ]
+            )
         if context and context.get("delta_packet"):
             runtime_context.extend(
                 [

--- a/src/cafe/phases/generic_workflow_step.py
+++ b/src/cafe/phases/generic_workflow_step.py
@@ -349,6 +349,7 @@ class GenericWorkflowStepExecutor(Phase):
                 "iteration_dir": iteration_dir,
                 "output_file": output_file,
                 "questions_xml_file": questions_xml_file,
+                "authoritative_inputs": context["authoritative_inputs"],
                 "capability_request_file": capability_request_file if capability_ids else None,
                 "publish_request_file": publish_request_file if step_name == "pr" else None,
                 "blackboard_state": blackboard_state,
@@ -1054,11 +1055,15 @@ class GenericWorkflowStepExecutor(Phase):
         contract = self._get_skill_loader().get_workflow_contract(skill_name)
         input_artifacts = self._step_input_artifacts(step_def, blackboard_state)
         try:
-            resolve_prompt_inputs(contract, input_artifacts)
+            authoritative_inputs = resolve_prompt_inputs(contract, input_artifacts)
         except DeclaredArtifactError as exc:
             raise ValueError(
                 f"Step {step_name!r}, skill {canonical_skill_name(skill_name)!r}: {exc}"
             ) from exc
+        context["authoritative_inputs"] = {
+            placeholder: self._display_path(Path(path))
+            for placeholder, path in authoritative_inputs.items()
+        }
         effective_inputs = resolve_effective_prompt_inputs(
             contract,
             input_artifacts,

--- a/src/cafe/phases/generic_workflow_step.py
+++ b/src/cafe/phases/generic_workflow_step.py
@@ -514,7 +514,9 @@ class GenericWorkflowStepExecutor(Phase):
                 "id": current.operation_id,
             }
         except (OSError, ValueError):
-            pass
+            # Unknown operation evidence is unsafe to treat as absent: a cold
+            # backup must status-check rather than risk relaunching it.
+            operation = {"state": "unknown"}
         snapshot = build_takeover_snapshot(
             reason=error,
             step=step_name,

--- a/src/cafe/phases/generic_workflow_step.py
+++ b/src/cafe/phases/generic_workflow_step.py
@@ -51,6 +51,7 @@ from cafe.skills.checklist_composer import compose_declared_checklist
 from cafe.skills.contracts import (
     DeclaredArtifactError,
     SkillWorkflowContract,
+    resolve_effective_prompt_inputs,
     resolve_prompt_inputs,
 )
 from cafe.skills.loader import SkillLoader, canonical_skill_name
@@ -977,16 +978,29 @@ class GenericWorkflowStepExecutor(Phase):
         contract = self._get_skill_loader().get_workflow_contract(skill_name)
         input_artifacts = self._step_input_artifacts(step_def, blackboard_state)
         try:
-            declared_inputs = resolve_prompt_inputs(contract, input_artifacts)
+            resolve_prompt_inputs(contract, input_artifacts)
         except DeclaredArtifactError as exc:
             raise ValueError(
                 f"Step {step_name!r}, skill {canonical_skill_name(skill_name)!r}: {exc}"
             ) from exc
+        effective_inputs = resolve_effective_prompt_inputs(
+            contract,
+            input_artifacts,
+            step=step_name,
+            iteration=self.iteration,
+            feedback=bool(
+                input_artifacts.get("review_feedback") or input_artifacts.get("pr_result")
+            ),
+            packet_dir=output_file.parent,
+        )
         context.update(
             {
-                placeholder: self._display_path(Path(path))
-                for placeholder, path in declared_inputs.items()
+                placeholder: self._display_path(Path(binding["path"]))
+                for placeholder, binding in effective_inputs.items()
             }
+        )
+        context["input_loading_modes"] = ", ".join(
+            f"{placeholder}={binding['mode']}" for placeholder, binding in sorted(effective_inputs.items())
         )
         self._add_template_context(
             context=context,

--- a/src/cafe/phases/generic_workflow_step.py
+++ b/src/cafe/phases/generic_workflow_step.py
@@ -1198,6 +1198,7 @@ class GenericWorkflowStepExecutor(Phase):
             agent_name=agent_name,
             role=str(step_def.get("role", "developer")),
             checklist_file_path=checklist_file,
+            step=step_name,
             iteration=self.iteration,
             context=context,
             artifacts=input_artifacts,

--- a/src/cafe/phases/generic_workflow_step.py
+++ b/src/cafe/phases/generic_workflow_step.py
@@ -503,16 +503,18 @@ class GenericWorkflowStepExecutor(Phase):
 
         operation: dict[str, Any] | None = None
         try:
-            current = get_operation_status(
-                issue_dir=self.issue_dir,
-                step=step_name,
-                iteration_dir=iteration_dir,
-                playbook=self.playbook,
-            )
-            operation = {
-                "state": "running" if current.state.value == "running" else "terminal",
-                "id": current.operation_id,
-            }
+            stored_operation = BlackboardStore(self.issue_dir).read_operation_artifact(iteration_dir)
+            if stored_operation is not None:
+                current = get_operation_status(
+                    issue_dir=self.issue_dir,
+                    step=step_name,
+                    iteration_dir=iteration_dir,
+                    playbook=self.playbook,
+                )
+                operation = {
+                    "state": "running" if current.state.value == "running" else "terminal",
+                    "id": current.operation_id,
+                }
         except (OSError, ValueError):
             # Unknown operation evidence is unsafe to treat as absent: a cold
             # backup must status-check rather than risk relaunching it.

--- a/src/cafe/phases/generic_workflow_step.py
+++ b/src/cafe/phases/generic_workflow_step.py
@@ -349,7 +349,7 @@ class GenericWorkflowStepExecutor(Phase):
                 "iteration_dir": iteration_dir,
                 "output_file": output_file,
                 "questions_xml_file": questions_xml_file,
-                "authoritative_inputs": context["authoritative_inputs"],
+                "authoritative_inputs": context.get("authoritative_inputs", {}),
                 "capability_request_file": capability_request_file if capability_ids else None,
                 "publish_request_file": publish_request_file if step_name == "pr" else None,
                 "blackboard_state": blackboard_state,

--- a/src/cafe/phases/generic_workflow_step.py
+++ b/src/cafe/phases/generic_workflow_step.py
@@ -24,6 +24,7 @@ from cafe.core.delta_packet import (
     persist_delta_packet,
 )
 from cafe.core.git import GitOperations
+from cafe.core.long_running_operation_helper import get_operation_status
 from cafe.core.phase import Phase
 from cafe.core.playbook import resolve_playbook_skills
 from cafe.core.resume_user_input import (
@@ -45,6 +46,7 @@ from cafe.core.status_codes import (
     transition_map_key,
 )
 from cafe.core.types import AgentCLI
+from cafe.core.takeover import build_takeover_snapshot
 from cafe.core.workflow_models import StepExecutionResult
 from cafe.phases.generic_phase import GenericPhase
 from cafe.skills.checklist_composer import compose_declared_checklist
@@ -305,6 +307,15 @@ class GenericWorkflowStepExecutor(Phase):
                     persist_status=False,
                     allowed_tools=attempt_allowed_tools,
                     phase_specific_data=phase_specific_data,
+                    backup_context_callback=lambda error: self._build_backup_takeover_context(
+                        error=error,
+                        step_name=step_name,
+                        step_def=step_def,
+                        blackboard_state=blackboard_state,
+                        output_file=output_file,
+                        checklist_file=checklist_file,
+                        iteration_dir=iteration_dir,
+                    ),
                 )
             finally:
                 # A phase agent can launch a controlled long-running operation,
@@ -454,6 +465,67 @@ class GenericWorkflowStepExecutor(Phase):
             auto_continue=auto_continue,
             events=events,
         )
+
+    def _build_backup_takeover_context(
+        self,
+        *,
+        error: object,
+        step_name: str,
+        step_def: Dict[str, Any],
+        blackboard_state: BlackboardState,
+        output_file: Path,
+        checklist_file: Path,
+        iteration_dir: Path,
+    ) -> str:
+        """Refresh a bounded cold-takeover snapshot just before a backup runs."""
+        contract = self._get_skill_loader().get_workflow_contract(
+            self._resolve_skill_name(step_def, self.iteration)
+        )
+        inputs = self._step_input_artifacts(step_def, blackboard_state)
+        resolved_inputs = resolve_effective_prompt_inputs(
+            contract,
+            inputs,
+            step=step_name,
+            iteration=self.iteration,
+            feedback=bool(inputs.get("review_feedback") or inputs.get("pr_result")),
+            packet_dir=iteration_dir,
+        )
+        workspace: dict[str, Any] = {}
+        try:
+            workspace["head"] = self.git_ops.run_git("rev-parse", "HEAD")
+            workspace["changed"] = [
+                line[3:]
+                for line in self.git_ops.get_status().splitlines()[:100]
+                if len(line) >= 4
+            ]
+        except Exception:
+            workspace["state"] = "unknown"
+
+        operation: dict[str, Any] | None = None
+        try:
+            current = get_operation_status(
+                issue_dir=self.issue_dir,
+                step=step_name,
+                iteration_dir=iteration_dir,
+                playbook=self.playbook,
+            )
+            operation = {
+                "state": "running" if current.state.value == "running" else "terminal",
+                "id": current.operation_id,
+            }
+        except (OSError, ValueError):
+            pass
+        snapshot = build_takeover_snapshot(
+            reason=error,
+            step=step_name,
+            iteration=self.iteration,
+            resolved_inputs=resolved_inputs,
+            output_file=output_file,
+            checklist_file=checklist_file,
+            operation=operation,
+            workspace=workspace,
+        )
+        return json.dumps(snapshot, ensure_ascii=False, separators=(",", ":"))
 
     def _load_iteration_user_input_candidate(self, step_name: str) -> str:
         """Load raw user input before resume-token optimization."""

--- a/src/cafe/phases/generic_workflow_step.py
+++ b/src/cafe/phases/generic_workflow_step.py
@@ -45,9 +45,13 @@ from cafe.core.status_codes import (
     step_on_declares,
     transition_map_key,
 )
-from cafe.core.types import AgentCLI
 from cafe.core.takeover import build_takeover_snapshot
+from cafe.core.types import AgentCLI
 from cafe.core.workflow_models import StepExecutionResult
+from cafe.core.workflow_runtime import (
+    operation_artifact_is_trusted,
+    operation_receipt_is_trusted,
+)
 from cafe.phases.generic_phase import GenericPhase
 from cafe.skills.checklist_composer import compose_declared_checklist
 from cafe.skills.contracts import (
@@ -503,20 +507,42 @@ class GenericWorkflowStepExecutor(Phase):
             workspace["state"] = "unknown"
 
         operation: dict[str, Any] | None = None
+        operation_store = BlackboardStore(self.issue_dir)
         try:
-            stored_operation = BlackboardStore(self.issue_dir).read_operation_artifact(iteration_dir)
+            stored_operation = operation_store.read_operation_artifact(iteration_dir)
             if stored_operation is not None:
-                current = get_operation_status(
-                    issue_dir=self.issue_dir,
-                    step=step_name,
+                current_blackboard = operation_store.load_or_create(step_name)
+                if not operation_artifact_is_trusted(
+                    blackboard_store=operation_store,
+                    blackboard=current_blackboard,
+                    current_step=step_name,
                     iteration_dir=iteration_dir,
-                    playbook=self.playbook,
-                )
-                operation = {
-                    "state": "running" if current.state.value == "running" else "terminal",
-                    "id": current.operation_id,
-                }
-        except (OSError, ValueError):
+                    artifact=stored_operation,
+                ):
+                    operation = {"state": "unknown"}
+                else:
+                    receipt = operation_store.read_operation_receipt(iteration_dir)
+                    if receipt is not None and not operation_receipt_is_trusted(
+                        blackboard_store=operation_store,
+                        blackboard=current_blackboard,
+                        current_step=step_name,
+                        iteration_dir=iteration_dir,
+                        operation=stored_operation,
+                        receipt=receipt,
+                    ):
+                        operation = {"state": "unknown"}
+                    else:
+                        current = get_operation_status(
+                            issue_dir=self.issue_dir,
+                            step=step_name,
+                            iteration_dir=iteration_dir,
+                            playbook=self.playbook,
+                        )
+                        operation = {
+                            "state": "running" if current.state.value == "running" else "terminal",
+                            "id": current.operation_id,
+                        }
+        except (OSError, ValueError, json.JSONDecodeError):
             # Unknown operation evidence is unsafe to treat as absent: a cold
             # backup must status-check rather than risk relaunching it.
             operation = {"state": "unknown"}

--- a/src/cafe/skills/checklist_composer.py
+++ b/src/cafe/skills/checklist_composer.py
@@ -36,19 +36,21 @@ _PLACEHOLDER_PATTERN = re.compile(r"\{([A-Za-z_][A-Za-z0-9_]*)\}")
 def _variant_matches(
     variant: ChecklistVariant,
     *,
+    step: str | None,
     iteration: int,
     artifacts: Mapping[str, Any],
     feedback: bool,
 ) -> bool:
     """Return whether one bounded, declared checklist selector applies."""
     return variant.when.matches(
-        step=None, iteration=iteration, artifacts=artifacts, feedback=feedback
+        step=step, iteration=iteration, artifacts=artifacts, feedback=feedback
     )
 
 
 def select_checklist_variant(
     contract: SkillWorkflowContract,
     *,
+    step: str | None = None,
     iteration: int,
     artifacts: Mapping[str, Any],
     feedback: bool,
@@ -57,7 +59,9 @@ def select_checklist_variant(
     if contract.checklist is None:
         raise ValueError("Skill does not declare checklist composition")
     for variant in contract.checklist.variants:
-        if _variant_matches(variant, iteration=iteration, artifacts=artifacts, feedback=feedback):
+        if _variant_matches(
+            variant, step=step, iteration=iteration, artifacts=artifacts, feedback=feedback
+        ):
             return variant
     raise ValueError(f"No checklist variant matches iteration {iteration}")
 
@@ -122,6 +126,7 @@ def compose_declared_checklist(
     agent_name: str,
     role: str,
     checklist_file_path: Path,
+    step: str | None = None,
     iteration: int,
     context: Mapping[str, str],
     artifacts: Mapping[str, Any],
@@ -136,6 +141,7 @@ def compose_declared_checklist(
 
     variant = select_checklist_variant(
         contract,
+        step=step,
         iteration=iteration,
         artifacts=artifacts,
         feedback=feedback,

--- a/src/cafe/skills/checklist_composer.py
+++ b/src/cafe/skills/checklist_composer.py
@@ -41,16 +41,9 @@ def _variant_matches(
     feedback: bool,
 ) -> bool:
     """Return whether one bounded, declared checklist selector applies."""
-    when = variant.when
-    if when.iteration is not None and when.iteration != iteration:
-        return False
-    if when.min_iteration is not None and iteration < when.min_iteration:
-        return False
-    if when.max_iteration is not None and iteration > when.max_iteration:
-        return False
-    if when.feedback is not None and when.feedback != feedback:
-        return False
-    return all(bool(artifacts.get(name)) for name in when.artifact_present)
+    return variant.when.matches(
+        step=None, iteration=iteration, artifacts=artifacts, feedback=feedback
+    )
 
 
 def select_checklist_variant(

--- a/src/cafe/skills/contracts.py
+++ b/src/cafe/skills/contracts.py
@@ -397,6 +397,9 @@ def resolve_effective_prompt_inputs(
     from cafe.core.context_packet import resolve_context_packet
 
     result: dict[str, dict[str, str]] = {}
+    relationships: list[
+        tuple[PromptInputContract, str, PromptInputLoadPolicy | None]
+    ] = []
     for mapping in contract.prompt_inputs:
         source = next(
             (
@@ -423,21 +426,43 @@ def resolve_effective_prompt_inputs(
             ),
             None,
         )
+        relationships.append((mapping, source, selected))
+
+    # A paired ``*_file`` / ``*_file_path`` declaration represents one input
+    # relationship.  Coalesce any declarations with the same source and
+    # packet policy so both placeholders receive the same validated envelope.
+    # Explicit full and packet declarations deliberately remain independent.
+    packet_groups: dict[
+        tuple[str, str], list[tuple[PromptInputContract, str, PromptInputLoadPolicy]]
+    ] = {}
+    for mapping, source, selected in relationships:
         if selected is None or selected.mode == "full":
             result[mapping.placeholder] = {"mode": "full", "path": source}
             continue
-        packet_path = Path(packet_dir) / f"context_{mapping.placeholder}.json"
+        contract_kind = selected.contract_kind
+        assert contract_kind is not None  # validated by PromptInputContract
+        packet_groups.setdefault((source, contract_kind), []).append(
+            (mapping, source, selected)
+        )
+
+    for (source, contract_kind), group in packet_groups.items():
+        placeholders = tuple(
+            mapping.placeholder for mapping, _source, _policy in group
+        )
+        packet_path = Path(packet_dir) / f"context_{placeholders[0]}.json"
         resolved = resolve_context_packet(
             source_path=source,
-            contract_kind=selected.contract_kind or "spec",
+            contract_kind=contract_kind,
             target_step=step,
             iteration=iteration,
-            placeholders=(mapping.placeholder,),
+            placeholders=placeholders,
             packet_path=packet_path,
         )
-        result[mapping.placeholder] = {
+        binding = {
             "mode": str(resolved["mode"]),
             "path": str(resolved["path"]),
             "reason": str(resolved.get("reason", "")),
         }
+        for mapping, _source, _policy in group:
+            result[mapping.placeholder] = dict(binding)
     return result

--- a/src/cafe/skills/contracts.py
+++ b/src/cafe/skills/contracts.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any, Optional, Tuple
+from pathlib import Path
+from typing import Any, Literal, Optional, Tuple
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
@@ -72,6 +73,7 @@ class PromptInputContract(BaseModel):
     artifacts: Tuple[str, ...]
     placeholder: str
     required: bool = False
+    load_policy: Tuple["PromptInputLoadPolicy", ...] = ()
 
     @field_validator("artifacts")
     @classmethod
@@ -88,12 +90,22 @@ class PromptInputContract(BaseModel):
     def _validate_placeholder(cls, value: str) -> str:
         return _safe_placeholder(value, field_name="placeholder")
 
+    @model_validator(mode="after")
+    def _validate_load_policy(self) -> "PromptInputContract":
+        if any(
+            policy.mode == "packet" and policy.contract_kind is None
+            for policy in self.load_policy
+        ):
+            raise ValueError("packet prompt input policy requires contract_kind")
+        return self
 
-class ChecklistWhen(BaseModel):
-    """Bounded runtime facts used to select a checklist variant."""
+
+class RuntimeWhen(BaseModel):
+    """One shared, strict selector for checklist and input-loading variants."""
 
     model_config = ConfigDict(extra="forbid")
 
+    step: Optional[str] = None
     iteration: Optional[int] = None
     min_iteration: Optional[int] = None
     max_iteration: Optional[int] = None
@@ -112,8 +124,13 @@ class ChecklistWhen(BaseModel):
     def _validate_artifact_presence(cls, value: Tuple[str, ...]) -> Tuple[str, ...]:
         return tuple(_safe_token(item, field_name="artifact_present") for item in value)
 
+    @field_validator("step")
+    @classmethod
+    def _validate_step(cls, value: Optional[str]) -> Optional[str]:
+        return _safe_token(value, field_name="step") if value is not None else None
+
     @model_validator(mode="after")
-    def _validate_bounds(self) -> "ChecklistWhen":
+    def _validate_bounds(self) -> "RuntimeWhen":
         if self.iteration is not None and any(
             bound is not None for bound in (self.min_iteration, self.max_iteration)
         ):
@@ -125,6 +142,37 @@ class ChecklistWhen(BaseModel):
         ):
             raise ValueError("min_iteration must not exceed max_iteration")
         return self
+
+    def matches(
+        self,
+        *,
+        step: Optional[str],
+        iteration: int,
+        artifacts: Mapping[str, Any],
+        feedback: bool,
+    ) -> bool:
+        return (
+            (self.step is None or self.step == step)
+            and (self.iteration is None or self.iteration == iteration)
+            and (self.min_iteration is None or iteration >= self.min_iteration)
+            and (self.max_iteration is None or iteration <= self.max_iteration)
+            and (self.feedback is None or self.feedback == feedback)
+            and all(bool(artifacts.get(name)) for name in self.artifact_present)
+        )
+
+
+# Retain the public name used by existing skill declarations and imports.
+ChecklistWhen = RuntimeWhen
+
+
+class PromptInputLoadPolicy(BaseModel):
+    """A declared full-or-packet policy for an individual consuming relation."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    when: RuntimeWhen = Field(default_factory=RuntimeWhen)
+    mode: Literal["full", "packet"] = "full"
+    contract_kind: Optional[Literal["spec", "plan"]] = None
 
 
 class ChecklistSection(BaseModel):
@@ -330,3 +378,66 @@ def resolve_prompt_inputs(
             if mapping.required:
                 raise DeclaredArtifactError(mapping.placeholder, mapping.artifacts)
     return resolved
+
+
+def resolve_effective_prompt_inputs(
+    contract: SkillWorkflowContract,
+    artifacts: Mapping[str, Any],
+    *,
+    step: str,
+    iteration: int,
+    feedback: bool,
+    packet_dir: str | Path,
+) -> dict[str, dict[str, str]]:
+    """Resolve declared input relationships without relying on artifact names.
+
+    Packet failures are deliberately local: other inputs remain in their
+    declared mode and the affected input exposes its complete source path.
+    """
+    from cafe.core.context_packet import resolve_context_packet
+
+    result: dict[str, dict[str, str]] = {}
+    for mapping in contract.prompt_inputs:
+        source = next(
+            (
+                _artifact_path(artifacts.get(name))
+                for name in mapping.artifacts
+                if _artifact_path(artifacts.get(name))
+            ),
+            None,
+        )
+        if source is None:
+            if mapping.required:
+                raise DeclaredArtifactError(mapping.placeholder, mapping.artifacts)
+            continue
+        selected = next(
+            (
+                policy
+                for policy in mapping.load_policy
+                if policy.when.matches(
+                    step=step,
+                    iteration=iteration,
+                    artifacts=artifacts,
+                    feedback=feedback,
+                )
+            ),
+            None,
+        )
+        if selected is None or selected.mode == "full":
+            result[mapping.placeholder] = {"mode": "full", "path": source}
+            continue
+        packet_path = Path(packet_dir) / f"context_{mapping.placeholder}.json"
+        resolved = resolve_context_packet(
+            source_path=source,
+            contract_kind=selected.contract_kind or "spec",
+            target_step=step,
+            iteration=iteration,
+            placeholders=(mapping.placeholder,),
+            packet_path=packet_path,
+        )
+        result[mapping.placeholder] = {
+            "mode": str(resolved["mode"]),
+            "path": str(resolved["path"]),
+            "reason": str(resolved.get("reason", "")),
+        }
+    return result

--- a/src/cafe/skills/contracts.py
+++ b/src/cafe/skills/contracts.py
@@ -93,8 +93,7 @@ class PromptInputContract(BaseModel):
     @model_validator(mode="after")
     def _validate_load_policy(self) -> "PromptInputContract":
         if any(
-            policy.mode == "packet" and policy.contract_kind is None
-            for policy in self.load_policy
+            policy.mode == "packet" and policy.contract_kind is None for policy in self.load_policy
         ):
             raise ValueError("packet prompt input policy requires contract_kind")
         return self
@@ -362,6 +361,15 @@ def _artifact_path(value: Any) -> Optional[str]:
     return text or None
 
 
+def _artifact_version(value: Any) -> int:
+    version = (
+        value.get("version") if isinstance(value, Mapping) else getattr(value, "version", None)
+    )
+    return (
+        version if isinstance(version, int) and not isinstance(version, bool) and version > 0 else 1
+    )
+
+
 def resolve_prompt_inputs(
     contract: SkillWorkflowContract,
     artifacts: Mapping[str, Any],
@@ -397,22 +405,21 @@ def resolve_effective_prompt_inputs(
     from cafe.core.context_packet import resolve_context_packet
 
     result: dict[str, dict[str, str]] = {}
-    relationships: list[
-        tuple[PromptInputContract, str, PromptInputLoadPolicy | None]
-    ] = []
+    relationships: list[tuple[PromptInputContract, str, str, int, PromptInputLoadPolicy | None]] = (
+        []
+    )
     for mapping in contract.prompt_inputs:
-        source = next(
-            (
-                _artifact_path(artifacts.get(name))
-                for name in mapping.artifacts
-                if _artifact_path(artifacts.get(name))
-            ),
+        source_name = next(
+            (name for name in mapping.artifacts if _artifact_path(artifacts.get(name))),
             None,
         )
-        if source is None:
+        if source_name is None:
             if mapping.required:
                 raise DeclaredArtifactError(mapping.placeholder, mapping.artifacts)
             continue
+        source_value = artifacts[source_name]
+        source = _artifact_path(source_value)
+        assert source is not None
         selected = next(
             (
                 policy
@@ -426,28 +433,32 @@ def resolve_effective_prompt_inputs(
             ),
             None,
         )
-        relationships.append((mapping, source, selected))
+        relationships.append(
+            (mapping, source, source_name, _artifact_version(source_value), selected)
+        )
 
     # A paired ``*_file`` / ``*_file_path`` declaration represents one input
     # relationship.  Coalesce any declarations with the same source and
     # packet policy so both placeholders receive the same validated envelope.
     # Explicit full and packet declarations deliberately remain independent.
     packet_groups: dict[
-        tuple[str, str], list[tuple[PromptInputContract, str, PromptInputLoadPolicy]]
+        tuple[str, str, str, int],
+        list[tuple[PromptInputContract, str, str, int, PromptInputLoadPolicy]],
     ] = {}
-    for mapping, source, selected in relationships:
+    for mapping, source, source_name, source_version, selected in relationships:
         if selected is None or selected.mode == "full":
             result[mapping.placeholder] = {"mode": "full", "path": source}
             continue
         contract_kind = selected.contract_kind
         assert contract_kind is not None  # validated by PromptInputContract
-        packet_groups.setdefault((source, contract_kind), []).append(
-            (mapping, source, selected)
+        packet_groups.setdefault((source, source_name, contract_kind, source_version), []).append(
+            (mapping, source, source_name, source_version, selected)
         )
 
-    for (source, contract_kind), group in packet_groups.items():
+    for (source, source_name, contract_kind, source_version), group in packet_groups.items():
         placeholders = tuple(
-            mapping.placeholder for mapping, _source, _policy in group
+            mapping.placeholder
+            for mapping, _source, _source_name, _source_version, _policy in group
         )
         packet_path = Path(packet_dir) / f"context_{placeholders[0]}.json"
         resolved = resolve_context_packet(
@@ -457,12 +468,15 @@ def resolve_effective_prompt_inputs(
             iteration=iteration,
             placeholders=placeholders,
             packet_path=packet_path,
+            source_artifact_name=source_name,
+            source_artifact_version=source_version,
         )
         binding = {
             "mode": str(resolved["mode"]),
             "path": str(resolved["path"]),
             "reason": str(resolved.get("reason", "")),
+            "source": dict(resolved.get("source", {})),
         }
-        for mapping, _source, _policy in group:
+        for mapping, _source, _source_name, _source_version, _policy in group:
             result[mapping.placeholder] = dict(binding)
     return result

--- a/tests/integration/test_agent_attempt_diagnostics.py
+++ b/tests/integration/test_agent_attempt_diagnostics.py
@@ -9,7 +9,7 @@ import pytest
 
 from cafe.agents.executor import AgentExecutionError
 from cafe.agents.manager import AgentManager
-from cafe.core.blackboard import BlackboardStore
+from cafe.core.blackboard import ArtifactEntry, ArtifactKind, BlackboardStore
 from cafe.core.long_running_operation_helper import get_operation_status, run_operation_command
 from cafe.core.types import (
     AgentCLI,
@@ -25,11 +25,23 @@ from cafe.skills.loader import SkillLoader
 from cafe.skills.native_bridge import NativeSkillBridge
 
 
-def _build_loader(tmp_path: Path) -> GenericPhase:
-    skill_root = tmp_path / "builtin" / "skills" / "develop"
+def _build_loader(
+    tmp_path: Path,
+    *,
+    skill_name: str = "develop",
+    input_artifact: str | None = None,
+) -> GenericPhase:
+    skill_root = tmp_path / "builtin" / "skills" / skill_name
     skill_root.mkdir(parents=True)
+    prompt_inputs = (
+        f"workflow:\n  prompt_inputs:\n    - artifacts: [{input_artifact}]\n"
+        f"      placeholder: {input_artifact}_file\n"
+        if input_artifact
+        else ""
+    )
     (skill_root / "SKILL.md").write_text(
-        "---\nname: develop\ndescription: desc\n---\n\nWrite output to: {output_file}\n",
+        f"---\nname: {skill_name}\ndescription: desc\n{prompt_inputs}---\n\n"
+        "Write output to: {output_file}\n",
         encoding="utf-8",
     )
     loader = SkillLoader(
@@ -48,9 +60,16 @@ def _build_loader(tmp_path: Path) -> GenericPhase:
     )
 
 
-def _build_executor(tmp_path: Path, manager: AgentManager) -> GenericWorkflowStepExecutor:
+def _build_executor(
+    tmp_path: Path,
+    manager: AgentManager,
+    *,
+    step_name: str = "develop",
+    skill_name: str = "develop",
+    input_artifact: str | None = None,
+) -> GenericWorkflowStepExecutor:
     issue_dir = tmp_path / ".cafe" / "issues" / "attempt-diagnostics"
-    phase_dir = issue_dir / "develop"
+    phase_dir = issue_dir / step_name
     spec_file = issue_dir / "spec" / "iteration_001" / "output.md"
     spec_file.parent.mkdir(parents=True, exist_ok=True)
     spec_file.write_text("# Initial Requirements\n", encoding="utf-8")
@@ -65,9 +84,17 @@ def _build_executor(tmp_path: Path, manager: AgentManager) -> GenericWorkflowSte
         playbook={
             "playbook": {"id": "default"},
             "roles": {"developer": {"default_agent": "David"}},
-            "steps": {"develop": {"skill": "develop", "role": "developer"}},
+            "steps": {
+                step_name: {
+                    "skill": skill_name,
+                    "role": "developer",
+                    **({"input_artifacts": [input_artifact]} if input_artifact else {}),
+                }
+            },
         },
-        generic_phase=_build_loader(tmp_path),
+        generic_phase=_build_loader(
+            tmp_path, skill_name=skill_name, input_artifact=input_artifact
+        ),
         agent_manager=manager,
         git_ops=git_ops,
         role_agent_map={"developer": "David"},
@@ -151,7 +178,10 @@ def test_fallback_success_preserves_primary_attempts_in_iteration_record(tmp_pat
 def test_cold_backup_chain_status_checks_a_running_operation_before_takeover(
     tmp_path: Path,
 ) -> None:
-    """IT-005 — each cold backup reuses, rather than relaunches, live work."""
+    """IT-005 — a custom workflow reuses, rather than relaunches, live work."""
+    step_name = "orbit_launch"
+    skill_name = "orbit_operator"
+    input_artifact = "mission_brief"
     manager = AgentManager()
     manager.register_agent(
         AgentConfig(
@@ -164,10 +194,25 @@ def test_cold_backup_chain_status_checks_a_running_operation_before_takeover(
             ],
         )
     )
-    executor = _build_executor(tmp_path, manager)
+    executor = _build_executor(
+        tmp_path,
+        manager,
+        step_name=step_name,
+        skill_name=skill_name,
+        input_artifact=input_artifact,
+    )
     executor.git_ops.run_git.return_value = "test-head"
     executor.git_ops.get_status.return_value = ""
-    state = BlackboardStore(executor.issue_dir).load_or_create("develop")
+    state = BlackboardStore(executor.issue_dir).load_or_create(step_name)
+    brief_file = tmp_path / "mission-brief.md"
+    brief_file.write_text("mission input", encoding="utf-8")
+    state.artifacts[input_artifact] = ArtifactEntry(
+        name=input_artifact,
+        kind=ArtifactKind.DOCUMENT,
+        version=1,
+        updated_by="orbit_intake",
+        path=str(brief_file),
+    )
     iteration_dir = executor.phase_dir / "iteration_001"
     output_file = iteration_dir / "output.md"
     checklist_file = iteration_dir / "checklist.md"
@@ -182,7 +227,7 @@ def test_cold_backup_chain_status_checks_a_running_operation_before_takeover(
     )
     launched = run_operation_command(
         issue_dir=executor.issue_dir,
-        step="develop",
+        step=step_name,
         iteration_dir=iteration_dir,
         command=[sys.executable, str(operation_script), str(release_file)],
         cwd=tmp_path,
@@ -197,8 +242,8 @@ def test_cold_backup_chain_status_checks_a_running_operation_before_takeover(
     def snapshot(error: AgentExecutionError) -> str:
         return executor._build_backup_takeover_context(
             error=error,
-            step_name="develop",
-            step_def={"skill": "develop", "role": "developer"},
+            step_name=step_name,
+            step_def=executor.playbook["steps"][step_name],
             blackboard_state=state,
             output_file=output_file,
             checklist_file=checklist_file,
@@ -227,7 +272,7 @@ def test_cold_backup_chain_status_checks_a_running_operation_before_takeover(
             response, *_ = manager.execute(
                 "David",
                 "perform the workflow step",
-                phase_name="develop",
+                phase_name=step_name,
                 backup_context_callback=snapshot,
             )
 
@@ -239,6 +284,11 @@ def test_cold_backup_chain_status_checks_a_running_operation_before_takeover(
     second_takeover = json.loads(prompts[2].split("provider-neutral):\n", 1)[1])
     assert response == "replacement output"
     assert first_takeover["reason"] != second_takeover["reason"]
+    assert first_takeover["target"]["step"] == step_name
+    assert first_takeover["resolved_inputs"][f"{input_artifact}_file"]["mode"] == "full"
+    assert first_takeover["resolved_inputs"][f"{input_artifact}_file"]["path"] == str(
+        brief_file
+    )
     assert first_takeover["partial"]["output"]["state"] == "missing"
     assert second_takeover["partial"]["output"]["state"] == "file"
     assert second_takeover["partial"]["checklist"]["completed"] == 1

--- a/tests/integration/test_agent_attempt_diagnostics.py
+++ b/tests/integration/test_agent_attempt_diagnostics.py
@@ -8,6 +8,7 @@ import pytest
 
 from cafe.agents.executor import AgentExecutionError
 from cafe.agents.manager import AgentManager
+from cafe.core.blackboard import BlackboardStore
 from cafe.core.types import (
     AgentCLI,
     AgentConfig,
@@ -143,6 +144,71 @@ def test_fallback_success_preserves_primary_attempts_in_iteration_record(tmp_pat
         ("claude", 2),
     ]
     assert "raw-primary-secret" not in iteration_path.read_text(encoding="utf-8")
+
+
+def test_cold_backup_chain_refreshes_takeover_reason_and_partial_progress(tmp_path: Path) -> None:
+    """IT-005 — each fresh provider receives current durable takeover state."""
+    manager = AgentManager()
+    manager.register_agent(
+        AgentConfig(
+            name="David",
+            cli=AgentCLI.CLAUDE,
+            clis=[
+                CliEntry(cli=AgentCLI.CLAUDE),
+                CliEntry(cli=AgentCLI.GEMINI),
+                CliEntry(cli=AgentCLI.CODEX),
+            ],
+        )
+    )
+    executor = _build_executor(tmp_path, manager)
+    executor.git_ops.run_git.return_value = "test-head"
+    executor.git_ops.get_status.return_value = ""
+    state = BlackboardStore(executor.issue_dir).load_or_create("develop")
+    iteration_dir = executor.phase_dir / "iteration_001"
+    output_file = iteration_dir / "output.md"
+    checklist_file = iteration_dir / "checklist.md"
+    primary_error = AgentExecutionError("primary rate limit", error_type="rate_limit")
+    backup_error = AgentExecutionError("backup rate limit", error_type="rate_limit")
+    prompts: list[str] = []
+
+    def snapshot(error: AgentExecutionError) -> str:
+        return executor._build_backup_takeover_context(
+            error=error,
+            step_name="develop",
+            step_def={"skill": "develop", "role": "developer"},
+            blackboard_state=state,
+            output_file=output_file,
+            checklist_file=checklist_file,
+            iteration_dir=iteration_dir,
+        )
+
+    def side_effect(prompt: str, *_args, **_kwargs):
+        prompts.append(prompt)
+        if len(prompts) == 1:
+            raise primary_error
+        if len(prompts) == 2:
+            iteration_dir.mkdir(parents=True, exist_ok=True)
+            output_file.write_text("partial output", encoding="utf-8")
+            checklist_file.write_text("[x] partial task\n", encoding="utf-8")
+            raise backup_error
+        return _success("replacement output")
+
+    with patch("cafe.agents.executor.AgentExecutor.execute", side_effect=side_effect):
+        response, *_ = manager.execute(
+            "David",
+            "perform the workflow step",
+            phase_name="develop",
+            backup_context_callback=snapshot,
+        )
+
+    first_takeover = json.loads(prompts[1].split("provider-neutral):\n", 1)[1])
+    second_takeover = json.loads(prompts[2].split("provider-neutral):\n", 1)[1])
+    assert response == "replacement output"
+    assert first_takeover["reason"] != second_takeover["reason"]
+    assert first_takeover["partial"]["output"]["state"] == "missing"
+    assert second_takeover["partial"]["output"]["state"] == "file"
+    assert second_takeover["partial"]["checklist"]["completed"] == 1
+    assert second_takeover["operation"]["state"] == "absent"
 
 
 def test_all_failed_journey_persists_sanitized_history_without_raw_secrets(tmp_path: Path) -> None:

--- a/tests/integration/test_agent_attempt_diagnostics.py
+++ b/tests/integration/test_agent_attempt_diagnostics.py
@@ -1,6 +1,7 @@
 """Journey tests for durable CLI-attempt diagnostics."""
 
 import json
+import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -9,6 +10,7 @@ import pytest
 from cafe.agents.executor import AgentExecutionError
 from cafe.agents.manager import AgentManager
 from cafe.core.blackboard import BlackboardStore
+from cafe.core.long_running_operation_helper import get_operation_status, run_operation_command
 from cafe.core.types import (
     AgentCLI,
     AgentConfig,
@@ -146,8 +148,10 @@ def test_fallback_success_preserves_primary_attempts_in_iteration_record(tmp_pat
     assert "raw-primary-secret" not in iteration_path.read_text(encoding="utf-8")
 
 
-def test_cold_backup_chain_refreshes_takeover_reason_and_partial_progress(tmp_path: Path) -> None:
-    """IT-005 — each fresh provider receives current durable takeover state."""
+def test_cold_backup_chain_status_checks_a_running_operation_before_takeover(
+    tmp_path: Path,
+) -> None:
+    """IT-005 — each cold backup reuses, rather than relaunches, live work."""
     manager = AgentManager()
     manager.register_agent(
         AgentConfig(
@@ -167,6 +171,25 @@ def test_cold_backup_chain_refreshes_takeover_reason_and_partial_progress(tmp_pa
     iteration_dir = executor.phase_dir / "iteration_001"
     output_file = iteration_dir / "output.md"
     checklist_file = iteration_dir / "checklist.md"
+    release_file = tmp_path / "release-operation"
+    operation_script = tmp_path / "wait-for-release.py"
+    operation_script.write_text(
+        "from pathlib import Path\n"
+        "import sys, time\n"
+        "while not Path(sys.argv[1]).exists():\n"
+        "    time.sleep(0.01)\n",
+        encoding="utf-8",
+    )
+    launched = run_operation_command(
+        issue_dir=executor.issue_dir,
+        step="develop",
+        iteration_dir=iteration_dir,
+        command=[sys.executable, str(operation_script), str(release_file)],
+        cwd=tmp_path,
+        playbook=executor.playbook,
+        reason="cold_backup_integration",
+    )
+    assert launched.started is True
     primary_error = AgentExecutionError("primary rate limit", error_type="rate_limit")
     backup_error = AgentExecutionError("backup rate limit", error_type="rate_limit")
     prompts: list[str] = []
@@ -193,13 +216,24 @@ def test_cold_backup_chain_refreshes_takeover_reason_and_partial_progress(tmp_pa
             raise backup_error
         return _success("replacement output")
 
-    with patch("cafe.agents.executor.AgentExecutor.execute", side_effect=side_effect):
-        response, *_ = manager.execute(
-            "David",
-            "perform the workflow step",
-            phase_name="develop",
-            backup_context_callback=snapshot,
-        )
+    try:
+        with (
+            patch("cafe.agents.executor.AgentExecutor.execute", side_effect=side_effect),
+            patch(
+                "cafe.phases.generic_workflow_step.get_operation_status",
+                wraps=get_operation_status,
+            ) as status_check,
+        ):
+            response, *_ = manager.execute(
+                "David",
+                "perform the workflow step",
+                phase_name="develop",
+                backup_context_callback=snapshot,
+            )
+
+        assert status_check.call_count == 2
+    finally:
+        release_file.write_text("release", encoding="utf-8")
 
     first_takeover = json.loads(prompts[1].split("provider-neutral):\n", 1)[1])
     second_takeover = json.loads(prompts[2].split("provider-neutral):\n", 1)[1])
@@ -208,7 +242,11 @@ def test_cold_backup_chain_refreshes_takeover_reason_and_partial_progress(tmp_pa
     assert first_takeover["partial"]["output"]["state"] == "missing"
     assert second_takeover["partial"]["output"]["state"] == "file"
     assert second_takeover["partial"]["checklist"]["completed"] == 1
-    assert second_takeover["operation"]["state"] == "absent"
+    assert first_takeover["operation"] == {
+        "state": "running",
+        "id": launched.operation.operation_id,
+    }
+    assert second_takeover["operation"] == first_takeover["operation"]
 
 
 def test_all_failed_journey_persists_sanitized_history_without_raw_secrets(tmp_path: Path) -> None:

--- a/tests/integration/test_declarative_skill_workflow.py
+++ b/tests/integration/test_declarative_skill_workflow.py
@@ -10,6 +10,7 @@ from cafe.core.blackboard import BlackboardStore
 from cafe.core.types import AgentCLI, TokenUsage
 from cafe.phases.generic_phase import GenericPhase
 from cafe.phases.generic_workflow_step import GenericWorkflowStepExecutor
+from cafe.playbooks.loader import PlaybookLoader
 from cafe.skills.loader import SkillLoader
 from cafe.skills.native_bridge import NativeSkillBridge
 
@@ -293,6 +294,128 @@ BODY-ONLY-SENTINEL GOAL-001 NONGOAL-001 AC-001 INV-001 TRUST-001
     assert "compact_brief=full_fallback" in second_manager.prompts[0]
     assert str(packet_source) in second_manager.prompts[0]
     assert "full_record=full" in second_manager.prompts[0]
+
+    packet_source.write_text(
+        """# Brief
+
+GOAL-001 NONGOAL-001 AC-001 INV-001 TRUST-001
+
+## Downstream Contract
+
+- Contract-Version: `1`
+- Artifact-Kind: `spec`
+
+### Goals
+| ID | Statement |
+| --- | --- |
+### Non-Goals
+| ID | Statement |
+| --- | --- |
+| NONGOAL-001 | No |
+### Acceptance Criteria
+| ID | Priority | Statement |
+| --- | --- | --- |
+| AC-001 | must | Yes |
+### Invariants
+| ID | Statement |
+| --- | --- |
+| INV-001 | Safe |
+### Trust Boundaries
+| ID | Statement |
+| --- | --- |
+| TRUST-001 | Local |
+""",
+        encoding="utf-8",
+    )
+    empty_table_manager = _AgentManager()
+    empty_table_executor = GenericWorkflowStepExecutor(
+        issue_dir=issue_dir,
+        issue_name="packet-journey",
+        playbook=playbook,
+        generic_phase=phase,
+        agent_manager=empty_table_manager,
+        git_ops=_GitOps(),
+        role_agent_map={"researcher": "David"},
+    )
+    empty_table_executor.execute_step("assemble", step, state)
+
+    assert "compact_brief=full_fallback" in empty_table_manager.prompts[0]
+    assert str(packet_source) in empty_table_manager.prompts[0]
+
+
+def test_packaged_workflow_uses_full_then_packet_then_legacy_fallback(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """IT-001/IT-002/IT-006 — real packaged stages retain authority and fail closed."""
+    monkeypatch.chdir(tmp_path)
+    root = Path(__file__).resolve().parents[2]
+    source_root = root / "src" / "cafe" / "data"
+    loader = SkillLoader(
+        project_root=tmp_path,
+        global_root=tmp_path / "global",
+        builtin_root=source_root,
+    )
+    loader.discover()
+    phase = GenericPhase(
+        loader,
+        skill_bridge=NativeSkillBridge(loader, project_root=tmp_path, home_dir=tmp_path / "home"),
+    )
+    playbook = PlaybookLoader().load("default")
+    issue_dir = tmp_path / ".cafe" / "issues" / "packaged-packet-journey"
+    spec = issue_dir / "spec" / "iteration_001" / "output.md"
+    plan = issue_dir / "plan" / "iteration_001" / "output.md"
+    code = issue_dir / "develop" / "iteration_001" / "output.md"
+    feedback = issue_dir / "review" / "iteration_001" / "output.md"
+    for artifact in (spec, plan, code, feedback):
+        artifact.parent.mkdir(parents=True, exist_ok=True)
+    spec.write_text(
+        "BODY-ONLY-PACKAGED-SENTINEL\n"
+        + (source_root / "skills/cafe-spec/assets/templates/default.md").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    plan.write_text(
+        (source_root / "skills/cafe-plan/assets/templates/default.md").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    code.write_text("implementation evidence", encoding="utf-8")
+    feedback.write_text("review evidence", encoding="utf-8")
+    store = BlackboardStore(issue_dir)
+    state = store.load_or_create("develop")
+    for name, artifact in (("spec", spec), ("plan", plan), ("code", code)):
+        store.set_artifact(state, name, str(artifact))
+
+    def run(step_name: str) -> _AgentManager:
+        manager = _AgentManager()
+        GenericWorkflowStepExecutor(
+            issue_dir=issue_dir,
+            issue_name="packaged-packet-journey",
+            playbook=playbook,
+            generic_phase=phase,
+            agent_manager=manager,
+            git_ops=_GitOps(),
+            role_agent_map={"developer": "David", "reviewer": "Richard"},
+        ).execute_step(step_name, playbook["steps"][step_name], state)
+        return manager
+
+    first_develop = run("develop")
+    assert "spec_file=full" in first_develop.prompts[0]
+    assert "plan_file=full" in first_develop.prompts[0]
+
+    store.set_artifact(state, "review_feedback", str(feedback))
+    correction_develop = run("develop")
+    review = run("review")
+    pr = run("pr")
+    for prompt in (correction_develop.prompts[0], review.prompts[0], pr.prompts[0]):
+        assert "spec_file=packet" in prompt
+        assert "plan_file=packet" in prompt
+    packets = list(issue_dir.glob("**/context_spec_file.json"))
+    assert packets
+    assert "BODY-ONLY-PACKAGED-SENTINEL" not in packets[-1].read_text(encoding="utf-8")
+
+    spec.write_text("# Legacy confirmed artifact\n", encoding="utf-8")
+    legacy_correction = run("develop")
+    assert "spec_file=full_fallback" in legacy_correction.prompts[0]
+    assert "plan_file=packet" in legacy_correction.prompts[0]
 
 
 def test_workflow_replace_removes_stale_native_skills(tmp_path: Path, monkeypatch) -> None:

--- a/tests/integration/test_declarative_skill_workflow.py
+++ b/tests/integration/test_declarative_skill_workflow.py
@@ -278,9 +278,40 @@ BODY-ONLY-SENTINEL GOAL-001 NONGOAL-001 AC-001 INV-001 TRUST-001
     assert "full_record=full" in first_manager.prompts[0]
     assert str(full_record) in first_manager.prompts[0]
 
+    # A syntactically valid source revision must not reuse a packet whose
+    # persisted provenance still identifies the previous source bytes.
+    packet_source.write_text(
+        packet_source.read_text(encoding="utf-8").replace(
+            "| GOAL-001 | Goal |", "| GOAL-001 | Revised goal |"
+        ),
+        encoding="utf-8",
+    )
     next_packet_path = packet_path.parent.parent / "iteration_002" / packet_path.name
     next_packet_path.parent.mkdir(parents=True)
-    next_packet_path.write_text("{tampered packet", encoding="utf-8")
+    stale_packet = json.loads(packet_path.read_text(encoding="utf-8"))
+    stale_packet["target"]["iteration"] = 2
+    next_packet_path.write_text(
+        json.dumps(stale_packet, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    stale_source_manager = _AgentManager()
+    stale_source_executor = GenericWorkflowStepExecutor(
+        issue_dir=issue_dir,
+        issue_name="packet-journey",
+        playbook=playbook,
+        generic_phase=phase,
+        agent_manager=stale_source_manager,
+        git_ops=_GitOps(),
+        role_agent_map={"researcher": "David"},
+    )
+    stale_source_executor.execute_step("assemble", step, state)
+
+    assert "compact_brief=full_fallback" in stale_source_manager.prompts[0]
+    assert str(packet_source) in stale_source_manager.prompts[0]
+
+    tampered_packet_path = packet_path.parent.parent / "iteration_003" / packet_path.name
+    tampered_packet_path.parent.mkdir(parents=True)
+    tampered_packet_path.write_text("{tampered packet", encoding="utf-8")
     tampered_packet_manager = _AgentManager()
     tampered_packet_executor = GenericWorkflowStepExecutor(
         issue_dir=issue_dir,

--- a/tests/integration/test_declarative_skill_workflow.py
+++ b/tests/integration/test_declarative_skill_workflow.py
@@ -160,6 +160,141 @@ Read {evidence_file} and use {template_file}.
     assert "evidence.md" in activated
 
 
+def test_custom_executor_preserves_full_inputs_and_falls_back_from_damaged_packet_source(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """IT-003/IT-004 — real custom execution keeps full authority and fails closed."""
+    monkeypatch.chdir(tmp_path)
+    builtin_root = tmp_path / "builtin"
+    skill_dir = builtin_root / "skills" / "assembly"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        """---
+name: assembly
+description: assembly
+workflow:
+  prompt_inputs:
+    - artifacts: [brief_packet]
+      placeholder: compact_brief
+      required: true
+      load_policy:
+        - mode: packet
+          contract_kind: spec
+    - artifacts: [full_record]
+      placeholder: full_record
+      required: true
+---
+
+Use {compact_brief} with {full_record}.
+""",
+        encoding="utf-8",
+    )
+    loader = SkillLoader(
+        project_root=tmp_path,
+        global_root=tmp_path / "global",
+        builtin_root=builtin_root,
+    )
+    loader.discover()
+    phase = GenericPhase(
+        loader,
+        skill_bridge=NativeSkillBridge(loader, project_root=tmp_path, home_dir=tmp_path / "home"),
+    )
+    issue_dir = tmp_path / ".cafe" / "issues" / "packet-journey"
+    packet_source = issue_dir / "brief" / "iteration_001" / "output.md"
+    full_record = issue_dir / "record" / "iteration_001" / "output.md"
+    packet_source.parent.mkdir(parents=True)
+    full_record.parent.mkdir(parents=True)
+    packet_source.write_text(
+        """# Brief
+
+BODY-ONLY-SENTINEL GOAL-001 NONGOAL-001 AC-001 INV-001 TRUST-001
+
+## Downstream Contract
+
+- Contract-Version: `1`
+- Artifact-Kind: `spec`
+
+### Goals
+| ID | Statement |
+| --- | --- |
+| GOAL-001 | Goal |
+### Non-Goals
+| ID | Statement |
+| --- | --- |
+| NONGOAL-001 | No |
+### Acceptance Criteria
+| ID | Priority | Statement |
+| --- | --- | --- |
+| AC-001 | must | Yes |
+### Invariants
+| ID | Statement |
+| --- | --- |
+| INV-001 | Safe |
+### Trust Boundaries
+| ID | Statement |
+| --- | --- |
+| TRUST-001 | Local |
+""",
+        encoding="utf-8",
+    )
+    full_record.write_text("AUTHORITATIVE-FULL-RECORD", encoding="utf-8")
+    store = BlackboardStore(issue_dir)
+    state = store.load_or_create("assemble")
+    store.set_artifact(state, "brief_packet", str(packet_source))
+    store.set_artifact(state, "full_record", str(full_record))
+    step = {
+        "skill": "assembly",
+        "role": "researcher",
+        "input_artifacts": ["brief_packet", "full_record"],
+        "output_artifact": "compiled_report",
+        "allowed_tools": ["Read"],
+        "valid_intents": ["confirmed"],
+        "on": {"await_agent": "_done"},
+    }
+    playbook = {
+        "playbook": {"id": "arbitrary-packet-journey"},
+        "roles": {"researcher": {"default_agent": "David"}},
+        "skills": {"workflow": {"shared": []}, "chat": {"shared": []}},
+        "steps": {"assemble": step},
+    }
+
+    first_manager = _AgentManager()
+    first = GenericWorkflowStepExecutor(
+        issue_dir=issue_dir,
+        issue_name="packet-journey",
+        playbook=playbook,
+        generic_phase=phase,
+        agent_manager=first_manager,
+        git_ops=_GitOps(),
+        role_agent_map={"researcher": "David"},
+    )
+    first.execute_step("assemble", step, state)
+
+    packet_path = issue_dir / "assemble" / "iteration_001" / "context_compact_brief.json"
+    packet = json.loads(packet_path.read_text(encoding="utf-8"))
+    assert "BODY-ONLY-SENTINEL" not in packet["contract"]["bytes"]
+    assert "compact_brief=packet" in first_manager.prompts[0]
+    assert "full_record=full" in first_manager.prompts[0]
+    assert str(full_record) in first_manager.prompts[0]
+
+    packet_source.write_text("# legacy source without a contract\n", encoding="utf-8")
+    second_manager = _AgentManager()
+    second = GenericWorkflowStepExecutor(
+        issue_dir=issue_dir,
+        issue_name="packet-journey",
+        playbook=playbook,
+        generic_phase=phase,
+        agent_manager=second_manager,
+        git_ops=_GitOps(),
+        role_agent_map={"researcher": "David"},
+    )
+    second.execute_step("assemble", step, state)
+
+    assert "compact_brief=full_fallback" in second_manager.prompts[0]
+    assert str(packet_source) in second_manager.prompts[0]
+    assert "full_record=full" in second_manager.prompts[0]
+
+
 def test_workflow_replace_removes_stale_native_skills(tmp_path: Path, monkeypatch) -> None:
     """I2 — a replace declaration leaves only the current workflow environment."""
     monkeypatch.chdir(tmp_path)

--- a/tests/integration/test_declarative_skill_workflow.py
+++ b/tests/integration/test_declarative_skill_workflow.py
@@ -278,6 +278,24 @@ BODY-ONLY-SENTINEL GOAL-001 NONGOAL-001 AC-001 INV-001 TRUST-001
     assert "full_record=full" in first_manager.prompts[0]
     assert str(full_record) in first_manager.prompts[0]
 
+    next_packet_path = packet_path.parent.parent / "iteration_002" / packet_path.name
+    next_packet_path.parent.mkdir(parents=True)
+    next_packet_path.write_text("{tampered packet", encoding="utf-8")
+    tampered_packet_manager = _AgentManager()
+    tampered_packet_executor = GenericWorkflowStepExecutor(
+        issue_dir=issue_dir,
+        issue_name="packet-journey",
+        playbook=playbook,
+        generic_phase=phase,
+        agent_manager=tampered_packet_manager,
+        git_ops=_GitOps(),
+        role_agent_map={"researcher": "David"},
+    )
+    tampered_packet_executor.execute_step("assemble", step, state)
+
+    assert "compact_brief=full_fallback" in tampered_packet_manager.prompts[0]
+    assert str(packet_source) in tampered_packet_manager.prompts[0]
+
     packet_source.write_text("# legacy source without a contract\n", encoding="utf-8")
     second_manager = _AgentManager()
     second = GenericWorkflowStepExecutor(
@@ -346,7 +364,7 @@ GOAL-001 NONGOAL-001 AC-001 INV-001 TRUST-001
 def test_packaged_workflow_uses_full_then_packet_then_legacy_fallback(
     tmp_path: Path, monkeypatch
 ) -> None:
-    """IT-001/IT-002/IT-006 — real packaged stages retain authority and fail closed."""
+    """IT-001/IT-002/IT-006 — packaged stages retain full host authority."""
     monkeypatch.chdir(tmp_path)
     root = Path(__file__).resolve().parents[2]
     source_root = root / "src" / "cafe" / "data"
@@ -356,7 +374,16 @@ def test_packaged_workflow_uses_full_then_packet_then_legacy_fallback(
         builtin_root=source_root,
     )
     loader.discover()
-    phase = GenericPhase(
+    class CapturingPhase(GenericPhase):
+        def __init__(self, *args, **kwargs) -> None:
+            super().__init__(*args, **kwargs)
+            self.host_contexts: list[dict[str, object]] = []
+
+        def execute(self, **kwargs):
+            self.host_contexts.append(dict(kwargs["hook_context"]))
+            return super().execute(**kwargs)
+
+    phase = CapturingPhase(
         loader,
         skill_bridge=NativeSkillBridge(loader, project_root=tmp_path, home_dir=tmp_path / "home"),
     )
@@ -405,12 +432,30 @@ def test_packaged_workflow_uses_full_then_packet_then_legacy_fallback(
     correction_develop = run("develop")
     review = run("review")
     pr = run("pr")
-    for prompt in (correction_develop.prompts[0], review.prompts[0], pr.prompts[0]):
+    pr_follow_up = run("pr")
+    for prompt in (
+        correction_develop.prompts[0],
+        review.prompts[0],
+        pr.prompts[0],
+        pr_follow_up.prompts[0],
+    ):
         assert "spec_file=packet" in prompt
         assert "plan_file=packet" in prompt
-    packets = list(issue_dir.glob("**/context_spec_file.json"))
-    assert packets
-    assert "BODY-ONLY-PACKAGED-SENTINEL" not in packets[-1].read_text(encoding="utf-8")
+    spec_packets = list(issue_dir.glob("**/context_spec_file.json"))
+    plan_packets = list(issue_dir.glob("**/context_plan_file.json"))
+    assert spec_packets and plan_packets
+    spec_packet = json.loads(spec_packets[-1].read_text(encoding="utf-8"))["contract"]["bytes"]
+    plan_packet = json.loads(plan_packets[-1].read_text(encoding="utf-8"))["contract"]["bytes"]
+    assert "BODY-ONLY-PACKAGED-SENTINEL" not in spec_packet
+    for identifier in ("GOAL-001", "NONGOAL-001", "AC-001", "INV-001", "TRUST-001"):
+        assert identifier in spec_packet
+    assert "### Test List" in plan_packet
+    assert "### Dependency ADR References" in plan_packet
+    assert "ADR-001" in plan_packet
+    assert "| TASK-001 | pending |" in plan_packet
+    final_host_inputs = phase.host_contexts[-1]["authoritative_inputs"]
+    assert Path(final_host_inputs["spec_file"]).resolve() == spec
+    assert Path(final_host_inputs["plan_file"]).resolve() == plan
 
     spec.write_text("# Legacy confirmed artifact\n", encoding="utf-8")
     legacy_correction = run("develop")

--- a/tests/integration/test_long_running_operation_workflow.py
+++ b/tests/integration/test_long_running_operation_workflow.py
@@ -88,7 +88,9 @@ def test_runtime_rechecks_operation_created_inside_executor_before_no_status_fal
         nonlocal executor_calls
         executor_calls += 1
         iteration_dir.mkdir(parents=True, exist_ok=True)
-        (iteration_dir / "iteration.json").write_text(json.dumps({"iteration": 1}), encoding="utf-8")
+        (iteration_dir / "iteration.json").write_text(
+            json.dumps({"iteration": 1}), encoding="utf-8"
+        )
         launched = run_operation_command(
             issue_dir=issue_dir,
             step=step_name,
@@ -154,7 +156,9 @@ def test_runtime_run_rechecks_helper_liveness_and_marks_lost_without_manual_stat
 
     def launching_executor(step_name: str, step_def: dict, state: object) -> StepExecutionResult:
         iteration_dir.mkdir(parents=True, exist_ok=True)
-        (iteration_dir / "iteration.json").write_text(json.dumps({"iteration": 1}), encoding="utf-8")
+        (iteration_dir / "iteration.json").write_text(
+            json.dumps({"iteration": 1}), encoding="utf-8"
+        )
         launched = run_operation_command(
             issue_dir=issue_dir,
             step=step_name,
@@ -220,10 +224,12 @@ def test_succeeded_operation_without_phase_artifacts_runs_finalize_only_once(
     script.write_text(
         "from __future__ import annotations\n"
         "import sys\n"
+        "import time\n"
         "from pathlib import Path\n"
         "counter = Path(sys.argv[1])\n"
         "count = int(counter.read_text(encoding='utf-8')) if counter.exists() else 0\n"
         "counter.write_text(str(count + 1), encoding='utf-8')\n"
+        "time.sleep(0.2)\n"
         "sys.exit(0)\n",
         encoding="utf-8",
     )
@@ -241,7 +247,9 @@ def test_succeeded_operation_without_phase_artifacts_runs_finalize_only_once(
         executor_calls += 1
         received_extra_prompts.append(extra_prompt)
         iteration_dir.mkdir(parents=True, exist_ok=True)
-        (iteration_dir / "iteration.json").write_text(json.dumps({"iteration": 1}), encoding="utf-8")
+        (iteration_dir / "iteration.json").write_text(
+            json.dumps({"iteration": 1}), encoding="utf-8"
+        )
         if executor_calls == 1:
             launched = run_operation_command(
                 issue_dir=issue_dir,
@@ -401,7 +409,13 @@ iteration_dir.mkdir(parents=True, exist_ok=True)
         issue_dir=issue_dir,
         step="develop",
         iteration_dir=iteration_dir,
-        command=[sys.executable, str(script), str(release_file), str(issue_dir), str(iteration_dir)],
+        command=[
+            sys.executable,
+            str(script),
+            str(release_file),
+            str(issue_dir),
+            str(iteration_dir),
+        ],
         cwd=tmp_path,
         playbook=_PLAYBOOK,
         reason="integration_fake_long_command",
@@ -410,19 +424,28 @@ iteration_dir.mkdir(parents=True, exist_ok=True)
         issue_dir=issue_dir,
         step="develop",
         iteration_dir=iteration_dir,
-        command=[sys.executable, str(script), str(release_file), str(issue_dir), str(iteration_dir)],
+        command=[
+            sys.executable,
+            str(script),
+            str(release_file),
+            str(issue_dir),
+            str(iteration_dir),
+        ],
         cwd=tmp_path,
         playbook=_PLAYBOOK,
         reason="integration_fake_long_command",
     )
     assert duplicate.operation.operation_id == launched.operation.operation_id
     assert duplicate.started is False
-    assert get_operation_status(
-        issue_dir=issue_dir,
-        step="develop",
-        iteration_dir=iteration_dir,
-        playbook=_PLAYBOOK,
-    ).state == LongRunningOperationState.RUNNING
+    assert (
+        get_operation_status(
+            issue_dir=issue_dir,
+            step="develop",
+            iteration_dir=iteration_dir,
+            playbook=_PLAYBOOK,
+        ).state
+        == LongRunningOperationState.RUNNING
+    )
 
     def duplicate_launch_executor(
         step_name: str, step_def: dict, state: object
@@ -458,7 +481,9 @@ iteration_dir.mkdir(parents=True, exist_ok=True)
     ).run(start_step="develop", single_step=True)
 
     assert second_result.final_status_code != "OPERATION_RUNNING"
-    assert json.loads((iteration_dir / "operation_receipt.json").read_text())["state"] == "succeeded"
+    assert (
+        json.loads((iteration_dir / "operation_receipt.json").read_text())["state"] == "succeeded"
+    )
     assert json.loads((iteration_dir / "operation.json").read_text())["state"] == "succeeded"
 
 
@@ -467,9 +492,7 @@ def test_production_helper_records_nonzero_exit_as_failed(tmp_path: Path) -> Non
     iteration_dir = issue_dir / "develop" / "iteration_001"
     script = tmp_path / "fake_long_failed.py"
     script.write_text(
-        "from __future__ import annotations\n"
-        "import sys\n"
-        "sys.exit(7)\n",
+        "from __future__ import annotations\n" "import sys\n" "sys.exit(7)\n",
         encoding="utf-8",
     )
 
@@ -634,6 +657,7 @@ def test_agent_writable_completion_evidence_without_receipt_does_not_promote_to_
 
     assert result.final_status_code == "OPERATION_LOST"
     assert json.loads((iteration_dir / "operation.json").read_text())["state"] == "lost"
+
 
 def test_agent_timeout_without_helper_evidence_becomes_lost_without_duplicate_launch(
     tmp_path: Path,

--- a/tests/unit/test_agent_executor.py
+++ b/tests/unit/test_agent_executor.py
@@ -422,10 +422,12 @@ class TestCodexPermissionExtraction:
         assert denials[0].tool_name == "Bash"
         assert denials[0].tool_input["command"].startswith("git add src/cafe/ui/cli.py")
 
-    def test_codex_exec_does_not_override_codex_home(self) -> None:
-        """Codex executions should inherit the default environment."""
+    def test_codex_exec_preserves_codex_home(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Codex executions should preserve the provider configuration environment."""
         config = AgentConfig(name="Nick", cli=AgentCLI.CODEX)
         executor = AgentExecutor(config)
+        codex_home = "/tmp/custom-codex-home"
+        monkeypatch.setenv("CODEX_HOME", codex_home)
 
         mock_process = MagicMock()
         mock_process.stdout.readline.side_effect = [
@@ -438,7 +440,7 @@ class TestCodexPermissionExtraction:
         with patch("subprocess.Popen", return_value=mock_process) as mock_popen, patch("sys.platform", "win32"):
             executor.execute("Test prompt")
 
-        assert "CODEX_HOME" not in mock_popen.call_args.kwargs["env"]
+        assert mock_popen.call_args.kwargs["env"]["CODEX_HOME"] == codex_home
 
 
 class TestTokenUsageTracking:

--- a/tests/unit/test_backup_agent.py
+++ b/tests/unit/test_backup_agent.py
@@ -217,6 +217,30 @@ class TestAgentManagerBackupRetry:
 
         assert response == "backup success"
 
+    def test_backup_receives_fresh_takeover_context_without_primary_session(self) -> None:
+        manager = AgentManager()
+        manager.register_agent(AgentConfig(name="David", cli=AgentCLI.CLAUDE, backup_clis=[AgentCLI.GEMINI]))
+        seen_prompts = []
+
+        def side_effect(prompt, *args, **kwargs):
+            seen_prompts.append(prompt)
+            if len(seen_prompts) == 1:
+                raise self._make_rate_limit_error()
+            return self._make_success_response("backup success")
+
+        with patch("cafe.agents.executor.AgentExecutor.execute", side_effect=side_effect):
+            response, *_ = manager.execute(
+                "David",
+                "primary prompt",
+                backup_context_callback=lambda _error: '{"operation":{"state":"running"}}',
+            )
+
+        assert response == "backup success"
+        assert len(seen_prompts) == 2
+        assert "Cold backup takeover context" in seen_prompts[1]
+        assert '"operation":{"state":"running"}' in seen_prompts[1]
+        assert "session-" not in seen_prompts[1]
+
     def test_first_backup_fails_second_succeeds(self) -> None:
         """Test that when the first backup also fails, the second backup is tried."""
         manager = AgentManager()

--- a/tests/unit/test_backup_agent.py
+++ b/tests/unit/test_backup_agent.py
@@ -100,7 +100,10 @@ class TestSetupAgentsBackupConfig:
                 "developer": {
                     "name": "David",
                     "cli": "claude",
-                    "backup": ["claude", "gemini"],  # "claude" matches primary CLI, should be filtered
+                    "backup": [
+                        "claude",
+                        "gemini",
+                    ],  # "claude" matches primary CLI, should be filtered
                 },
                 "reviewer": {"name": "Richard", "cli": "copilot"},
             }
@@ -128,7 +131,10 @@ class TestSetupAgentsBackupConfig:
                     "cli": "claude",
                     "models": {
                         "claude": {"plan": "opus", "develop": "sonnet", "pr": "haiku"},
-                        "gemini": {"plan": "gemini-3-flash-preview", "develop": "gemini-3-flash-preview"},
+                        "gemini": {
+                            "plan": "gemini-3-flash-preview",
+                            "develop": "gemini-3-flash-preview",
+                        },
                     },
                 },
                 "reviewer": {"name": "Richard", "cli": "copilot"},
@@ -219,7 +225,9 @@ class TestAgentManagerBackupRetry:
 
     def test_backup_receives_fresh_takeover_context_without_primary_session(self) -> None:
         manager = AgentManager()
-        manager.register_agent(AgentConfig(name="David", cli=AgentCLI.CLAUDE, backup_clis=[AgentCLI.GEMINI]))
+        manager.register_agent(
+            AgentConfig(name="David", cli=AgentCLI.CLAUDE, backup_clis=[AgentCLI.GEMINI])
+        )
         seen_prompts = []
 
         def side_effect(prompt, *args, **kwargs):
@@ -240,6 +248,26 @@ class TestAgentManagerBackupRetry:
         assert "Cold backup takeover context" in seen_prompts[1]
         assert '"operation":{"state":"running"}' in seen_prompts[1]
         assert "session-" not in seen_prompts[1]
+
+    def test_backup_is_not_started_when_takeover_snapshot_cannot_be_built(self) -> None:
+        manager = AgentManager()
+        manager.register_agent(
+            AgentConfig(name="David", cli=AgentCLI.CLAUDE, backup_clis=[AgentCLI.GEMINI])
+        )
+
+        with patch(
+            "cafe.agents.executor.AgentExecutor.execute", side_effect=self._make_rate_limit_error()
+        ) as execute:
+            with pytest.raises(AgentExecutionError, match="takeover context unavailable"):
+                manager.execute(
+                    "David",
+                    "primary prompt",
+                    backup_context_callback=lambda _error: (_ for _ in ()).throw(
+                        OSError("snapshot unavailable")
+                    ),
+                )
+
+        assert execute.call_count == 1
 
     def test_first_backup_fails_second_succeeds(self) -> None:
         """Test that when the first backup also fails, the second backup is tried."""
@@ -335,7 +363,9 @@ class TestAgentManagerBackupRetry:
         manager.register_agent(config)
 
         with patch("cafe.agents.executor.AgentExecutor.execute") as mock_exec:
-            mock_exec.side_effect = AgentExecutionError("permission denied", error_type="permission_denied")
+            mock_exec.side_effect = AgentExecutionError(
+                "permission denied", error_type="permission_denied"
+            )
 
             with pytest.raises(AgentExecutionError):
                 manager.execute("David", "test prompt")
@@ -356,7 +386,9 @@ class TestAgentManagerBackupRetry:
 
         created_executors = []
 
-        original_init = __import__("cafe.agents.executor", fromlist=["AgentExecutor"]).AgentExecutor.__init__
+        original_init = __import__(
+            "cafe.agents.executor", fromlist=["AgentExecutor"]
+        ).AgentExecutor.__init__
 
         def capture_executor(self, config):
             created_executors.append(config)
@@ -371,8 +403,10 @@ class TestAgentManagerBackupRetry:
                 raise AgentExecutionError("rate limit", error_type="rate_limit")
             return AgentResponse(response="ok", token_usage=TokenUsage())
 
-        with patch("cafe.agents.executor.AgentExecutor.__init__", capture_executor), \
-             patch("cafe.agents.executor.AgentExecutor.execute", side_effect=side_effect):
+        with (
+            patch("cafe.agents.executor.AgentExecutor.__init__", capture_executor),
+            patch("cafe.agents.executor.AgentExecutor.execute", side_effect=side_effect),
+        ):
             manager.execute("David", "test prompt", phase_name="plan")
 
         # The second executor should be the backup CLI (gemini) with the correct model
@@ -392,7 +426,9 @@ class TestAgentManagerBackupRetry:
         manager.register_agent(config)
 
         created_configs = []
-        original_init = __import__("cafe.agents.executor", fromlist=["AgentExecutor"]).AgentExecutor.__init__
+        original_init = __import__(
+            "cafe.agents.executor", fromlist=["AgentExecutor"]
+        ).AgentExecutor.__init__
 
         def capture_executor(self, config):
             created_configs.append(config)
@@ -407,8 +443,10 @@ class TestAgentManagerBackupRetry:
                 raise AgentExecutionError("rate limit", error_type="rate_limit")
             return AgentResponse(response="ok", token_usage=TokenUsage())
 
-        with patch("cafe.agents.executor.AgentExecutor.__init__", capture_executor), \
-             patch("cafe.agents.executor.AgentExecutor.execute", side_effect=side_effect):
+        with (
+            patch("cafe.agents.executor.AgentExecutor.__init__", capture_executor),
+            patch("cafe.agents.executor.AgentExecutor.execute", side_effect=side_effect),
+        ):
             manager.execute("David", "test prompt", phase_name="develop")
 
         backup_configs = [c for c in created_configs if c.cli == AgentCLI.GEMINI]

--- a/tests/unit/test_backup_agent.py
+++ b/tests/unit/test_backup_agent.py
@@ -249,6 +249,40 @@ class TestAgentManagerBackupRetry:
         assert '"operation":{"state":"running"}' in seen_prompts[1]
         assert "session-" not in seen_prompts[1]
 
+    def test_each_backup_receives_the_immediately_preceding_failure(self) -> None:
+        """A later cold backup must see the failed backup, not stale primary context."""
+        manager = AgentManager()
+        manager.register_agent(
+            AgentConfig(
+                name="David",
+                cli=AgentCLI.CLAUDE,
+                backup_clis=[AgentCLI.GEMINI, AgentCLI.COPILOT],
+            )
+        )
+        primary_error = self._make_rate_limit_error()
+        backup_error = AgentExecutionError("backup rate limit", error_type="rate_limit")
+        callback_errors = []
+        execution_calls = 0
+
+        def side_effect(*_args, **_kwargs):
+            nonlocal execution_calls
+            execution_calls += 1
+            if execution_calls == 1:
+                raise primary_error
+            if execution_calls == 2:
+                raise backup_error
+            return self._make_success_response("second backup success")
+
+        with patch("cafe.agents.executor.AgentExecutor.execute", side_effect=side_effect):
+            response, *_ = manager.execute(
+                "David",
+                "primary prompt",
+                backup_context_callback=callback_errors.append,
+            )
+
+        assert response == "second backup success"
+        assert callback_errors == [primary_error, backup_error]
+
     def test_backup_is_not_started_when_takeover_snapshot_cannot_be_built(self) -> None:
         manager = AgentManager()
         manager.register_agent(

--- a/tests/unit/test_chat.py
+++ b/tests/unit/test_chat.py
@@ -242,6 +242,7 @@ class TestLaunchChatSession:
         mock_config_manager_cls,
         mock_run,
         mock_extract_session,
+        monkeypatch,
     ):
         """Test that Codex chat stores a new session after interactive launch."""
         mock_config = MagicMock()
@@ -251,12 +252,14 @@ class TestLaunchChatSession:
         agent_manager = self._make_agent_manager("Nick", "codex", session_id=None, model="gpt-5.4")
         mock_agent_manager_cls.return_value = agent_manager
         mock_run.return_value = MagicMock(returncode=0)
+        codex_home = "/tmp/custom-codex-home"
+        monkeypatch.setenv("CODEX_HOME", codex_home)
 
         result = launch_chat_session("developer", "issue123")
 
         assert result == 0
         assert mock_run.call_args.args[0] == ["codex", "--model", "gpt-5.4"]
-        assert "CODEX_HOME" not in mock_run.call_args.kwargs["env"]
+        assert mock_run.call_args.kwargs["env"]["CODEX_HOME"] == codex_home
         agent_manager.session_manager.save_session.assert_called_once_with(
             "Nick",
             AgentCLI.CODEX,
@@ -272,6 +275,7 @@ class TestLaunchChatSession:
         mock_agent_manager_cls,
         mock_config_manager_cls,
         mock_run,
+        monkeypatch,
     ):
         """Test Codex interactive resume and session persistence."""
         mock_config = MagicMock()
@@ -283,12 +287,14 @@ class TestLaunchChatSession:
         )
         mock_agent_manager_cls.return_value = agent_manager
         mock_run.return_value = MagicMock(returncode=0)
+        codex_home = "/tmp/custom-codex-home"
+        monkeypatch.setenv("CODEX_HOME", codex_home)
 
         result = launch_chat_session("developer", "issue123")
 
         assert result == 0
         assert mock_run.call_args.args[0] == ["codex", "--model", "gpt-5.4", "resume", "sess-codex"]
-        assert "CODEX_HOME" not in mock_run.call_args.kwargs["env"]
+        assert mock_run.call_args.kwargs["env"]["CODEX_HOME"] == codex_home
         agent_manager.session_manager.save_session.assert_called_once_with(
             "Nick",
             AgentCLI.CODEX,

--- a/tests/unit/test_codex_cli.py
+++ b/tests/unit/test_codex_cli.py
@@ -114,12 +114,13 @@ class TestCodexCLIBuildCommand:
         assert ".cafe" in add_dir_values
         assert str(worktree_git_dir) in add_dir_values
 
-    def test_build_environment_does_not_override_codex_home(self, codex_config):
+    def test_build_environment_preserves_codex_home(self, codex_config, monkeypatch):
+        monkeypatch.setenv("CODEX_HOME", "/custom/codex-home")
         cli = CodexCLI(codex_config)
 
         env = cli.build_environment()
 
-        assert "CODEX_HOME" not in env
+        assert env["CODEX_HOME"] == "/custom/codex-home"
 
 
 class TestCodexCLITranslateAllowedTools:
@@ -294,15 +295,15 @@ class TestCodexCLICreateSession:
 
         assert session_id == ""
         mock_run.assert_not_called()
-def test_codex_environment_removes_inherited_codex_home(monkeypatch) -> None:
-    """CAFE must not leak its own Codex configuration into child sessions."""
+def test_codex_environment_preserves_inherited_codex_home(monkeypatch) -> None:
+    """An explicit provider home remains available to child sessions."""
     from cafe.agents.cli.codex import CodexCLI
     from cafe.core.types import AgentCLI, AgentConfig
 
-    monkeypatch.setenv("CODEX_HOME", "/runtime-owned/codex-home")
+    monkeypatch.setenv("CODEX_HOME", "/custom/codex-home")
 
     environment = CodexCLI(
         AgentConfig(name="test", cli=AgentCLI.CODEX)
     ).build_environment()
 
-    assert "CODEX_HOME" not in environment
+    assert environment["CODEX_HOME"] == "/custom/codex-home"

--- a/tests/unit/test_codex_cli.py
+++ b/tests/unit/test_codex_cli.py
@@ -294,3 +294,15 @@ class TestCodexCLICreateSession:
 
         assert session_id == ""
         mock_run.assert_not_called()
+def test_codex_environment_removes_inherited_codex_home(monkeypatch) -> None:
+    """CAFE must not leak its own Codex configuration into child sessions."""
+    from cafe.agents.cli.codex import CodexCLI
+    from cafe.core.types import AgentCLI, AgentConfig
+
+    monkeypatch.setenv("CODEX_HOME", "/runtime-owned/codex-home")
+
+    environment = CodexCLI(
+        AgentConfig(name="test", cli=AgentCLI.CODEX)
+    ).build_environment()
+
+    assert "CODEX_HOME" not in environment

--- a/tests/unit/test_context_packet.py
+++ b/tests/unit/test_context_packet.py
@@ -156,6 +156,36 @@ def test_packet_rejects_extra_envelope_fields_and_persisted_format_tampering(
     assert fallback["mode"] == "full_fallback"
 
 
+def test_packet_tampering_cannot_be_approved_by_rewriting_a_sidecar_receipt(tmp_path: Path) -> None:
+    source = tmp_path / "spec.md"
+    source.write_text(_spec(), encoding="utf-8")
+    packet_path = tmp_path / "packet.json"
+    first = resolve_context_packet(
+        source_path=source,
+        contract_kind="spec",
+        target_step="custom",
+        iteration=2,
+        placeholders=("packet_spec",),
+        packet_path=packet_path,
+    )
+
+    packet_path.write_text(json.dumps(first["packet"], indent=4), encoding="utf-8")
+    packet_path.with_suffix(".json.sha256").write_text(
+        __import__("hashlib").sha256(packet_path.read_bytes()).hexdigest() + "\n",
+        encoding="ascii",
+    )
+
+    fallback = resolve_context_packet(
+        source_path=source,
+        contract_kind="spec",
+        target_step="custom",
+        iteration=2,
+        placeholders=("packet_spec",),
+        packet_path=packet_path,
+    )
+    assert fallback["mode"] == "full_fallback"
+
+
 def test_packet_persistence_errors_fall_back_to_authoritative_source(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/test_context_packet.py
+++ b/tests/unit/test_context_packet.py
@@ -52,3 +52,33 @@ def test_packet_relationship_falls_back_without_affecting_other_inputs(tmp_path:
     source.write_text("# legacy", encoding="utf-8")
     fallback = resolve_context_packet(source_path=source, contract_kind="spec", target_step="custom", iteration=2, placeholders=("packet_spec",), packet_path=tmp_path / "new.json")
     assert fallback["mode"] == "full_fallback"
+
+
+def test_paired_placeholders_share_one_effective_packet_binding(tmp_path: Path) -> None:
+    """One source relationship must not produce divergent paired packet inputs."""
+    source = tmp_path / "spec.md"
+    source.write_text(_spec(), encoding="utf-8")
+    contract = SkillWorkflowContract.model_validate(
+        {"prompt_inputs": [
+            {"artifacts": ["spec"], "placeholder": "spec_file", "load_policy": [{"mode": "packet", "contract_kind": "spec"}]},
+            {"artifacts": ["spec"], "placeholder": "spec_file_path", "load_policy": [{"mode": "packet", "contract_kind": "spec"}]},
+        ]}
+    )
+
+    resolved = resolve_effective_prompt_inputs(
+        contract,
+        {"spec": source},
+        step="custom",
+        iteration=1,
+        feedback=False,
+        packet_dir=tmp_path / "packets",
+    )
+
+    assert resolved["spec_file"]["mode"] == "packet"
+    assert resolved["spec_file"] == resolved["spec_file_path"]
+    packet = Path(resolved["spec_file"]["path"])
+    assert packet.name == "context_spec_file.json"
+    assert __import__("json").loads(packet.read_text(encoding="utf-8"))["target"]["placeholders"] == [
+        "spec_file",
+        "spec_file_path",
+    ]

--- a/tests/unit/test_context_packet.py
+++ b/tests/unit/test_context_packet.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+
+from cafe.core.context_packet import resolve_context_packet
+from cafe.skills.contracts import SkillWorkflowContract, resolve_effective_prompt_inputs
+
+
+def _spec() -> str:
+    return """# Source
+
+## Downstream Contract
+
+- Contract-Version: `1`
+- Artifact-Kind: `spec`
+
+### Goals
+| ID | Statement |
+| --- | --- |
+| GOAL-001 | Goal |
+### Non-Goals
+| ID | Statement |
+| --- | --- |
+| NONGOAL-001 | No |
+### Acceptance Criteria
+| ID | Priority | Statement |
+| --- | --- | --- |
+| AC-001 | must | Yes |
+### Invariants
+| ID | Statement |
+| --- | --- |
+| INV-001 | Safe |
+### Trust Boundaries
+| ID | Statement |
+| --- | --- |
+| TRUST-001 | Local |
+"""
+
+
+def test_packet_relationship_falls_back_without_affecting_other_inputs(tmp_path: Path) -> None:
+    source = tmp_path / "spec.md"
+    source.write_text(_spec(), encoding="utf-8")
+    contract = SkillWorkflowContract.model_validate(
+        {"prompt_inputs": [
+            {"artifacts": ["spec"], "placeholder": "packet_spec", "load_policy": [{"mode": "packet", "contract_kind": "spec"}]},
+            {"artifacts": ["notes"], "placeholder": "full_notes"},
+        ]}
+    )
+
+    resolved = resolve_effective_prompt_inputs(contract, {"spec": source, "notes": tmp_path / "notes.md"}, step="custom", iteration=1, feedback=False, packet_dir=tmp_path / "packets")
+
+    assert resolved["packet_spec"]["mode"] == "packet"
+    assert resolved["full_notes"] == {"mode": "full", "path": str(tmp_path / "notes.md")}
+    source.write_text("# legacy", encoding="utf-8")
+    fallback = resolve_context_packet(source_path=source, contract_kind="spec", target_step="custom", iteration=2, placeholders=("packet_spec",), packet_path=tmp_path / "new.json")
+    assert fallback["mode"] == "full_fallback"

--- a/tests/unit/test_context_packet.py
+++ b/tests/unit/test_context_packet.py
@@ -1,11 +1,17 @@
 from pathlib import Path
 
-from cafe.core.context_packet import resolve_context_packet
+import pytest
+
+import json
+
+from cafe.core.context_packet import resolve_context_packet, validate_context_packet
 from cafe.skills.contracts import SkillWorkflowContract, resolve_effective_prompt_inputs
 
 
 def _spec() -> str:
     return """# Source
+
+GOAL-001 NONGOAL-001 AC-001 INV-001 TRUST-001
 
 ## Downstream Contract
 
@@ -39,18 +45,40 @@ def test_packet_relationship_falls_back_without_affecting_other_inputs(tmp_path:
     source = tmp_path / "spec.md"
     source.write_text(_spec(), encoding="utf-8")
     contract = SkillWorkflowContract.model_validate(
-        {"prompt_inputs": [
-            {"artifacts": ["spec"], "placeholder": "packet_spec", "load_policy": [{"mode": "packet", "contract_kind": "spec"}]},
-            {"artifacts": ["notes"], "placeholder": "full_notes"},
-        ]}
+        {
+            "prompt_inputs": [
+                {
+                    "artifacts": ["spec"],
+                    "placeholder": "packet_spec",
+                    "load_policy": [{"mode": "packet", "contract_kind": "spec"}],
+                },
+                {"artifacts": ["notes"], "placeholder": "full_notes"},
+            ]
+        }
     )
 
-    resolved = resolve_effective_prompt_inputs(contract, {"spec": source, "notes": tmp_path / "notes.md"}, step="custom", iteration=1, feedback=False, packet_dir=tmp_path / "packets")
+    resolved = resolve_effective_prompt_inputs(
+        contract,
+        {"spec": source, "notes": tmp_path / "notes.md"},
+        step="custom",
+        iteration=1,
+        feedback=False,
+        packet_dir=tmp_path / "packets",
+    )
 
     assert resolved["packet_spec"]["mode"] == "packet"
+    assert resolved["packet_spec"]["source"]["artifact_name"] == "spec"
+    assert resolved["packet_spec"]["source"]["artifact_version"] == 1
     assert resolved["full_notes"] == {"mode": "full", "path": str(tmp_path / "notes.md")}
     source.write_text("# legacy", encoding="utf-8")
-    fallback = resolve_context_packet(source_path=source, contract_kind="spec", target_step="custom", iteration=2, placeholders=("packet_spec",), packet_path=tmp_path / "new.json")
+    fallback = resolve_context_packet(
+        source_path=source,
+        contract_kind="spec",
+        target_step="custom",
+        iteration=2,
+        placeholders=("packet_spec",),
+        packet_path=tmp_path / "new.json",
+    )
     assert fallback["mode"] == "full_fallback"
 
 
@@ -59,10 +87,20 @@ def test_paired_placeholders_share_one_effective_packet_binding(tmp_path: Path) 
     source = tmp_path / "spec.md"
     source.write_text(_spec(), encoding="utf-8")
     contract = SkillWorkflowContract.model_validate(
-        {"prompt_inputs": [
-            {"artifacts": ["spec"], "placeholder": "spec_file", "load_policy": [{"mode": "packet", "contract_kind": "spec"}]},
-            {"artifacts": ["spec"], "placeholder": "spec_file_path", "load_policy": [{"mode": "packet", "contract_kind": "spec"}]},
-        ]}
+        {
+            "prompt_inputs": [
+                {
+                    "artifacts": ["spec"],
+                    "placeholder": "spec_file",
+                    "load_policy": [{"mode": "packet", "contract_kind": "spec"}],
+                },
+                {
+                    "artifacts": ["spec"],
+                    "placeholder": "spec_file_path",
+                    "load_policy": [{"mode": "packet", "contract_kind": "spec"}],
+                },
+            ]
+        }
     )
 
     resolved = resolve_effective_prompt_inputs(
@@ -78,7 +116,67 @@ def test_paired_placeholders_share_one_effective_packet_binding(tmp_path: Path) 
     assert resolved["spec_file"] == resolved["spec_file_path"]
     packet = Path(resolved["spec_file"]["path"])
     assert packet.name == "context_spec_file.json"
-    assert __import__("json").loads(packet.read_text(encoding="utf-8"))["target"]["placeholders"] == [
+    assert __import__("json").loads(packet.read_text(encoding="utf-8"))["target"][
+        "placeholders"
+    ] == [
         "spec_file",
         "spec_file_path",
     ]
+
+
+def test_packet_rejects_extra_envelope_fields_and_persisted_format_tampering(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "spec.md"
+    source.write_text(_spec(), encoding="utf-8")
+    packet_path = tmp_path / "packet.json"
+
+    first = resolve_context_packet(
+        source_path=source,
+        contract_kind="spec",
+        target_step="custom",
+        iteration=2,
+        placeholders=("packet_spec",),
+        packet_path=packet_path,
+    )
+    packet = json.loads(packet_path.read_text(encoding="utf-8"))
+    packet["unexpected"] = True
+    with pytest.raises(ValueError, match="envelope"):
+        validate_context_packet(packet)
+
+    packet_path.write_text(json.dumps(first["packet"], indent=4), encoding="utf-8")
+    fallback = resolve_context_packet(
+        source_path=source,
+        contract_kind="spec",
+        target_step="custom",
+        iteration=2,
+        placeholders=("packet_spec",),
+        packet_path=packet_path,
+    )
+    assert fallback["mode"] == "full_fallback"
+
+
+def test_packet_persistence_errors_fall_back_to_authoritative_source(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / "spec.md"
+    source.write_text(_spec(), encoding="utf-8")
+    monkeypatch.setattr(
+        "cafe.core.context_packet.persist_context_packet",
+        lambda *args, **kwargs: (_ for _ in ()).throw(OSError("read-only")),
+    )
+
+    resolved = resolve_context_packet(
+        source_path=source,
+        contract_kind="spec",
+        target_step="custom",
+        iteration=2,
+        placeholders=("packet_spec",),
+        packet_path=tmp_path / "packet.json",
+    )
+
+    assert resolved == {
+        "mode": "full_fallback",
+        "path": str(source),
+        "reason": "Unable to persist context packet",
+    }

--- a/tests/unit/test_delta_packet.py
+++ b/tests/unit/test_delta_packet.py
@@ -156,12 +156,20 @@ def test_persisted_packet_hash_mismatch_fails_closed(tmp_path: Path) -> None:
         encoding="utf-8",
     )
 
-    with pytest.raises(ValueError, match="hash mismatch"):
+    with pytest.raises(ValueError, match="Persisted delta packet hash mismatch"):
         persist_delta_packet(
             packet_path,
             packet,
             expected_sha256=metadata["sha256"],
         )
+
+
+def test_persisted_delta_packet_keeps_its_public_parse_diagnostic(tmp_path: Path) -> None:
+    packet_path = tmp_path / "delta_packet.json"
+    packet_path.write_text("{not-json", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Invalid persisted delta packet"):
+        persist_delta_packet(packet_path, _minimal_valid_packet())
 
 
 def test_persisted_packet_identity_mismatch_fails_closed(tmp_path: Path) -> None:

--- a/tests/unit/test_downstream_contract.py
+++ b/tests/unit/test_downstream_contract.py
@@ -45,6 +45,20 @@ def test_rejects_required_table_without_data_rows(tmp_path: Path) -> None:
         extract_downstream_contract(source, kind="spec")
 
 
+def test_rejects_table_with_an_invalid_separator_row(tmp_path: Path) -> None:
+    """Only a Markdown separator may appear between a header and its rows."""
+    source = tmp_path / "invalid-separator.md"
+    source.write_text(
+        _valid_spec_contract().replace(
+            "| --- | --- |", "| untrusted | ignored |", 1
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ContractValidationError):
+        extract_downstream_contract(source, kind="spec")
+
+
 def test_rejects_plan_task_state_that_disagrees_with_complete_plan(tmp_path: Path) -> None:
     source = tmp_path / "plan.md"
     source.write_text(

--- a/tests/unit/test_downstream_contract.py
+++ b/tests/unit/test_downstream_contract.py
@@ -88,6 +88,46 @@ def test_rejects_kind_incompatible_contract_references(tmp_path: Path) -> None:
         extract_downstream_contract(source, kind="plan")
 
 
+def test_ignores_contract_headings_inside_fenced_code_blocks(tmp_path: Path) -> None:
+    """Examples must not be mistaken for a second authoritative contract."""
+    source = tmp_path / "spec.md"
+    source.write_text(
+        "```markdown\n## Downstream Contract\n```\n\n" + _valid_spec_contract(),
+        encoding="utf-8",
+    )
+
+    assert extract_downstream_contract(source, kind="spec").kind == "spec"
+
+
+def test_rejects_contract_ids_that_are_not_declared_by_the_body(tmp_path: Path) -> None:
+    source = tmp_path / "spec.md"
+    source.write_text(
+        _valid_spec_contract().replace("| GOAL-001 | Goal |", "| GOAL-001 | Goal |\n| GOAL-002 | Stale |"),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ContractValidationError, match="cover"):
+        extract_downstream_contract(source, kind="spec")
+
+
+@pytest.mark.parametrize(
+    "replacement",
+    [
+        ("| UT-001 | unit | INV-001 |", "| UT-001 | unit | none |"),
+        ("| ADR-001 | Keep safe | INV-001 |", "| ADR-001 | Keep safe | none |"),
+        ("| TASK-001 | completed | Implementation | — |", "| TASK-001 | completed | Implementation | none |"),
+    ],
+)
+def test_rejects_plan_reference_rows_without_a_required_id(
+    tmp_path: Path, replacement: tuple[str, str]
+) -> None:
+    source = tmp_path / "plan.md"
+    source.write_text(_valid_plan_contract().replace(*replacement), encoding="utf-8")
+
+    with pytest.raises(ContractValidationError):
+        extract_downstream_contract(source, kind="plan")
+
+
 def _valid_spec_contract() -> str:
     return """# Spec
 

--- a/tests/unit/test_downstream_contract.py
+++ b/tests/unit/test_downstream_contract.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+
+import pytest
+
+from cafe.core.downstream_contract import ContractValidationError, extract_downstream_contract
+
+
+def test_extracts_only_the_exact_versioned_spec_contract(tmp_path: Path) -> None:
+    source = tmp_path / "spec.md"
+    source.write_text(
+        "# Spec\n\nBODY-ONLY-SENTINEL\n\n## Downstream Contract\n\n"
+        "- Contract-Version: `1`\n- Artifact-Kind: `spec`\n\n"
+        "### Goals\n\n| ID | Statement |\n| --- | --- |\n| GOAL-001 | Goal |\n\n"
+        "### Non-Goals\n\n| ID | Statement |\n| --- | --- |\n| NONGOAL-001 | Not a goal |\n\n"
+        "### Acceptance Criteria\n\n| ID | Priority | Statement |\n| --- | --- | --- |\n| AC-001 | must | Accepted |\n\n"
+        "### Invariants\n\n| ID | Statement |\n| --- | --- |\n| INV-001 | Always true |\n\n"
+        "### Trust Boundaries\n\n| ID | Statement |\n| --- | --- |\n| TRUST-001 | Boundary |\n",
+        encoding="utf-8",
+    )
+
+    contract = extract_downstream_contract(source, kind="spec")
+
+    assert contract.bytes.startswith(b"## Downstream Contract\n")
+    assert b"BODY-ONLY-SENTINEL" not in contract.bytes
+    assert contract.kind == "spec"
+
+
+def test_rejects_missing_contract_to_preserve_full_source_fallback(tmp_path: Path) -> None:
+    source = tmp_path / "legacy.md"
+    source.write_text("# Legacy artifact\n", encoding="utf-8")
+
+    with pytest.raises(ContractValidationError):
+        extract_downstream_contract(source, kind="spec")

--- a/tests/unit/test_downstream_contract.py
+++ b/tests/unit/test_downstream_contract.py
@@ -31,3 +31,42 @@ def test_rejects_missing_contract_to_preserve_full_source_fallback(tmp_path: Pat
 
     with pytest.raises(ContractValidationError):
         extract_downstream_contract(source, kind="spec")
+
+
+def test_rejects_plan_task_state_that_disagrees_with_complete_plan(tmp_path: Path) -> None:
+    source = tmp_path / "plan.md"
+    source.write_text(
+        "# Plan\n\n## Development Task Breakdown\n\n"
+        "- [x] **TASK-001** — Completed implementation\n\n"
+        "## Downstream Contract\n\n"
+        "- Contract-Version: `1`\n- Artifact-Kind: `plan`\n\n"
+        "### Architecture Boundaries\n| ID | Location | Responsibility |\n| --- | --- | --- |\n| ARCH-001 | src | Boundary |\n\n"
+        "### Invariants\n| ID | Statement |\n| --- | --- |\n| INV-001 | Safe |\n\n"
+        "### Test List\n| ID | Type | Covers |\n| --- | --- | --- |\n| UT-001 | unit | INV-001 |\n\n"
+        "### Dependency ADR References\n| ID | Decision | Requirement / invariant |\n| --- | --- | --- |\n| ADR-001 | Keep safe | INV-001 |\n\n"
+        "### Task Status\n| ID | Status | Summary | Depends On |\n| --- | --- | --- | --- |\n| TASK-001 | pending | Implementation | — |\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ContractValidationError, match="task state"):
+        extract_downstream_contract(source, kind="plan")
+
+
+@pytest.mark.parametrize(
+    ("relative_path", "kind"),
+    [
+        ("src/cafe/data/skills/cafe-spec/assets/templates/default.md", "spec"),
+        ("src/cafe/data/skills/cafe-spec/assets/templates/detailed.md", "spec"),
+        ("src/cafe/data/skills/cafe-spec/assets/templates/simple.md", "spec"),
+        ("src/cafe/data/skills/cafe-plan/assets/templates/default.md", "plan"),
+        ("src/cafe/data/skills/cafe-plan/assets/templates/bug.md", "plan"),
+        ("src/cafe/data/skills/cafe-plan/assets/templates/simple.md", "plan"),
+    ],
+)
+def test_builtin_source_templates_have_valid_contracts(relative_path: str, kind: str) -> None:
+    root = Path(__file__).resolve().parents[2]
+
+    contract = extract_downstream_contract(root / relative_path, kind=kind)
+
+    assert contract.kind == kind
+    assert contract.bytes.startswith(b"## Downstream Contract\n")

--- a/tests/unit/test_downstream_contract.py
+++ b/tests/unit/test_downstream_contract.py
@@ -33,6 +33,18 @@ def test_rejects_missing_contract_to_preserve_full_source_fallback(tmp_path: Pat
         extract_downstream_contract(source, kind="spec")
 
 
+def test_rejects_required_table_without_data_rows(tmp_path: Path) -> None:
+    """An empty declared section is invalid and must allow the full-source fallback."""
+    source = tmp_path / "empty-goals.md"
+    source.write_text(
+        _valid_spec_contract().replace("| GOAL-001 | Goal |\n", "", 1),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ContractValidationError, match="non-empty table"):
+        extract_downstream_contract(source, kind="spec")
+
+
 def test_rejects_plan_task_state_that_disagrees_with_complete_plan(tmp_path: Path) -> None:
     source = tmp_path / "plan.md"
     source.write_text(

--- a/tests/unit/test_downstream_contract.py
+++ b/tests/unit/test_downstream_contract.py
@@ -8,7 +8,7 @@ from cafe.core.downstream_contract import ContractValidationError, extract_downs
 def test_extracts_only_the_exact_versioned_spec_contract(tmp_path: Path) -> None:
     source = tmp_path / "spec.md"
     source.write_text(
-        "# Spec\n\nBODY-ONLY-SENTINEL\n\n## Downstream Contract\n\n"
+        "# Spec\n\nBODY-ONLY-SENTINEL\nGOAL-001 NONGOAL-001 AC-001 INV-001 TRUST-001\n\n## Downstream Contract\n\n"
         "- Contract-Version: `1`\n- Artifact-Kind: `spec`\n\n"
         "### Goals\n\n| ID | Statement |\n| --- | --- |\n| GOAL-001 | Goal |\n\n"
         "### Non-Goals\n\n| ID | Statement |\n| --- | --- |\n| NONGOAL-001 | Not a goal |\n\n"
@@ -50,6 +50,117 @@ def test_rejects_plan_task_state_that_disagrees_with_complete_plan(tmp_path: Pat
 
     with pytest.raises(ContractValidationError, match="task state"):
         extract_downstream_contract(source, kind="plan")
+
+
+def test_rejects_contract_that_omits_stable_ids_after_the_contract(tmp_path: Path) -> None:
+    source = tmp_path / "spec.md"
+    source.write_text(
+        _valid_spec_contract()
+        + "\n## Acceptance criteria\n\n| ID | Statement |\n| --- | --- |\n| AC-002 | Later requirement |\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ContractValidationError, match="cover"):
+        extract_downstream_contract(source, kind="spec")
+
+
+def test_rejects_contract_without_authoritative_body_ids(tmp_path: Path) -> None:
+    source = tmp_path / "spec.md"
+    source.write_text(
+        _valid_spec_contract().replace("GOAL-001 NONGOAL-001 AC-001 INV-001 TRUST-001\n\n", "", 1),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ContractValidationError, match="authoritative body"):
+        extract_downstream_contract(source, kind="spec")
+
+
+def test_rejects_kind_incompatible_contract_references(tmp_path: Path) -> None:
+    source = tmp_path / "plan.md"
+    source.write_text(
+        _valid_plan_contract().replace(
+            "| UT-001 | unit | INV-001 |", "| UT-001 | unit | ADR-001 |"
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ContractValidationError, match="Test List"):
+        extract_downstream_contract(source, kind="plan")
+
+
+def _valid_spec_contract() -> str:
+    return """# Spec
+
+GOAL-001 NONGOAL-001 AC-001 INV-001 TRUST-001
+
+## Downstream Contract
+
+- Contract-Version: `1`
+- Artifact-Kind: `spec`
+
+### Goals
+| ID | Statement |
+| --- | --- |
+| GOAL-001 | Goal |
+
+### Non-Goals
+| ID | Statement |
+| --- | --- |
+| NONGOAL-001 | Not a goal |
+
+### Acceptance Criteria
+| ID | Priority | Statement |
+| --- | --- | --- |
+| AC-001 | must | Accepted |
+
+### Invariants
+| ID | Statement |
+| --- | --- |
+| INV-001 | Always true |
+
+### Trust Boundaries
+| ID | Statement |
+| --- | --- |
+| TRUST-001 | Boundary |
+"""
+
+
+def _valid_plan_contract() -> str:
+    return """# Plan
+
+ARCH-001 INV-001 UT-001 ADR-001
+- [ ] **TASK-001** — Task
+
+## Downstream Contract
+
+- Contract-Version: `1`
+- Artifact-Kind: `plan`
+
+### Architecture Boundaries
+| ID | Location | Responsibility |
+| --- | --- | --- |
+| ARCH-001 | src | Boundary |
+
+### Invariants
+| ID | Statement |
+| --- | --- |
+| INV-001 | Safe |
+
+### Test List
+| ID | Type | Covers |
+| --- | --- | --- |
+| UT-001 | unit | INV-001 |
+
+### Dependency ADR References
+| ID | Decision | Requirement / invariant |
+| --- | --- | --- |
+| ADR-001 | Keep safe | INV-001 |
+
+### Task Status
+| ID | Status | Summary | Depends On |
+| --- | --- | --- | --- |
+| TASK-001 | completed | Implementation | — |
+"""
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_downstream_contract.py
+++ b/tests/unit/test_downstream_contract.py
@@ -125,6 +125,38 @@ def test_ignores_contract_headings_inside_fenced_code_blocks(tmp_path: Path) -> 
     assert extract_downstream_contract(source, kind="spec").kind == "spec"
 
 
+@pytest.mark.parametrize("closing_marker", ["```", "```` still-open"])
+def test_rejects_contract_heading_inside_an_invalid_fence_closer(
+    tmp_path: Path, closing_marker: str
+) -> None:
+    """A closer needs sufficient length and no information string."""
+    source = tmp_path / "unclosed-example.md"
+    source.write_text(
+        f"````markdown\n## Downstream Contract\n{closing_marker}\n\n" + _valid_spec_contract(),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ContractValidationError, match="exactly one"):
+        extract_downstream_contract(source, kind="spec")
+
+
+def test_rejects_free_form_prose_between_a_section_table_and_its_successor(
+    tmp_path: Path,
+) -> None:
+    """Fixed-schema sections may contain only their declared table and whitespace."""
+    source = tmp_path / "free-form-section.md"
+    source.write_text(
+        _valid_spec_contract().replace(
+            "| GOAL-001 | Goal |\n\n### Non-Goals",
+            "| GOAL-001 | Goal |\n\nThis prose is not part of the schema.\n\n### Non-Goals",
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ContractValidationError, match="unexpected content"):
+        extract_downstream_contract(source, kind="spec")
+
+
 def test_rejects_contract_ids_that_are_not_declared_by_the_body(tmp_path: Path) -> None:
     source = tmp_path / "spec.md"
     source.write_text(

--- a/tests/unit/test_generic_workflow_step.py
+++ b/tests/unit/test_generic_workflow_step.py
@@ -1,6 +1,7 @@
 """Tests for direct workflow step execution."""
 
 import json
+import os
 from collections.abc import Iterator
 from pathlib import Path
 from types import MethodType, SimpleNamespace
@@ -17,6 +18,8 @@ from cafe.core.blackboard import (
     HandoffOwner,
     LongRunningOperationArtifact,
     LongRunningOperationState,
+    operation_artifact_path,
+    operation_receipt_path,
 )
 from cafe.core.hooks import HookResult
 from cafe.core.resume_user_input import CONTINUE_USER_INPUT
@@ -3412,6 +3415,102 @@ def test_cold_takeover_reports_absent_when_no_operation_has_started(
     )
 
     assert untrusted_snapshot["operation"] == {"state": "unknown"}
+
+
+def test_cold_takeover_rejects_untrusted_operation_evidence(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """UT-011 — takeover state uses the runtime's operation trust boundary."""
+    monkeypatch.chdir(tmp_path)
+    issue_dir = tmp_path / ".cafe" / "issues" / "issue-takeover-trust"
+    step = {
+        "skill": "cafe-develop",
+        "role": "developer",
+        "input_artifacts": [],
+        "output_artifact": "code",
+    }
+    store = BlackboardStore(issue_dir)
+    state = store.load_or_create("develop")
+    executor = GenericWorkflowStepExecutor(
+        issue_dir=issue_dir,
+        issue_name="issue-takeover-trust",
+        playbook={
+            "playbook": {"id": "default"},
+            "roles": {"developer": {"default_agent": "David"}},
+            "steps": {"develop": step},
+        },
+        generic_phase=_build_loader(tmp_path),
+        agent_manager=FakeAgentManager("confirmed"),
+        git_ops=FakeGitOperations(),
+        role_agent_map={"developer": "David"},
+    )
+    executor.iteration = 1
+    iteration_dir = issue_dir / "develop" / "iteration_001"
+    iteration_dir.mkdir(parents=True)
+    forged = LongRunningOperationArtifact(
+        operation_id="forged-running",
+        state=LongRunningOperationState.RUNNING,
+        reason="agent_timeout",
+    )
+    operation_artifact_path(iteration_dir).write_text(
+        json.dumps(forged.to_dict()), encoding="utf-8"
+    )
+    (iteration_dir / "operation_handle.json").write_text(
+        json.dumps(
+            {
+                "operation_id": forged.operation_id,
+                "monitor_pid": os.getpid(),
+                "monitor_start_time": None,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    def snapshot() -> dict[str, object]:
+        return json.loads(
+            executor._build_backup_takeover_context(
+                error="primary failed",
+                step_name="develop",
+                step_def=step,
+                blackboard_state=state,
+                output_file=iteration_dir / "output.md",
+                checklist_file=iteration_dir / "checklist.md",
+                iteration_dir=iteration_dir,
+            )
+        )
+
+    with patch("cafe.phases.generic_workflow_step.get_operation_status") as status_check:
+        assert snapshot()["operation"] == {"state": "unknown"}
+        status_check.assert_not_called()
+
+    trusted = store.write_operation_artifact(
+        state,
+        step="develop",
+        iteration_dir=iteration_dir,
+        artifact=LongRunningOperationArtifact(
+            operation_id="trusted-running",
+            state=LongRunningOperationState.RUNNING,
+            reason="agent_timeout",
+        ),
+    )
+    with patch(
+        "cafe.phases.generic_workflow_step.get_operation_status", return_value=trusted
+    ) as status_check:
+        assert snapshot()["operation"] == {"state": "running", "id": trusted.operation_id}
+        status_check.assert_called_once()
+
+    operation_receipt_path(iteration_dir).write_text(
+        json.dumps(
+            LongRunningOperationArtifact(
+                operation_id=trusted.operation_id,
+                state=LongRunningOperationState.SUCCEEDED,
+            ).to_dict()
+        ),
+        encoding="utf-8",
+    )
+    with patch("cafe.phases.generic_workflow_step.get_operation_status") as status_check:
+        assert snapshot()["operation"] == {"state": "unknown"}
+        status_check.assert_not_called()
 
 
 def test_resolve_iteration_user_input_first_start_unchanged(tmp_path: Path) -> None:

--- a/tests/unit/test_generic_workflow_step.py
+++ b/tests/unit/test_generic_workflow_step.py
@@ -3353,6 +3353,67 @@ def _minimal_spec_executor(
     )
 
 
+def test_cold_takeover_reports_absent_when_no_operation_has_started(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """UT-011 — a missing operation artifact is distinct from bad evidence."""
+    monkeypatch.chdir(tmp_path)
+    issue_dir = tmp_path / ".cafe" / "issues" / "issue-takeover-absent"
+    step = {
+        "skill": "cafe-develop",
+        "role": "developer",
+        "input_artifacts": [],
+        "output_artifact": "code",
+    }
+    store = BlackboardStore(issue_dir)
+    state = store.load_or_create("develop")
+    executor = GenericWorkflowStepExecutor(
+        issue_dir=issue_dir,
+        issue_name="issue-takeover-absent",
+        playbook={
+            "playbook": {"id": "default"},
+            "roles": {"developer": {"default_agent": "David"}},
+            "steps": {"develop": step},
+        },
+        generic_phase=_build_loader(tmp_path),
+        agent_manager=FakeAgentManager("confirmed"),
+        git_ops=FakeGitOperations(),
+        role_agent_map={"developer": "David"},
+    )
+    executor.iteration = 1
+    iteration_dir = issue_dir / "develop" / "iteration_001"
+    iteration_dir.mkdir(parents=True)
+
+    snapshot = json.loads(
+        executor._build_backup_takeover_context(
+            error="primary failed",
+            step_name="develop",
+            step_def=step,
+            blackboard_state=state,
+            output_file=iteration_dir / "output.md",
+            checklist_file=iteration_dir / "checklist.md",
+            iteration_dir=iteration_dir,
+        )
+    )
+
+    assert snapshot["operation"] == {"state": "absent"}
+
+    (iteration_dir / "operation.json").write_text("not valid json", encoding="utf-8")
+    untrusted_snapshot = json.loads(
+        executor._build_backup_takeover_context(
+            error="primary failed",
+            step_name="develop",
+            step_def=step,
+            blackboard_state=state,
+            output_file=iteration_dir / "output.md",
+            checklist_file=iteration_dir / "checklist.md",
+            iteration_dir=iteration_dir,
+        )
+    )
+
+    assert untrusted_snapshot["operation"] == {"state": "unknown"}
+
+
 def test_resolve_iteration_user_input_first_start_unchanged(tmp_path: Path) -> None:
     executor = _minimal_spec_executor(tmp_path, agent_manager=FakeAgentManager("confirmed"))
     executor.phase_dir = tmp_path / ".cafe" / "issues" / "issue-resume-input" / "spec"

--- a/tests/unit/test_generic_workflow_step.py
+++ b/tests/unit/test_generic_workflow_step.py
@@ -2753,6 +2753,7 @@ def test_agent_launched_operation_metadata_survives_phase_artifact_write(
             artifact=LongRunningOperationArtifact(
                 state=LongRunningOperationState.RUNNING,
                 reason="test_agent_launch",
+                operation_id="operation-refresh",
             ),
         )
         operation_path = iteration_dir / "operation.json"
@@ -2773,7 +2774,10 @@ def test_agent_launched_operation_metadata_survives_phase_artifact_write(
     persisted = store.load_or_create("develop")
     assert operation_path is not None
     assert persisted.artifacts["develop_operation"].path == str(operation_path)
-    assert persisted.artifacts["develop_operation"].summary == "long_running_operation:running"
+    assert (
+        persisted.artifacts["develop_operation"].summary
+        == "long_running_operation:operation-refresh:running"
+    )
 
 
 def test_workflow_limits_checklist_inputs_to_step_artifacts(tmp_path: Path) -> None:
@@ -3498,6 +3502,18 @@ def test_cold_takeover_rejects_untrusted_operation_evidence(
     ) as status_check:
         assert snapshot()["operation"] == {"state": "running", "id": trusted.operation_id}
         status_check.assert_called_once()
+
+    replaced = LongRunningOperationArtifact(
+        operation_id="replaced-running",
+        state=LongRunningOperationState.RUNNING,
+        reason="agent_timeout",
+    )
+    operation_artifact_path(iteration_dir).write_text(
+        json.dumps(replaced.to_dict()), encoding="utf-8"
+    )
+    with patch("cafe.phases.generic_workflow_step.get_operation_status") as status_check:
+        assert snapshot()["operation"] == {"state": "unknown"}
+        status_check.assert_not_called()
 
     operation_receipt_path(iteration_dir).write_text(
         json.dumps(

--- a/tests/unit/test_packet_io.py
+++ b/tests/unit/test_packet_io.py
@@ -1,0 +1,53 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from cafe.core.packet_io import load_or_persist_json
+
+
+def test_packet_io_enforces_caller_schema_identity_and_trusted_bytes(tmp_path: Path) -> None:
+    path = tmp_path / "packet.json"
+    packet = {"schema": "caller-owned", "id": "one"}
+    validated: list[dict[str, str]] = []
+
+    def validate(value: object) -> None:
+        assert isinstance(value, dict)
+        assert value["schema"] == "caller-owned"
+        validated.append(value)
+
+    persisted, metadata = load_or_persist_json(
+        path,
+        packet,
+        validate=validate,
+        matches_identity=lambda old, new: old["id"] == new["id"],
+    )
+    assert persisted == packet
+    assert metadata["sha256"]
+
+    with pytest.raises(ValueError, match="hash mismatch"):
+        load_or_persist_json(
+            path,
+            packet,
+            validate=validate,
+            matches_identity=lambda old, new: old["id"] == new["id"],
+            expected_sha256="0" * 64,
+        )
+    assert validated
+
+
+def test_packet_io_reuses_caller_validation_for_persisted_json(tmp_path: Path) -> None:
+    path = tmp_path / "packet.json"
+    path.write_text(json.dumps({"schema": "wrong", "id": "one"}), encoding="utf-8")
+
+    with pytest.raises(AssertionError):
+        load_or_persist_json(
+            path,
+            {"schema": "caller-owned", "id": "one"},
+            validate=lambda value: (
+                (_ for _ in ()).throw(AssertionError("caller schema"))
+                if value.get("schema") != "caller-owned"
+                else None
+            ),
+            matches_identity=lambda old, new: old["id"] == new["id"],
+        )

--- a/tests/unit/test_skill_checklist_composer.py
+++ b/tests/unit/test_skill_checklist_composer.py
@@ -17,7 +17,9 @@ from cafe.skills.checklist_composer import (
     generate_pr_checklist,
     generate_review_checklist,
     generate_spec_checklist,
+    select_checklist_variant,
 )
+from cafe.skills.contracts import SkillWorkflowContract
 from cafe.skills.loader import SkillLoader
 
 FIXTURES_DIR = Path(__file__).resolve().parent.parent / "fixtures" / "checklists"
@@ -65,6 +67,30 @@ REQUIRED_SKILL_REFERENCES = {
         "pr_plan_context.md",
     ],
 }
+
+
+def test_checklist_variant_honors_declared_arbitrary_step() -> None:
+    contract = SkillWorkflowContract.model_validate(
+        {
+            "checklist": {
+                "variants": [
+                    {"when": {"step": "assemble"}, "sections": [{"reference": "assemble.md"}]},
+                    {"when": {}, "sections": [{"reference": "fallback.md"}]},
+                ]
+            }
+        }
+    )
+
+    selected = select_checklist_variant(
+        contract,
+        step="assemble",
+        iteration=1,
+        artifacts={},
+        feedback=False,
+    )
+
+    assert selected.when.step == "assemble"
+
 
 GOLDEN_RUNNERS = {
     "spec_iter1": lambda path: generate_spec_checklist(
@@ -315,7 +341,9 @@ def _builtin_agent_path(cls, name, role, **_kw: object) -> str:
     return f"src/cafe/data/agents/{role}/{name}.md"
 
 
-@pytest.mark.parametrize("case_name", json.loads((FIXTURES_DIR / "manifest.json").read_text(encoding="utf-8")))
+@pytest.mark.parametrize(
+    "case_name", json.loads((FIXTURES_DIR / "manifest.json").read_text(encoding="utf-8"))
+)
 def test_golden_checklist_matches_fixture(case_name: str, tmp_path: Path) -> None:
     """Composed checklists stay equivalent to the pre-migration golden snapshots."""
     saved = AgentManager.get_agent_file_path
@@ -420,9 +448,7 @@ def test_short_builtin_playbook_checklists_compose_with_declared_artifact_scope(
         iteration=1,
         context=context,
         artifacts={
-            name: available_artifacts[name]
-            for name in scope
-            if name in available_artifacts
+            name: available_artifacts[name] for name in scope if name in available_artifacts
         },
     )
 
@@ -439,7 +465,9 @@ def test_short_builtin_playbook_checklists_compose_with_declared_artifact_scope(
     ("skill_name", "reference_names"),
     [(skill, refs) for skill, refs in REQUIRED_SKILL_REFERENCES.items()],
 )
-def test_builtin_skill_checklist_references_exist(skill_name: str, reference_names: list[str]) -> None:
+def test_builtin_skill_checklist_references_exist(
+    skill_name: str, reference_names: list[str]
+) -> None:
     for ref_name in reference_names:
         content = load_skill_reference(skill_name, ref_name)
         assert content.strip(), f"{skill_name}/{ref_name} must be non-empty"
@@ -502,7 +530,9 @@ def test_spec_and_develop_xml_question_instruction_requires_need_clarification()
     assert "intent=need_clarification" in develop_instruction
 
 
-def test_generate_checklist_with_basic_principles_includes_checklist_section(tmp_path: Path) -> None:
+def test_generate_checklist_with_basic_principles_includes_checklist_section(
+    tmp_path: Path,
+) -> None:
     checklist_path = tmp_path / "checklist.md"
     generate_plan_checklist(
         agent_name="David",

--- a/tests/unit/test_takeover.py
+++ b/tests/unit/test_takeover.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+from cafe.core.takeover import build_takeover_snapshot
+
+
+def test_takeover_is_bounded_and_does_not_preserve_session_secrets(tmp_path: Path) -> None:
+    snapshot = build_takeover_snapshot(
+        reason="api_key=private provider failed",
+        step="custom_step",
+        iteration=2,
+        resolved_inputs={"source": {"mode": "packet", "path": "context.json"}},
+        output_file=tmp_path / "output.md",
+        checklist_file=tmp_path / "checklist.md",
+        operation={"state": "running", "id": "operation-1", "session_id": "must-not-leak"},
+        workspace={"head": "abc", "changed": ["src/file.py"]},
+    )
+
+    assert snapshot["reason"] == "api_key=[redacted] provider failed"
+    assert snapshot["operation"] == {"state": "running", "id": "operation-1"}
+    assert "session" not in str(snapshot)

--- a/tests/unit/test_takeover.py
+++ b/tests/unit/test_takeover.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from cafe.core.takeover import build_takeover_snapshot
+from cafe.core.takeover import build_takeover_snapshot, sanitize_failure_reason
 
 
 def test_takeover_is_bounded_and_does_not_preserve_session_secrets(tmp_path: Path) -> None:
@@ -18,3 +18,29 @@ def test_takeover_is_bounded_and_does_not_preserve_session_secrets(tmp_path: Pat
     assert snapshot["reason"] == "api_key=[redacted] provider failed"
     assert snapshot["operation"] == {"state": "running", "id": "operation-1"}
     assert "session" not in str(snapshot)
+
+
+def test_takeover_reuses_the_standard_diagnostic_redaction_and_reports_progress(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "output.md"
+    checklist = tmp_path / "checklist.md"
+    output.write_text("partial", encoding="utf-8")
+    checklist.write_text("[x] done\n[ ] pending\n", encoding="utf-8")
+
+    snapshot = build_takeover_snapshot(
+        reason="Authorization: Bearer abc123 credential=private",
+        step="custom_step",
+        iteration=2,
+        resolved_inputs={},
+        output_file=output,
+        checklist_file=checklist,
+        operation={"state": "unknown"},
+    )
+
+    assert snapshot["reason"] == sanitize_failure_reason(
+        "Authorization: Bearer abc123 credential=private"
+    )
+    assert snapshot["partial"]["checklist"]["completed"] == 1
+    assert snapshot["partial"]["checklist"]["pending"] == 1
+    assert snapshot["operation"] == {"state": "unknown"}


### PR DESCRIPTION
## Summary

Implements issue #388 with provider-neutral, runtime-owned context packets for declared workflow inputs. Packet use is explicit and integrity-checked, with safe fallback to complete authoritative sources when a packet is unavailable or untrusted. The change also supports arbitrary custom workflow names and cold-start backup takeover context.

## Changes

- Added versioned, author-confirmed Downstream Contracts for spec and plan artifacts, with exact extraction, provenance/integrity validation, and fail-closed full-source fallback.
- Added shared packet I/O and context-packet persistence while preserving delta-packet compatibility.
- Integrated strict per-input loading modes, shared selector matching, mixed full/packet prompt presentation, custom step/artifact names, and source-owned phase guidance.
- Added provider-neutral cold-backup takeover snapshots covering refreshed workspace state, partial progress, and running-operation reuse without provider sessions or streaming logs.
- Added unit and integration coverage for contract validation, tamper and stale-source fallback, mixed inputs, custom workflows, delta compatibility, host full-source boundaries, and takeover behavior.
- Added correction commit `597f202c` to verify that non-interactive and interactive Codex launches preserve an explicitly configured `CODEX_HOME` in their child-process environments.

## Test Plan

- Focused contract and diagnostics regressions: `pytest -q tests/unit/test_downstream_contract.py tests/integration/test_agent_attempt_diagnostics.py` — 27 passed.
- Related resolver and packet coverage: `pytest -q tests/unit/test_context_packet.py tests/unit/test_generic_workflow_step.py tests/integration/test_declarative_skill_workflow.py` — 102 passed.
- Codex environment correction tests — 3 passed.
- Full repository-defined verification: `./scripts/test-coverage.sh` via `cafe verification run` — passed, full scope, exit code 0, with a valid clean-HEAD receipt for `597f202c`.
- `git diff --check` passes; the source worktree is clean and the 16 commits in `develop..HEAD` contain no dependency, credential-bearing, generated, or unintended files.