### PR TITLE
Enforce safe correction continuation and evidence gates

### DIFF
--- a/src/cafe/data/skills/use-cafe-workflow/references/correction_ab_experiment.md
+++ b/src/cafe/data/skills/use-cafe-workflow/references/correction_ab_experiment.md
@@ -26,4 +26,4 @@ Analyze it with:
 python3 <skill-dir>/scripts/analyze_correction_ab.py <manifest.json>
 ```
 
-The script reports every pair, arm-order balance, protocol readiness, medians, deterministic 95% bootstrap confidence intervals, and `claim_ready`. Do not claim the 30% target until `claim_ready: yes`; directional unpaired workflow observations remain operational telemetry only.
+The script always reports every pair, arm-order balance, protocol readiness, and `claim_ready`. It reports aggregate medians and deterministic 95% bootstrap confidence intervals only when there are at least ten pairs with balanced arm order, complete protocol attestations, and quality-preserving fresh arms. Otherwise, both the default Markdown report and `--json` output mark aggregate statistics unavailable and leave the 30% target unclaimable. Do not claim the 30% target until `claim_ready: yes`; directional unpaired workflow observations remain operational telemetry only.

--- a/src/cafe/data/skills/use-cafe-workflow/scripts/analyze_correction_ab.py
+++ b/src/cafe/data/skills/use-cafe-workflow/scripts/analyze_correction_ab.py
@@ -294,14 +294,14 @@ def analyze(manifest: dict[str, Any]) -> dict[str, Any]:
         and max(order_counts.values()) - min(order_counts.values()) <= 1
     )
     protocol_ready = all(protocol.values()) and order_balanced
-    claim_ready = (
+    aggregate_available = (
         len(rows) >= 10
         and protocol_ready
-        and aggregate["credit_reduction"]["median"] >= 0.30
         and not quality_regressions
         and not fresh_quality_failures
     )
-    return {
+    claim_ready = aggregate_available and aggregate["credit_reduction"]["median"] >= 0.30
+    report = {
         "schema_version": SCHEMA_VERSION,
         "pair_count": len(rows),
         "protocol": protocol,
@@ -309,7 +309,7 @@ def analyze(manifest: dict[str, Any]) -> dict[str, Any]:
         "arm_order_counts": order_counts,
         "arm_order_balanced": order_balanced,
         "pairs": rows,
-        "aggregate": aggregate,
+        "aggregate_available": aggregate_available,
         "quality_regressions": quality_regressions,
         "fresh_quality_failures": fresh_quality_failures,
         "claim_ready": claim_ready,
@@ -320,6 +320,9 @@ def analyze(manifest: dict[str, Any]) -> dict[str, Any]:
             "finding; no paired quality regression"
         ),
     }
+    if aggregate_available:
+        report["aggregate"] = aggregate
+    return report
 
 
 def _percent(value: float) -> str:
@@ -351,17 +354,27 @@ def format_markdown(report: dict[str, Any]) -> str:
                 quality="pass" if row["fresh_quality_pass"] else "fail",
             )
         )
-    lines.extend(
-        [
-            "",
-            "| Metric | Median | 95% bootstrap CI |",
-            "| --- | ---: | ---: |",
-        ]
-    )
-    for metric, values in report["aggregate"].items():
-        lines.append(
-            f"| {metric} | {_percent(values['median'])} | "
-            f"{_percent(values['ci95_low'])} to {_percent(values['ci95_high'])} |"
+    aggregate = report.get("aggregate")
+    if aggregate:
+        lines.extend(
+            [
+                "",
+                "| Metric | Median | 95% bootstrap CI |",
+                "| --- | ---: | ---: |",
+            ]
+        )
+        for metric, values in aggregate.items():
+            lines.append(
+                f"| {metric} | {_percent(values['median'])} | "
+                f"{_percent(values['ci95_low'])} to {_percent(values['ci95_high'])} |"
+            )
+    else:
+        lines.extend(
+            [
+                "",
+                "- Aggregate statistics are unavailable until the paired evidence is "
+                "complete, balanced, and quality-preserving.",
+            ]
         )
     lines.extend(
         [

--- a/src/cafe/phases/generic_workflow_step.py
+++ b/src/cafe/phases/generic_workflow_step.py
@@ -862,13 +862,6 @@ class GenericWorkflowStepExecutor(Phase):
             )
             return exact or SessionContinuation.new()
 
-        if self.iteration > 1 and step_def.get("correction_session", "fresh") == "resume":
-            exact = exact_continuation_from_context(
-                previous_data,
-                configured_clis=configured_clis,
-            )
-            return exact or SessionContinuation.new()
-
         return SessionContinuation.new()
 
     def _git_snapshot(self) -> Dict[str, str]:

--- a/tests/unit/test_generic_workflow_step.py
+++ b/tests/unit/test_generic_workflow_step.py
@@ -4291,7 +4291,7 @@ def test_completed_correction_selects_new_session_by_default(tmp_path: Path) -> 
     assert continuation.policy == SessionContinuationPolicy.NEW
 
 
-def test_correction_resume_override_uses_only_previous_exact_pair(tmp_path: Path) -> None:
+def test_completed_correction_ignores_resume_override(tmp_path: Path) -> None:
     executor = _minimal_spec_executor(
         tmp_path,
         agent_manager=FakeAgentManager("confirmed"),
@@ -4320,9 +4320,7 @@ def test_correction_resume_override_uses_only_previous_exact_pair(tmp_path: Path
         step_def=step_def,
     )
 
-    assert continuation.policy == SessionContinuationPolicy.RESUME_EXACT
-    assert continuation.cli == AgentCLI.CODEX
-    assert continuation.session_id == "old-session"
+    assert continuation.policy == SessionContinuationPolicy.NEW
 
 
 def test_incomplete_iteration_selects_exact_resume(tmp_path: Path) -> None:

--- a/tests/unit/test_workflow_efficiency_contracts.py
+++ b/tests/unit/test_workflow_efficiency_contracts.py
@@ -152,6 +152,7 @@ def test_correction_ab_requires_ten_quality_preserving_pairs_for_claim(
     assert result.returncode == 0, result.stderr
     report = json.loads(result.stdout)
     assert report["pair_count"] == 10
+    assert report["aggregate_available"] is True
     assert report["aggregate"]["credit_reduction"]["median"] == 0.4
     assert report["arm_order_balanced"] is True
     assert report["protocol_ready"] is True
@@ -163,7 +164,10 @@ def test_correction_ab_does_not_claim_from_too_few_pairs(tmp_path: Path) -> None
     result = _run_ab_script(tmp_path, _manifest(9))
 
     assert result.returncode == 0, result.stderr
-    assert json.loads(result.stdout)["claim_ready"] is False
+    report = json.loads(result.stdout)
+    assert report["aggregate_available"] is False
+    assert "aggregate" not in report
+    assert report["claim_ready"] is False
 
 
 def test_correction_ab_does_not_claim_unbalanced_arm_order(tmp_path: Path) -> None:
@@ -175,8 +179,23 @@ def test_correction_ab_does_not_claim_unbalanced_arm_order(tmp_path: Path) -> No
 
     assert result.returncode == 0, result.stderr
     report = json.loads(result.stdout)
+    assert report["aggregate_available"] is False
+    assert "aggregate" not in report
     assert report["arm_order_balanced"] is False
     assert report["protocol_ready"] is False
+    assert report["claim_ready"] is False
+
+
+def test_correction_ab_hides_aggregate_for_quality_regression(tmp_path: Path) -> None:
+    manifest = _manifest(10)
+    manifest["pairs"][0]["fresh"] = _arm(policy="fresh", credits=60, quality=False)  # type: ignore[index]
+
+    result = _run_ab_script(tmp_path, manifest)
+
+    assert result.returncode == 0, result.stderr
+    report = json.loads(result.stdout)
+    assert report["aggregate_available"] is False
+    assert "aggregate" not in report
     assert report["claim_ready"] is False
 
 

--- a/tests/unit/test_workflow_efficiency_contracts.py
+++ b/tests/unit/test_workflow_efficiency_contracts.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
 import yaml
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
@@ -131,12 +132,17 @@ def _manifest(pair_count: int) -> dict[str, object]:
     }
 
 
-def _run_ab_script(tmp_path: Path, manifest: dict[str, object]) -> subprocess.CompletedProcess[str]:
+def _run_ab_script(
+    tmp_path: Path, manifest: dict[str, object], *, as_json: bool = True
+) -> subprocess.CompletedProcess[str]:
     manifest_path = tmp_path / "manifest.json"
     manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
     script = SKILLS / "use-cafe-workflow/scripts/analyze_correction_ab.py"
+    command = [sys.executable, str(script), str(manifest_path)]
+    if as_json:
+        command.append("--json")
     return subprocess.run(
-        [sys.executable, str(script), str(manifest_path), "--json"],
+        command,
         cwd=PROJECT_ROOT,
         text=True,
         capture_output=True,
@@ -197,6 +203,29 @@ def test_correction_ab_hides_aggregate_for_quality_regression(tmp_path: Path) ->
     assert report["aggregate_available"] is False
     assert "aggregate" not in report
     assert report["claim_ready"] is False
+
+
+@pytest.mark.parametrize(
+    "failure",
+    ("insufficient_pairs", "unbalanced_arm_order", "quality_regression"),
+)
+def test_correction_ab_default_report_hides_aggregate_until_evidence_is_valid(
+    tmp_path: Path, failure: str
+) -> None:
+    manifest = _manifest(9 if failure == "insufficient_pairs" else 10)
+    if failure == "unbalanced_arm_order":
+        for pair in manifest["pairs"]:  # type: ignore[union-attr]
+            pair["arm_order"] = "fresh_first"
+    elif failure == "quality_regression":
+        manifest["pairs"][0]["fresh"] = _arm(  # type: ignore[index]
+            policy="fresh", credits=60, quality=False
+        )
+
+    result = _run_ab_script(tmp_path, manifest, as_json=False)
+
+    assert result.returncode == 0, result.stderr
+    assert "Aggregate statistics are unavailable" in result.stdout
+    assert "| Metric | Median |" not in result.stdout
 
 
 def test_correction_ab_rejects_missing_billed_credits(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Implements issue381's confirmed requirements for explicit, recoverable correction
continuation and quality-preserving paired rollout evidence. Completed corrections
now start with fresh context, while exact continuation remains limited to the same
incomplete agent/session pair. Efficiency evidence remains non-claimable until its
sample, balance, protocol, and quality gates pass.

## Changes

- `981883f8` (`issue381: enforce correction evidence gates`)
  - Prevent completed corrections from reusing a persisted resume session, while
    preserving exact continuation for interrupted work.
  - Make the A/B analyzer expose aggregate statistics only when at least ten
    balanced, protocol-ready, quality-preserving pairs are available.
  - Add JSON regression coverage for insufficient, unbalanced, and
    quality-regressed evidence.
- `2e8db5ca` (`issue381: cover markdown evidence gates`)
  - Align the correction A/B protocol documentation with the analyzer's aggregate
    availability boundary.
  - Add default Markdown CLI regression coverage ensuring unsupported aggregate
    results are explicitly unavailable and no aggregate table is emitted.

These changes cover the original requirements' continuation, correction
reviewability, telemetry, and paired-observation criteria (AC-001 through
AC-011), without adding pricing reconstruction or a new workflow handoff model.

## Test Plan

- `pytest tests/unit/test_workflow_efficiency_contracts.py` — 14 passed.
- `ruff check tests/unit/test_workflow_efficiency_contracts.py` — passed.
- Full repository suite: `./scripts/test-coverage.sh`, executed through
  `cafe verification run --scope full` — passed. The reusable receipt is
  `.cafe/issues/issue381/develop/iteration_004/verification.json` for clean HEAD
  `2e8db5ca8eaba3271423200cc02924e1b761a93f`.