### PR TITLE
Make workflow behavior declarative and step-name independent

### DIFF
--- a/src/cafe/agents/manager.py
+++ b/src/cafe/agents/manager.py
@@ -33,9 +33,8 @@ class AgentManager:
     CAFE_DIR = ".cafe"
     AGENTS_DIR = "agents"
     FALLBACKABLE_ERROR_TYPES = ("rate_limit", "cli_not_found", "cli_unavailable", "model_not_found")
-    DEVELOP_READ_ONLY_COMMAND_LIMIT = 20
-    DEVELOP_READ_ONLY_RETRY_LIMIT = 3
-    DEVELOP_READ_ONLY_RETRY_PROMPT = (
+    READ_ONLY_RETRY_LIMIT = 3
+    READ_ONLY_RETRY_PROMPT = (
         "The runtime stopped your previous attempt because it exhausted the read-only "
         "progress budget without making the next file edit. Do not restart discovery or reread "
         "the spec, plan, skills, or unchanged source files. Your FIRST tool action must be "
@@ -418,6 +417,7 @@ class AgentManager:
         phase_name: Optional[str] = None,
         continuation: Optional[SessionContinuation] = None,
         backup_context_callback: Optional[Callable[[AgentExecutionError], str]] = None,
+        max_read_only_commands: Optional[int] = None,
     ) -> Tuple[str, TokenUsage, List, Optional[List[str]], List[str], Optional[str]]:
         """Execute prompt with specified agent.
 
@@ -428,6 +428,7 @@ class AgentManager:
             allowed_directories: List of allowed directories
             streaming_output_file: Optional file path to write streaming output line-by-line
             phase_name: Current phase name for phase-specific model lookup in backup agents
+            max_read_only_commands: Declared read-only progress guard limit, if enabled
 
         Returns:
             Tuple of (agent's response, token usage, permission denials, cli_command_args, streaming_log, model)
@@ -473,9 +474,7 @@ class AgentManager:
         transient_retry_done = False
         primary_attempt = 1
         attempt_prompt = prompt
-        read_only_command_limit = (
-            self.DEVELOP_READ_ONLY_COMMAND_LIMIT if phase_name == "develop" else None
-        )
+        read_only_command_limit = max_read_only_commands
         initial_read_only_command_limit = None
 
         while True:
@@ -508,10 +507,10 @@ class AgentManager:
                     and not read_only_budget_retried
                 ):
                     read_only_budget_retried = True
-                    attempt_prompt = self.DEVELOP_READ_ONLY_RETRY_PROMPT
-                    initial_read_only_command_limit = self.DEVELOP_READ_ONLY_RETRY_LIMIT
+                    attempt_prompt = self.READ_ONLY_RETRY_PROMPT
+                    initial_read_only_command_limit = self.READ_ONLY_RETRY_LIMIT
                     print(
-                        "⚠️  Resuming the develop session once with an immediate-edit instruction..."
+                        "⚠️  Resuming the session once with an immediate-edit instruction..."
                     )
                     primary_attempt += 1
                 elif (
@@ -542,6 +541,7 @@ class AgentManager:
                         streaming_output_file=streaming_output_file,
                         phase_name=phase_name,
                         continuation=continuation,
+                        max_read_only_commands=read_only_command_limit,
                         backup_context_callback=backup_context_callback,
                     )
                     break  # Backup succeeded, exit loop
@@ -650,6 +650,7 @@ class AgentManager:
         streaming_output_file: Optional[str] = None,
         phase_name: Optional[str] = None,
         continuation: Optional[SessionContinuation] = None,
+        max_read_only_commands: Optional[int] = None,
         backup_context_callback: Optional[Callable[[AgentExecutionError], str]] = None,
     ) -> "AgentResponse":
         """Try backup agents in order until one succeeds or all fail.
@@ -763,10 +764,8 @@ class AgentManager:
             while True:
                 try:
                     execute_kwargs = {}
-                    if phase_name == "develop":
-                        execute_kwargs["max_read_only_commands"] = (
-                            self.DEVELOP_READ_ONLY_COMMAND_LIMIT
-                        )
+                    if max_read_only_commands is not None:
+                        execute_kwargs["max_read_only_commands"] = max_read_only_commands
                     agent_response = backup_executor.execute(
                         backup_prompt,
                         allowed_tools,

--- a/src/cafe/core/hooks/native.py
+++ b/src/cafe/core/hooks/native.py
@@ -1181,7 +1181,9 @@ class GitHubPRCreator(NoOpHook):
         if not formatted_comments:
             return HookResult(context_updates=context_updates)
 
-        phase.step_user_inputs[str(kwargs.get("step_name") or "pr")] = formatted_comments
+        step_name = kwargs.get("step_name")
+        if isinstance(step_name, str) and step_name:
+            phase.step_user_inputs[step_name] = formatted_comments
         context_updates["user_input"] = formatted_comments
         context_updates["pr_comment_count"] = str(len(unresolved_comments))
         context_updates["pr_mode"] = "comments"

--- a/src/cafe/core/hooks/native.py
+++ b/src/cafe/core/hooks/native.py
@@ -79,15 +79,29 @@ def _hook_status_value(raw_status: Any) -> str:
     return ""
 
 
-def _pr_publish_requested(
+def _publish_confirmation_declared(
+    *, context: Optional[dict[str, Any]] = None, step_def: Any = None
+) -> bool:
+    """Return the publish selector supplied by a validated workflow contract."""
+    if isinstance(context, dict) and "publish_confirmation" in context:
+        return bool(context["publish_confirmation"])
+    if isinstance(step_def, dict):
+        behavior = step_def.get("behavior")
+        if isinstance(behavior, dict):
+            return bool(behavior.get("publish_confirmation"))
+    return False
+
+
+def _publish_requested(
     *,
     phase: Any,
     step_name: str,
     status_code: Any,
     context: Optional[dict[str, Any]] = None,
+    step_def: Any = None,
 ) -> bool:
-    """Return True when the PR step has reached its publish handoff."""
-    if step_name and step_name != "pr":
+    """Return True when a declared publishing step reaches its handoff."""
+    if not _publish_confirmation_declared(context=context, step_def=step_def):
         return False
     if _hook_status_value(status_code) == PhaseStatusCode.CONFIRMED.value:
         return True
@@ -119,7 +133,7 @@ def _pr_publish_requested(
         return False
 
     return (
-        contract.from_step == "pr"
+        contract.from_step == step_name
         and contract.to_owner == HandoffOwner.DONE
         and contract.to_step == "done"
         and contract.intent in {HandoffIntent.AWAIT_AGENT, HandoffIntent.WORKFLOW_COMPLETE}
@@ -136,12 +150,8 @@ def _declared_capability_ids(step_def: Any) -> list[str]:
 
 
 def _effective_capability_ids(*, step_name: str, step_def: Any) -> list[str]:
-    declared = _declared_capability_ids(step_def)
-    if declared:
-        return declared
-    if step_name == "pr":
-        return ["cafe.pr.publish"]
-    return []
+    del step_name
+    return _declared_capability_ids(step_def)
 
 
 def _capability_execution_requested(
@@ -155,12 +165,13 @@ def _capability_execution_requested(
     capability_ids = _effective_capability_ids(step_name=step_name, step_def=step_def)
     if not capability_ids:
         return False
-    if step_name == "pr" and "cafe.pr.publish" in capability_ids:
-        return _pr_publish_requested(
+    if "cafe.pr.publish" in capability_ids:
+        return _publish_requested(
             phase=phase,
             step_name=step_name,
             status_code=status_code,
             context=context,
+            step_def=step_def,
         )
     if _hook_status_value(status_code) == PhaseStatusCode.CONFIRMED.value:
         return True
@@ -315,9 +326,12 @@ class UserInputCollector(NoOpHook):
         if previous_status not in {"need_clarification", "ready_for_review"}:
             return HookResult()
 
-        # PR step uses ready_for_review to loop back and check for new comments,
-        # not to request user confirmation — skip the review prompt entirely.
-        if step_name == "pr" and previous_status in {"ready_for_review", "confirm_output"}:
+        # Publishing steps use ready_for_review to inspect external feedback,
+        # not to request a duplicate user confirmation.
+        if _publish_confirmation_declared(step_def=step_def) and previous_status in {
+            "ready_for_review",
+            "confirm_output",
+        }:
             return HookResult()
 
         current_iter_dir = phase._get_iteration_dir(phase.iteration)
@@ -1437,11 +1451,12 @@ class PRCommentPoster(NoOpHook):
             return HookResult()
         phase = kwargs.get("phase")
         step_name = str(kwargs.get("step_name") or "")
-        if not _pr_publish_requested(
+        if not _publish_requested(
             phase=phase,
             step_name=step_name,
             status_code=kwargs.get("status_code"),
             context=kwargs.get("context"),
+            step_def=kwargs.get("step_def"),
         ):
             return HookResult()
         output_file = kwargs.get("output_file")
@@ -1529,17 +1544,16 @@ class LocalPRReviewer(NoOpHook):
             return HookResult()
         phase = kwargs.get("phase")
         step_name = str(kwargs.get("step_name") or "")
-        if not _pr_publish_requested(
+        if not _publish_requested(
             phase=phase,
             step_name=step_name,
             status_code=kwargs.get("status_code"),
             context=kwargs.get("context"),
+            step_def=kwargs.get("step_def"),
         ):
             return HookResult()
         output_file = kwargs.get("output_file")
         if not isinstance(output_file, Path):
-            return HookResult()
-        if step_name != "pr":
             return HookResult()
         if not self._is_local_pr_mode(phase):
             return HookResult()
@@ -1617,11 +1631,12 @@ class PRLinkOpener(NoOpHook):
             return HookResult()
         phase = kwargs.get("phase")
         step_name = str(kwargs.get("step_name") or "")
-        if not _pr_publish_requested(
+        if not _publish_requested(
             phase=phase,
             step_name=step_name,
             status_code=kwargs.get("status_code"),
             context=kwargs.get("context"),
+            step_def=kwargs.get("step_def"),
         ):
             return HookResult()
 

--- a/src/cafe/core/hooks/native.py
+++ b/src/cafe/core/hooks/native.py
@@ -328,7 +328,9 @@ class UserInputCollector(NoOpHook):
 
         # Publishing steps use ready_for_review to inspect external feedback,
         # not to request a duplicate user confirmation.
-        if _publish_confirmation_declared(step_def=step_def) and previous_status in {
+        if _publish_confirmation_declared(
+            context=kwargs.get("context"), step_def=step_def
+        ) and previous_status in {
             "ready_for_review",
             "confirm_output",
         }:

--- a/src/cafe/core/hooks/native.py
+++ b/src/cafe/core/hooks/native.py
@@ -922,7 +922,7 @@ class InitialInputProviderResolver(NoOpHook):
 
 
 class GitHubIssueFetcher(NoOpHook):
-    """Compatibility adapter for legacy ``spec`` initial-input hooks."""
+    """Compatibility adapter for legacy initial-input hooks."""
 
     name = "GitHubIssueFetcher"
 
@@ -932,7 +932,7 @@ class GitHubIssueFetcher(NoOpHook):
         phase = kwargs.get("phase")
         step_name = str(kwargs.get("step_name") or "")
         output_file: Optional[Path] = kwargs.get("output_file")
-        if phase is None or step_name != "spec" or output_file is None:
+        if phase is None or output_file is None:
             return HookResult()
         if getattr(phase, "iteration", 0) != 1:
             return HookResult()
@@ -971,7 +971,10 @@ class GitHubIssueFetcher(NoOpHook):
         legacy_step_def = dict(kwargs.get("step_def") or {})
         legacy_step_def["initial_input"] = {
             "providers": [MANUAL_TEXT_PROVIDER, GITHUB_ISSUE_PROVIDER],
-            "bind": {"artifact": "spec", "prompt_context": "user_input"},
+            "bind": {
+                "artifact": legacy_step_def.get("output_artifact", step_name),
+                "prompt_context": "user_input",
+            },
         }
         resolver_kwargs = dict(kwargs)
         resolver_kwargs.update(

--- a/src/cafe/core/phase.py
+++ b/src/cafe/core/phase.py
@@ -811,6 +811,7 @@ class Phase(PhaseStateMixin, PhaseSandboxMixin, PhaseReviewMixin, PhaseChecklist
         denied_tools: Optional[List[str]] = None,
         phase_specific_data: Optional[Dict[str, Any]] = None,
         backup_context_callback: Optional[Callable[[AgentExecutionError], str]] = None,
+        max_read_only_commands: Optional[int] = None,
     ) -> tuple[str, Optional[PhaseStatusCode]]:
         """Common agent execution flow that all phases can use.
 
@@ -1021,6 +1022,11 @@ class Phase(PhaseStateMixin, PhaseSandboxMixin, PhaseReviewMixin, PhaseChecklist
                 for param in execute_signature.parameters.values()
             ):
                 execute_kwargs["continuation"] = requested_continuation
+            if "max_read_only_commands" in execute_signature.parameters or any(
+                param.kind == inspect.Parameter.VAR_KEYWORD
+                for param in execute_signature.parameters.values()
+            ):
+                execute_kwargs["max_read_only_commands"] = max_read_only_commands
             if backup_context_callback is not None and getattr(
                 self.agent_manager, "SUPPORTS_COLD_TAKEOVER", False
             ) and (

--- a/src/cafe/core/phase_checklist_mixin.py
+++ b/src/cafe/core/phase_checklist_mixin.py
@@ -28,6 +28,7 @@ class PhaseChecklistMixin:
         user_input: str,
         valid_intents: List[PhaseStatusCode],
         allowed_tools: Optional[List[str]] = None,
+        max_read_only_commands: Optional[int] = None,
         max_retries: int = 3,
     ) -> tuple[str, Optional[PhaseStatusCode], bool]:
         """Validate checklist completion and retry if incomplete.
@@ -41,6 +42,7 @@ class PhaseChecklistMixin:
             user_input: User input for this iteration
             valid_intents: Valid status codes for this phase
             allowed_tools: Tools available to agent
+            max_read_only_commands: Declared read-only progress guard limit, if enabled
             max_retries: Maximum number of retry attempts (default: 3)
 
         Returns:
@@ -144,6 +146,8 @@ Do NOT return a status code until ALL checklist items are marked as complete [x]
                     execute_kwargs["phase_name"] = getattr(self, "phase_name", None)
                 if self._call_accepts_keyword(execute_method, "continuation"):
                     execute_kwargs["continuation"] = self._current_session_continuation()
+                if self._call_accepts_keyword(execute_method, "max_read_only_commands"):
+                    execute_kwargs["max_read_only_commands"] = max_read_only_commands
                 retry_response, retry_token_usage, _, _, retry_streaming_log, retry_model = (
                     self.agent_manager.execute(
                         agent_name,

--- a/src/cafe/core/playbook.py
+++ b/src/cafe/core/playbook.py
@@ -276,6 +276,17 @@ def _behavior_value(
     return fallback if value is None else value
 
 
+def _behavior_sequence(
+    defaults: StepBehaviorDeclaration, override: StepBehaviorDeclaration, field_name: str
+) -> List[str]:
+    """Merge additive runtime selections while retaining declaration order."""
+    return list(
+        dict.fromkeys(
+            [*(getattr(defaults, field_name) or []), *(getattr(override, field_name) or [])]
+        )
+    )
+
+
 class StepConfig(BaseModel):
     """One playbook step."""
 
@@ -606,8 +617,8 @@ def resolve_step_behavior(
         completion=_behavior_value(defaults, override, "completion", "status_code"),
         publish_confirmation=_behavior_value(defaults, override, "publish_confirmation", False),
         feedback_target=_behavior_value(defaults, override, "feedback_target", None),
-        context_providers=list(_behavior_value(defaults, override, "context_providers", [])),
-        runtime_tool_grants=list(_behavior_value(defaults, override, "runtime_tool_grants", [])),
+        context_providers=_behavior_sequence(defaults, override, "context_providers"),
+        runtime_tool_grants=_behavior_sequence(defaults, override, "runtime_tool_grants"),
     )
 
 

--- a/src/cafe/core/playbook.py
+++ b/src/cafe/core/playbook.py
@@ -229,6 +229,7 @@ class StepBehaviorDeclaration(BaseModel):
     feedback_target: Optional[str] = None
     context_providers: Optional[List[str]] = None
     runtime_tool_grants: Optional[List[str]] = None
+    max_read_only_commands: Optional[int] = Field(default=None, ge=1)
 
     @field_validator("context_providers", "runtime_tool_grants")
     @classmethod
@@ -261,6 +262,7 @@ class EffectiveStepBehavior(BaseModel):
     feedback_target: Optional[str] = None
     context_providers: List[str] = Field(default_factory=list)
     runtime_tool_grants: List[str] = Field(default_factory=list)
+    max_read_only_commands: Optional[int] = None
 
 
 def _behavior_value(
@@ -612,6 +614,9 @@ def resolve_step_behavior(
         feedback_target=_behavior_value(defaults, override, "feedback_target", None),
         context_providers=_behavior_value(defaults, override, "context_providers", []),
         runtime_tool_grants=_behavior_value(defaults, override, "runtime_tool_grants", []),
+        max_read_only_commands=_behavior_value(
+            defaults, override, "max_read_only_commands", None
+        ),
     )
 
 

--- a/src/cafe/core/playbook.py
+++ b/src/cafe/core/playbook.py
@@ -276,17 +276,6 @@ def _behavior_value(
     return fallback if value is None else value
 
 
-def _behavior_sequence(
-    defaults: StepBehaviorDeclaration, override: StepBehaviorDeclaration, field_name: str
-) -> List[str]:
-    """Merge additive runtime selections while retaining declaration order."""
-    return list(
-        dict.fromkeys(
-            [*(getattr(defaults, field_name) or []), *(getattr(override, field_name) or [])]
-        )
-    )
-
-
 class StepConfig(BaseModel):
     """One playbook step."""
 

--- a/src/cafe/core/playbook.py
+++ b/src/cafe/core/playbook.py
@@ -585,9 +585,13 @@ class PlaybookDefinition(BaseModel):
                 raise ValueError(
                     f"steps.{step_name}.behavior.feedback_target {target!r} is not a defined step"
                 )
-            if behavior.publish_confirmation and not step.capability_requests:
+            if (
+                behavior.publish_confirmation
+                and "cafe.pr.publish" not in step.capability_requests
+            ):
                 raise ValueError(
-                    f"steps.{step_name}.behavior.publish_confirmation requires capability_requests"
+                    f"steps.{step_name}.behavior.publish_confirmation requires "
+                    "the cafe.pr.publish capability request"
                 )
         return self
 
@@ -617,8 +621,8 @@ def resolve_step_behavior(
         completion=_behavior_value(defaults, override, "completion", "status_code"),
         publish_confirmation=_behavior_value(defaults, override, "publish_confirmation", False),
         feedback_target=_behavior_value(defaults, override, "feedback_target", None),
-        context_providers=_behavior_sequence(defaults, override, "context_providers"),
-        runtime_tool_grants=_behavior_sequence(defaults, override, "runtime_tool_grants"),
+        context_providers=_behavior_value(defaults, override, "context_providers", []),
+        runtime_tool_grants=_behavior_value(defaults, override, "runtime_tool_grants", []),
     )
 
 

--- a/src/cafe/core/playbook.py
+++ b/src/cafe/core/playbook.py
@@ -28,6 +28,8 @@ from cafe.templates.manager import TemplateManager
 
 DONE_TARGET = "_done"
 SCRIPT_HOOK_STAGES = {"before_execute", "after_execute"}
+RUNTIME_CONTEXT_PROVIDERS = frozenset({"workflow_metadata", "git_history"})
+RUNTIME_TOOL_GRANTS = frozenset({"web_research", "git_inspection"})
 
 RigorLevel = Literal["low", "medium", "high"]
 InputMethodDefault = Literal["manual", "github"]
@@ -209,6 +211,71 @@ class InitialInputDeclaration(BaseModel):
         return providers
 
 
+CompletionMode = Literal["status_code", "baton"]
+
+
+class StepBehaviorDeclaration(BaseModel):
+    """Optional behavior selectors declared by a playbook or one step.
+
+    This model intentionally contains only runtime-owned identifiers.  A
+    playbook can select existing providers and grants, but cannot introduce
+    import paths or executable host behavior.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    completion: Optional[CompletionMode] = None
+    publish_confirmation: Optional[bool] = None
+    feedback_target: Optional[str] = None
+    context_providers: Optional[List[str]] = None
+    runtime_tool_grants: Optional[List[str]] = None
+
+    @field_validator("context_providers", "runtime_tool_grants")
+    @classmethod
+    def _validate_runtime_owned_identifiers(
+        cls, value: Optional[List[str]], info: Any
+    ) -> Optional[List[str]]:
+        if value is None:
+            return None
+        allowed = (
+            RUNTIME_CONTEXT_PROVIDERS
+            if info.field_name == "context_providers"
+            else RUNTIME_TOOL_GRANTS
+        )
+        cleaned = [str(item).strip() for item in value]
+        if not all(cleaned) or len(cleaned) != len(set(cleaned)):
+            raise ValueError(f"{info.field_name} must contain unique non-empty identifiers")
+        unknown = [item for item in cleaned if item not in allowed]
+        if unknown:
+            raise ValueError(f"{info.field_name} contains unknown runtime-owned id {unknown[0]!r}")
+        return cleaned
+
+
+class EffectiveStepBehavior(BaseModel):
+    """Fully resolved, name-independent runtime behavior for one step."""
+
+    model_config = ConfigDict(frozen=True)
+
+    completion: CompletionMode = "status_code"
+    publish_confirmation: bool = False
+    feedback_target: Optional[str] = None
+    context_providers: List[str] = Field(default_factory=list)
+    runtime_tool_grants: List[str] = Field(default_factory=list)
+
+
+def _behavior_value(
+    defaults: StepBehaviorDeclaration,
+    override: StepBehaviorDeclaration,
+    field_name: str,
+    fallback: Any,
+) -> Any:
+    value = getattr(override, field_name)
+    if value is not None:
+        return value
+    value = getattr(defaults, field_name)
+    return fallback if value is None else value
+
+
 class StepConfig(BaseModel):
     """One playbook step."""
 
@@ -227,6 +294,7 @@ class StepConfig(BaseModel):
     template: Optional[str] = None
     allowed_tools: List[str] = Field(default_factory=list)
     capability_requests: List[str] = Field(default_factory=list)
+    behavior: StepBehaviorDeclaration = Field(default_factory=StepBehaviorDeclaration)
     valid_intents: List[str] = Field(default_factory=list)
     max_iterations: Optional[Union[int, str]] = None
     correction_session: Literal["fresh", "resume"] = "fresh"
@@ -490,6 +558,7 @@ class PlaybookDefinition(BaseModel):
     playbook: PlaybookMeta
     roles: Dict[str, PlaybookRole] = Field(default_factory=dict)
     skills: Optional[PlaybookSkillEnvironments] = None
+    behavior: StepBehaviorDeclaration = Field(default_factory=StepBehaviorDeclaration)
     steps: Dict[str, StepConfig]
     commands: Optional[CommandsConfig] = None
     entry_point: Optional[str] = None
@@ -498,7 +567,48 @@ class PlaybookDefinition(BaseModel):
     def _default_entry_point(self) -> "PlaybookDefinition":
         if self.entry_point is None:
             self.entry_point = next(iter(self.steps.keys()))
+        for step_name, step in self.steps.items():
+            behavior = resolve_step_behavior(self, step_name)
+            target = behavior.feedback_target
+            if target is not None and target not in self.steps:
+                raise ValueError(
+                    f"steps.{step_name}.behavior.feedback_target {target!r} is not a defined step"
+                )
+            if behavior.publish_confirmation and not step.capability_requests:
+                raise ValueError(
+                    f"steps.{step_name}.behavior.publish_confirmation requires capability_requests"
+                )
         return self
+
+
+def resolve_step_behavior(
+    playbook: PlaybookDefinition | Dict[str, Any], step_name: str
+) -> EffectiveStepBehavior:
+    """Resolve one step's declaration without considering its name.
+
+    Omitted declarations use universal schema defaults.  This function is the
+    only behavior merge point used by the runtime.
+    """
+    if isinstance(playbook, PlaybookDefinition):
+        defaults = playbook.behavior
+        step = playbook.steps[step_name]
+        override = step.behavior
+    else:
+        defaults = StepBehaviorDeclaration.model_validate(playbook.get("behavior") or {})
+        steps = playbook.get("steps") or {}
+        if step_name not in steps:
+            # Direct helper calls can supply a transient step definition that
+            # is not part of a test fixture's complete playbook.  It receives
+            # the same universal defaults as every omitted declaration.
+            return EffectiveStepBehavior()
+        override = StepBehaviorDeclaration.model_validate(steps[step_name].get("behavior") or {})
+    return EffectiveStepBehavior(
+        completion=_behavior_value(defaults, override, "completion", "status_code"),
+        publish_confirmation=_behavior_value(defaults, override, "publish_confirmation", False),
+        feedback_target=_behavior_value(defaults, override, "feedback_target", None),
+        context_providers=list(_behavior_value(defaults, override, "context_providers", [])),
+        runtime_tool_grants=list(_behavior_value(defaults, override, "runtime_tool_grants", [])),
+    )
 
 
 def resolve_playbook_skills(

--- a/src/cafe/core/workflow_runtime.py
+++ b/src/cafe/core/workflow_runtime.py
@@ -26,6 +26,7 @@ from cafe.core.blackboard import (
     operation_receipt_path,
 )
 from cafe.core.capabilities import CAPABILITY_PR_PUBLISH_ID
+from cafe.core.playbook import resolve_step_behavior
 from cafe.core.questions_schema import validate_questions_xml
 from cafe.core.status_codes import (
     PhaseStatusCode,
@@ -137,8 +138,6 @@ def operation_receipt_is_trusted(
 class BlackboardWorkflowRuntime:
     """Workflow runtime that prefers blackboard/baton-driven transitions."""
 
-    BATON_DRIVEN_STEPS = {"pr"}
-
     def __init__(
         self,
         *,
@@ -210,17 +209,14 @@ class BlackboardWorkflowRuntime:
 
     def _required_capability_ids(self, current_step: str) -> list[str]:
         step_def = self.steps.get(current_step, {})
-        if current_step == "pr" and not self._pr_step_requires_publish_receipt(current_step):
-            return []
         declared = self._step_declared_capability_ids(step_def)
-        if declared:
-            return declared
-        if current_step == "pr":
-            return [CAPABILITY_PR_PUBLISH_ID]
-        return []
+        behavior = resolve_step_behavior(self.playbook, current_step)
+        if behavior.publish_confirmation and not self._step_requires_publish_receipt(current_step):
+            return []
+        return declared
 
     def _is_baton_driven_step(self, current_step: str) -> bool:
-        return current_step in self.BATON_DRIVEN_STEPS or bool(
+        return resolve_step_behavior(self.playbook, current_step).completion == "baton" or bool(
             self._required_capability_ids(current_step)
         )
 
@@ -638,8 +634,8 @@ class BlackboardWorkflowRuntime:
         self.blackboard_store.write_handoff_contract(self.blackboard, contract)
         return contract
 
-    def _pr_step_requires_publish_receipt(self, current_step: str) -> bool:
-        if current_step != "pr":
+    def _step_requires_publish_receipt(self, current_step: str) -> bool:
+        if not resolve_step_behavior(self.playbook, current_step).publish_confirmation:
             return False
         issue_yaml = self.issue_dir / "issue.yaml"
         if not issue_yaml.exists():
@@ -1908,7 +1904,10 @@ class BlackboardWorkflowRuntime:
                 )
 
             require_capability_receipts = next_step != "user"
-            if current_step == "pr" and next_step != "done":
+            if (
+                resolve_step_behavior(self.playbook, current_step).publish_confirmation
+                and next_step != "done"
+            ):
                 require_capability_receipts = False
 
             if require_capability_receipts:

--- a/src/cafe/data/playbooks/default.yaml
+++ b/src/cafe/data/playbooks/default.yaml
@@ -3,6 +3,9 @@ playbook:
   name: "Standard Development Workflow"
   conversation_locale: en-US
 
+behavior:
+  completion: status_code
+
 skills:
   workflow:
     shared: [cafe-workflow-common, cafe-github_sync]
@@ -37,6 +40,8 @@ steps:
     assignee_type: agent
     input_artifacts: []
     output_artifact: spec
+    behavior:
+      completion: status_code
     initial_input:
       providers: [manual_text, github_issue]
       bind:
@@ -69,6 +74,8 @@ steps:
     assignee_type: agent
     input_artifacts: [spec]
     output_artifact: plan
+    behavior:
+      completion: status_code
     human_tasks:
       - trigger: initial
         task_id: development-guide
@@ -112,6 +119,8 @@ steps:
     assignee_type: agent
     input_artifacts: [spec, plan, review_feedback, pr_result]
     output_artifact: code
+    behavior:
+      completion: status_code
     human_tasks:
       - trigger: need_clarification
         task_id: clarification-feedback
@@ -139,6 +148,9 @@ steps:
     assignee_type: agent
     input_artifacts: [spec, plan, code]
     output_artifact: review_feedback
+    behavior:
+      completion: status_code
+      runtime_tool_grants: [web_research, git_inspection]
     human_tasks:
       - trigger: need_clarification
         task_id: clarification-feedback
@@ -163,6 +175,11 @@ steps:
     assignee_type: agent
     input_artifacts: [spec, plan, code, review_feedback]
     output_artifact: pr_result
+    behavior:
+      completion: baton
+      publish_confirmation: true
+      feedback_target: develop
+      context_providers: [git_history]
     allowed_tools: [Read, Edit, Write, Grep, Glob]
     capability_requests: [cafe.pr.publish]
     allowed_goto: [develop, review]

--- a/src/cafe/data/playbooks/default.yaml
+++ b/src/cafe/data/playbooks/default.yaml
@@ -121,6 +121,7 @@ steps:
     output_artifact: code
     behavior:
       completion: status_code
+      max_read_only_commands: 20
     human_tasks:
       - trigger: need_clarification
         task_id: clarification-feedback

--- a/src/cafe/data/playbooks/editorial.yaml
+++ b/src/cafe/data/playbooks/editorial.yaml
@@ -3,6 +3,9 @@ playbook:
   name: "Editorial Workflow（撰稿 → 審閱 → 發佈）"
   conversation_locale: en-US
 
+behavior:
+  completion: status_code
+
 skills:
   workflow:
     shared: [cafe-workflow-common, cafe-github_sync]

--- a/src/cafe/data/playbooks/hotfix.yaml
+++ b/src/cafe/data/playbooks/hotfix.yaml
@@ -3,6 +3,9 @@ playbook:
   name: "Hotfix Workflow"
   conversation_locale: en-US
 
+behavior:
+  completion: status_code
+
 skills:
   workflow:
     shared: [cafe-workflow-common, cafe-github_sync]
@@ -102,6 +105,12 @@ steps:
     assignee_type: agent
     input_artifacts: [code, review_feedback]
     output_artifact: pr_result
+    behavior:
+      completion: baton
+      publish_confirmation: true
+      feedback_target: develop
+      context_providers: [git_history]
+    capability_requests: [cafe.pr.publish]
     allowed_tools: [Read, Edit, Write, Grep, Glob]
     allowed_goto: [develop, review]
     hooks:

--- a/src/cafe/data/playbooks/hotfix.yaml
+++ b/src/cafe/data/playbooks/hotfix.yaml
@@ -80,6 +80,8 @@ steps:
     type: skill
     skill: cafe-review
     role: reviewer
+    behavior:
+      runtime_tool_grants: [web_research, git_inspection]
     assignee_type: agent
     input_artifacts: [code]
     output_artifact: review_feedback

--- a/src/cafe/data/playbooks/hotfix.yaml
+++ b/src/cafe/data/playbooks/hotfix.yaml
@@ -62,6 +62,8 @@ steps:
     assignee_type: agent
     input_artifacts: [review_feedback, pr_result]
     output_artifact: code
+    behavior:
+      max_read_only_commands: 20
     human_tasks:
       - trigger: need_clarification
         task_id: clarification-feedback

--- a/src/cafe/data/playbooks/incident.yaml
+++ b/src/cafe/data/playbooks/incident.yaml
@@ -3,6 +3,9 @@ playbook:
   name: "Incident Response Workflow（偵測 → 分類 → 緩解 → 事後檢討）"
   conversation_locale: en-US
 
+behavior:
+  completion: status_code
+
 skills:
   workflow:
     shared: [cafe-workflow-common, cafe-github_sync]

--- a/src/cafe/data/playbooks/research.yaml
+++ b/src/cafe/data/playbooks/research.yaml
@@ -3,6 +3,9 @@ playbook:
   name: "Research Workflow（問題 → 搜尋整理 → 綜合 → 報告）"
   conversation_locale: en-US
 
+behavior:
+  completion: status_code
+
 skills:
   workflow:
     shared: [cafe-workflow-common, cafe-github_sync]

--- a/src/cafe/data/playbooks/simple.yaml
+++ b/src/cafe/data/playbooks/simple.yaml
@@ -64,6 +64,8 @@ steps:
     assignee_type: agent
     input_artifacts: [spec]
     output_artifact: code
+    behavior:
+      max_read_only_commands: 20
     human_tasks:
       - trigger: need_clarification
         task_id: clarification-feedback

--- a/src/cafe/data/playbooks/simple.yaml
+++ b/src/cafe/data/playbooks/simple.yaml
@@ -3,6 +3,9 @@ playbook:
   name: "Simple Workflow"
   conversation_locale: en-US
 
+behavior:
+  completion: status_code
+
 skills:
   workflow:
     shared: [cafe-workflow-common, cafe-github_sync]
@@ -81,6 +84,12 @@ steps:
     assignee_type: agent
     input_artifacts: [spec, code]
     output_artifact: pr_result
+    behavior:
+      completion: baton
+      publish_confirmation: true
+      feedback_target: develop
+      context_providers: [git_history]
+    capability_requests: [cafe.pr.publish]
     allowed_tools: [Read, Edit, Write, Grep, Glob]
     allowed_goto: [develop]
     hooks:

--- a/src/cafe/data/playbooks/tdd.yaml
+++ b/src/cafe/data/playbooks/tdd.yaml
@@ -3,6 +3,9 @@ playbook:
   name: "Test-Driven Development Workflow"
   conversation_locale: en-US
 
+behavior:
+  completion: status_code
+
 skills:
   workflow:
     shared: [cafe-workflow-common, cafe-github_sync]
@@ -163,6 +166,12 @@ steps:
     assignee_type: agent
     input_artifacts: [spec, plan, code, review_feedback]
     output_artifact: pr_result
+    behavior:
+      completion: baton
+      publish_confirmation: true
+      feedback_target: develop
+      context_providers: [git_history]
+    capability_requests: [cafe.pr.publish]
     allowed_tools: [Read, Edit, Write, Grep, Glob]
     allowed_goto: [develop, review]
     hooks:

--- a/src/cafe/data/playbooks/tdd.yaml
+++ b/src/cafe/data/playbooks/tdd.yaml
@@ -115,6 +115,8 @@ steps:
     assignee_type: agent
     input_artifacts: [spec, plan, review_feedback, pr_result]
     output_artifact: code
+    behavior:
+      max_read_only_commands: 20
     human_tasks:
       - trigger: need_clarification
         task_id: clarification-feedback

--- a/src/cafe/data/playbooks/tdd.yaml
+++ b/src/cafe/data/playbooks/tdd.yaml
@@ -137,6 +137,8 @@ steps:
     type: skill
     skill: cafe-review
     role: reviewer
+    behavior:
+      runtime_tool_grants: [web_research, git_inspection]
     handoff_label: "Run review again"
     chat_role: reviewer
     assignee_type: agent

--- a/src/cafe/phases/generic_workflow_step.py
+++ b/src/cafe/phases/generic_workflow_step.py
@@ -1062,6 +1062,7 @@ class GenericWorkflowStepExecutor(Phase):
             str(k): ("done" if str(v) in ("_done", "done") else str(v)) for k, v in step_on.items()
         }
         valid_baton_intents = effective_step_handoff_intents(step_def)
+        behavior = resolve_step_behavior(playbook, step_name)
         context = {
             "agent_file": AgentManager.get_agent_file_path(agent_name, role_dir),
             "handoff_summary": getattr(blackboard_state, "handoff_summary", ""),
@@ -1076,6 +1077,7 @@ class GenericWorkflowStepExecutor(Phase):
             "valid_to_steps": ", ".join(valid_to_steps),
             "valid_baton_intents": ", ".join(valid_baton_intents),
             "step_transitions": ", ".join(f"{i}→{s}" for i, s in step_transitions.items()),
+            "publish_confirmation": behavior.publish_confirmation,
         }
 
         skill_name = self._resolve_skill_name(step_def, self.iteration)
@@ -1118,7 +1120,7 @@ class GenericWorkflowStepExecutor(Phase):
             contract=contract,
         )
 
-        if "git_history" in resolve_step_behavior(playbook, step_name).context_providers:
+        if "git_history" in behavior.context_providers:
             base_branch = self._get_issue_config_value(self.issue_dir / "issue.yaml", "base_branch")
             resolved_base = str(base_branch or self.git_ops.get_default_base_branch())
             context["base_branch"] = resolved_base

--- a/src/cafe/phases/generic_workflow_step.py
+++ b/src/cafe/phases/generic_workflow_step.py
@@ -1118,7 +1118,7 @@ class GenericWorkflowStepExecutor(Phase):
             contract=contract,
         )
 
-        if "git_history" in resolve_step_behavior(self.playbook, step_name).context_providers:
+        if "git_history" in resolve_step_behavior(playbook, step_name).context_providers:
             base_branch = self._get_issue_config_value(self.issue_dir / "issue.yaml", "base_branch")
             resolved_base = str(base_branch or self.git_ops.get_default_base_branch())
             context["base_branch"] = resolved_base

--- a/src/cafe/phases/generic_workflow_step.py
+++ b/src/cafe/phases/generic_workflow_step.py
@@ -392,6 +392,7 @@ class GenericWorkflowStepExecutor(Phase):
                     user_input=resolved_user_input,
                     valid_intents=valid_intents,
                     allowed_tools=allowed_tools,
+                    max_read_only_commands=behavior.max_read_only_commands,
                     max_retries=3,
                 )
             )

--- a/src/cafe/phases/generic_workflow_step.py
+++ b/src/cafe/phases/generic_workflow_step.py
@@ -26,7 +26,7 @@ from cafe.core.delta_packet import (
 from cafe.core.git import GitOperations
 from cafe.core.long_running_operation_helper import get_operation_status
 from cafe.core.phase import Phase
-from cafe.core.playbook import resolve_playbook_skills
+from cafe.core.playbook import resolve_playbook_skills, resolve_step_behavior
 from cafe.core.resume_user_input import (
     is_interrupted_iteration,
     load_prior_run_context,
@@ -74,13 +74,9 @@ def align_pr_baton_after_execution(
     step_name: str,
     status_code: Optional[str],
 ) -> None:
-    """If PR feedback needs code changes, ensure the baton leaves the PR step.
-
-    Agents should update ``next_step.txt`` themselves, but when they return
-    ``manual_handoff`` while the baton still targets ``pr``, advance it to
-    ``develop`` so ``BlackboardWorkflowRuntime`` can transition.
-    """
-    if step_name != "pr" or not status_code:
+    """Realign stale feedback batons using the declared repair target."""
+    behavior = resolve_step_behavior(playbook, step_name)
+    if not status_code or behavior.feedback_target is None:
         return
     if status_code != PhaseStatusCode.NEEDS_CHANGES.value:
         return
@@ -91,21 +87,21 @@ def align_pr_baton_after_execution(
         blackboard_state,
         allowed_steps=allowed,
     )
-    if contract.to_owner != HandoffOwner.AGENT or contract.to_step != "pr":
+    if contract.to_owner != HandoffOwner.AGENT or contract.to_step != step_name:
         return
 
     store.update_handoff_contract(
         blackboard_state,
-        from_step="pr",
+        from_step=step_name,
         to_owner=HandoffOwner.AGENT,
-        to_step="develop",
+        to_step=behavior.feedback_target,
         intent=HandoffIntent.AWAIT_AGENT,
         status_code=status_code,
-        source="workflow.pr_needs_changes",
+        source="workflow.declared_feedback_target",
     )
     store.set_handoff_summary(
         blackboard_state,
-        "PR feedback requires development work; next playbook step is develop.",
+        f"Feedback requires work; next declared step is {behavior.feedback_target}.",
     )
 
 
@@ -212,7 +208,7 @@ class GenericWorkflowStepExecutor(Phase):
                 capability_request_file=capability_request_file,
                 capability_ids=capability_ids,
             )
-            if step_name == "pr":
+            if resolve_step_behavior(self.playbook, step_name).publish_confirmation:
                 self._write_publish_request(
                     output_file=output_file,
                     publish_request_file=publish_request_file,
@@ -355,7 +351,11 @@ class GenericWorkflowStepExecutor(Phase):
                 "questions_xml_file": questions_xml_file,
                 "authoritative_inputs": context.get("authoritative_inputs", {}),
                 "capability_request_file": capability_request_file if capability_ids else None,
-                "publish_request_file": publish_request_file if step_name == "pr" else None,
+                "publish_request_file": (
+                    publish_request_file
+                    if resolve_step_behavior(self.playbook, step_name).publish_confirmation
+                    else None
+                ),
                 "blackboard_state": blackboard_state,
                 "transform_runtime_context": (
                     lambda runtime_context: self._apply_resume_to_runtime_context(
@@ -1003,16 +1003,17 @@ class GenericWorkflowStepExecutor(Phase):
         add_writable_file(self.issue_dir / "blackboard.json")
         add_writable_file(self.issue_dir / "next_step.txt")
 
-        if step_name in {"spec", "plan", "review", "pr"}:
-            add_writable_file(output_file)
-            add_writable_file(checklist_file)
+        add_writable_file(output_file)
+        add_writable_file(checklist_file)
 
         if step_on_declares(step_def, "need_clarification"):
             add_writable_file(questions_xml_file)
 
-        if step_name == "review":
+        grants = resolve_step_behavior(self.playbook, step_name).runtime_tool_grants
+        if "web_research" in grants:
             add("web_fetch")
             add("web_search")
+        if "git_inspection" in grants:
             add("bash(git log)")
             add("bash(git diff)")
             add("bash(git show)")
@@ -1117,7 +1118,7 @@ class GenericWorkflowStepExecutor(Phase):
             contract=contract,
         )
 
-        if canonical_skill_name(skill_name) == "cafe-pr":
+        if "git_history" in resolve_step_behavior(self.playbook, step_name).context_providers:
             base_branch = self._get_issue_config_value(self.issue_dir / "issue.yaml", "base_branch")
             resolved_base = str(base_branch or self.git_ops.get_default_base_branch())
             context["base_branch"] = resolved_base
@@ -1379,9 +1380,8 @@ class GenericWorkflowStepExecutor(Phase):
             return False
         return event.get("source") in {"questions_xml", "prompt", "user_input_file"}
 
-    @staticmethod
-    def _step_requires_status_code(step_name: str) -> bool:
-        return step_name != "pr"
+    def _step_requires_status_code(self, step_name: str) -> bool:
+        return resolve_step_behavior(self.playbook, step_name).completion == "status_code"
 
     @staticmethod
     def _resolve_handoff_intent(
@@ -1470,7 +1470,7 @@ class GenericWorkflowStepExecutor(Phase):
         existing skills, but the workflow runtime should consume the baton
         written here instead of re-deriving transitions from agent text.
         """
-        if step_name == "pr":
+        if resolve_step_behavior(self.playbook, step_name).completion == "baton":
             return
 
         store = BlackboardStore(self.issue_dir)
@@ -1657,7 +1657,7 @@ class GenericWorkflowStepExecutor(Phase):
         output_file.parent.mkdir(parents=True, exist_ok=True)
         if output_file.exists():
             return
-        if step_name == "pr":
+        if resolve_step_behavior(self.playbook, step_name).publish_confirmation:
             output_file.write_text(
                 "# [Your PR Title Here]\n\n## Summary\n\n## Changes\n\n## Test Plan\n",
                 encoding="utf-8",
@@ -1674,11 +1674,7 @@ class GenericWorkflowStepExecutor(Phase):
 
     def _effective_capability_ids(self, step_name: str, step_def: Dict[str, Any]) -> List[str]:
         declared = self._declared_capability_ids(step_def)
-        if declared:
-            return declared
-        if step_name == "pr":
-            return [CAPABILITY_PR_PUBLISH_ID]
-        return []
+        return declared
 
     def _write_capability_request(
         self,

--- a/src/cafe/phases/generic_workflow_step.py
+++ b/src/cafe/phases/generic_workflow_step.py
@@ -1120,6 +1120,18 @@ class GenericWorkflowStepExecutor(Phase):
             contract=contract,
         )
 
+        if "workflow_metadata" in behavior.context_providers:
+            context["workflow_metadata"] = json.dumps(
+                {
+                    "entry_point": str(
+                        playbook.get("entry_point") or next(iter(playbook.get("steps", {})), "")
+                    ),
+                    "playbook_id": str(playbook.get("playbook", {}).get("id", "")),
+                    "steps": valid_to_steps[:-2],
+                },
+                sort_keys=True,
+            )
+
         if "git_history" in behavior.context_providers:
             base_branch = self._get_issue_config_value(self.issue_dir / "issue.yaml", "base_branch")
             resolved_base = str(base_branch or self.git_ops.get_default_base_branch())

--- a/src/cafe/phases/generic_workflow_step.py
+++ b/src/cafe/phases/generic_workflow_step.py
@@ -201,6 +201,7 @@ class GenericWorkflowStepExecutor(Phase):
         if self.iteration > 1 and not output_file.exists():
             self._copy_previous_version(step_name, self.iteration, self.phase_dir)
         self._ensure_output_file_initialized(step_name, output_file)
+        behavior = resolve_step_behavior(self.playbook, step_name)
         capability_ids = self._effective_capability_ids(step_name, step_def)
         if capability_ids:
             self._write_capability_request(
@@ -208,7 +209,7 @@ class GenericWorkflowStepExecutor(Phase):
                 capability_request_file=capability_request_file,
                 capability_ids=capability_ids,
             )
-            if resolve_step_behavior(self.playbook, step_name).publish_confirmation:
+            if behavior.publish_confirmation:
                 self._write_publish_request(
                     output_file=output_file,
                     publish_request_file=publish_request_file,
@@ -307,6 +308,7 @@ class GenericWorkflowStepExecutor(Phase):
                     persist_status=False,
                     allowed_tools=attempt_allowed_tools,
                     phase_specific_data=phase_specific_data,
+                    max_read_only_commands=behavior.max_read_only_commands,
                     backup_context_callback=lambda error: self._build_backup_takeover_context(
                         error=error,
                         step_name=step_name,

--- a/src/cafe/ui/cli_shared.py
+++ b/src/cafe/ui/cli_shared.py
@@ -566,27 +566,30 @@ _get_latest_versioned_file = get_latest_versioned_file
 
 
 def _resolve_issue_playbook_name(issue_name: str) -> str:
-    """Resolve the playbook id associated with an issue."""
+    """Resolve an issue playbook without hiding persisted metadata failures."""
     issue_dir = Path.cwd() / ".cafe" / "issues" / issue_name
     blackboard_file = issue_dir / "blackboard.json"
     if blackboard_file.exists():
         try:
             raw = json.loads(blackboard_file.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
-            raw = {}
-        if isinstance(raw, dict) and raw.get("playbook_id"):
+        except (OSError, json.JSONDecodeError) as exc:
+            raise ValueError(f"Issue {issue_name!r} has unreadable workflow metadata") from exc
+        if not isinstance(raw, dict):
+            raise ValueError(f"Issue {issue_name!r} has unreadable workflow metadata")
+        if raw.get("playbook_id"):
             return str(raw["playbook_id"])
 
     issue_config_file = issue_dir / "issue.yaml"
     if issue_config_file.exists():
         try:
             config = yaml.safe_load(issue_config_file.read_text(encoding="utf-8")) or {}
-        except (OSError, yaml.YAMLError):
-            config = {}
-        if isinstance(config, dict):
-            configured_playbook = config.get("playbook_id") or config.get("playbook")
-            if configured_playbook:
-                return str(configured_playbook)
+        except (OSError, yaml.YAMLError) as exc:
+            raise ValueError(f"Issue {issue_name!r} has unreadable workflow metadata") from exc
+        if not isinstance(config, dict):
+            raise ValueError(f"Issue {issue_name!r} has unreadable workflow metadata")
+        configured_playbook = config.get("playbook_id") or config.get("playbook")
+        if configured_playbook:
+            return str(configured_playbook)
     return "default"
 
 

--- a/src/cafe/ui/cli_shared.py
+++ b/src/cafe/ui/cli_shared.py
@@ -305,13 +305,7 @@ def setup_agents(
                     return role.strip()
         except Exception:
             pass
-        return {
-            "spec": "pm",
-            "plan": "developer",
-            "develop": "developer",
-            "review": "reviewer",
-            "pr": "developer",
-        }.get(phase_name)
+        return None
 
     phase_target_role = _resolve_phase_target_role()
 

--- a/src/cafe/ui/cli_shared.py
+++ b/src/cafe/ui/cli_shared.py
@@ -589,9 +589,23 @@ def _load_playbook_step_names(playbook_name: str) -> List[str]:
 
 
 def _load_issue_step_names(issue_name: str) -> List[str]:
-    """Load ordered step names for the current issue playbook."""
-    playbook_name = _resolve_issue_playbook_name(issue_name)
-    return _load_playbook_step_names(playbook_name)
+    """Load issue-owned steps, retaining legacy phases only without metadata."""
+    blackboard_file = Path.cwd() / ".cafe" / "issues" / issue_name / "blackboard.json"
+    if not blackboard_file.exists():
+        return list(ALL_PHASES)
+    try:
+        raw = json.loads(blackboard_file.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"Issue {issue_name!r} has unreadable workflow metadata") from exc
+    if not isinstance(raw, dict) or not raw.get("playbook_id"):
+        return list(ALL_PHASES)
+    playbook_name = str(raw["playbook_id"])
+    try:
+        return list(PlaybookLoader().load(playbook_name)["steps"].keys())
+    except Exception as exc:
+        raise ValueError(
+            f"Issue {issue_name!r} declares playbook {playbook_name!r}, which could not be loaded"
+        ) from exc
 
 
 def _resolve_selected_playbook(playbook_name: Optional[str]) -> str:
@@ -2672,20 +2686,10 @@ def _print_workflow_pause_guidance(*, step_name: str, status_code: Optional[str]
         console.print(
             "[dim]Agent finished without updating the workflow baton for this step.[/dim]"
         )
-        if step_name == "pr":
-            console.print("[bold]Recommended next action:[/bold] Open chat with role `developer`")
-            console.print("[bold]Suggested prompt:[/bold]")
-            console.print(
-                "  Do not wait for remote PR existence. Complete the local PR artifact/checklist,"
-            )
-            console.print(
-                "  update the workflow baton, and treat remote PR publish as a later host-side hook."
-            )
-        else:
-            console.print(
-                "[bold]Recommended next action:[/bold] Open chat with the role responsible for this step,"
-            )
-            console.print("  or leave a handoff note in the workflow UI before resuming.")
+        console.print(
+            "[bold]Recommended next action:[/bold] Open chat with the role responsible for this step,"
+        )
+        console.print("  or leave a handoff note in the workflow UI before resuming.")
         console.print(
             "[dim]After the chat or handoff is written back, run cafe make again to resume.[/dim]"
         )

--- a/src/cafe/ui/cli_shared.py
+++ b/src/cafe/ui/cli_shared.py
@@ -190,13 +190,7 @@ def check_agent_clis_available(
                 context=f"file={phase_config_file} step={active_step} field=clis",
             )
 
-        target_role = active_role or phase_resolution.role or {
-            "spec": "pm",
-            "plan": "developer",
-            "develop": "developer",
-            "review": "reviewer",
-            "pr": "developer",
-        }.get(active_step)
+        target_role = active_role or phase_resolution.role
         if target_role:
             return _check_chain(
                 _configured_chain(_role_config(target_role, "copilot")),

--- a/src/cafe/ui/cli_shared.py
+++ b/src/cafe/ui/cli_shared.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import typer
+import yaml
 from rich.console import Console
 
 from cafe.agents.manager import AgentManager
@@ -566,17 +567,27 @@ _get_latest_versioned_file = get_latest_versioned_file
 
 def _resolve_issue_playbook_name(issue_name: str) -> str:
     """Resolve the playbook id associated with an issue."""
-    blackboard_file = Path.cwd() / ".cafe" / "issues" / issue_name / "blackboard.json"
-    if not blackboard_file.exists():
-        return "default"
+    issue_dir = Path.cwd() / ".cafe" / "issues" / issue_name
+    blackboard_file = issue_dir / "blackboard.json"
+    if blackboard_file.exists():
+        try:
+            raw = json.loads(blackboard_file.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            raw = {}
+        if isinstance(raw, dict) and raw.get("playbook_id"):
+            return str(raw["playbook_id"])
 
-    try:
-        raw = json.loads(blackboard_file.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return "default"
-
-    playbook_id = raw.get("playbook_id")
-    return str(playbook_id) if playbook_id else "default"
+    issue_config_file = issue_dir / "issue.yaml"
+    if issue_config_file.exists():
+        try:
+            config = yaml.safe_load(issue_config_file.read_text(encoding="utf-8")) or {}
+        except (OSError, yaml.YAMLError):
+            config = {}
+        if isinstance(config, dict):
+            configured_playbook = config.get("playbook_id") or config.get("playbook")
+            if configured_playbook:
+                return str(configured_playbook)
+    return "default"
 
 
 def _load_playbook_step_names(playbook_name: str) -> List[str]:
@@ -590,16 +601,34 @@ def _load_playbook_step_names(playbook_name: str) -> List[str]:
 
 def _load_issue_step_names(issue_name: str) -> List[str]:
     """Load issue-owned steps, retaining legacy phases only without metadata."""
-    blackboard_file = Path.cwd() / ".cafe" / "issues" / issue_name / "blackboard.json"
-    if not blackboard_file.exists():
+    issue_dir = Path.cwd() / ".cafe" / "issues" / issue_name
+    blackboard_file = issue_dir / "blackboard.json"
+    issue_config_file = issue_dir / "issue.yaml"
+    playbook_name: Optional[str] = None
+
+    if blackboard_file.exists():
+        try:
+            raw = json.loads(blackboard_file.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise ValueError(f"Issue {issue_name!r} has unreadable workflow metadata") from exc
+        if not isinstance(raw, dict):
+            raise ValueError(f"Issue {issue_name!r} has unreadable workflow metadata")
+        if raw.get("playbook_id"):
+            playbook_name = str(raw["playbook_id"])
+
+    if playbook_name is None and issue_config_file.exists():
+        try:
+            config = yaml.safe_load(issue_config_file.read_text(encoding="utf-8")) or {}
+        except (OSError, yaml.YAMLError) as exc:
+            raise ValueError(f"Issue {issue_name!r} has unreadable workflow metadata") from exc
+        if not isinstance(config, dict):
+            raise ValueError(f"Issue {issue_name!r} has unreadable workflow metadata")
+        configured_playbook = config.get("playbook_id") or config.get("playbook")
+        if configured_playbook:
+            playbook_name = str(configured_playbook)
+
+    if playbook_name is None:
         return list(ALL_PHASES)
-    try:
-        raw = json.loads(blackboard_file.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        raise ValueError(f"Issue {issue_name!r} has unreadable workflow metadata") from exc
-    if not isinstance(raw, dict) or not raw.get("playbook_id"):
-        return list(ALL_PHASES)
-    playbook_name = str(raw["playbook_id"])
     try:
         return list(PlaybookLoader().load(playbook_name)["steps"].keys())
     except Exception as exc:

--- a/src/cafe/ui/commands/issues.py
+++ b/src/cafe/ui/commands/issues.py
@@ -206,10 +206,12 @@ def list_issues() -> None:
         # visible; metadata-absent issues retain the legacy fallback inside
         # the shared resolver.
         issue_name = str(issue.relative_to(issues_dir))
+        step_resolution_error = None
         try:
             phase_names = _load_issue_step_names(issue_name)
-        except ValueError:
+        except ValueError as exc:
             phase_names = []
+            step_resolution_error = str(exc)
 
         # Check which phases exist
         # If worktree_path exists, read phases from worktree location
@@ -235,7 +237,11 @@ def list_issues() -> None:
                 if phase_dir.exists():
                     phases.append(phase)
 
-        phases_str = ", ".join(phases) if phases else "empty"
+        phases_str = (
+            step_resolution_error
+            if step_resolution_error is not None
+            else ", ".join(phases) if phases else "empty"
+        )
 
         # Get last modified time
         mtime = datetime.fromtimestamp(issue.stat().st_mtime)

--- a/src/cafe/ui/commands/issues.py
+++ b/src/cafe/ui/commands/issues.py
@@ -12,6 +12,7 @@ import yaml
 from rich.console import Console
 
 from cafe.ui.commands import lifecycle as lifecycle_commands
+from cafe.ui.cli_shared import _load_issue_step_names
 from cafe.ui.inquirer_prompts import prompt_confirm, prompt_text  # noqa: F401 — kept for type resolution; actual calls go through cli for test-patch compat
 from cafe.utils.config import ConfigError, ConfigManager
 
@@ -201,6 +202,15 @@ def list_issues() -> None:
                 # If read fails, keep default value "-"
                 pass
 
+        # Use the issue's declared workflow steps so custom flows remain
+        # visible; metadata-absent issues retain the legacy fallback inside
+        # the shared resolver.
+        issue_name = str(issue.relative_to(issues_dir))
+        try:
+            phase_names = _load_issue_step_names(issue_name)
+        except ValueError:
+            phase_names = []
+
         # Check which phases exist
         # If worktree_path exists, read phases from worktree location
         phases = []
@@ -208,19 +218,19 @@ def list_issues() -> None:
             # Read phases from worktree/.cafe/issues/{issue_name}/
             worktree_issue_dir = Path(worktree_path) / ".cafe" / "issues" / issue.relative_to(issues_dir)
             if worktree_issue_dir.exists():
-                for phase in ALL_PHASES:
+                for phase in phase_names:
                     phase_dir = worktree_issue_dir / phase
                     if phase_dir.exists():
                         phases.append(phase)
             # If worktree issue dir doesn't exist, fall back to current location
             if not phases:
-                for phase in ALL_PHASES:
+                for phase in phase_names:
                     phase_dir = issue / phase
                     if phase_dir.exists():
                         phases.append(phase)
         else:
             # No worktree, read phases from current location
-            for phase in ALL_PHASES:
+            for phase in phase_names:
                 phase_dir = issue / phase
                 if phase_dir.exists():
                     phases.append(phase)
@@ -231,7 +241,6 @@ def list_issues() -> None:
         mtime = datetime.fromtimestamp(issue.stat().st_mtime)
         mtime_str = mtime.strftime("%Y-%m-%d %H:%M")
 
-        issue_name = str(issue.relative_to(issues_dir))
         table.add_row(issue_name, phases_str, worktree_path, mtime_str)
 
     console.print(table)

--- a/src/cafe/ui/commands/lifecycle.py
+++ b/src/cafe/ui/commands/lifecycle.py
@@ -1572,6 +1572,17 @@ def reset(
             console.print(f"[red]Error: Failed to get current branch: {e}[/red]")
             raise typer.Exit(1)
 
+        # Lifecycle commands operate on the issue's declared workflow.  The
+        # shared resolver retains the legacy list only when metadata is absent
+        # and surfaces configured-playbook failures instead of hiding them.
+        from cafe.ui.cli_shared import _load_issue_step_names
+
+        try:
+            valid_phases = _load_issue_step_names(issue_name)
+        except ValueError as exc:
+            console.print(f"[red]Error: {exc}[/red]")
+            raise typer.Exit(1) from exc
+
         # 2. If phase not provided, find the last phase with iterations based on end_time or timestamp
         if phase is None:
             from datetime import datetime
@@ -1583,7 +1594,7 @@ def reset(
             latest_time = None
 
             # Check all phases to find the one with the latest end_time (or timestamp if incomplete)
-            for phase_name in VALID_PHASES:
+            for phase_name in valid_phases:
                 iterations = service.load_iteration_statuses(issue_name, phase_name)
                 if not iterations:
                     continue
@@ -1608,9 +1619,9 @@ def reset(
             console.print(f"[dim]Auto-detected last phase: {phase}[/dim]")
 
         # 3. Validate phase name
-        if phase not in VALID_PHASES:
+        if phase not in valid_phases:
             console.print(f"[red]Error: Invalid phase '{phase}'[/red]")
-            console.print(f"[dim]Valid phases: {', '.join(VALID_PHASES)}[/dim]")
+            console.print(f"[dim]Valid phases: {', '.join(valid_phases)}[/dim]")
             raise typer.Exit(1)
 
         # 4. Verify phase directory exists

--- a/src/cafe/ui/commands/workflow.py
+++ b/src/cafe/ui/commands/workflow.py
@@ -14,6 +14,7 @@ from rich.console import Console
 
 from cafe.core.blackboard import BlackboardStore, HandoffIntent, HandoffOwner
 from cafe.core.issue_resolution import ActiveIssueResolutionError, resolve_active_issue
+from cafe.core.playbook import resolve_step_behavior
 from cafe.core.types import CriticalPhaseError
 from cafe.core.workflow_models import StepExecutionResult, StepInterrupted
 from cafe.core.workflow_runtime import BlackboardWorkflowRuntime
@@ -637,7 +638,7 @@ def workflow(
             output_path = issue_dir / step_name / "output.md"
             output_path.parent.mkdir(parents=True, exist_ok=True)
             output_path.write_text(f"# {step_name}\n\nDry-run output\n", encoding="utf-8")
-            if step_name == "pr":
+            if resolve_step_behavior(playbook_data, step_name).publish_confirmation:
                 store = BlackboardStore(issue_dir)
                 blackboard = store.load_or_create(
                     str(playbook_data.get("entry_point") or next(iter(playbook_data["steps"].keys()))),
@@ -645,7 +646,7 @@ def workflow(
                 )
                 store.update_handoff_contract(
                     blackboard,
-                    from_step="pr",
+                    from_step=step_name,
                     to_owner=HandoffOwner.DONE,
                     to_step="done",
                     intent=HandoffIntent.WORKFLOW_COMPLETE,
@@ -1001,10 +1002,13 @@ def workflow(
             if (
                 not single_step
                 and result.final_status_code != "BATON_POSITION_REALIGNED"
-                and latest_blackboard.current_step == "pr"
-                and effective_start_step != "pr"
+                and latest_blackboard.current_step in playbook_data["steps"]
+                and resolve_step_behavior(
+                    playbook_data, latest_blackboard.current_step
+                ).publish_confirmation
+                and effective_start_step != latest_blackboard.current_step
             ):
-                pending_start_step = "pr"
+                pending_start_step = latest_blackboard.current_step
                 continue
             if interactive and not dry_run and not single_step and latest_blackboard.current_step == "user":
                 pending_start_step = "user"

--- a/src/cafe/ui/commands/workflow.py
+++ b/src/cafe/ui/commands/workflow.py
@@ -102,6 +102,11 @@ def _resolve_selected_playbook(*a, **kw):
     from cafe.ui.cli import _resolve_selected_playbook as _fn
     return _fn(*a, **kw)
 
+
+def _resolve_issue_playbook_name(*a, **kw):
+    from cafe.ui.cli import _resolve_issue_playbook_name as _fn
+    return _fn(*a, **kw)
+
 console = Console()
 
 _USER_INPUT_HELP = (
@@ -609,7 +614,20 @@ def workflow(
             raise typer.Exit(1)
         issue_name = resolved.issue_name
         issue_dir = cafe_dir / "issues" / issue_name
-        selected_playbook = _resolve_selected_playbook(playbook)
+        # An explicit flag starts a requested playbook; otherwise an existing
+        # issue must resume the playbook persisted in its own workflow state.
+        has_issue_workflow = (issue_dir / "blackboard.json").exists() or (
+            issue_dir / "issue.yaml"
+        ).exists()
+        selected_playbook = (
+            _resolve_selected_playbook(playbook)
+            if playbook
+            else (
+                _resolve_issue_playbook_name(issue_name)
+                if has_issue_workflow
+                else _resolve_selected_playbook(None)
+            )
+        )
         config_manager = _get_ConfigManager()(".cafe")
         try:
             config_manager.load_config()

--- a/tests/integration/test_workflow_e2e.py
+++ b/tests/integration/test_workflow_e2e.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from types import SimpleNamespace
 from typing import List, Optional
 from unittest.mock import MagicMock, patch
 
@@ -25,10 +26,15 @@ from cafe.core.blackboard import (
 )
 from cafe.core.workflow_models import StepExecutionResult
 from cafe.core.workflow_runtime import BlackboardWorkflowRuntime
+from cafe.core.types import AgentCLI, TokenUsage
 from cafe.core.status_codes import PhaseStatusCode
 from cafe.core.playbook import resolve_step_behavior
 from cafe.phases.generic_workflow_step import align_pr_baton_after_execution
+from cafe.phases.generic_workflow_step import GenericWorkflowStepExecutor
+from cafe.phases.generic_phase import GenericPhase
 from cafe.playbooks.loader import PlaybookLoader
+from cafe.skills.loader import SkillLoader
+from cafe.skills.native_bridge import NativeSkillBridge
 from cafe.ui.cli import _consume_pending_chat_handoff, app
 from cafe.ui.cli_shared import _load_issue_step_names
 
@@ -48,8 +54,61 @@ def _write_pr_done_baton(issue_dir: Path) -> None:
     )
 
 
+class _BatonWritingAgentManager:
+    """Test-double agent boundary that writes the workflow's public baton."""
+
+    def __init__(self, issue_dir: Path) -> None:
+        self.issue_dir = issue_dir
+        self.agent = SimpleNamespace(
+            config=SimpleNamespace(cli=AgentCLI.CODEX, session_id="integration-test", model=None)
+        )
+
+    def get_agent(self, _name: str) -> SimpleNamespace:
+        return self.agent
+
+    def execute(self, _name: str, _prompt: str, **_kwargs):
+        state = BlackboardStore(self.issue_dir).load_or_create("release")
+        BlackboardStore(self.issue_dir).update_handoff_contract(
+            state,
+            from_step="release",
+            to_owner=HandoffOwner.DONE,
+            to_step="done",
+            intent=HandoffIntent.WORKFLOW_COMPLETE,
+            status_code="confirmed",
+            source="test.agent",
+        )
+        return "completed", TokenUsage(), [], [], [], None
+
+
+class _GitOperations:
+    def get_default_base_branch(self) -> str:
+        return "main"
+
+    def get_repo_root(self) -> Path:
+        return Path.cwd()
+
+
+def _build_integration_generic_phase(tmp_path: Path) -> GenericPhase:
+    skill_dir = tmp_path / "builtin" / "skills" / "cafe-develop"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: cafe-develop\ndescription: Integration test skill\n---\n\n# Develop\n",
+        encoding="utf-8",
+    )
+    loader = SkillLoader(
+        project_root=tmp_path,
+        global_root=tmp_path / "global",
+        builtin_root=tmp_path / "builtin",
+    )
+    loader.discover()
+    return GenericPhase(
+        loader,
+        skill_bridge=NativeSkillBridge(loader, project_root=tmp_path, home_dir=tmp_path / "home"),
+    )
+
+
 def test_custom_publish_feedback_and_lifecycle_contracts(tmp_path: Path, monkeypatch) -> None:
-    """IT-001/IT-002: custom contracts publish, repair, and expose lifecycle steps."""
+    """IT-001/IT-002: a custom publish journey uses executor, hooks, and receipts."""
     monkeypatch.chdir(tmp_path)
     issue_dir = tmp_path / ".cafe" / "issues" / "release-journey"
     issue_dir.mkdir(parents=True)
@@ -62,6 +121,8 @@ def test_custom_publish_feedback_and_lifecycle_contracts(tmp_path: Path, monkeyp
         """
 playbook:
   id: release-flow
+roles:
+  developer: {default_agent: David}
 steps:
   repair:
     skill: cafe-develop
@@ -75,35 +136,89 @@ steps:
       completion: baton
       publish_confirmation: true
       feedback_target: repair
+    hooks:
+      prepare_input: [UserInputCollector]
+      publish_output: [GitHubPRCreator]
     on: {await_agent: _done}
 """.strip(),
         encoding="utf-8",
     )
     playbook = PlaybookLoader().load("release-flow")
 
-    def executor(step_name: str, _step_def: dict, state: BlackboardState) -> StepExecutionResult:
-        BlackboardStore(issue_dir).update_handoff_contract(
-            state,
-            from_step=step_name,
-            to_owner=HandoffOwner.DONE,
-            to_step="done",
-            intent=HandoffIntent.WORKFLOW_COMPLETE,
-            status_code="confirmed",
-            source="test.executor",
-        )
-        return StepExecutionResult(
-            response="confirmed",
-            artifacts={},
-            status_code="confirmed",
-            events=[{"type": "pr_synced"}],
-        )
-
-    result = BlackboardWorkflowRuntime(
-        issue_dir=issue_dir, playbook=playbook, executor=executor
-    ).run(start_step="release")
+    executor = GenericWorkflowStepExecutor(
+        issue_dir=issue_dir,
+        issue_name="release-journey",
+        playbook=playbook,
+        generic_phase=_build_integration_generic_phase(tmp_path),
+        agent_manager=_BatonWritingAgentManager(issue_dir),
+        git_ops=_GitOperations(),
+        role_agent_map={"developer": "David"},
+    )
+    receipt = {
+        "capability": "cafe.pr.publish",
+        "correlation_id": "release-journey",
+        "success": True,
+        "category": "success",
+        "code": "published",
+        "inputs": {},
+        "outputs": {"pr_url": "https://example.test/pr/1", "pr_number": "1"},
+    }
+    with (
+        patch("cafe.core.capabilities.load_capability_registry", return_value=object()),
+        patch(
+            "cafe.core.capabilities.run_capability_request",
+            return_value=SimpleNamespace(
+                receipt=receipt,
+                pr_synced_event={"type": "pr_synced", "url": "https://example.test/pr/1"},
+            ),
+        ),
+    ):
+        result = BlackboardWorkflowRuntime(
+            issue_dir=issue_dir,
+            playbook=playbook,
+            executor=executor.execute_step,
+        ).run(start_step="release")
 
     assert result.completed is True
     assert _load_issue_step_names("release-journey") == ["repair", "release"]
+
+    iteration_dir = issue_dir / "release" / "iteration_001"
+    assert json.loads((iteration_dir / "publish_request.json").read_text(encoding="utf-8"))[
+        "capability"
+    ] == ("cafe.pr.publish")
+    state = BlackboardStore(issue_dir).load_or_create("release")
+    assert state.capability_receipts == [receipt]
+
+    runner = CliRunner()
+    git_factory = lambda: SimpleNamespace(get_current_branch=lambda: "release-journey")
+    with patch("cafe.ui.commands.workflow._get_GitOperations", return_value=git_factory):
+        show_result = runner.invoke(app, ["show", "release"])
+    assert show_result.exit_code == 0
+
+    class _SummaryService:
+        def get_current_issue(self) -> str:
+            return "release-journey"
+
+        def load_phase_status(self, _issue: str, _step: str):
+            return None
+
+        def load_iteration_statuses(self, _issue: str, _step: str):
+            return []
+
+    with patch("cafe.services.summary_service.SummaryService", _SummaryService):
+        status_result = runner.invoke(app, ["status"])
+    assert status_result.exit_code == 0
+
+    with (
+        patch("cafe.ui.cli.GitOperations", return_value=git_factory()),
+        patch("cafe.ui.cli.prompt_confirm", return_value=False),
+        patch("cafe.ui.commands.lifecycle.GitOperations", return_value=git_factory()),
+        patch("cafe.ui.commands.lifecycle._get_project_path", return_value="test/project"),
+        patch("cafe.ui.commands.lifecycle.prompt_confirm", return_value=False),
+    ):
+        reset_result = runner.invoke(app, ["reset", "release"])
+    assert reset_result.exit_code == 0
+    assert iteration_dir.exists()
 
     store = BlackboardStore(issue_dir)
     state = store.load_or_create("release")
@@ -124,12 +239,12 @@ steps:
         status_code=PhaseStatusCode.NEEDS_CHANGES.value,
     )
 
-    assert store.load_handoff_contract(state, allowed_steps=["repair", "release"]).to_step == "repair"
+    assert (
+        store.load_handoff_contract(state, allowed_steps=["repair", "release"]).to_step == "repair"
+    )
 
 
-def test_default_parity_and_metadata_absent_lifecycle_boundary(
-    tmp_path: Path, monkeypatch
-) -> None:
+def test_default_parity_and_metadata_absent_lifecycle_boundary(tmp_path: Path, monkeypatch) -> None:
     """IT-003: default declarations stay explicit and broken metadata never falls back."""
     monkeypatch.chdir(tmp_path)
 
@@ -198,17 +313,17 @@ def _run_until_settled(
     return last_result
 
 
-
-
 # ---------------------------------------------------------------------------
 # Task 2: Happy Path E2E 測試
 # ---------------------------------------------------------------------------
+
 
 class TestHappyPath:
     def test_full_workflow_completes(self, tmp_path: Path) -> None:
         """完整 spec→plan→develop→review→pr→_done happy path。"""
         issue_dir = tmp_path / ".cafe" / "issues" / "issue-e2e-happy"
         playbook = _load_default_playbook()
+
         def executor(step_name: str, step_def: dict, state: BlackboardState) -> StepExecutionResult:
             events = []
             if step_name == "pr":
@@ -216,7 +331,9 @@ class TestHappyPath:
                 events.append({"type": "pr_synced", "url": "https://example.com/pr/1"})
             return StepExecutionResult(
                 response="confirmed",
-                artifacts={str(step_def.get("output_artifact", step_name)): f"{step_name}/output.md"},
+                artifacts={
+                    str(step_def.get("output_artifact", step_name)): f"{step_name}/output.md"
+                },
                 status_code="confirmed",
                 events=events,
             )
@@ -233,9 +350,7 @@ class TestHappyPath:
 
         blackboard = BlackboardStore(issue_dir).load_or_create("spec")
         step_completed_steps = [
-            e.data.get("step")
-            for e in blackboard.events
-            if e.event_type == "step_completed"
+            e.data.get("step") for e in blackboard.events if e.event_type == "step_completed"
         ]
         for step in ("spec", "plan", "develop", "review", "pr"):
             assert step in step_completed_steps, f"step_completed event missing for {step}"
@@ -244,6 +359,7 @@ class TestHappyPath:
         """每個步驟的 artifact 正確寫入 blackboard。"""
         issue_dir = tmp_path / ".cafe" / "issues" / "issue-e2e-artifacts"
         playbook = _load_default_playbook()
+
         def executor(step_name: str, step_def: dict, state: BlackboardState) -> StepExecutionResult:
             artifact_key = str(step_def.get("output_artifact", step_name))
             events = []
@@ -276,6 +392,7 @@ class TestHappyPath:
 # Task 3: Self-loop 迭代測試（全步驟）
 # ---------------------------------------------------------------------------
 
+
 class TestSelfLoop:
     def _run_single_step_loop(
         self,
@@ -306,7 +423,9 @@ class TestSelfLoop:
                     )
                 return StepExecutionResult(
                     response=final_status,
-                    artifacts={str(step_def.get("output_artifact", step_name)): f"{step_name}/output.md"},
+                    artifacts={
+                        str(step_def.get("output_artifact", step_name)): f"{step_name}/output.md"
+                    },
                     status_code=final_status,
                 )
             subsequent_calls[step_name] = subsequent_calls.get(step_name, 0) + 1
@@ -316,7 +435,9 @@ class TestSelfLoop:
                 events.append({"type": "pr_synced", "url": "https://example.com/pr/1"})
             return StepExecutionResult(
                 response="confirmed",
-                artifacts={str(step_def.get("output_artifact", step_name)): f"{step_name}/output.md"},
+                artifacts={
+                    str(step_def.get("output_artifact", step_name)): f"{step_name}/output.md"
+                },
                 status_code="confirmed",
                 events=events,
             )
@@ -401,7 +522,9 @@ class TestSelfLoop:
                 )
             return StepExecutionResult(
                 response="confirmed",
-                artifacts={str(step_def.get("output_artifact", step_name)): f"{step_name}/output.md"},
+                artifacts={
+                    str(step_def.get("output_artifact", step_name)): f"{step_name}/output.md"
+                },
                 status_code="confirmed",
             )
 
@@ -435,7 +558,9 @@ class TestSelfLoop:
                     )
             return StepExecutionResult(
                 response="confirmed",
-                artifacts={str(step_def.get("output_artifact", step_name)): f"{step_name}/output.md"},
+                artifacts={
+                    str(step_def.get("output_artifact", step_name)): f"{step_name}/output.md"
+                },
                 status_code="confirmed",
             )
 
@@ -448,7 +573,8 @@ class TestSelfLoop:
 
         blackboard = BlackboardStore(issue_dir).load_or_create("spec")
         spec_started_events = [
-            e for e in blackboard.events
+            e
+            for e in blackboard.events
             if e.event_type == "step_started" and e.data.get("step") == "spec"
         ]
         visits = [e.data.get("visit") for e in spec_started_events]
@@ -458,6 +584,7 @@ class TestSelfLoop:
 # ---------------------------------------------------------------------------
 # Task 4: User Handoff + Same-Run Continue 測試
 # ---------------------------------------------------------------------------
+
 
 class TestUserHandoff:
     def test_user_handoff_pauses_workflow(self, tmp_path: Path) -> None:
@@ -486,9 +613,7 @@ class TestUserHandoff:
         pause_events = [e for e in blackboard.events if e.event_type == "workflow_paused"]
         assert pause_events, "workflow_paused event should be recorded"
 
-    def test_contract_mismatch_realigns_before_resuming_agent_step(
-        self, tmp_path: Path
-    ) -> None:
+    def test_contract_mismatch_realigns_before_resuming_agent_step(self, tmp_path: Path) -> None:
         """A valid baton/current_step mismatch pauses once before the target step runs."""
         issue_dir = tmp_path / ".cafe" / "issues" / "issue-contract-mismatch"
         playbook = {
@@ -519,9 +644,7 @@ class TestUserHandoff:
         )
         executed_steps: list[str] = []
 
-        def executor(
-            step_name: str, step_def: dict, state: BlackboardState
-        ) -> StepExecutionResult:
+        def executor(step_name: str, step_def: dict, state: BlackboardState) -> StepExecutionResult:
             executed_steps.append(step_name)
             return StepExecutionResult(
                 response="confirmed",
@@ -540,9 +663,7 @@ class TestUserHandoff:
         assert executed_steps == []
         blackboard = BlackboardStore(issue_dir).load_or_create("spec")
         assert blackboard.current_step == "plan"
-        assert any(
-            e.event_type == "runtime_position_realigned" for e in blackboard.events
-        )
+        assert any(e.event_type == "runtime_position_realigned" for e in blackboard.events)
 
         second = BlackboardWorkflowRuntime(
             issue_dir=issue_dir,
@@ -554,9 +675,7 @@ class TestUserHandoff:
         assert second.final_step == "plan"
         assert executed_steps == ["plan"]
 
-    def test_contract_owner_user_and_done_are_terminal_positions(
-        self, tmp_path: Path
-    ) -> None:
+    def test_contract_owner_user_and_done_are_terminal_positions(self, tmp_path: Path) -> None:
         """Contract owner states should not execute an agent step while resuming."""
         playbook = {
             "playbook": {"id": "default"},
@@ -575,9 +694,7 @@ class TestUserHandoff:
         }
         executed_steps: list[str] = []
 
-        def executor(
-            step_name: str, step_def: dict, state: BlackboardState
-        ) -> StepExecutionResult:
+        def executor(step_name: str, step_def: dict, state: BlackboardState) -> StepExecutionResult:
             executed_steps.append(step_name)
             return StepExecutionResult(
                 response="confirmed",
@@ -607,10 +724,7 @@ class TestUserHandoff:
         assert user_result.completed is False
         assert user_result.final_step == "develop"
         assert user_result.final_status_code == "need_clarification"
-        assert (
-            BlackboardStore(user_issue_dir).load_or_create("develop").current_step
-            == "user"
-        )
+        assert BlackboardStore(user_issue_dir).load_or_create("develop").current_step == "user"
 
         done_issue_dir = tmp_path / ".cafe" / "issues" / "issue-contract-done"
         done_store = BlackboardStore(done_issue_dir)
@@ -633,10 +747,7 @@ class TestUserHandoff:
 
         assert done_result.completed is True
         assert done_result.final_step == "review"
-        assert (
-            BlackboardStore(done_issue_dir).load_or_create("develop").current_step
-            == "done"
-        )
+        assert BlackboardStore(done_issue_dir).load_or_create("develop").current_step == "done"
         assert executed_steps == []
 
     def test_user_handoff_auto_continue_resumes_in_same_run(self, tmp_path: Path) -> None:
@@ -662,7 +773,9 @@ class TestUserHandoff:
                 events.append({"type": "pr_synced", "url": "https://example.com/pr/1"})
             return StepExecutionResult(
                 response="confirmed",
-                artifacts={str(step_def.get("output_artifact", step_name)): f"{step_name}/output.md"},
+                artifacts={
+                    str(step_def.get("output_artifact", step_name)): f"{step_name}/output.md"
+                },
                 status_code="confirmed",
                 events=events,
             )
@@ -691,7 +804,10 @@ class TestUserHandoff:
 
         class FakeExecutor:
             def execute_step(
-                self, step_name: str, step_def: dict, blackboard_state: object,
+                self,
+                step_name: str,
+                step_def: dict,
+                blackboard_state: object,
                 extra_prompt: Optional[str] = None,
             ) -> StepExecutionResult:
                 nonlocal spec_calls
@@ -708,7 +824,9 @@ class TestUserHandoff:
                         )
                 return StepExecutionResult(
                     response="confirmed",
-                    artifacts={str(step_def.get("output_artifact", step_name)): f"{step_name}/output.md"},
+                    artifacts={
+                        str(step_def.get("output_artifact", step_name)): f"{step_name}/output.md"
+                    },
                     status_code="confirmed",
                 )
 
@@ -742,8 +860,11 @@ class TestUserHandoff:
 # Task 5.0: next_step.txt Lifecycle
 # ---------------------------------------------------------------------------
 
+
 class TestNextStepLifecycle:
-    def test_workflow_initializes_next_step_txt_when_missing(self, tmp_path: Path, monkeypatch) -> None:
+    def test_workflow_initializes_next_step_txt_when_missing(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
         """next_step.txt missing initially should be created once workflow starts."""
         monkeypatch.chdir(tmp_path)
 
@@ -768,7 +889,10 @@ class TestNextStepLifecycle:
 
         class FakeExecutor:
             def execute_step(
-                self, step_name: str, step_def: dict, blackboard_state: object,
+                self,
+                step_name: str,
+                step_def: dict,
+                blackboard_state: object,
                 extra_prompt: Optional[str] = None,
             ) -> tuple[str, dict[str, str]]:
                 if step_name == "pr":
@@ -802,6 +926,7 @@ class TestNextStepLifecycle:
 # ---------------------------------------------------------------------------
 # Task 5: Chat Baton 消費測試
 # ---------------------------------------------------------------------------
+
 
 class TestChatBaton:
     def _make_playbook_data(self) -> dict:
@@ -985,7 +1110,9 @@ class TestChatBaton:
             )
 
         assert result is None
-        assert next_step_path.exists(), "next_step.txt should NOT be deleted when uncommitted changes exist"
+        assert (
+            next_step_path.exists()
+        ), "next_step.txt should NOT be deleted when uncommitted changes exist"
 
     def test_chat_baton_no_file_returns_none(self, tmp_path: Path) -> None:
         """next_step.txt 不存在時應返回 None。"""

--- a/tests/integration/test_workflow_e2e.py
+++ b/tests/integration/test_workflow_e2e.py
@@ -58,6 +58,8 @@ class _BatonWritingAgentManager:
 
     def __init__(self, issue_dir: Path) -> None:
         self.issue_dir = issue_dir
+        self.prompts: list[str] = []
+        self.allowed_tools_calls: list[list[str] | None] = []
         self.agent = SimpleNamespace(
             config=SimpleNamespace(cli=AgentCLI.CODEX, session_id="integration-test", model=None)
         )
@@ -66,6 +68,8 @@ class _BatonWritingAgentManager:
         return self.agent
 
     def execute(self, _name: str, _prompt: str, **_kwargs):
+        self.prompts.append(_prompt)
+        self.allowed_tools_calls.append(_kwargs.get("allowed_tools"))
         state = BlackboardStore(self.issue_dir).load_or_create("release")
         BlackboardStore(self.issue_dir).update_handoff_contract(
             state,
@@ -153,6 +157,8 @@ steps:
       completion: baton
       publish_confirmation: true
       feedback_target: repair
+      context_providers: [workflow_metadata]
+      runtime_tool_grants: [git_inspection]
     hooks:
       prepare_input: [UserInputCollector]
       publish_output: [GitHubPRCreator]
@@ -162,12 +168,13 @@ steps:
     )
     playbook = PlaybookLoader().load("release-flow")
 
+    agent_manager = _BatonWritingAgentManager(issue_dir)
     executor = GenericWorkflowStepExecutor(
         issue_dir=issue_dir,
         issue_name="release-journey",
         playbook=playbook,
         generic_phase=_build_integration_generic_phase(tmp_path),
-        agent_manager=_BatonWritingAgentManager(issue_dir),
+        agent_manager=agent_manager,
         git_ops=_GitOperations(),
         role_agent_map={"developer": "David"},
     )
@@ -197,6 +204,8 @@ steps:
         ).run(start_step="release")
 
     assert result.completed is True
+    assert '"playbook_id": "release-flow"' in agent_manager.prompts[0]
+    assert "bash(git status)" in (agent_manager.allowed_tools_calls[0] or [])
     assert _load_issue_step_names("release-journey") == ["repair", "release"]
 
     iteration_dir = issue_dir / "release" / "iteration_001"

--- a/tests/integration/test_workflow_e2e.py
+++ b/tests/integration/test_workflow_e2e.py
@@ -25,8 +25,12 @@ from cafe.core.blackboard import (
 )
 from cafe.core.workflow_models import StepExecutionResult
 from cafe.core.workflow_runtime import BlackboardWorkflowRuntime
+from cafe.core.status_codes import PhaseStatusCode
+from cafe.core.playbook import resolve_step_behavior
+from cafe.phases.generic_workflow_step import align_pr_baton_after_execution
 from cafe.playbooks.loader import PlaybookLoader
 from cafe.ui.cli import _consume_pending_chat_handoff, app
+from cafe.ui.cli_shared import _load_issue_step_names
 
 
 def _write_pr_done_baton(issue_dir: Path) -> None:
@@ -42,6 +46,107 @@ def _write_pr_done_baton(issue_dir: Path) -> None:
         status_code="confirmed",
         source="test.executor",
     )
+
+
+def test_custom_publish_feedback_and_lifecycle_contracts(tmp_path: Path, monkeypatch) -> None:
+    """IT-001/IT-002: custom contracts publish, repair, and expose lifecycle steps."""
+    monkeypatch.chdir(tmp_path)
+    issue_dir = tmp_path / ".cafe" / "issues" / "release-journey"
+    issue_dir.mkdir(parents=True)
+    (issue_dir / "issue.yaml").write_text(
+        "playbook: release-flow\npr:\n  auto_create: true\n", encoding="utf-8"
+    )
+    playbook_dir = tmp_path / ".cafe" / "playbooks"
+    playbook_dir.mkdir(parents=True)
+    (playbook_dir / "release-flow.yaml").write_text(
+        """
+playbook:
+  id: release-flow
+steps:
+  repair:
+    skill: cafe-develop
+    role: developer
+    on: {await_agent: release}
+  release:
+    skill: cafe-develop
+    role: developer
+    capability_requests: [cafe.pr.publish]
+    behavior:
+      completion: baton
+      publish_confirmation: true
+      feedback_target: repair
+    on: {await_agent: _done}
+""".strip(),
+        encoding="utf-8",
+    )
+    playbook = PlaybookLoader().load("release-flow")
+
+    def executor(step_name: str, _step_def: dict, state: BlackboardState) -> StepExecutionResult:
+        BlackboardStore(issue_dir).update_handoff_contract(
+            state,
+            from_step=step_name,
+            to_owner=HandoffOwner.DONE,
+            to_step="done",
+            intent=HandoffIntent.WORKFLOW_COMPLETE,
+            status_code="confirmed",
+            source="test.executor",
+        )
+        return StepExecutionResult(
+            response="confirmed",
+            artifacts={},
+            status_code="confirmed",
+            events=[{"type": "pr_synced"}],
+        )
+
+    result = BlackboardWorkflowRuntime(
+        issue_dir=issue_dir, playbook=playbook, executor=executor
+    ).run(start_step="release")
+
+    assert result.completed is True
+    assert _load_issue_step_names("release-journey") == ["repair", "release"]
+
+    store = BlackboardStore(issue_dir)
+    state = store.load_or_create("release")
+    store.update_handoff_contract(
+        state,
+        from_step="release",
+        to_owner=HandoffOwner.AGENT,
+        to_step="release",
+        intent=HandoffIntent.AWAIT_AGENT,
+        status_code=PhaseStatusCode.NEEDS_CHANGES.value,
+        source="test.feedback",
+    )
+    align_pr_baton_after_execution(
+        issue_dir=issue_dir,
+        playbook=playbook,
+        blackboard_state=state,
+        step_name="release",
+        status_code=PhaseStatusCode.NEEDS_CHANGES.value,
+    )
+
+    assert store.load_handoff_contract(state, allowed_steps=["repair", "release"]).to_step == "repair"
+
+
+def test_default_parity_and_metadata_absent_lifecycle_boundary(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """IT-003: default declarations stay explicit and broken metadata never falls back."""
+    monkeypatch.chdir(tmp_path)
+
+    default = PlaybookLoader().load("default")
+    assert resolve_step_behavior(default, "pr").publish_confirmation is True
+    assert resolve_step_behavior(default, "review").runtime_tool_grants == [
+        "web_research",
+        "git_inspection",
+    ]
+    assert _load_issue_step_names("metadata-absent") == ["spec", "plan", "develop", "review", "pr"]
+
+    issue_dir = tmp_path / ".cafe" / "issues" / "configured-invalid"
+    issue_dir.mkdir(parents=True)
+    (issue_dir / "issue.yaml").write_text("playbook: unavailable\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="could not be loaded"):
+        _load_issue_step_names("configured-invalid")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_workflow_e2e.py
+++ b/tests/integration/test_workflow_e2e.py
@@ -29,7 +29,6 @@ from cafe.core.workflow_runtime import BlackboardWorkflowRuntime
 from cafe.core.types import AgentCLI, TokenUsage
 from cafe.core.status_codes import PhaseStatusCode
 from cafe.core.playbook import resolve_step_behavior
-from cafe.phases.generic_workflow_step import align_pr_baton_after_execution
 from cafe.phases.generic_workflow_step import GenericWorkflowStepExecutor
 from cafe.phases.generic_phase import GenericPhase
 from cafe.playbooks.loader import PlaybookLoader
@@ -80,6 +79,24 @@ class _BatonWritingAgentManager:
         return "completed", TokenUsage(), [], [], [], None
 
 
+class _FeedbackAgentManager(_BatonWritingAgentManager):
+    """Test-double agent that reports publish feedback through the normal executor."""
+
+    def execute(self, _name: str, _prompt: str, **_kwargs):
+        store = BlackboardStore(self.issue_dir)
+        state = store.load_or_create("release")
+        store.update_handoff_contract(
+            state,
+            from_step="release",
+            to_owner=HandoffOwner.AGENT,
+            to_step="repair",
+            intent=HandoffIntent.AWAIT_AGENT,
+            status_code=PhaseStatusCode.NEEDS_CHANGES.value,
+            source="test.feedback",
+        )
+        return "needs_changes", TokenUsage(), [], [], [], None
+
+
 class _GitOperations:
     def get_default_base_branch(self) -> str:
         return "main"
@@ -90,7 +107,7 @@ class _GitOperations:
 
 def _build_integration_generic_phase(tmp_path: Path) -> GenericPhase:
     skill_dir = tmp_path / "builtin" / "skills" / "cafe-develop"
-    skill_dir.mkdir(parents=True)
+    skill_dir.mkdir(parents=True, exist_ok=True)
     (skill_dir / "SKILL.md").write_text(
         "---\nname: cafe-develop\ndescription: Integration test skill\n---\n\n# Develop\n",
         encoding="utf-8",
@@ -108,7 +125,7 @@ def _build_integration_generic_phase(tmp_path: Path) -> GenericPhase:
 
 
 def test_custom_publish_feedback_and_lifecycle_contracts(tmp_path: Path, monkeypatch) -> None:
-    """IT-001/IT-002: a custom publish journey uses executor, hooks, and receipts."""
+    """IT-001/IT-002: custom publish feedback resumes its declared repair step."""
     monkeypatch.chdir(tmp_path)
     issue_dir = tmp_path / ".cafe" / "issues" / "release-journey"
     issue_dir.mkdir(parents=True)
@@ -191,6 +208,76 @@ steps:
 
     runner = CliRunner()
     git_factory = lambda: SimpleNamespace(get_current_branch=lambda: "release-journey")
+
+    feedback_executor = GenericWorkflowStepExecutor(
+        issue_dir=issue_dir,
+        issue_name="release-journey",
+        playbook=playbook,
+        generic_phase=_build_integration_generic_phase(tmp_path),
+        agent_manager=_FeedbackAgentManager(issue_dir),
+        git_ops=_GitOperations(),
+        role_agent_map={"developer": "David"},
+    )
+    BlackboardWorkflowRuntime(
+        issue_dir=issue_dir,
+        playbook=playbook,
+        executor=feedback_executor.execute_step,
+    ).run(start_step="release", single_step=True)
+
+    state = BlackboardStore(issue_dir).load_or_create("release")
+    assert (
+        BlackboardStore(issue_dir)
+        .load_handoff_contract(state, allowed_steps=["repair", "release"])
+        .to_step
+        == "repair"
+    )
+
+    resumed_steps: list[str] = []
+
+    class _ResumeExecutor:
+        def execute_step(
+            self,
+            step_name: str,
+            step_def: dict,
+            blackboard_state: object,
+            extra_prompt: Optional[str] = None,
+        ) -> StepExecutionResult:
+            resumed_steps.append(step_name)
+            if step_name == "release":
+                BlackboardStore(issue_dir).update_handoff_contract(
+                    blackboard_state,
+                    from_step="release",
+                    to_owner=HandoffOwner.DONE,
+                    to_step="done",
+                    intent=HandoffIntent.WORKFLOW_COMPLETE,
+                    source="test.resume",
+                )
+            return StepExecutionResult(
+                response="confirmed",
+                artifacts={},
+                status_code="confirmed",
+            )
+
+    with (
+        patch("cafe.ui.cli.GitOperations", return_value=git_factory()),
+        patch("cafe.ui.cli._build_workflow_step_executor", return_value=_ResumeExecutor()),
+    ):
+        resume_result = runner.invoke(
+            app,
+            [
+                "workflow",
+                "--playbook",
+                "release-flow",
+                "--issue",
+                "release-journey",
+                "--start-step",
+                "repair",
+                "--execute",
+            ],
+        )
+    assert resume_result.exit_code == 0, resume_result.output
+    assert resumed_steps == ["repair", "release"]
+
     with patch("cafe.ui.commands.workflow._get_GitOperations", return_value=git_factory):
         show_result = runner.invoke(app, ["show", "release"])
     assert show_result.exit_code == 0
@@ -209,43 +296,24 @@ steps:
         status_result = runner.invoke(app, ["status"])
     assert status_result.exit_code == 0
 
+    feedback_iteration_dir = issue_dir / "release" / "iteration_002"
+    assert feedback_iteration_dir.exists()
     with (
         patch("cafe.ui.cli.GitOperations", return_value=git_factory()),
-        patch("cafe.ui.cli.prompt_confirm", return_value=False),
+        patch("cafe.ui.cli.prompt_confirm", return_value=True),
         patch("cafe.ui.commands.lifecycle.GitOperations", return_value=git_factory()),
         patch("cafe.ui.commands.lifecycle._get_project_path", return_value="test/project"),
-        patch("cafe.ui.commands.lifecycle.prompt_confirm", return_value=False),
+        patch("cafe.ui.commands.lifecycle.prompt_confirm", return_value=True),
+        patch("cafe.ui.commands.lifecycle.Path.home", return_value=tmp_path / "home"),
     ):
         reset_result = runner.invoke(app, ["reset", "release"])
-    assert reset_result.exit_code == 0
+    assert reset_result.exit_code == 0, reset_result.output
     assert iteration_dir.exists()
-
-    store = BlackboardStore(issue_dir)
-    state = store.load_or_create("release")
-    store.update_handoff_contract(
-        state,
-        from_step="release",
-        to_owner=HandoffOwner.AGENT,
-        to_step="release",
-        intent=HandoffIntent.AWAIT_AGENT,
-        status_code=PhaseStatusCode.NEEDS_CHANGES.value,
-        source="test.feedback",
-    )
-    align_pr_baton_after_execution(
-        issue_dir=issue_dir,
-        playbook=playbook,
-        blackboard_state=state,
-        step_name="release",
-        status_code=PhaseStatusCode.NEEDS_CHANGES.value,
-    )
-
-    assert (
-        store.load_handoff_contract(state, allowed_steps=["repair", "release"]).to_step == "repair"
-    )
+    assert not feedback_iteration_dir.exists()
 
 
 def test_default_parity_and_metadata_absent_lifecycle_boundary(tmp_path: Path, monkeypatch) -> None:
-    """IT-003: default declarations stay explicit and broken metadata never falls back."""
+    """IT-003: default completion, correction, review, and publish remain observable."""
     monkeypatch.chdir(tmp_path)
 
     default = PlaybookLoader().load("default")
@@ -254,6 +322,46 @@ def test_default_parity_and_metadata_absent_lifecycle_boundary(tmp_path: Path, m
         "web_research",
         "git_inspection",
     ]
+
+    issue_dir = tmp_path / ".cafe" / "issues" / "default-parity"
+    executed_steps: list[str] = []
+    review_visits = 0
+
+    def default_executor(
+        step_name: str, step_def: dict, state: BlackboardState
+    ) -> StepExecutionResult:
+        nonlocal review_visits
+        executed_steps.append(step_name)
+        if step_name == "review":
+            review_visits += 1
+            if review_visits == 1:
+                return StepExecutionResult(
+                    response="needs_changes",
+                    artifacts={},
+                    status_code="needs_changes",
+                )
+        events = []
+        if step_name == "pr":
+            _write_pr_done_baton(issue_dir)
+            events.append({"type": "pr_synced", "url": "https://example.test/pr/default"})
+        return StepExecutionResult(
+            response="confirmed",
+            artifacts={str(step_def.get("output_artifact", step_name)): f"{step_name}/output.md"},
+            status_code="confirmed",
+            events=events,
+        )
+
+    result = _run_until_settled(
+        issue_dir=issue_dir,
+        playbook=default,
+        executor=default_executor,
+        max_transitions=20,
+    )
+    assert result.completed is True
+    assert executed_steps.count("develop") == 2
+    assert executed_steps.count("review") == 2
+    assert executed_steps[-1] == "pr"
+
     assert _load_issue_step_names("metadata-absent") == ["spec", "plan", "develop", "review", "pr"]
 
     issue_dir = tmp_path / ".cafe" / "issues" / "configured-invalid"

--- a/tests/unit/test_agent_manager.py
+++ b/tests/unit/test_agent_manager.py
@@ -190,7 +190,7 @@ class TestAgentExecution:
         with pytest.raises(AgentNotFoundError, match="No current agent selected"):
             manager.execute_current("Test prompt")
 
-    def test_develop_read_only_budget_resumes_once_with_immediate_edit_prompt(self) -> None:
+    def test_declared_read_only_budget_resumes_once_with_immediate_edit_prompt(self) -> None:
         from cafe.core.types import AgentResponse, TokenUsage
 
         manager = AgentManager()
@@ -219,7 +219,8 @@ class TestAgentExecution:
             response, *_ = manager.execute(
                 "David",
                 "original phase prompt",
-                phase_name="develop",
+                phase_name="build",
+                max_read_only_commands=20,
             )
 
         assert response == "done"
@@ -227,6 +228,36 @@ class TestAgentExecution:
         assert calls[1][1:] == (20, 3)
         assert "FIRST tool action must be a file edit" in calls[1][0]
         assert "Do not restart discovery" in calls[1][0]
+
+    def test_declared_read_only_budget_is_shared_with_backup_agents(self) -> None:
+        from cafe.core.types import AgentResponse, TokenUsage
+
+        manager = AgentManager()
+        manager.register_agent(
+            AgentConfig(
+                name="David",
+                cli=AgentCLI.CODEX,
+                backup_clis=[AgentCLI.CLAUDE],
+            )
+        )
+        limits = []
+
+        def execute_side_effect(*args, max_read_only_commands=None, **kwargs):
+            limits.append(max_read_only_commands)
+            if len(limits) == 1:
+                raise AgentExecutionError("temporary failure", error_type="rate_limit")
+            return AgentResponse(response="done", token_usage=TokenUsage())
+
+        with patch.object(AgentExecutor, "execute", side_effect=execute_side_effect):
+            response, *_ = manager.execute(
+                "David",
+                "original phase prompt",
+                phase_name="build",
+                max_read_only_commands=7,
+            )
+
+        assert response == "done"
+        assert limits == [7, 7]
 
 
 class TestSessionManagement:

--- a/tests/unit/test_cli_ls_rm.py
+++ b/tests/unit/test_cli_ls_rm.py
@@ -195,6 +195,31 @@ class TestLsCommand:
             assert "empty" not in line
         assert ".cafe/worktrees/issue27" in result.stdout
 
+    def test_ls_displays_custom_playbook_step_directories(self, temp_issues_dir):
+        """UT-009: issue display derives phases from the configured playbook."""
+        issue = temp_issues_dir / "release-issue"
+        issue.mkdir()
+        (issue / "issue.yaml").write_text("playbook: release-flow\n", encoding="utf-8")
+        (issue / "repair").mkdir()
+        (issue / "release").mkdir()
+        playbook_dir = temp_issues_dir.parent / "playbooks"
+        playbook_dir.mkdir()
+        (playbook_dir / "release-flow.yaml").write_text(
+            """
+playbook:
+  id: release-flow
+steps:
+  repair: {skill: cafe-develop, role: developer, on: {await_agent: release}}
+  release: {skill: cafe-pr, role: developer, on: {await_agent: _done}}
+""".strip(),
+            encoding="utf-8",
+        )
+
+        result = runner.invoke(app, ["ls"])
+
+        assert result.exit_code == 0
+        assert "repair, release" in result.stdout
+
 
 class TestRmCommand:
     """Test rm command."""

--- a/tests/unit/test_cli_ls_rm.py
+++ b/tests/unit/test_cli_ls_rm.py
@@ -220,6 +220,18 @@ steps:
         assert result.exit_code == 0
         assert "repair, release" in result.stdout
 
+    def test_ls_surfaces_invalid_configured_playbook(self, temp_issues_dir):
+        """UT-009: configured-playbook failures are never displayed as empty."""
+        issue = temp_issues_dir / "broken-issue"
+        issue.mkdir()
+        (issue / "issue.yaml").write_text("playbook: missing-flow\n", encoding="utf-8")
+
+        result = runner.invoke(app, ["ls"])
+
+        assert result.exit_code == 0
+        assert "broken-issue" in result.stdout
+        assert "could not be loaded" in result.stdout
+
 
 class TestRmCommand:
     """Test rm command."""

--- a/tests/unit/test_cli_setup_agents.py
+++ b/tests/unit/test_cli_setup_agents.py
@@ -137,6 +137,7 @@ class TestSetupAgentsPhaseAware:
         (tmp_path / ".cafe" / "phases.yaml").write_text(
             """
 spec:
+  role: pm
   clis:
     - cli: copilot
       model: claude-3-haiku-20240307

--- a/tests/unit/test_cli_workflow_command.py
+++ b/tests/unit/test_cli_workflow_command.py
@@ -3277,6 +3277,52 @@ steps:
         assert executed_steps == ["develop", "pr"]
 
 
+def test_workflow_resume_uses_the_issue_owned_playbook_before_global_config(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """UT-009: an existing issue resumes its recorded workflow, not global config."""
+    monkeypatch.chdir(tmp_path)
+    cafe_dir = tmp_path / ".cafe"
+    issue_dir = cafe_dir / "issues" / "issue-owned-flow"
+    issue_dir.mkdir(parents=True)
+    (cafe_dir / "config.yaml").write_text("playbook: default\n", encoding="utf-8")
+    (issue_dir / "issue.yaml").write_text("playbook: release-flow\n", encoding="utf-8")
+    playbook_dir = cafe_dir / "playbooks"
+    playbook_dir.mkdir()
+    (playbook_dir / "release-flow.yaml").write_text(
+        """
+playbook:
+  id: release-flow
+steps:
+  ship:
+    skill: cafe-develop
+    role: developer
+    on: {await_agent: _done}
+""".strip(),
+        encoding="utf-8",
+    )
+    executed_steps: list[str] = []
+
+    with (
+        patch("cafe.ui.cli.GitOperations") as mock_git_cls,
+        patch("cafe.ui.cli._build_workflow_step_executor") as mock_builder,
+    ):
+        git = MagicMock()
+        git.get_current_branch.return_value = "issue-owned-flow"
+        mock_git_cls.return_value = git
+        executor = MagicMock()
+        executor.execute_step.side_effect = lambda step_name, step_def, state, **kwargs: (
+            executed_steps.append(step_name)
+            or _result(status_code="confirmed", step_name=step_name, step_def=step_def, artifacts={})
+        )
+        mock_builder.return_value = executor
+
+        result = runner.invoke(app, ["workflow", "--issue", "issue-owned-flow", "--execute"])
+
+    assert result.exit_code == 0, result.output
+    assert executed_steps == ["ship"]
+
+
 def test_workflow_execute_syncs_active_issue_on_healthy_branch(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.chdir(tmp_path)
     cafe_dir = tmp_path / ".cafe"

--- a/tests/unit/test_cli_workflow_command.py
+++ b/tests/unit/test_cli_workflow_command.py
@@ -167,6 +167,52 @@ def test_workflow_command_runs_dry_mode(tmp_path: Path, monkeypatch) -> None:
         assert blackboard_file.exists()
 
 
+def test_workflow_dry_mode_completes_declared_custom_publish_step(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """IT-001: dry execution recognizes publish behavior, not a step name."""
+    monkeypatch.chdir(tmp_path)
+    playbook_dir = tmp_path / ".cafe" / "playbooks"
+    playbook_dir.mkdir(parents=True)
+    (playbook_dir / "custom.yaml").write_text(
+        """
+playbook:
+  id: custom
+steps:
+  release:
+    skill: cafe-pr
+    role: developer
+    capability_requests: [cafe.pr.publish]
+    behavior:
+      completion: baton
+      publish_confirmation: true
+    on:
+      await_agent: _done
+""".strip(),
+        encoding="utf-8",
+    )
+
+    with patch("cafe.ui.cli.GitOperations") as mock_git_cls:
+        git = MagicMock()
+        git.get_current_branch.return_value = "issue-custom-publish"
+        mock_git_cls.return_value = git
+
+        result = runner.invoke(app, ["workflow", "--playbook", "custom", "--dry-run"])
+
+    assert result.exit_code == 0
+    assert "Workflow completed" in result.stdout
+    blackboard = json.loads(
+        (
+            tmp_path
+            / ".cafe"
+            / "issues"
+            / "issue-custom-publish"
+            / "blackboard.json"
+        ).read_text(encoding="utf-8")
+    )
+    assert blackboard["current_step"] == "done"
+
+
 def test_workflow_command_runs_execute_mode(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.chdir(tmp_path)
     executed_steps: list[str] = []

--- a/tests/unit/test_cli_workflow_command.py
+++ b/tests/unit/test_cli_workflow_command.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
 from typer.testing import CliRunner
 
 from cafe.agents.executor import AgentExecutionError
@@ -64,6 +65,26 @@ steps:
     )
     assert _resolve_issue_playbook_name("custom-issue") == "release-flow"
     assert _load_issue_step_names("custom-issue") == ["prepare", "deploy"]
+
+
+@pytest.mark.parametrize(
+    ("filename", "contents"),
+    [
+        ("blackboard.json", "{not json"),
+        ("issue.yaml", "playbook: [not valid"),
+    ],
+)
+def test_issue_playbook_resolution_rejects_unreadable_persisted_metadata(
+    tmp_path: Path, monkeypatch, filename: str, contents: str
+) -> None:
+    """UT-009: resume never replaces present broken metadata with ``default``."""
+    monkeypatch.chdir(tmp_path)
+    issue_dir = tmp_path / ".cafe" / "issues" / "broken-issue"
+    issue_dir.mkdir(parents=True)
+    (issue_dir / filename).write_text(contents, encoding="utf-8")
+
+    with pytest.raises(ValueError, match="unreadable workflow metadata"):
+        _resolve_issue_playbook_name("broken-issue")
 
 
 def _result(

--- a/tests/unit/test_cli_workflow_command.py
+++ b/tests/unit/test_cli_workflow_command.py
@@ -19,12 +19,51 @@ from cafe.ui.cli import (
 from cafe.ui.cli_shared import (
     _alignment_checkpoint_menu_choices,
     _build_workflow_step_executor,
+    _load_issue_step_names,
+    _resolve_issue_playbook_name,
     apply_alignment_decision_from_payload,
 )
 from cafe.ui.commands.workflow import _reset_baton_for_explicit_start_step
 from cafe.utils.config import ConfigManager
 
 runner = CliRunner()
+
+
+def test_issue_step_resolution_uses_issue_yaml_before_blackboard_exists(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """UT-009: configured custom steps are valid before the runtime creates state."""
+    monkeypatch.chdir(tmp_path)
+    issue_dir = tmp_path / ".cafe" / "issues" / "custom-issue"
+    issue_dir.mkdir(parents=True)
+    (issue_dir / "issue.yaml").write_text("playbook: release-flow\n", encoding="utf-8")
+    playbook_dir = tmp_path / ".cafe" / "playbooks"
+    playbook_dir.mkdir(parents=True)
+    (playbook_dir / "release-flow.yaml").write_text(
+        """
+playbook:
+  id: release-flow
+steps:
+  prepare:
+    skill: cafe-develop
+    role: developer
+    on: {await_agent: deploy}
+  deploy:
+    skill: cafe-develop
+    role: developer
+    on: {await_agent: _done}
+""".strip(),
+        encoding="utf-8",
+    )
+
+    assert _resolve_issue_playbook_name("custom-issue") == "release-flow"
+    assert _load_issue_step_names("custom-issue") == ["prepare", "deploy"]
+
+    (issue_dir / "blackboard.json").write_text(
+        json.dumps({"current_step": "prepare"}), encoding="utf-8"
+    )
+    assert _resolve_issue_playbook_name("custom-issue") == "release-flow"
+    assert _load_issue_step_names("custom-issue") == ["prepare", "deploy"]
 
 
 def _result(

--- a/tests/unit/test_generic_workflow_step.py
+++ b/tests/unit/test_generic_workflow_step.py
@@ -305,7 +305,10 @@ def test_generic_step_passes_declared_read_only_guard_to_agent_manager(
                 "output_artifact": "spec",
                 "allowed_tools": ["Read"],
                 "valid_intents": ["confirmed"],
-                "behavior": {"max_read_only_commands": 7},
+                "behavior": {
+                    "completion": "status_code",
+                    "max_read_only_commands": 7,
+                },
                 "on": {"await_agent": "_done"},
             }
         },
@@ -325,6 +328,74 @@ def test_generic_step_passes_declared_read_only_guard_to_agent_manager(
     executor.execute_step("build", playbook["steps"]["build"], state)
 
     assert agent_manager.max_read_only_commands_calls == [7]
+
+
+def test_generic_step_forwards_declared_read_only_guard_on_checklist_retry(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """UT-003: a custom step preserves its guard when checklist retrying."""
+    monkeypatch.chdir(tmp_path)
+    issue_dir = tmp_path / ".cafe" / "issues" / "issue-declared-guard-retry"
+    checklist = issue_dir / "build" / "iteration_001" / "checklist.md"
+
+    class ChecklistRetryManager(FakeAgentManager):
+        def __init__(self) -> None:
+            super().__init__(["confirmed", "confirmed"])
+
+        def execute(self, *args, continuation=None, **kwargs):
+            result = super().execute(*args, **kwargs)
+            checklist.write_text(
+                "[ ] complete task\n"
+                if len(self.max_read_only_commands_calls) == 1
+                else "[x] complete task\n",
+                encoding="utf-8",
+            )
+            return result
+
+    playbook = {
+        "playbook": {"id": "custom"},
+        "roles": {"pm": {"default_agent": "Roger"}},
+        "steps": {
+            "build": {
+                "skill": {"default": "spec_first"},
+                "role": "pm",
+                "output_artifact": "spec",
+                "allowed_tools": ["Read"],
+                "valid_intents": ["confirmed"],
+                "behavior": {
+                    "completion": "status_code",
+                    "max_read_only_commands": 7,
+                },
+                "on": {"await_agent": "_done"},
+            }
+        },
+    }
+    state = BlackboardStore(issue_dir).load_or_create("build")
+    agent_manager = ChecklistRetryManager()
+    generic_phase = _build_loader(tmp_path)
+    executor = GenericWorkflowStepExecutor(
+        issue_dir=issue_dir,
+        issue_name="issue-declared-guard-retry",
+        playbook=playbook,
+        generic_phase=generic_phase,
+        agent_manager=agent_manager,
+        git_ops=FakeGitOperations(),
+        role_agent_map={"pm": "Roger"},
+    )
+
+    def execute_with_confirmed_status(*args, **kwargs):
+        response = kwargs["agent_executor"]("prompt")
+        return GenericPhaseExecution(
+            response=response,
+            status_code=PhaseStatusCode.CONFIRMED,
+            goto_target=None,
+        )
+
+    monkeypatch.setattr(generic_phase, "execute", execute_with_confirmed_status)
+
+    executor.execute_step("build", playbook["steps"]["build"], state)
+
+    assert agent_manager.max_read_only_commands_calls == [7, 7]
 
 
 def test_resolve_agent_name_uses_phase_config_name(tmp_path: Path, monkeypatch) -> None:

--- a/tests/unit/test_generic_workflow_step.py
+++ b/tests/unit/test_generic_workflow_step.py
@@ -1062,6 +1062,8 @@ def test_generic_workflow_step_prompt_keeps_skill_invocations_only(
             "pr": {
                 "skill": "pr",
                 "role": "developer",
+                "behavior": {"completion": "baton", "publish_confirmation": True},
+                "capability_requests": ["cafe.pr.publish"],
                 "output_artifact": "pr",
                 "allowed_tools": ["Read"],
                 "valid_intents": ["confirmed"],
@@ -1165,6 +1167,8 @@ def test_generic_workflow_step_writes_pr_publish_request_contract(
             "pr": {
                 "skill": "pr",
                 "role": "developer",
+                "behavior": {"completion": "baton", "publish_confirmation": True},
+                "capability_requests": ["cafe.pr.publish"],
                 "output_artifact": "pr",
                 "allowed_tools": ["Read"],
                 "valid_intents": ["confirmed"],
@@ -1858,6 +1862,7 @@ def test_generic_workflow_step_restores_review_runtime_allowed_tools(
             "review": {
                 "skill": "review",
                 "role": "reviewer",
+                "behavior": {"runtime_tool_grants": ["web_research", "git_inspection"]},
                 "output_artifact": "review_feedback",
                 "allowed_tools": ["Read", "Grep", "Glob", "Bash(git:*)"],
                 "valid_intents": ["confirmed"],
@@ -2045,6 +2050,7 @@ def test_generic_workflow_step_pr_does_not_parse_status_from_response(
             "pr": {
                 "skill": "pr",
                 "role": "developer",
+                "behavior": {"completion": "baton"},
                 "output_artifact": "pr_result",
                 "allowed_tools": ["Read"],
                 "valid_intents": ["confirmed"],

--- a/tests/unit/test_generic_workflow_step.py
+++ b/tests/unit/test_generic_workflow_step.py
@@ -4632,6 +4632,7 @@ def test_checklist_retry_receives_exact_session_and_phase_name(
         prompt="prompt",
         user_input="",
         valid_intents=[PhaseStatusCode.CONFIRMED],
+        max_read_only_commands=7,
         max_retries=1,
     )
 
@@ -4640,6 +4641,7 @@ def test_checklist_retry_receives_exact_session_and_phase_name(
     assert manager.received[0][0].policy == SessionContinuationPolicy.RESUME_EXACT
     assert manager.received[0][0].session_id == "fresh-session"
     assert manager.received[0][1] == "spec"
+    assert manager.max_read_only_commands_calls == [7]
 
 
 def test_checklist_retry_accumulates_raw_iteration_telemetry(

--- a/tests/unit/test_generic_workflow_step.py
+++ b/tests/unit/test_generic_workflow_step.py
@@ -54,6 +54,7 @@ class FakeAgentManager:
         self.prompts: list[str] = []
         self.allowed_tools_calls: list[list[str] | None] = []
         self.allowed_directories_calls: list[list[str] | None] = []
+        self.max_read_only_commands_calls: list[int | None] = []
         self.preview_calls: list[list[str] | None] = []
         self.agent = SimpleNamespace(
             config=SimpleNamespace(cli=AgentCLI.CODEX, session_id="session-1", model=None)
@@ -88,12 +89,14 @@ class FakeAgentManager:
         allowed_directories=None,
         streaming_output_file=None,
         phase_name=None,
+        max_read_only_commands=None,
     ):
         self.prompts.append(prompt)
         self.allowed_tools_calls.append(list(allowed_tools) if allowed_tools is not None else None)
         self.allowed_directories_calls.append(
             list(allowed_directories) if allowed_directories is not None else None
         )
+        self.max_read_only_commands_calls.append(max_read_only_commands)
         response = next(self._responses)
         if self.on_execute is not None:
             self.on_execute(
@@ -284,6 +287,44 @@ def test_generic_workflow_step_executor_writes_iteration_files(tmp_path: Path, m
     assert reloaded.handoff_contract.intent == HandoffIntent.WORKFLOW_COMPLETE
     assert reloaded.handoff_contract.status_code == "confirmed"
     assert reloaded.handoff_contract.source == "workflow.status_transition_adapter"
+
+
+def test_generic_step_passes_declared_read_only_guard_to_agent_manager(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """UT-003: a custom step forwards its resolved guard to execution."""
+    monkeypatch.chdir(tmp_path)
+    issue_dir = tmp_path / ".cafe" / "issues" / "issue-declared-guard"
+    playbook = {
+        "playbook": {"id": "custom"},
+        "roles": {"pm": {"default_agent": "Roger"}},
+        "steps": {
+            "build": {
+                "skill": {"default": "spec_first"},
+                "role": "pm",
+                "output_artifact": "spec",
+                "allowed_tools": ["Read"],
+                "valid_intents": ["confirmed"],
+                "behavior": {"max_read_only_commands": 7},
+                "on": {"await_agent": "_done"},
+            }
+        },
+    }
+    state = BlackboardStore(issue_dir).load_or_create("build")
+    agent_manager = FakeAgentManager("confirmed")
+    executor = GenericWorkflowStepExecutor(
+        issue_dir=issue_dir,
+        issue_name="issue-declared-guard",
+        playbook=playbook,
+        generic_phase=_build_loader(tmp_path),
+        agent_manager=agent_manager,
+        git_ops=FakeGitOperations(),
+        role_agent_map={"pm": "Roger"},
+    )
+
+    executor.execute_step("build", playbook["steps"]["build"], state)
+
+    assert agent_manager.max_read_only_commands_calls == [7]
 
 
 def test_resolve_agent_name_uses_phase_config_name(tmp_path: Path, monkeypatch) -> None:

--- a/tests/unit/test_native_user_input_hook.py
+++ b/tests/unit/test_native_user_input_hook.py
@@ -218,6 +218,31 @@ def test_user_input_collector_plan_ready_for_review_falls_back_to_full_output_wi
     mock_display_output.assert_called_once()
 
 
+def test_user_input_collector_uses_resolved_publish_contract_from_context(tmp_path: Path) -> None:
+    """UT-004: playbook-level publish behavior bypasses duplicate confirmation."""
+    phase_dir = tmp_path / "release"
+    previous_dir = phase_dir / "iteration_001"
+    previous_dir.mkdir(parents=True, exist_ok=True)
+    (previous_dir / "output.md").write_text("# Release\n", encoding="utf-8")
+    _record_previous_step_status(tmp_path, "release", "ready_for_review")
+
+    phase = _FakePhase(phase_dir=phase_dir, iteration=2)
+    phase._ask_user_for_review_decision = MagicMock(return_value="confirm")
+    hook = UserInputCollector()
+
+    result = hook.run(
+        stage="prepare_input",
+        phase=phase,
+        step_name="release",
+        step_def={"role": "developer"},
+        context={"publish_confirmation": True},
+        agent_name="David",
+    )
+
+    assert result.continue_pipeline is True
+    phase._ask_user_for_review_decision.assert_not_called()
+
+
 def test_user_input_collector_loads_interactive_qa_for_need_clarification(tmp_path: Path) -> None:
     phase_dir = tmp_path / "spec"
     prev_iter_dir = phase_dir / "iteration_001"

--- a/tests/unit/test_native_user_input_hook.py
+++ b/tests/unit/test_native_user_input_hook.py
@@ -21,6 +21,12 @@ from cafe.phases.generic_phase import GenericPhaseExecution
 from cafe.phases.generic_workflow_step import GenericWorkflowStepExecutor
 
 
+PUBLISH_STEP = {
+    "capability_requests": ["cafe.pr.publish"],
+    "behavior": {"publish_confirmation": True},
+}
+
+
 class _FakePhase:
     def __init__(self, phase_dir: Path, iteration: int, issue_name: str = "demo") -> None:
         self.phase_dir = phase_dir
@@ -883,7 +889,9 @@ def test_pr_link_opener_opens_current_pr_url_when_confirmed() -> None:
             "https://github.com/test/repo/pull/123"
         )
 
-        result = hook.run(stage="publish_output", status_code=PhaseStatusCode.CONFIRMED)
+        result = hook.run(
+            stage="publish_output", status_code=PhaseStatusCode.CONFIRMED, step_def=PUBLISH_STEP
+        )
 
     mock_open.assert_called_once_with("https://github.com/test/repo/pull/123")
     assert result.events == [
@@ -903,7 +911,9 @@ def test_pr_link_opener_skips_browser_in_non_interactive() -> None:
             "https://github.com/test/repo/pull/123"
         )
 
-        result = hook.run(stage="publish_output", status_code=PhaseStatusCode.CONFIRMED)
+        result = hook.run(
+            stage="publish_output", status_code=PhaseStatusCode.CONFIRMED, step_def=PUBLISH_STEP
+        )
 
     mock_open.assert_not_called()
     assert result.events == []
@@ -918,7 +928,9 @@ def test_pr_link_opener_noops_when_pr_url_unavailable() -> None:
     ):
         mock_github_ops.return_value.get_current_pr_url.side_effect = Exception("no pr")
 
-        result = hook.run(stage="publish_output", status_code=PhaseStatusCode.CONFIRMED)
+        result = hook.run(
+            stage="publish_output", status_code=PhaseStatusCode.CONFIRMED, step_def=PUBLISH_STEP
+        )
 
     mock_open.assert_not_called()
     assert result.events == []
@@ -938,7 +950,9 @@ def test_pr_link_opener_noops_when_browser_open_fails() -> None:
             "https://github.com/test/repo/pull/123"
         )
 
-        result = hook.run(stage="publish_output", status_code=PhaseStatusCode.CONFIRMED)
+        result = hook.run(
+            stage="publish_output", status_code=PhaseStatusCode.CONFIRMED, step_def=PUBLISH_STEP
+        )
 
     mock_open.assert_called_once_with("https://github.com/test/repo/pull/123")
     assert result.events == []
@@ -969,6 +983,7 @@ def test_local_pr_reviewer_displays_diff_and_confirms_local_mode(tmp_path: Path)
         agent_name="Nick",
         output_file=output_file,
         status_code=PhaseStatusCode.CONFIRMED,
+        step_def=PUBLISH_STEP,
     )
 
     phase.git_ops.get_diff.assert_called_once_with("develop", "HEAD")
@@ -1002,6 +1017,7 @@ def test_local_pr_reviewer_writes_feedback_todo_and_requests_changes(tmp_path: P
         agent_name="Nick",
         output_file=output_file,
         status_code=PhaseStatusCode.CONFIRMED,
+        step_def=PUBLISH_STEP,
     )
 
     assert result.override_status_code == PhaseStatusCode.NEEDS_CHANGES
@@ -1132,6 +1148,7 @@ def test_github_pr_creator_publish_output_runs_sync_pr_script(tmp_path: Path) ->
             stage="publish_output",
             phase=phase,
             step_name="pr",
+            step_def=PUBLISH_STEP,
             output_file=output_file,
             publish_request_file=publish_request_file,
             status_code=PhaseStatusCode.CONFIRMED,
@@ -1317,6 +1334,7 @@ def test_github_pr_creator_publish_output_runs_from_workflow_complete_baton_with
             stage="publish_output",
             phase=phase,
             step_name="pr",
+            step_def=PUBLISH_STEP,
             output_file=output_file,
             publish_request_file=publish_request_file,
             context={"next_step_path": str(next_step_file)},
@@ -1386,6 +1404,7 @@ def test_github_pr_creator_publish_output_runs_from_pr_done_await_agent_baton(
             stage="publish_output",
             phase=phase,
             step_name="pr",
+            step_def=PUBLISH_STEP,
             output_file=output_file,
             publish_request_file=publish_request_file,
             context={"next_step_path": str(next_step_file)},
@@ -1441,6 +1460,7 @@ def test_github_pr_creator_publish_output_runs_from_legacy_done_baton(
             stage="publish_output",
             phase=phase,
             step_name="pr",
+            step_def=PUBLISH_STEP,
             output_file=output_file,
             publish_request_file=publish_request_file,
             context={"next_step_path": str(next_step_file)},
@@ -1474,6 +1494,7 @@ def test_github_pr_creator_publish_output_skips_local_pr_mode(tmp_path: Path) ->
             stage="publish_output",
             phase=phase,
             step_name="pr",
+            step_def=PUBLISH_STEP,
             output_file=output_file,
             publish_request_file=publish_request_file,
             status_code=PhaseStatusCode.CONFIRMED,
@@ -1524,6 +1545,7 @@ def test_github_pr_creator_publish_ignores_untrusted_script_field_in_request(
             stage="publish_output",
             phase=phase,
             step_name="pr",
+            step_def=PUBLISH_STEP,
             output_file=output_file,
             publish_request_file=publish_request_file,
             status_code=PhaseStatusCode.CONFIRMED,
@@ -1554,6 +1576,7 @@ def test_pr_comment_poster_posts_todo_comment_only_when_confirmed_and_complete(
             phase=phase,
             output_file=output_file,
             status_code=PhaseStatusCode.CONFIRMED,
+            step_def=PUBLISH_STEP,
         )
 
     mock_github_ops.return_value.add_pr_comment.assert_called_once()

--- a/tests/unit/test_playbook_behavior_contract.py
+++ b/tests/unit/test_playbook_behavior_contract.py
@@ -7,7 +7,8 @@ import pytest
 
 from cafe.core.playbook import PlaybookDefinition, resolve_step_behavior
 from cafe.core.workflow_runtime import BlackboardWorkflowRuntime
-from cafe.core.hooks.native import GitHubIssueFetcher, _publish_requested
+from cafe.core.hooks.native import GitHubIssueFetcher, GitHubPRCreator, _publish_requested
+from cafe.playbooks.loader import PlaybookLoader
 
 
 def _playbook(*, build_behavior=None, defaults=None):
@@ -81,6 +82,17 @@ def test_behavior_contract_step_values_override_playbook_defaults():
 
     assert behavior.context_providers == ["git_history"]
     assert behavior.runtime_tool_grants == ["git_inspection"]
+
+
+@pytest.mark.parametrize("playbook_id", ["tdd", "hotfix"])
+def test_bundled_review_steps_preserve_declared_runtime_review_grants(playbook_id):
+    """UT-007: bundled review steps retain their declared inspection capabilities."""
+    playbook = PlaybookLoader().load_model(playbook_id).model
+
+    assert resolve_step_behavior(playbook, "review").runtime_tool_grants == [
+        "web_research",
+        "git_inspection",
+    ]
 
 
 @pytest.mark.parametrize("step_name", ["assemble", "quality_gate"])
@@ -171,9 +183,14 @@ def test_custom_named_publish_hook_accepts_declared_terminal_baton(tmp_path):
 
 def test_runtime_hooks_do_not_compare_steps_to_default_workflow_names():
     """UT-010: a bounded runtime source audit rejects name-derived behavior."""
-    source = inspect.getsource(GitHubIssueFetcher.run)
+    issue_fetcher_source = inspect.getsource(GitHubIssueFetcher.run)
+    pr_creator_source = inspect.getsource(GitHubPRCreator._prepare_input)
 
     assert not re.search(
         r"step_name\s*(?:==|!=)\s*['\"](?:spec|plan|develop|review|pr)['\"]",
-        source,
+        issue_fetcher_source,
+    )
+    assert not re.search(
+        r"str\(kwargs\.get\(['\"]step_name['\"]\)\s+or\s+['\"]pr['\"]\)",
+        pr_creator_source,
     )

--- a/tests/unit/test_playbook_behavior_contract.py
+++ b/tests/unit/test_playbook_behavior_contract.py
@@ -55,7 +55,28 @@ def test_behavior_contract_merges_defaults_for_arbitrary_step_names():
     assert behavior.publish_confirmation is True
     assert behavior.feedback_target == "verify"
     assert behavior.context_providers == ["workflow_metadata"]
-    assert behavior.runtime_tool_grants == ["git_inspection"]
+    assert behavior.runtime_tool_grants == ["web_research", "git_inspection"]
+
+
+def test_behavior_contract_combines_declared_provider_and_grant_layers():
+    """UT-002/UT-006/UT-007: step additions retain playbook-wide grants."""
+    model = PlaybookDefinition.model_validate(
+        _playbook(
+            defaults={
+                "context_providers": ["workflow_metadata"],
+                "runtime_tool_grants": ["web_research"],
+            },
+            build_behavior={
+                "context_providers": ["git_history"],
+                "runtime_tool_grants": ["git_inspection"],
+            },
+        )
+    )
+
+    behavior = resolve_step_behavior(model, "build")
+
+    assert behavior.context_providers == ["workflow_metadata", "git_history"]
+    assert behavior.runtime_tool_grants == ["web_research", "git_inspection"]
 
 
 @pytest.mark.parametrize("step_name", ["assemble", "quality_gate"])

--- a/tests/unit/test_playbook_behavior_contract.py
+++ b/tests/unit/test_playbook_behavior_contract.py
@@ -6,6 +6,7 @@ import inspect
 import pytest
 
 from cafe.core import workflow_runtime
+from cafe.agents import manager as agent_manager
 from cafe.core.hooks import native as native_hooks
 from cafe.core.playbook import PlaybookDefinition, resolve_step_behavior
 from cafe.core.workflow_runtime import BlackboardWorkflowRuntime
@@ -120,6 +121,46 @@ def test_omitted_behavior_uses_same_universal_defaults_for_any_step_name(step_na
     assert behavior.runtime_tool_grants == []
 
 
+def test_read_only_progress_guard_is_declarative_and_name_independent():
+    """UT-002: equally declared arbitrary steps receive the same guard."""
+    model = PlaybookDefinition.model_validate(
+        {
+            "playbook": {"id": "arbitrary"},
+            "steps": {
+                "build": {
+                    "skill": "cafe-develop",
+                    "role": "developer",
+                    "behavior": {"max_read_only_commands": 20},
+                    "on": {"await_agent": "verify"},
+                },
+                "assemble": {
+                    "skill": "cafe-develop",
+                    "role": "developer",
+                    "behavior": {"max_read_only_commands": 20},
+                    "on": {"await_agent": "verify"},
+                },
+                "verify": {
+                    "skill": "cafe-review",
+                    "role": "reviewer",
+                    "on": {"await_agent": "build"},
+                },
+            },
+        }
+    )
+
+    assert resolve_step_behavior(model, "build").max_read_only_commands == 20
+    assert resolve_step_behavior(model, "assemble").max_read_only_commands == 20
+    assert resolve_step_behavior(model, "verify").max_read_only_commands is None
+
+
+@pytest.mark.parametrize("playbook_id", ["default", "simple", "tdd", "hotfix"])
+def test_bundled_implementation_steps_preserve_read_only_progress_guard(playbook_id):
+    """UT-008: bundled workflows explicitly preserve develop-step protection."""
+    playbook = PlaybookLoader().load_model(playbook_id).model
+
+    assert resolve_step_behavior(playbook, "develop").max_read_only_commands == 20
+
+
 def test_behavior_contract_rejects_unknown_grant_and_unknown_feedback_target():
     """UT-001: declarations fail closed before workflow execution."""
     with pytest.raises(ValueError, match="runtime_tool_grants"):
@@ -192,6 +233,7 @@ _RUNTIME_LIFECYCLE_MODULES = (
     workflow_runtime,
     generic_phase,
     generic_workflow_step,
+    agent_manager,
     cli_shared,
 )
 

--- a/tests/unit/test_playbook_behavior_contract.py
+++ b/tests/unit/test_playbook_behavior_contract.py
@@ -4,6 +4,7 @@ import pytest
 
 from cafe.core.playbook import PlaybookDefinition, resolve_step_behavior
 from cafe.core.workflow_runtime import BlackboardWorkflowRuntime
+from cafe.core.hooks.native import _publish_requested
 
 
 def _playbook(*, build_behavior=None, defaults=None):
@@ -129,3 +130,28 @@ def test_custom_named_publish_step_uses_declared_baton_and_receipt_contract(tmp_
     assert runtime._is_baton_driven_step("build") is True
     assert runtime._required_capability_ids("build") == ["cafe.pr.publish"]
     assert runtime._is_baton_driven_step("verify") is False
+
+
+def test_custom_named_publish_hook_accepts_declared_terminal_baton(tmp_path):
+    """UT-004: native publish hooks consume the declaration, not ``pr``."""
+    baton_file = tmp_path / "next_step.txt"
+    baton_file.write_text(
+        """{
+  "version": 1,
+  "from_step": "release",
+  "to_owner": "done",
+  "to_step": "done",
+  "intent": "workflow_complete"
+}""",
+        encoding="utf-8",
+    )
+
+    assert _publish_requested(
+        phase=object(),
+        step_name="release",
+        status_code="",
+        context={
+            "publish_confirmation": True,
+            "next_step_path": str(baton_file),
+        },
+    )

--- a/tests/unit/test_playbook_behavior_contract.py
+++ b/tests/unit/test_playbook_behavior_contract.py
@@ -1,14 +1,18 @@
 """Behavior-contract tests for arbitrary playbook step names."""
 
+import ast
 import inspect
-import re
 
 import pytest
 
+from cafe.core import workflow_runtime
+from cafe.core.hooks import native as native_hooks
 from cafe.core.playbook import PlaybookDefinition, resolve_step_behavior
 from cafe.core.workflow_runtime import BlackboardWorkflowRuntime
-from cafe.core.hooks.native import GitHubIssueFetcher, GitHubPRCreator, _publish_requested
+from cafe.core.hooks.native import _publish_requested
+from cafe.phases import generic_phase, generic_workflow_step
 from cafe.playbooks.loader import PlaybookLoader
+from cafe.ui import cli_shared
 
 
 def _playbook(*, build_behavior=None, defaults=None):
@@ -181,16 +185,66 @@ def test_custom_named_publish_hook_accepts_declared_terminal_baton(tmp_path):
     )
 
 
-def test_runtime_hooks_do_not_compare_steps_to_default_workflow_names():
-    """UT-010: a bounded runtime source audit rejects name-derived behavior."""
-    issue_fetcher_source = inspect.getsource(GitHubIssueFetcher.run)
-    pr_creator_source = inspect.getsource(GitHubPRCreator._prepare_input)
+_DEFAULT_WORKFLOW_STEPS = frozenset({"spec", "plan", "develop", "review", "pr"})
+_STEP_IDENTITY_NAMES = frozenset({"step_name", "active_step", "current_step", "phase_name"})
+_RUNTIME_LIFECYCLE_MODULES = (
+    native_hooks,
+    workflow_runtime,
+    generic_phase,
+    generic_workflow_step,
+    cli_shared,
+)
 
-    assert not re.search(
-        r"step_name\s*(?:==|!=)\s*['\"](?:spec|plan|develop|review|pr)['\"]",
-        issue_fetcher_source,
+
+def _node_contains_step_identity(node):
+    return any(
+        (isinstance(child, ast.Name) and child.id in _STEP_IDENTITY_NAMES)
+        or (isinstance(child, ast.Constant) and child.value == "step_name")
+        for child in ast.walk(node)
     )
-    assert not re.search(
-        r"str\(kwargs\.get\(['\"]step_name['\"]\)\s+or\s+['\"]pr['\"]\)",
-        pr_creator_source,
-    )
+
+
+def _workflow_step_literals(node):
+    return {
+        child.value
+        for child in ast.walk(node)
+        if isinstance(child, ast.Constant) and child.value in _DEFAULT_WORKFLOW_STEPS
+    }
+
+
+def _fixed_name_step_policy_violations(module):
+    """Return runtime branches that infer behavior from legacy workflow names."""
+    tree = ast.parse(inspect.getsource(module))
+    violations = []
+
+    for node in ast.walk(tree):
+        uses_step_identity = _node_contains_step_identity(node)
+        fixed_names = _workflow_step_literals(node)
+        if not uses_step_identity or not fixed_names:
+            continue
+
+        if isinstance(node, (ast.Compare, ast.IfExp)):
+            violations.append((node.lineno, sorted(fixed_names)))
+        elif isinstance(node, ast.BoolOp) and isinstance(node.op, ast.Or):
+            violations.append((node.lineno, sorted(fixed_names)))
+        elif (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "get"
+            and len(node.args) >= 2
+        ):
+            violations.append((node.lineno, sorted(fixed_names)))
+
+    return violations
+
+
+def test_runtime_and_lifecycle_modules_do_not_infer_behavior_from_default_step_names():
+    """UT-010: bounded runtime/lifecycle policy forbids fixed-name behavior branches."""
+    violations = {
+        module.__name__: _fixed_name_step_policy_violations(module)
+        for module in _RUNTIME_LIFECYCLE_MODULES
+    }
+
+    assert violations == {
+        module.__name__: [] for module in _RUNTIME_LIFECYCLE_MODULES
+    }

--- a/tests/unit/test_playbook_behavior_contract.py
+++ b/tests/unit/test_playbook_behavior_contract.py
@@ -56,11 +56,11 @@ def test_behavior_contract_merges_defaults_for_arbitrary_step_names():
     assert behavior.publish_confirmation is True
     assert behavior.feedback_target == "verify"
     assert behavior.context_providers == ["workflow_metadata"]
-    assert behavior.runtime_tool_grants == ["web_research", "git_inspection"]
+    assert behavior.runtime_tool_grants == ["git_inspection"]
 
 
-def test_behavior_contract_combines_declared_provider_and_grant_layers():
-    """UT-002/UT-006/UT-007: step additions retain playbook-wide grants."""
+def test_behavior_contract_step_values_override_playbook_defaults():
+    """UT-002/UT-006/UT-007: a step can narrow inherited runtime access."""
     model = PlaybookDefinition.model_validate(
         _playbook(
             defaults={
@@ -76,8 +76,8 @@ def test_behavior_contract_combines_declared_provider_and_grant_layers():
 
     behavior = resolve_step_behavior(model, "build")
 
-    assert behavior.context_providers == ["workflow_metadata", "git_history"]
-    assert behavior.runtime_tool_grants == ["web_research", "git_inspection"]
+    assert behavior.context_providers == ["git_history"]
+    assert behavior.runtime_tool_grants == ["git_inspection"]
 
 
 @pytest.mark.parametrize("step_name", ["assemble", "quality_gate"])
@@ -112,6 +112,15 @@ def test_behavior_contract_rejects_unknown_grant_and_unknown_feedback_target():
         PlaybookDefinition.model_validate(
             _playbook(build_behavior={"feedback_target": "missing"})
         )
+
+
+def test_publish_confirmation_requires_the_publish_capability():
+    """UT-001: publishing contracts cannot be satisfied by an unrelated grant."""
+    payload = _playbook(build_behavior={"publish_confirmation": True})
+    payload["steps"]["build"]["capability_requests"] = ["cafe.github.read"]
+
+    with pytest.raises(ValueError, match="cafe.pr.publish"):
+        PlaybookDefinition.model_validate(payload)
 
 
 def test_custom_named_publish_step_uses_declared_baton_and_receipt_contract(tmp_path):

--- a/tests/unit/test_playbook_behavior_contract.py
+++ b/tests/unit/test_playbook_behavior_contract.py
@@ -1,10 +1,13 @@
 """Behavior-contract tests for arbitrary playbook step names."""
 
+import inspect
+import re
+
 import pytest
 
 from cafe.core.playbook import PlaybookDefinition, resolve_step_behavior
 from cafe.core.workflow_runtime import BlackboardWorkflowRuntime
-from cafe.core.hooks.native import _publish_requested
+from cafe.core.hooks.native import GitHubIssueFetcher, _publish_requested
 
 
 def _playbook(*, build_behavior=None, defaults=None):
@@ -163,4 +166,14 @@ def test_custom_named_publish_hook_accepts_declared_terminal_baton(tmp_path):
             "publish_confirmation": True,
             "next_step_path": str(baton_file),
         },
+    )
+
+
+def test_runtime_hooks_do_not_compare_steps_to_default_workflow_names():
+    """UT-010: a bounded runtime source audit rejects name-derived behavior."""
+    source = inspect.getsource(GitHubIssueFetcher.run)
+
+    assert not re.search(
+        r"step_name\s*(?:==|!=)\s*['\"](?:spec|plan|develop|review|pr)['\"]",
+        source,
     )

--- a/tests/unit/test_playbook_behavior_contract.py
+++ b/tests/unit/test_playbook_behavior_contract.py
@@ -1,0 +1,110 @@
+"""Behavior-contract tests for arbitrary playbook step names."""
+
+import pytest
+
+from cafe.core.playbook import PlaybookDefinition, resolve_step_behavior
+from cafe.core.workflow_runtime import BlackboardWorkflowRuntime
+
+
+def _playbook(*, build_behavior=None, defaults=None):
+    payload = {
+        "playbook": {"id": "custom"},
+        "steps": {
+            "build": {
+                "role": "operator",
+                "skill": "phase",
+                "on": {"await_agent": "verify"},
+            },
+            "verify": {
+                "role": "operator",
+                "skill": "phase",
+                "on": {"await_agent": "_done"},
+            },
+        },
+    }
+    if defaults is not None:
+        payload["behavior"] = defaults
+    if build_behavior is not None:
+        payload["steps"]["build"]["behavior"] = build_behavior
+        if build_behavior.get("publish_confirmation"):
+            payload["steps"]["build"]["capability_requests"] = ["cafe.pr.publish"]
+    return payload
+
+
+def test_behavior_contract_merges_defaults_for_arbitrary_step_names():
+    """UT-002: step declarations override stable playbook-wide defaults."""
+    model = PlaybookDefinition.model_validate(
+        _playbook(
+            defaults={
+                "completion": "status_code",
+                "context_providers": ["workflow_metadata"],
+                "runtime_tool_grants": ["web_research"],
+            },
+            build_behavior={
+                "completion": "baton",
+                "publish_confirmation": True,
+                "feedback_target": "verify",
+                "runtime_tool_grants": ["git_inspection"],
+            },
+        )
+    )
+
+    behavior = resolve_step_behavior(model, "build")
+
+    assert behavior.completion == "baton"
+    assert behavior.publish_confirmation is True
+    assert behavior.feedback_target == "verify"
+    assert behavior.context_providers == ["workflow_metadata"]
+    assert behavior.runtime_tool_grants == ["git_inspection"]
+
+
+@pytest.mark.parametrize("step_name", ["assemble", "quality_gate"])
+def test_omitted_behavior_uses_same_universal_defaults_for_any_step_name(step_name):
+    """UT-002: omission never recovers semantics from reserved phase names."""
+    model = PlaybookDefinition.model_validate(
+        {
+            "playbook": {"id": "arbitrary"},
+            "steps": {
+                step_name: {"role": "operator", "skill": "phase", "on": {"await_agent": "_done"}}
+            },
+        }
+    )
+
+    behavior = resolve_step_behavior(model, step_name)
+
+    assert behavior.completion == "status_code"
+    assert behavior.publish_confirmation is False
+    assert behavior.feedback_target is None
+    assert behavior.context_providers == []
+    assert behavior.runtime_tool_grants == []
+
+
+def test_behavior_contract_rejects_unknown_grant_and_unknown_feedback_target():
+    """UT-001: declarations fail closed before workflow execution."""
+    with pytest.raises(ValueError, match="runtime_tool_grants"):
+        PlaybookDefinition.model_validate(
+            _playbook(build_behavior={"runtime_tool_grants": ["untrusted_shell"]})
+        )
+
+    with pytest.raises(ValueError, match="feedback_target"):
+        PlaybookDefinition.model_validate(
+            _playbook(build_behavior={"feedback_target": "missing"})
+        )
+
+
+def test_custom_named_publish_step_uses_declared_baton_and_receipt_contract(tmp_path):
+    """UT-003/UT-004: completion and publish gates have no reserved step name."""
+    playbook = _playbook(
+        build_behavior={"completion": "baton", "publish_confirmation": True}
+    )
+    playbook["steps"]["build"]["capability_requests"] = ["cafe.pr.publish"]
+
+    runtime = BlackboardWorkflowRuntime(
+        issue_dir=tmp_path / ".cafe" / "issues" / "custom",
+        playbook=playbook,
+        executor=lambda *_args, **_kwargs: None,
+    )
+
+    assert runtime._is_baton_driven_step("build") is True
+    assert runtime._required_capability_ids("build") == ["cafe.pr.publish"]
+    assert runtime._is_baton_driven_step("verify") is False

--- a/tests/unit/test_playbook_behavior_contract.py
+++ b/tests/unit/test_playbook_behavior_contract.py
@@ -231,7 +231,7 @@ def _fixed_name_step_policy_violations(module):
             isinstance(node, ast.Call)
             and isinstance(node.func, ast.Attribute)
             and node.func.attr == "get"
-            and len(node.args) >= 2
+            and node.args
         ):
             violations.append((node.lineno, sorted(fixed_names)))
 

--- a/tests/unit/test_pr_baton_alignment.py
+++ b/tests/unit/test_pr_baton_alignment.py
@@ -30,7 +30,7 @@ def test_align_pr_baton_updates_when_needs_changes_and_stale(tmp_path: Path) -> 
     issue_dir = tmp_path / ".cafe" / "issues" / "demo-pr-baton"
     _bootstrap_issue(issue_dir)
 
-    playbook = {"steps": {"pr": {}, "develop": {}, "review": {}}}
+    playbook = {"steps": {"pr": {"behavior": {"feedback_target": "develop"}}, "develop": {}, "review": {}}}
     (issue_dir / "next_step.txt").write_text(
         json.dumps(
             {

--- a/tests/unit/test_reset_command.py
+++ b/tests/unit/test_reset_command.py
@@ -2,6 +2,7 @@
 
 import json
 import pytest
+import typer
 from pathlib import Path
 from typer.testing import CliRunner
 from unittest.mock import MagicMock, patch, Mock
@@ -9,6 +10,7 @@ import tempfile
 import shutil
 
 from cafe.ui.cli import app
+from cafe.ui.commands import lifecycle as lifecycle_commands
 
 runner = CliRunner()
 
@@ -76,6 +78,46 @@ class TestResetCommandArgumentParsing:
         invalid_phase = "invalid_phase"
         valid_phases = ["spec", "plan", "develop", "review", "pr"]
         assert invalid_phase not in valid_phases
+
+    def test_reset_accepts_step_declared_by_issue_playbook(self, tmp_path: Path, monkeypatch):
+        """UT-009: reset validates against the issue playbook, not legacy names."""
+        monkeypatch.chdir(tmp_path)
+        issue_dir = tmp_path / ".cafe" / "issues" / "test_issue"
+        iteration_dir = issue_dir / "qa" / "iteration_001"
+        iteration_dir.mkdir(parents=True)
+        (iteration_dir / "iteration.json").write_text('{"iteration": 1}', encoding="utf-8")
+        (issue_dir / "blackboard.json").write_text(
+            '{"schema_version": 1, "playbook_id": "custom", "current_step": "qa", '
+            '"artifacts": {}, "events": [], "decisions": []}',
+            encoding="utf-8",
+        )
+        playbook_dir = tmp_path / ".cafe" / "playbooks"
+        playbook_dir.mkdir()
+        (playbook_dir / "custom.yaml").write_text(
+            """
+playbook:
+  id: custom
+steps:
+  qa:
+    skill: cafe-review
+    role: reviewer
+    allowed_tools: ["Bash(cafe verification check:*)"]
+    on:
+      await_agent: _done
+""".strip(),
+            encoding="utf-8",
+        )
+
+        with (
+            patch("cafe.ui.commands.lifecycle.GitOperations") as mock_git_cls,
+            patch("cafe.ui.commands.lifecycle.prompt_confirm", return_value=False),
+            pytest.raises(typer.Exit) as exit_info,
+        ):
+            mock_git_cls.return_value.get_current_branch.return_value = "test_issue"
+            lifecycle_commands.reset("qa", iteration=0)
+
+        assert exit_info.value.exit_code == 0
+        assert iteration_dir.exists()
 
     def test_iteration_number_parsing_positive(self):
         """Test 1.2: Parse positive iteration numbers."""

--- a/tests/unit/test_workflow_runtime.py
+++ b/tests/unit/test_workflow_runtime.py
@@ -152,7 +152,7 @@ def test_runtime_blocks_pr_done_without_publish_receipt(tmp_path: Path) -> None:
     playbook = {
         "playbook": {"id": "default"},
         "steps": {
-            "pr": {"skill": "spec_first", "role": "developer", "on": {"await_agent": "_done"}},
+            "pr": {"skill": "spec_first", "role": "developer", "behavior": {"completion": "baton", "publish_confirmation": True}, "capability_requests": ["cafe.pr.publish"], "on": {"await_agent": "_done"}},
         },
     }
 
@@ -181,7 +181,7 @@ def test_runtime_completes_pr_when_publish_receipt_exists(tmp_path: Path) -> Non
     playbook = {
         "playbook": {"id": "default"},
         "steps": {
-            "pr": {"skill": "spec_first", "role": "developer", "on": {"await_agent": "_done"}},
+            "pr": {"skill": "spec_first", "role": "developer", "behavior": {"completion": "baton", "publish_confirmation": True}, "capability_requests": ["cafe.pr.publish"], "on": {"await_agent": "_done"}},
         },
     }
 
@@ -212,7 +212,7 @@ def test_runtime_completes_pr_when_capability_receipt_success_exists(tmp_path: P
     playbook = {
         "playbook": {"id": "default"},
         "steps": {
-            "pr": {"skill": "spec_first", "role": "developer", "on": {"await_agent": "_done"}},
+            "pr": {"skill": "spec_first", "role": "developer", "behavior": {"completion": "baton", "publish_confirmation": True}, "capability_requests": ["cafe.pr.publish"], "on": {"await_agent": "_done"}},
         },
     }
 
@@ -525,6 +525,8 @@ def test_runtime_hands_off_to_pr_runtime_boundary(tmp_path: Path) -> None:
             "pr": {
                 "skill": "spec_first",
                 "role": "developer",
+                "behavior": {"completion": "baton", "publish_confirmation": True},
+                "capability_requests": ["cafe.pr.publish"],
                 "on": {"await_agent": "_done"},
             },
         },
@@ -928,6 +930,8 @@ def test_runtime_legacy_step_honors_review_confirmed_advance(tmp_path: Path) -> 
             "pr": {
                 "skill": "spec_first",
                 "role": "developer",
+                "behavior": {"completion": "baton", "publish_confirmation": True},
+                "capability_requests": ["cafe.pr.publish"],
                 "on": {"await_agent": "_done"},
             },
         },
@@ -987,6 +991,8 @@ def test_runtime_review_confirmed_routes_to_pr_without_legacy_class(tmp_path: Pa
             "pr": {
                 "skill": "pr",
                 "role": "developer",
+                "behavior": {"completion": "baton", "publish_confirmation": True},
+                "capability_requests": ["cafe.pr.publish"],
                 "on": {"await_agent": "_done"},
             },
         },
@@ -1840,7 +1846,7 @@ def test_runtime_emits_expected_runtime_labels_per_path(tmp_path: Path) -> None:
                 "valid_intents": ["confirmed"],
                 "on": {"await_agent": "pr"},
             },
-            "pr": {"skill": "spec_first", "role": "developer", "on": {"await_agent": "_done"}},
+            "pr": {"skill": "spec_first", "role": "developer", "behavior": {"completion": "baton", "publish_confirmation": True}, "capability_requests": ["cafe.pr.publish"], "on": {"await_agent": "_done"}},
         },
     }
 
@@ -1880,7 +1886,7 @@ def test_runtime_emits_expected_runtime_labels_per_path(tmp_path: Path) -> None:
     playbook_pr = {
         "playbook": {"id": "default"},
         "steps": {
-            "pr": {"skill": "spec_first", "role": "developer", "on": {"await_agent": "_done"}},
+            "pr": {"skill": "spec_first", "role": "developer", "behavior": {"completion": "baton", "publish_confirmation": True}, "capability_requests": ["cafe.pr.publish"], "on": {"await_agent": "_done"}},
         },
     }
 
@@ -1971,7 +1977,7 @@ def test_runtime_chains_pr_need_changes_through_develop_to_review(tmp_path: Path
     playbook = {
         "playbook": {"id": "default"},
         "steps": {
-            "pr": {"skill": "spec_first", "role": "developer", "assignee_type": "agent", "on": {}},
+            "pr": {"skill": "spec_first", "role": "developer", "assignee_type": "agent", "behavior": {"completion": "baton", "feedback_target": "develop"}, "on": {}},
             "develop": {
                 "skill": "develop",
                 "role": "developer",
@@ -1984,7 +1990,7 @@ def test_runtime_chains_pr_need_changes_through_develop_to_review(tmp_path: Path
                 "role": "reviewer",
                 "assignee_type": "agent",
                 "valid_intents": ["confirmed"],
-                "on": {"await_agent": "_done"},
+                "on": {"await_agent": "_done", "manual_handoff": "user"},
             },
         },
     }


### PR DESCRIPTION
## Summary

Implements GitHub issue #352 by replacing workflow behavior inferred from reserved step names with validated playbook and step declarations, while preserving the default workflow's observable completion, correction, lifecycle, and publish behavior.

## Changes

- Added validated declarative contracts for completion mode, publish confirmation, feedback routing, runtime context providers, supplemental tool grants, and phase roles.
- Updated bundled playbooks and runtime orchestration to resolve behavior from playbook/step declarations without expanding capability or publish authorization boundaries.
- Updated lifecycle and issue commands to use configured playbook steps, retaining the five-step fallback only when playbook metadata is absent and surfacing configured-playbook errors clearly.
- Added unit and integration coverage for contract validation, arbitrary custom step names, default-playbook parity, publish and recovery journeys, lifecycle resolution, fixed-name policy auditing, and checklist-retry read-only guards.
- Includes the 16-commit issue #352 series from `54bdc70b` through `baae1df0`, with the final correction covering the declared read-only progress guard across checklist retries.

## Test Plan

- Passed the repository-defined full gate through `cafe verification run`: `./scripts/test-coverage.sh` (exit code 0).
- Focused regression: `pytest -q tests/unit/test_generic_workflow_step.py -k 'declared_read_only_guard'` — 2 passed.
- Focused contract/runtime set: `pytest -q tests/unit/test_generic_workflow_step.py tests/unit/test_playbook_behavior_contract.py` — 110 passed.
- Verified the clean-HEAD receipt with `cafe verification check --require-scope full`; `valid: true` for HEAD `baae1df057c2001a081f72f720610286889bd3a9`.