### PR TITLE
Persist durable HumanTasks across workflow handoffs

### DIFF
--- a/docs/human-task-runtime.md
+++ b/docs/human-task-runtime.md
@@ -1,0 +1,68 @@
+# Durable human-task runtime
+
+CAFE persists user-owned handoffs as workflow-local records. This is a runtime
+foundation only: it does not provide an inbox, scheduling, reminders,
+notifications, or a task-management UI.
+
+## Files and ownership
+
+Each workflow instance stores its durable state below `.cafe/issues/<issue>/`:
+
+| File | Schema | Owner | Purpose |
+| --- | --- | --- | --- |
+| `blackboard.json` | 2 | `BlackboardStore` | The workflow position, baton, and stable `workflow_id`. |
+| `human_tasks.json` | 1 | `HumanTaskRecordStore` | HumanTask, Assignment, WaitState, TaskResult, and lifecycle evidence. |
+
+`human_tasks.json` is written atomically. It is runtime state and should not be
+edited by hand while a workflow is active.
+
+## Record lifecycle
+
+When the runtime reaches a declared user-owned handoff, it resolves the same
+#345 policy/binding used by the existing handoff UI, then creates or reuses a
+single task identified by its workflow id, producing step, iteration, trigger,
+and policy id. The task snapshots the prompt, expected-result contract, and
+declared continuations needed to understand the pause after a restart.
+
+Each task has:
+
+- an `Assignment` (currently assignee type `user` and optional identity);
+- a `WaitState`, which records the workflow/task correlation and pause reason;
+- at most one `TaskResult`, containing the already-validated response, source,
+  and completion time; and
+- append-only lifecycle events for `created`, `completed`, `rejected`,
+  `cancelled`, and `configuration_error` outcomes.
+
+Invalid responses retain the pending wait and append rejection evidence. A
+cancelled or completed task cannot create another result. Replaying a completed
+request leaves the original result intact and never emits another continuation.
+
+## Completion and correlation
+
+The #345 `HumanTaskPolicy` and payload validator remain the authority for
+validating a human response and selecting a declared continuation. Durable
+records add a second guard after that validation:
+
+1. The active WaitState must match the current `workflow_id`, source step,
+   trigger, and policy.
+2. When present, `human_task_id` in the interactive or JSON payload must match
+   that active task.
+3. The selected continuation must be one captured by that task's handoff.
+4. CAFE persists the one TaskResult before it updates the baton.
+
+This prevents a result from another workflow, a stale/cancelled task, a
+duplicate completion, or a changed continuation from advancing the workflow.
+
+## Migration and compatibility
+
+Blackboard schema 1 did not contain a workflow id. On first load, CAFE assigns
+and persists a new stable `workflow_id` as schema 2. This migration does not
+create a HumanTask for a workflow that was already paused.
+
+An in-progress #345 handoff with no `human_tasks.json` remains taskless and
+uses the established interactive and `--user-input` completion paths. New
+user-owned handoffs materialize durable records normally.
+
+`human_tasks.json` currently supports only schema version 1. A missing file is
+the supported legacy case. A malformed file or an unknown future schema fails
+closed and is not rewritten, so it cannot silently authorize a continuation.

--- a/docs/human-task-runtime.md
+++ b/docs/human-task-runtime.md
@@ -45,8 +45,10 @@ records add a second guard after that validation:
 
 1. The active WaitState must match the current `workflow_id`, source step,
    trigger, and policy.
-2. When present, `human_task_id` in the interactive or JSON payload must match
-   that active task.
+2. A new interactive or JSON response for a durable task must include a
+   `human_task_id` that matches that active task. After an interruption that
+   occurs after result persistence, interactive recovery reuses the matching
+   stored result and task id without asking the participant to resubmit it.
 3. The selected continuation must be one captured by that task's handoff.
 4. CAFE persists the one TaskResult before it updates the baton.
 

--- a/src/cafe/core/blackboard.py
+++ b/src/cafe/core/blackboard.py
@@ -13,7 +13,7 @@ from typing import Any, Dict, List, Optional
 from cafe.core.workflow_models import BatonRejected
 
 BLACKBOARD_FILENAME = "blackboard.json"
-BLACKBOARD_SCHEMA_VERSION = 1
+BLACKBOARD_SCHEMA_VERSION = 2
 NEXT_STEP_FILENAME = "next_step.txt"
 HANDOFF_CONTRACT_VERSION = 1
 OPERATION_ARTIFACT_FILENAME = "operation.json"
@@ -22,6 +22,16 @@ OPERATION_RECEIPT_FILENAME = "operation_receipt.json"
 
 def _now_iso() -> str:
     return datetime.now().astimezone().isoformat()
+
+
+def _legacy_workflow_id(data: Dict[str, Any], initial_step: str) -> str:
+    """Provide a deterministic in-memory id before the store persists a legacy state."""
+    identity = {
+        "current_step": str(data.get("current_step", initial_step)),
+        "playbook_id": str(data.get("playbook_id", "default")),
+        "updated_at": str(data.get("updated_at", "")),
+    }
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, json.dumps(identity, sort_keys=True)))
 
 
 class ArtifactKind(str, Enum):
@@ -463,6 +473,7 @@ class BlackboardState:
 
     current_step: str
     playbook_id: str = "default"
+    workflow_id: str = field(default_factory=lambda: str(uuid.uuid4()))
     schema_version: int = BLACKBOARD_SCHEMA_VERSION
     artifacts: Dict[str, ArtifactEntry] = field(default_factory=dict)
     events: List[EventEntry] = field(default_factory=list)
@@ -477,6 +488,7 @@ class BlackboardState:
             "schema_version": self.schema_version,
             "current_step": self.current_step,
             "playbook_id": self.playbook_id,
+            "workflow_id": self.workflow_id,
             "artifacts": {name: entry.to_dict() for name, entry in self.artifacts.items()},
             "events": [entry.to_dict() for entry in self.events],
             "decisions": [entry.to_dict() for entry in self.decisions],
@@ -516,7 +528,8 @@ class BlackboardState:
         return cls(
             current_step=str(data.get("current_step", initial_step)),
             playbook_id=str(data.get("playbook_id", "default")),
-            schema_version=int(data.get("schema_version", BLACKBOARD_SCHEMA_VERSION)),
+            workflow_id=str(data.get("workflow_id") or _legacy_workflow_id(data, initial_step)),
+            schema_version=BLACKBOARD_SCHEMA_VERSION,
             artifacts=artifacts,
             events=[EventEntry.from_dict(entry) for entry in data.get("events", [])],
             decisions=[DecisionEntry.from_dict(entry) for entry in data.get("decisions", [])],
@@ -551,6 +564,9 @@ class BlackboardStore:
         if self.file_path.exists():
             raw = json.loads(self.file_path.read_text(encoding="utf-8"))
             state = BlackboardState.from_dict(raw, initial_step=initial_step)
+            if not raw.get("workflow_id"):
+                state.workflow_id = str(uuid.uuid4())
+                self.save(state)
             if not getattr(state, "playbook_id", None):
                 state.playbook_id = playbook_id
                 self.save(state)

--- a/src/cafe/core/human_task_records.py
+++ b/src/cafe/core/human_task_records.py
@@ -2,13 +2,20 @@
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 from dataclasses import dataclass, replace
 from datetime import datetime
 from enum import Enum
 import json
 from pathlib import Path
+import threading
 from typing import Any, Mapping, Optional
 from uuid import uuid4
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - Windows falls back to the local lock.
+    fcntl = None
 
 from cafe.core.packet_io import atomic_write_bytes, canonical_json
 
@@ -298,9 +305,14 @@ class _Envelope:
 class HumanTaskRecordStore:
     """Versioned local store for durable task, wait, result, and audit records."""
 
+    _thread_locks: dict[Path, threading.RLock] = {}
+    _thread_locks_guard = threading.Lock()
+
     def __init__(self, issue_dir: Path) -> None:
         self.issue_dir = issue_dir
         self.file_path = issue_dir / HUMAN_TASK_RECORD_FILENAME
+        self.lock_path = issue_dir / f".{HUMAN_TASK_RECORD_FILENAME}.lock"
+        self._transaction_depth = 0
 
     @property
     def exists(self) -> bool:
@@ -370,44 +382,45 @@ class HumanTaskRecordStore:
         assignee_type: str,
         assignee_id: Optional[str] = None,
     ) -> HumanTask:
-        envelope = self._load_for_workflow(workflow_id, create=True)
-        handoff_key = _handoff_key(workflow_id, step, iteration, trigger, policy_id)
-        existing = next(
-            (task for task in envelope.tasks.values() if task.handoff_key == handoff_key), None
-        )
-        if existing is not None:
-            return existing
-        now = _now_iso()
-        task = HumanTask(
-            id=str(uuid4()),
-            handoff_key=handoff_key,
-            workflow_id=workflow_id,
-            step=_text(step, "step"),
-            iteration=_positive(iteration, "iteration"),
-            trigger=_text(trigger, "trigger"),
-            policy_id=_text(policy_id, "policy_id"),
-            prompt=_text(prompt, "prompt"),
-            expected_result=dict(expected_result),
-            continuations=_string_mapping_value(continuations, "continuations"),
-            status=HumanTaskStatus.PENDING,
-            created_at=now,
-        )
-        envelope.tasks[task.id] = task
-        envelope.assignments[task.id] = Assignment(
-            task_id=task.id,
-            assignee_type=_text(assignee_type, "assignee_type"),
-            assignee_id=_optional_text(assignee_id),
-            created_at=now,
-        )
-        envelope.wait_states[task.id] = WaitState(
-            task_id=task.id,
-            workflow_id=workflow_id,
-            pause_reason=task.trigger,
-            created_at=now,
-        )
-        self._append_event(envelope, "created", task_id=task.id, context={"handoff_key": handoff_key})
-        self._save(envelope)
-        return task
+        with self.transaction():
+            envelope = self._load_for_workflow(workflow_id, create=True)
+            handoff_key = _handoff_key(workflow_id, step, iteration, trigger, policy_id)
+            existing = next(
+                (task for task in envelope.tasks.values() if task.handoff_key == handoff_key), None
+            )
+            if existing is not None:
+                return existing
+            now = _now_iso()
+            task = HumanTask(
+                id=str(uuid4()),
+                handoff_key=handoff_key,
+                workflow_id=workflow_id,
+                step=_text(step, "step"),
+                iteration=_positive(iteration, "iteration"),
+                trigger=_text(trigger, "trigger"),
+                policy_id=_text(policy_id, "policy_id"),
+                prompt=_text(prompt, "prompt"),
+                expected_result=dict(expected_result),
+                continuations=_string_mapping_value(continuations, "continuations"),
+                status=HumanTaskStatus.PENDING,
+                created_at=now,
+            )
+            envelope.tasks[task.id] = task
+            envelope.assignments[task.id] = Assignment(
+                task_id=task.id,
+                assignee_type=_text(assignee_type, "assignee_type"),
+                assignee_id=_optional_text(assignee_id),
+                created_at=now,
+            )
+            envelope.wait_states[task.id] = WaitState(
+                task_id=task.id,
+                workflow_id=workflow_id,
+                pause_reason=task.trigger,
+                created_at=now,
+            )
+            self._append_event(envelope, "created", task_id=task.id, context={"handoff_key": handoff_key})
+            self._save(envelope)
+            return task
 
     def complete(
         self,
@@ -417,54 +430,57 @@ class HumanTaskRecordStore:
         payload: Mapping[str, Any],
         source: str,
     ) -> TaskResult:
-        envelope = self._load_for_workflow(workflow_id, create=False)
-        task = self._task(envelope, task_id)
-        existing = envelope.results.get(task.id)
-        if existing is not None:
-            return existing
-        if task.status is not HumanTaskStatus.PENDING:
-            raise HumanTaskCorrelationError(f"task {task.id} is not pending")
-        wait_state = envelope.wait_states[task.id]
-        if wait_state.released_at is not None:
-            raise HumanTaskCorrelationError(f"task {task.id} has no active wait state")
-        now = _now_iso()
-        result = TaskResult(
-            id=str(uuid4()),
-            task_id=task.id,
-            workflow_id=workflow_id,
-            payload=dict(payload),
-            source=_text(source, "source"),
-            completed_at=now,
-        )
-        envelope.results[task.id] = result
-        envelope.tasks[task.id] = replace(task, status=HumanTaskStatus.COMPLETED, completed_at=now)
-        envelope.wait_states[task.id] = replace(wait_state, released_at=now)
-        self._append_event(envelope, "completed", task_id=task.id, context={"result_id": result.id})
-        self._save(envelope)
-        return result
+        with self.transaction():
+            envelope = self._load_for_workflow(workflow_id, create=False)
+            task = self._task(envelope, task_id)
+            existing = envelope.results.get(task.id)
+            if existing is not None:
+                return existing
+            if task.status is not HumanTaskStatus.PENDING:
+                raise HumanTaskCorrelationError(f"task {task.id} is not pending")
+            wait_state = envelope.wait_states[task.id]
+            if wait_state.released_at is not None:
+                raise HumanTaskCorrelationError(f"task {task.id} has no active wait state")
+            now = _now_iso()
+            result = TaskResult(
+                id=str(uuid4()),
+                task_id=task.id,
+                workflow_id=workflow_id,
+                payload=dict(payload),
+                source=_text(source, "source"),
+                completed_at=now,
+            )
+            envelope.results[task.id] = result
+            envelope.tasks[task.id] = replace(task, status=HumanTaskStatus.COMPLETED, completed_at=now)
+            envelope.wait_states[task.id] = replace(wait_state, released_at=now)
+            self._append_event(envelope, "completed", task_id=task.id, context={"result_id": result.id})
+            self._save(envelope)
+            return result
 
     def record_rejection(self, *, workflow_id: str, task_id: str, reason: str) -> None:
-        envelope = self._load_for_workflow(workflow_id, create=False)
-        self._task(envelope, task_id)
-        self._append_event(
-            envelope, "rejected", task_id=task_id, context={"reason": _text(reason, "reason")}
-        )
-        self._save(envelope)
+        with self.transaction():
+            envelope = self._load_for_workflow(workflow_id, create=False)
+            self._task(envelope, task_id)
+            self._append_event(
+                envelope, "rejected", task_id=task_id, context={"reason": _text(reason, "reason")}
+            )
+            self._save(envelope)
 
     def cancel(self, *, workflow_id: str, task_id: str, reason: str) -> HumanTask:
-        envelope = self._load_for_workflow(workflow_id, create=False)
-        task = self._task(envelope, task_id)
-        if task.status is not HumanTaskStatus.PENDING:
-            return task
-        now = _now_iso()
-        cancelled = replace(task, status=HumanTaskStatus.CANCELLED, cancelled_at=now)
-        envelope.tasks[task.id] = cancelled
-        envelope.wait_states[task.id] = replace(envelope.wait_states[task.id], released_at=now)
-        self._append_event(
-            envelope, "cancelled", task_id=task.id, context={"reason": _text(reason, "reason")}
-        )
-        self._save(envelope)
-        return cancelled
+        with self.transaction():
+            envelope = self._load_for_workflow(workflow_id, create=False)
+            task = self._task(envelope, task_id)
+            if task.status is not HumanTaskStatus.PENDING:
+                return task
+            now = _now_iso()
+            cancelled = replace(task, status=HumanTaskStatus.CANCELLED, cancelled_at=now)
+            envelope.tasks[task.id] = cancelled
+            envelope.wait_states[task.id] = replace(envelope.wait_states[task.id], released_at=now)
+            self._append_event(
+                envelope, "cancelled", task_id=task.id, context={"reason": _text(reason, "reason")}
+            )
+            self._save(envelope)
+            return cancelled
 
     def record_configuration_error(
         self,
@@ -475,19 +491,50 @@ class HumanTaskRecordStore:
         trigger: str,
         reason: str,
     ) -> None:
-        envelope = self._load_for_workflow(workflow_id, create=True)
-        self._append_event(
-            envelope,
-            "configuration_error",
-            task_id=None,
-            context={
-                "step": _text(step, "step"),
-                "iteration": _positive(iteration, "iteration"),
-                "trigger": _text(trigger, "trigger"),
-                "reason": _text(reason, "reason"),
-            },
-        )
-        self._save(envelope)
+        with self.transaction():
+            envelope = self._load_for_workflow(workflow_id, create=True)
+            self._append_event(
+                envelope,
+                "configuration_error",
+                task_id=None,
+                context={
+                    "step": _text(step, "step"),
+                    "iteration": _positive(iteration, "iteration"),
+                    "trigger": _text(trigger, "trigger"),
+                    "reason": _text(reason, "reason"),
+                },
+            )
+            self._save(envelope)
+
+    @contextmanager
+    def transaction(self):
+        """Serialize a durable record transition across threads and POSIX processes."""
+        if self._transaction_depth:
+            self._transaction_depth += 1
+            try:
+                yield
+            finally:
+                self._transaction_depth -= 1
+            return
+
+        with self._thread_lock_for(self.file_path):
+            self.issue_dir.mkdir(parents=True, exist_ok=True)
+            with self.lock_path.open("a+", encoding="utf-8") as lock_file:
+                if fcntl is not None:
+                    fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+                self._transaction_depth = 1
+                try:
+                    yield
+                finally:
+                    self._transaction_depth = 0
+                    if fcntl is not None:
+                        fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+    @classmethod
+    def _thread_lock_for(cls, file_path: Path) -> threading.RLock:
+        resolved = file_path.resolve()
+        with cls._thread_locks_guard:
+            return cls._thread_locks.setdefault(resolved, threading.RLock())
 
     def _load(self) -> _Envelope:
         if not self.file_path.exists():

--- a/src/cafe/core/human_task_records.py
+++ b/src/cafe/core/human_task_records.py
@@ -1,0 +1,598 @@
+"""Durable, file-backed records for policy-defined human workflow tasks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from datetime import datetime
+from enum import Enum
+import json
+from pathlib import Path
+from typing import Any, Mapping, Optional
+from uuid import uuid4
+
+from cafe.core.packet_io import atomic_write_bytes, canonical_json
+
+
+HUMAN_TASK_RECORD_FILENAME = "human_tasks.json"
+HUMAN_TASK_RECORD_SCHEMA_VERSION = 1
+
+
+def _now_iso() -> str:
+    return datetime.now().astimezone().isoformat()
+
+
+class HumanTaskRecordError(ValueError):
+    """Base error for a durable human-task record operation."""
+
+
+class HumanTaskRecordSchemaError(HumanTaskRecordError):
+    """The on-disk record cannot safely be interpreted by this runtime."""
+
+
+class HumanTaskCorrelationError(HumanTaskRecordError):
+    """A result does not belong to the pending task it tries to affect."""
+
+
+class HumanTaskStatus(str, Enum):
+    """Lifecycle state of the actionable human task."""
+
+    PENDING = "pending"
+    COMPLETED = "completed"
+    CANCELLED = "cancelled"
+    CONFIGURATION_ERROR = "configuration_error"
+
+
+@dataclass(frozen=True)
+class HumanTask:
+    """A stable, workflow-owned unit of human work."""
+
+    id: str
+    handoff_key: str
+    workflow_id: str
+    step: str
+    iteration: int
+    trigger: str
+    policy_id: str
+    prompt: str
+    expected_result: dict[str, Any]
+    continuations: dict[str, str]
+    status: HumanTaskStatus
+    created_at: str
+    completed_at: Optional[str] = None
+    cancelled_at: Optional[str] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "handoff_key": self.handoff_key,
+            "workflow_id": self.workflow_id,
+            "step": self.step,
+            "iteration": self.iteration,
+            "trigger": self.trigger,
+            "policy_id": self.policy_id,
+            "prompt": self.prompt,
+            "expected_result": dict(self.expected_result),
+            "continuations": dict(self.continuations),
+            "status": self.status.value,
+            "created_at": self.created_at,
+            "completed_at": self.completed_at,
+            "cancelled_at": self.cancelled_at,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "HumanTask":
+        try:
+            return cls(
+                id=_required_text(data, "id"),
+                handoff_key=_required_text(data, "handoff_key"),
+                workflow_id=_required_text(data, "workflow_id"),
+                step=_required_text(data, "step"),
+                iteration=_positive_int(data, "iteration"),
+                trigger=_required_text(data, "trigger"),
+                policy_id=_required_text(data, "policy_id"),
+                prompt=_required_text(data, "prompt"),
+                expected_result=_mapping(data, "expected_result"),
+                continuations=_string_mapping(data, "continuations"),
+                status=HumanTaskStatus(_required_text(data, "status")),
+                created_at=_required_text(data, "created_at"),
+                completed_at=_optional_text(data.get("completed_at")),
+                cancelled_at=_optional_text(data.get("cancelled_at")),
+            )
+        except (TypeError, ValueError) as exc:
+            raise HumanTaskRecordSchemaError(f"invalid human task: {exc}") from exc
+
+
+@dataclass(frozen=True)
+class Assignment:
+    """The declared human assignee for one task."""
+
+    task_id: str
+    assignee_type: str
+    assignee_id: Optional[str]
+    created_at: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "task_id": self.task_id,
+            "assignee_type": self.assignee_type,
+            "assignee_id": self.assignee_id,
+            "created_at": self.created_at,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "Assignment":
+        try:
+            return cls(
+                task_id=_required_text(data, "task_id"),
+                assignee_type=_required_text(data, "assignee_type"),
+                assignee_id=_optional_text(data.get("assignee_id")),
+                created_at=_required_text(data, "created_at"),
+            )
+        except (TypeError, ValueError) as exc:
+            raise HumanTaskRecordSchemaError(f"invalid assignment: {exc}") from exc
+
+
+@dataclass(frozen=True)
+class WaitState:
+    """The correlation fence which authorizes a pending task to resume work."""
+
+    task_id: str
+    workflow_id: str
+    pause_reason: str
+    created_at: str
+    released_at: Optional[str] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "task_id": self.task_id,
+            "workflow_id": self.workflow_id,
+            "pause_reason": self.pause_reason,
+            "created_at": self.created_at,
+            "released_at": self.released_at,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "WaitState":
+        try:
+            return cls(
+                task_id=_required_text(data, "task_id"),
+                workflow_id=_required_text(data, "workflow_id"),
+                pause_reason=_required_text(data, "pause_reason"),
+                created_at=_required_text(data, "created_at"),
+                released_at=_optional_text(data.get("released_at")),
+            )
+        except (TypeError, ValueError) as exc:
+            raise HumanTaskRecordSchemaError(f"invalid wait state: {exc}") from exc
+
+
+@dataclass(frozen=True)
+class TaskResult:
+    """One already-validated completion attached to its matching task."""
+
+    id: str
+    task_id: str
+    workflow_id: str
+    payload: dict[str, Any]
+    source: str
+    completed_at: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "task_id": self.task_id,
+            "workflow_id": self.workflow_id,
+            "payload": dict(self.payload),
+            "source": self.source,
+            "completed_at": self.completed_at,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "TaskResult":
+        try:
+            return cls(
+                id=_required_text(data, "id"),
+                task_id=_required_text(data, "task_id"),
+                workflow_id=_required_text(data, "workflow_id"),
+                payload=_mapping(data, "payload"),
+                source=_required_text(data, "source"),
+                completed_at=_required_text(data, "completed_at"),
+            )
+        except (TypeError, ValueError) as exc:
+            raise HumanTaskRecordSchemaError(f"invalid task result: {exc}") from exc
+
+
+@dataclass(frozen=True)
+class LifecycleEvent:
+    """Append-only evidence for task lifecycle decisions and rejections."""
+
+    event_type: str
+    workflow_id: str
+    task_id: Optional[str]
+    occurred_at: str
+    context: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "event_type": self.event_type,
+            "workflow_id": self.workflow_id,
+            "task_id": self.task_id,
+            "occurred_at": self.occurred_at,
+            "context": dict(self.context),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "LifecycleEvent":
+        try:
+            return cls(
+                event_type=_required_text(data, "event_type"),
+                workflow_id=_required_text(data, "workflow_id"),
+                task_id=_optional_text(data.get("task_id")),
+                occurred_at=_required_text(data, "occurred_at"),
+                context=_mapping(data, "context"),
+            )
+        except (TypeError, ValueError) as exc:
+            raise HumanTaskRecordSchemaError(f"invalid human-task lifecycle event: {exc}") from exc
+
+
+@dataclass
+class _Envelope:
+    workflow_id: str
+    tasks: dict[str, HumanTask]
+    assignments: dict[str, Assignment]
+    wait_states: dict[str, WaitState]
+    results: dict[str, TaskResult]
+    lifecycle_events: list[LifecycleEvent]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": HUMAN_TASK_RECORD_SCHEMA_VERSION,
+            "workflow_id": self.workflow_id,
+            "tasks": [task.to_dict() for task in self.tasks.values()],
+            "assignments": [assignment.to_dict() for assignment in self.assignments.values()],
+            "wait_states": [wait_state.to_dict() for wait_state in self.wait_states.values()],
+            "results": [result.to_dict() for result in self.results.values()],
+            "lifecycle_events": [event.to_dict() for event in self.lifecycle_events],
+        }
+
+    @classmethod
+    def empty(cls) -> "_Envelope":
+        return cls("", {}, {}, {}, {}, [])
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "_Envelope":
+        version = data.get("schema_version")
+        if version != HUMAN_TASK_RECORD_SCHEMA_VERSION:
+            raise HumanTaskRecordSchemaError(
+                f"unsupported human-task schema version {version!r}; expected {HUMAN_TASK_RECORD_SCHEMA_VERSION}"
+            )
+        workflow_id = _required_text(data, "workflow_id")
+        tasks = _records_by_task_id(data, "tasks", HumanTask.from_dict)
+        assignments = _records_by_task_id(data, "assignments", Assignment.from_dict)
+        waits = _records_by_task_id(data, "wait_states", WaitState.from_dict)
+        results = _records_by_task_id(data, "results", TaskResult.from_dict)
+        raw_events = data.get("lifecycle_events", [])
+        if not isinstance(raw_events, list):
+            raise HumanTaskRecordSchemaError("lifecycle_events must be a list")
+        events = [LifecycleEvent.from_dict(_as_mapping(item, "lifecycle event")) for item in raw_events]
+        envelope = cls(workflow_id, tasks, assignments, waits, results, events)
+        envelope.validate()
+        return envelope
+
+    def validate(self) -> None:
+        for task_id, task in self.tasks.items():
+            if task_id != task.id or task.workflow_id != self.workflow_id:
+                raise HumanTaskRecordSchemaError("task identity does not match its workflow envelope")
+            assignment = self.assignments.get(task_id)
+            wait_state = self.wait_states.get(task_id)
+            if assignment is None or assignment.task_id != task_id:
+                raise HumanTaskRecordSchemaError("every task requires a matching assignment")
+            if wait_state is None or wait_state.task_id != task_id or wait_state.workflow_id != self.workflow_id:
+                raise HumanTaskRecordSchemaError("every task requires a matching wait state")
+            result = self.results.get(task_id)
+            if task.status is HumanTaskStatus.COMPLETED and result is None:
+                raise HumanTaskRecordSchemaError("completed task has no result")
+            if result is not None and (result.task_id != task_id or result.workflow_id != self.workflow_id):
+                raise HumanTaskRecordSchemaError("result does not match its task/workflow")
+
+
+class HumanTaskRecordStore:
+    """Versioned local store for durable task, wait, result, and audit records."""
+
+    def __init__(self, issue_dir: Path) -> None:
+        self.issue_dir = issue_dir
+        self.file_path = issue_dir / HUMAN_TASK_RECORD_FILENAME
+
+    @property
+    def exists(self) -> bool:
+        return self.file_path.exists()
+
+    def tasks(self) -> tuple[HumanTask, ...]:
+        return tuple(self._load().tasks.values())
+
+    def results(self) -> tuple[TaskResult, ...]:
+        return tuple(self._load().results.values())
+
+    def lifecycle_events(self) -> tuple[LifecycleEvent, ...]:
+        return tuple(self._load().lifecycle_events)
+
+    def get_task(self, task_id: str) -> HumanTask:
+        return self._task(self._load(), task_id)
+
+    def get_assignment(self, task_id: str) -> Assignment:
+        envelope = self._load()
+        self._task(envelope, task_id)
+        return envelope.assignments[task_id]
+
+    def get_wait_state(self, task_id: str) -> WaitState:
+        envelope = self._load()
+        self._task(envelope, task_id)
+        return envelope.wait_states[task_id]
+
+    def get_result(self, task_id: str) -> Optional[TaskResult]:
+        envelope = self._load()
+        self._task(envelope, task_id)
+        return envelope.results.get(task_id)
+
+    def active_wait_state(
+        self,
+        workflow_id: str,
+        *,
+        step: Optional[str] = None,
+        trigger: Optional[str] = None,
+        policy_id: Optional[str] = None,
+    ) -> Optional[WaitState]:
+        envelope = self._load_for_workflow(workflow_id, create=False)
+        candidates = []
+        for task_id, wait_state in envelope.wait_states.items():
+            task = envelope.tasks[task_id]
+            if wait_state.released_at is not None or task.status is not HumanTaskStatus.PENDING:
+                continue
+            if step is not None and task.step != step:
+                continue
+            if trigger is not None and task.trigger != trigger:
+                continue
+            if policy_id is not None and task.policy_id != policy_id:
+                continue
+            candidates.append(wait_state)
+        return candidates[0] if candidates else None
+
+    def materialize(
+        self,
+        *,
+        workflow_id: str,
+        step: str,
+        iteration: int,
+        trigger: str,
+        policy_id: str,
+        prompt: str,
+        expected_result: Mapping[str, Any],
+        continuations: Mapping[str, str],
+        assignee_type: str,
+        assignee_id: Optional[str] = None,
+    ) -> HumanTask:
+        envelope = self._load_for_workflow(workflow_id, create=True)
+        handoff_key = _handoff_key(workflow_id, step, iteration, trigger, policy_id)
+        existing = next(
+            (task for task in envelope.tasks.values() if task.handoff_key == handoff_key), None
+        )
+        if existing is not None:
+            return existing
+        now = _now_iso()
+        task = HumanTask(
+            id=str(uuid4()),
+            handoff_key=handoff_key,
+            workflow_id=workflow_id,
+            step=_text(step, "step"),
+            iteration=_positive(iteration, "iteration"),
+            trigger=_text(trigger, "trigger"),
+            policy_id=_text(policy_id, "policy_id"),
+            prompt=_text(prompt, "prompt"),
+            expected_result=dict(expected_result),
+            continuations=_string_mapping_value(continuations, "continuations"),
+            status=HumanTaskStatus.PENDING,
+            created_at=now,
+        )
+        envelope.tasks[task.id] = task
+        envelope.assignments[task.id] = Assignment(
+            task_id=task.id,
+            assignee_type=_text(assignee_type, "assignee_type"),
+            assignee_id=_optional_text(assignee_id),
+            created_at=now,
+        )
+        envelope.wait_states[task.id] = WaitState(
+            task_id=task.id,
+            workflow_id=workflow_id,
+            pause_reason=task.trigger,
+            created_at=now,
+        )
+        self._append_event(envelope, "created", task_id=task.id, context={"handoff_key": handoff_key})
+        self._save(envelope)
+        return task
+
+    def complete(
+        self,
+        *,
+        workflow_id: str,
+        task_id: str,
+        payload: Mapping[str, Any],
+        source: str,
+    ) -> TaskResult:
+        envelope = self._load_for_workflow(workflow_id, create=False)
+        task = self._task(envelope, task_id)
+        existing = envelope.results.get(task.id)
+        if existing is not None:
+            return existing
+        if task.status is not HumanTaskStatus.PENDING:
+            raise HumanTaskCorrelationError(f"task {task.id} is not pending")
+        wait_state = envelope.wait_states[task.id]
+        if wait_state.released_at is not None:
+            raise HumanTaskCorrelationError(f"task {task.id} has no active wait state")
+        now = _now_iso()
+        result = TaskResult(
+            id=str(uuid4()),
+            task_id=task.id,
+            workflow_id=workflow_id,
+            payload=dict(payload),
+            source=_text(source, "source"),
+            completed_at=now,
+        )
+        envelope.results[task.id] = result
+        envelope.tasks[task.id] = replace(task, status=HumanTaskStatus.COMPLETED, completed_at=now)
+        envelope.wait_states[task.id] = replace(wait_state, released_at=now)
+        self._append_event(envelope, "completed", task_id=task.id, context={"result_id": result.id})
+        self._save(envelope)
+        return result
+
+    def record_rejection(self, *, workflow_id: str, task_id: str, reason: str) -> None:
+        envelope = self._load_for_workflow(workflow_id, create=False)
+        self._task(envelope, task_id)
+        self._append_event(
+            envelope, "rejected", task_id=task_id, context={"reason": _text(reason, "reason")}
+        )
+        self._save(envelope)
+
+    def cancel(self, *, workflow_id: str, task_id: str, reason: str) -> HumanTask:
+        envelope = self._load_for_workflow(workflow_id, create=False)
+        task = self._task(envelope, task_id)
+        if task.status is not HumanTaskStatus.PENDING:
+            return task
+        now = _now_iso()
+        cancelled = replace(task, status=HumanTaskStatus.CANCELLED, cancelled_at=now)
+        envelope.tasks[task.id] = cancelled
+        envelope.wait_states[task.id] = replace(envelope.wait_states[task.id], released_at=now)
+        self._append_event(
+            envelope, "cancelled", task_id=task.id, context={"reason": _text(reason, "reason")}
+        )
+        self._save(envelope)
+        return cancelled
+
+    def record_configuration_error(
+        self,
+        *,
+        workflow_id: str,
+        step: str,
+        iteration: int,
+        trigger: str,
+        reason: str,
+    ) -> None:
+        envelope = self._load_for_workflow(workflow_id, create=True)
+        self._append_event(
+            envelope,
+            "configuration_error",
+            task_id=None,
+            context={
+                "step": _text(step, "step"),
+                "iteration": _positive(iteration, "iteration"),
+                "trigger": _text(trigger, "trigger"),
+                "reason": _text(reason, "reason"),
+            },
+        )
+        self._save(envelope)
+
+    def _load(self) -> _Envelope:
+        if not self.file_path.exists():
+            return _Envelope.empty()
+        try:
+            raw = json.loads(self.file_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise HumanTaskRecordSchemaError(f"cannot read human-task records: {exc}") from exc
+        return _Envelope.from_dict(_as_mapping(raw, "human-task record envelope"))
+
+    def _load_for_workflow(self, workflow_id: str, *, create: bool) -> _Envelope:
+        requested = _text(workflow_id, "workflow_id")
+        envelope = self._load()
+        if not envelope.workflow_id:
+            if not create:
+                return envelope
+            envelope.workflow_id = requested
+            return envelope
+        if envelope.workflow_id != requested:
+            raise HumanTaskCorrelationError("human-task record belongs to a different workflow")
+        return envelope
+
+    @staticmethod
+    def _task(envelope: _Envelope, task_id: str) -> HumanTask:
+        task = envelope.tasks.get(task_id)
+        if task is None:
+            raise HumanTaskCorrelationError(f"unknown human task {task_id!r}")
+        return task
+
+    @staticmethod
+    def _append_event(
+        envelope: _Envelope, event_type: str, *, task_id: Optional[str], context: Mapping[str, Any]
+    ) -> None:
+        envelope.lifecycle_events.append(
+            LifecycleEvent(
+                event_type=event_type,
+                workflow_id=envelope.workflow_id,
+                task_id=task_id,
+                occurred_at=_now_iso(),
+                context=dict(context),
+            )
+        )
+
+    def _save(self, envelope: _Envelope) -> None:
+        envelope.validate()
+        atomic_write_bytes(self.file_path, canonical_json(envelope.to_dict()))
+
+
+def _records_by_task_id(data: Mapping[str, Any], field_name: str, parser: Any) -> dict[str, Any]:
+    raw = data.get(field_name, [])
+    if not isinstance(raw, list):
+        raise HumanTaskRecordSchemaError(f"{field_name} must be a list")
+    records: dict[str, Any] = {}
+    for item in raw:
+        record = parser(_as_mapping(item, field_name))
+        task_id = getattr(record, "task_id", getattr(record, "id", None))
+        if not isinstance(task_id, str) or not task_id or task_id in records:
+            raise HumanTaskRecordSchemaError(f"{field_name} has an invalid or duplicate task id")
+        records[task_id] = record
+    return records
+
+
+def _handoff_key(workflow_id: str, step: str, iteration: int, trigger: str, policy_id: str) -> str:
+    return "\u001f".join((workflow_id, step, str(iteration), trigger, policy_id))
+
+
+def _as_mapping(value: Any, field_name: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise HumanTaskRecordSchemaError(f"{field_name} must be an object")
+    return value
+
+
+def _mapping(data: Mapping[str, Any], field_name: str) -> dict[str, Any]:
+    return dict(_as_mapping(data.get(field_name), field_name))
+
+
+def _string_mapping(data: Mapping[str, Any], field_name: str) -> dict[str, str]:
+    return _string_mapping_value(_as_mapping(data.get(field_name), field_name), field_name)
+
+
+def _string_mapping_value(value: Mapping[str, Any], field_name: str) -> dict[str, str]:
+    return {_text(str(key), field_name): _text(str(item), field_name) for key, item in value.items()}
+
+
+def _required_text(data: Mapping[str, Any], field_name: str) -> str:
+    return _text(data.get(field_name), field_name)
+
+
+def _optional_text(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    return _text(value, "optional value")
+
+
+def _text(value: Any, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field_name} must be a non-empty string")
+    return value.strip()
+
+
+def _positive_int(data: Mapping[str, Any], field_name: str) -> int:
+    return _positive(data.get(field_name), field_name)
+
+
+def _positive(value: Any, field_name: str) -> int:
+    if not isinstance(value, int) or value < 1:
+        raise ValueError(f"{field_name} must be a positive integer")
+    return value

--- a/src/cafe/core/human_tasks.py
+++ b/src/cafe/core/human_tasks.py
@@ -227,6 +227,45 @@ def resolve_human_task_policy(
     return HumanTaskPolicy.model_validate({**policy.model_dump(), **changes})
 
 
+def resolve_step_human_task(
+    *,
+    playbook_data: Mapping[str, Any],
+    step_name: str,
+    trigger: str,
+    skill_loader: Optional[Any] = None,
+    iteration: int = 1,
+) -> tuple[HumanTaskPolicy, HumanTaskBinding]:
+    """Resolve a declared policy/binding pair for runtime and UI callers alike."""
+    raw_steps = playbook_data.get("steps")
+    if not isinstance(raw_steps, Mapping):
+        raise HumanTaskPolicyError("Playbook has no step declarations")
+    raw_step = raw_steps.get(step_name)
+    if not isinstance(raw_step, Mapping):
+        raise HumanTaskPolicyError(f"Unknown playbook step {step_name!r}")
+    raw_bindings = raw_step.get("human_tasks")
+    if not isinstance(raw_bindings, Sequence) or isinstance(raw_bindings, (str, bytes)):
+        raise HumanTaskPolicyError(
+            f"Step {step_name!r} has no declared human task for trigger {trigger!r}"
+        )
+    bindings = [
+        HumanTaskBinding.model_validate(raw)
+        for raw in raw_bindings
+        if isinstance(raw, Mapping) and raw.get("trigger") == trigger
+    ]
+    if len(bindings) != 1:
+        raise HumanTaskPolicyError(
+            f"Step {step_name!r} requires exactly one human task for trigger {trigger!r}"
+        )
+    if skill_loader is None:
+        from cafe.skills.loader import SkillLoader
+
+        skill_loader = SkillLoader()
+    skill_name = _select_step_skill_name(raw_step, iteration)
+    contract = skill_loader.get_workflow_contract(skill_name)
+    policy = resolve_human_task_policy(defaults=contract.human_tasks, binding=bindings[0])
+    return policy, bindings[0]
+
+
 def validate_human_task_completion(
     policy: HumanTaskPolicy,
     raw_payload: str | Mapping[str, Any],
@@ -349,3 +388,21 @@ def _answer_values(value: Any) -> tuple[str, ...]:
 
 def _reject(policy: HumanTaskPolicy, message: str) -> HumanTaskRejection:
     return HumanTaskRejection(message=message, correction_guidance=policy.correction_guidance)
+
+
+def _select_step_skill_name(step_def: Mapping[str, Any], iteration: int) -> str:
+    """Select the existing iteration-aware skill declaration for a task binding."""
+    raw_skill = step_def.get("skill")
+    if isinstance(raw_skill, str) and raw_skill.strip():
+        return raw_skill
+    if isinstance(raw_skill, Mapping):
+        exact = raw_skill.get(str(iteration))
+        if isinstance(exact, str) and exact.strip():
+            return exact
+        default = raw_skill.get("default")
+        if isinstance(default, str) and default.strip():
+            return default
+        for value in raw_skill.values():
+            if isinstance(value, str) and value.strip():
+                return value
+    raise HumanTaskPolicyError("Human-task step must select a skill")

--- a/src/cafe/core/workflow_runtime.py
+++ b/src/cafe/core/workflow_runtime.py
@@ -26,6 +26,8 @@ from cafe.core.blackboard import (
     operation_receipt_path,
 )
 from cafe.core.capabilities import CAPABILITY_PR_PUBLISH_ID
+from cafe.core.human_task_records import HumanTaskRecordStore
+from cafe.core.human_tasks import resolve_step_human_task
 from cafe.core.playbook import resolve_step_behavior
 from cafe.core.questions_schema import validate_questions_xml
 from cafe.core.status_codes import (
@@ -902,6 +904,7 @@ class BlackboardWorkflowRuntime:
                 status_code=status_code,
                 source=contract_source,
             )
+        self._materialize_user_handoff_task(current_step=current_step)
         if record_event:
             self.blackboard_store.record_event(
                 self.blackboard,
@@ -919,6 +922,80 @@ class BlackboardWorkflowRuntime:
             final_status_code=status_code,
             completed=False,
         )
+
+    def _materialize_user_handoff_task(self, *, current_step: str) -> None:
+        """Create or recover a declared task before exposing the user pause."""
+        step_def = self.steps.get(current_step)
+        if not isinstance(step_def, dict):
+            return
+        raw_bindings = step_def.get("human_tasks")
+        if not isinstance(raw_bindings, (list, tuple)):
+            return
+        contract = self.blackboard.handoff_contract
+        if (
+            contract is None
+            or contract.to_owner is not HandoffOwner.USER
+            or contract.to_step != "user"
+            or contract.from_step != current_step
+        ):
+            return
+        trigger = contract.intent.value
+        iteration = self._human_task_iteration(current_step)
+        records = HumanTaskRecordStore(self.issue_dir)
+        try:
+            policy, binding = resolve_step_human_task(
+                playbook_data=self.playbook,
+                step_name=current_step,
+                trigger=trigger,
+                iteration=iteration,
+            )
+        except (LookupError, TypeError, ValueError) as exc:
+            records.record_configuration_error(
+                workflow_id=self.blackboard.workflow_id,
+                step=current_step,
+                iteration=iteration,
+                trigger=trigger,
+                reason=str(exc),
+            )
+            self.blackboard_store.record_event(
+                self.blackboard,
+                "human_task_configuration_error",
+                {"step": current_step, "trigger": trigger, "reason": str(exc)},
+            )
+            return
+
+        existing_wait = records.active_wait_state(
+            self.blackboard.workflow_id,
+            step=current_step,
+            trigger=trigger,
+            policy_id=policy.id,
+        )
+        task = records.materialize(
+            workflow_id=self.blackboard.workflow_id,
+            step=current_step,
+            iteration=iteration,
+            trigger=trigger,
+            policy_id=policy.id,
+            prompt=policy.prompt,
+            expected_result=policy.model_dump(mode="json"),
+            continuations=binding.outcomes,
+            assignee_type="user",
+        )
+        if existing_wait is None:
+            self.blackboard_store.record_event(
+                self.blackboard,
+                "human_task_materialized",
+                {"step": current_step, "trigger": trigger, "task_id": task.id},
+            )
+
+    def _human_task_iteration(self, current_step: str) -> int:
+        iteration_dir = self._latest_iteration_dir(current_step)
+        if iteration_dir is None:
+            return 1
+        try:
+            return int(iteration_dir.name.removeprefix("iteration_"))
+        except ValueError:
+            return 1
 
     def _emit_complete(
         self,

--- a/src/cafe/ui/cli_shared.py
+++ b/src/cafe/ui/cli_shared.py
@@ -22,7 +22,7 @@ from rich.console import Console
 
 from cafe.agents.manager import AgentManager
 from cafe.core.blackboard import BlackboardStore, HandoffIntent, HandoffOwner
-from cafe.core.human_task_records import HumanTaskRecordStore
+from cafe.core.human_task_records import HumanTaskRecordStore, HumanTaskStatus
 from cafe.core.types import AgentCLI, AgentConfig
 from cafe.core.workflow_models import BatonRejected
 from cafe.core.workflow_runtime import BlackboardWorkflowRuntime
@@ -1045,24 +1045,52 @@ def _handle_declared_human_task_handoff(
         if questions_file is not None and questions_file.exists() and validate_questions_xml(questions_file):
             questions = parse_questions_xml(questions_file)
     durable_task_id = None
-    durable_wait = HumanTaskRecordStore(issue_dir).active_wait_state(
+    record_store = HumanTaskRecordStore(issue_dir)
+    durable_wait = record_store.active_wait_state(
         blackboard.workflow_id,
         step=from_step,
         trigger=trigger,
         policy_id=policy.id,
     )
+    recovered_payload: Optional[dict[str, Any]] = None
     if durable_wait is not None:
         durable_task_id = durable_wait.task_id
-    payload = collect_human_task_payload(
-        policy,
-        questions=questions,
-        role=_resolve_step_chat_role(playbook_data, from_step),
-        issue_name=issue_name,
-        agent_name=_resolve_role_agent_name(
-            playbook_data, _resolve_step_chat_role(playbook_data, from_step)
-        ),
-        human_task_id=durable_task_id,
-    )
+    elif record_store.exists:
+        iteration = latest_step_iteration(issue_dir=issue_dir, step_name=from_step)
+        completed_task = next(
+            (
+                task
+                for task in record_store.tasks()
+                if task.workflow_id == blackboard.workflow_id
+                and task.step == from_step
+                and task.iteration == iteration
+                and task.trigger == trigger
+                and task.policy_id == policy.id
+                and task.status is HumanTaskStatus.COMPLETED
+            ),
+            None,
+        )
+        if completed_task is not None:
+            recorded_result = record_store.get_result(completed_task.id)
+            if recorded_result is not None:
+                recovered_payload = {
+                    key: recorded_result.payload[key]
+                    for key in ("task", "decision", "answers", "feedback", "target")
+                    if key in recorded_result.payload
+                }
+                recovered_payload["human_task_id"] = completed_task.id
+    payload = recovered_payload
+    if payload is None:
+        payload = collect_human_task_payload(
+            policy,
+            questions=questions,
+            role=_resolve_step_chat_role(playbook_data, from_step),
+            issue_name=issue_name,
+            agent_name=_resolve_role_agent_name(
+                playbook_data, _resolve_step_chat_role(playbook_data, from_step)
+            ),
+            human_task_id=durable_task_id,
+        )
     if isinstance(payload, dict) and payload.get("decision") == "chat":
         from cafe.ui.cli import _consume_pending_chat_handoff, launch_chat_session
 

--- a/src/cafe/ui/cli_shared.py
+++ b/src/cafe/ui/cli_shared.py
@@ -22,6 +22,7 @@ from rich.console import Console
 
 from cafe.agents.manager import AgentManager
 from cafe.core.blackboard import BlackboardStore, HandoffIntent, HandoffOwner
+from cafe.core.human_task_records import HumanTaskRecordStore
 from cafe.core.types import AgentCLI, AgentConfig
 from cafe.core.workflow_models import BatonRejected
 from cafe.core.workflow_runtime import BlackboardWorkflowRuntime
@@ -1043,6 +1044,15 @@ def _handle_declared_human_task_handoff(
         questions_file = iteration_dirs[-1] / "questions.xml" if iteration_dirs else None
         if questions_file is not None and questions_file.exists() and validate_questions_xml(questions_file):
             questions = parse_questions_xml(questions_file)
+    durable_task_id = None
+    durable_wait = HumanTaskRecordStore(issue_dir).active_wait_state(
+        blackboard.workflow_id,
+        step=from_step,
+        trigger=trigger,
+        policy_id=policy.id,
+    )
+    if durable_wait is not None:
+        durable_task_id = durable_wait.task_id
     payload = collect_human_task_payload(
         policy,
         questions=questions,
@@ -1051,6 +1061,7 @@ def _handle_declared_human_task_handoff(
         agent_name=_resolve_role_agent_name(
             playbook_data, _resolve_step_chat_role(playbook_data, from_step)
         ),
+        human_task_id=durable_task_id,
     )
     if isinstance(payload, dict) and payload.get("decision") == "chat":
         from cafe.ui.cli import _consume_pending_chat_handoff, launch_chat_session

--- a/src/cafe/ui/cli_shared.py
+++ b/src/cafe/ui/cli_shared.py
@@ -1057,13 +1057,21 @@ def _handle_declared_human_task_handoff(
         durable_task_id = durable_wait.task_id
     elif record_store.exists:
         iteration = latest_step_iteration(issue_dir=issue_dir, step_name=from_step)
+        latest_iteration = issue_dir / from_step / f"iteration_{iteration:03d}"
+        recovery_iterations = {iteration}
+        if (
+            (latest_iteration / "user_input.md").exists()
+            and not (latest_iteration / "iteration.json").exists()
+            and not (latest_iteration / "context.json").exists()
+        ):
+            recovery_iterations.add(iteration - 1)
         completed_task = next(
             (
                 task
                 for task in record_store.tasks()
                 if task.workflow_id == blackboard.workflow_id
                 and task.step == from_step
-                and task.iteration == iteration
+                and task.iteration in recovery_iterations
                 and task.trigger == trigger
                 and task.policy_id == policy.id
                 and task.status is HumanTaskStatus.COMPLETED

--- a/src/cafe/ui/human_tasks.py
+++ b/src/cafe/ui/human_tasks.py
@@ -26,6 +26,7 @@ from cafe.core.human_task_records import (
     HumanTaskCorrelationError,
     HumanTaskRecordStore,
     HumanTaskStatus,
+    TaskResult,
 )
 from cafe.core.phase_state_mixin import next_runnable_iteration_number
 from cafe.skills.loader import SkillLoader
@@ -187,8 +188,33 @@ def apply_human_task_payload(
     source: str,
 ) -> HumanTaskApplication:
     """Validate and apply one response while retaining a pause on rejection."""
-    store = BlackboardStore(issue_dir)
     record_store = HumanTaskRecordStore(issue_dir)
+    with record_store.transaction():
+        return _apply_human_task_payload(
+            issue_dir=issue_dir,
+            playbook_data=playbook_data,
+            blackboard=blackboard,
+            from_step=from_step,
+            trigger=trigger,
+            raw_payload=raw_payload,
+            source=source,
+            record_store=record_store,
+        )
+
+
+def _apply_human_task_payload(
+    *,
+    issue_dir: Path,
+    playbook_data: Mapping[str, Any],
+    blackboard: Any,
+    from_step: str,
+    trigger: str,
+    raw_payload: str | Mapping[str, Any],
+    source: str,
+    record_store: HumanTaskRecordStore,
+) -> HumanTaskApplication:
+    """Apply a response while holding the matching durable-record transaction."""
+    store = BlackboardStore(issue_dir)
     try:
         iteration = latest_step_iteration(issue_dir=issue_dir, step_name=from_step)
         questions = _load_dynamic_questions(
@@ -228,7 +254,7 @@ def apply_human_task_payload(
             )
         return HumanTaskApplication(target=None, policy=None, rejection=rejection)
 
-    durable_task, durable_rejection = _resolve_durable_task(
+    durable_task, durable_result, durable_rejection = _resolve_durable_task(
         record_store=record_store,
         workflow_id=blackboard.workflow_id,
         from_step=from_step,
@@ -249,52 +275,104 @@ def apply_human_task_payload(
         )
         return HumanTaskApplication(target=None, policy=policy, rejection=durable_rejection)
 
-    if isinstance(completion, HumanTaskRejection):
-        if durable_task is not None:
+    recovered_agent_input = ""
+    if durable_result is not None:
+        blackboard = store.load_or_create(
+            from_step, playbook_id=getattr(blackboard, "playbook_id", "default")
+        )
+        if blackboard.current_step != "user":
+            rejection = HumanTaskRejection(
+                message="This human task has already completed.",
+                correction_guidance=policy.correction_guidance,
+            )
             record_store.record_rejection(
                 workflow_id=blackboard.workflow_id,
                 task_id=durable_task.id,
-                reason=completion.message,
+                reason=rejection.message,
             )
-        store.record_event(
-            blackboard,
-            "human_task_rejected",
-            {
-                "step": from_step,
-                "trigger": trigger,
-                "task_id": policy.id,
-                "reason": completion.message,
-            },
+            store.record_event(
+                blackboard,
+                "human_task_rejected",
+                {
+                    "step": from_step,
+                    "trigger": trigger,
+                    "task_id": policy.id,
+                    "reason": rejection.message,
+                },
+            )
+            return HumanTaskApplication(target=None, policy=policy, rejection=rejection)
+        continuation, recovered_agent_input = _recorded_result_continuation(
+            durable_result, policy=policy
         )
-        return HumanTaskApplication(target=None, policy=policy, rejection=completion)
-
-    continuation = resolve_step_human_task_continuation(
-        playbook_data=playbook_data,
-        policy=policy,
-        binding=binding,
-        completion=completion,
-    )
-    if isinstance(continuation, HumanTaskRejection):
-        if durable_task is not None:
+        if isinstance(continuation, HumanTaskRejection):
             record_store.record_rejection(
                 workflow_id=blackboard.workflow_id,
                 task_id=durable_task.id,
                 reason=continuation.message,
             )
-        store.record_event(
-            blackboard,
-            "human_task_rejected",
-            {
-                "step": from_step,
-                "trigger": trigger,
-                "task_id": policy.id,
-                "reason": continuation.message,
-            },
+            store.record_event(
+                blackboard,
+                "human_task_rejected",
+                {
+                    "step": from_step,
+                    "trigger": trigger,
+                    "task_id": policy.id,
+                    "reason": continuation.message,
+                },
+            )
+            return HumanTaskApplication(target=None, policy=policy, rejection=continuation)
+    else:
+        if isinstance(completion, HumanTaskRejection):
+            if durable_task is not None:
+                record_store.record_rejection(
+                    workflow_id=blackboard.workflow_id,
+                    task_id=durable_task.id,
+                    reason=completion.message,
+                )
+            store.record_event(
+                blackboard,
+                "human_task_rejected",
+                {
+                    "step": from_step,
+                    "trigger": trigger,
+                    "task_id": policy.id,
+                    "reason": completion.message,
+                },
+            )
+            return HumanTaskApplication(target=None, policy=policy, rejection=completion)
+
+        continuation = resolve_step_human_task_continuation(
+            playbook_data=playbook_data,
+            policy=policy,
+            binding=binding,
+            completion=completion,
         )
-        return HumanTaskApplication(target=None, policy=policy, rejection=continuation)
+        if isinstance(continuation, HumanTaskRejection):
+            if durable_task is not None:
+                record_store.record_rejection(
+                    workflow_id=blackboard.workflow_id,
+                    task_id=durable_task.id,
+                    reason=continuation.message,
+                )
+            store.record_event(
+                blackboard,
+                "human_task_rejected",
+                {
+                    "step": from_step,
+                    "trigger": trigger,
+                    "task_id": policy.id,
+                    "reason": continuation.message,
+                },
+            )
+            return HumanTaskApplication(target=None, policy=policy, rejection=continuation)
 
     selected_decision = next(
-        (item for item in policy.decisions if item.id == completion.decision), None
+        (
+            item
+            for item in policy.decisions
+            if durable_result is None and item.id == completion.decision
+        ),
+        None,
     )
     is_correction = selected_decision is not None and selected_decision.correction
     qualification_rejection = (
@@ -306,6 +384,8 @@ def apply_human_task_payload(
             correction_guidance=policy.correction_guidance,
         )
         if (
+            durable_result is None
+            and
             trigger == "confirm_output"
             and continuation != from_step
             and not is_correction
@@ -360,38 +440,33 @@ def apply_human_task_payload(
                 },
             )
             return HumanTaskApplication(target=None, policy=policy, rejection=rejection)
-        if record_store.get_result(durable_task.id) is not None:
-            rejection = HumanTaskRejection(
-                message="This human task has already completed.",
-                correction_guidance=policy.correction_guidance,
-            )
-            record_store.record_rejection(
-                workflow_id=blackboard.workflow_id,
-                task_id=durable_task.id,
-                reason=rejection.message,
-            )
-            return HumanTaskApplication(target=None, policy=policy, rejection=rejection)
-        try:
-            record_store.complete(
-                workflow_id=blackboard.workflow_id,
-                task_id=durable_task.id,
-                payload=_validated_completion_payload(completion, continuation),
-                source=source,
-            )
-        except HumanTaskCorrelationError as exc:
-            rejection = HumanTaskRejection(
-                message=str(exc), correction_guidance=policy.correction_guidance
-            )
-            record_store.record_rejection(
-                workflow_id=blackboard.workflow_id,
-                task_id=durable_task.id,
-                reason=rejection.message,
-            )
-            return HumanTaskApplication(target=None, policy=policy, rejection=rejection)
+        if durable_result is None:
+            try:
+                record_store.complete(
+                    workflow_id=blackboard.workflow_id,
+                    task_id=durable_task.id,
+                    payload=_validated_completion_payload(completion, continuation),
+                    source=source,
+                )
+            except HumanTaskCorrelationError as exc:
+                rejection = HumanTaskRejection(
+                    message=str(exc), correction_guidance=policy.correction_guidance
+                )
+                record_store.record_rejection(
+                    workflow_id=blackboard.workflow_id,
+                    task_id=durable_task.id,
+                    reason=rejection.message,
+                )
+                return HumanTaskApplication(target=None, policy=policy, rejection=rejection)
 
-    agent_input = completion.agent_input()
+    agent_input = recovered_agent_input if durable_result is not None else completion.agent_input()
     if agent_input:
-        input_step = continuation if completion.feedback and continuation != "_done" else from_step
+        has_feedback = (
+            isinstance(durable_result.payload.get("feedback"), str)
+            if durable_result is not None
+            else bool(completion.feedback)
+        )
+        input_step = continuation if has_feedback and continuation != "_done" else from_step
         _write_next_iteration_user_input(
             issue_dir=issue_dir,
             step_name=input_step,
@@ -432,10 +507,10 @@ def _resolve_durable_task(
     trigger: str,
     policy: HumanTaskPolicy,
     raw_payload: str | Mapping[str, Any],
-) -> tuple[Optional[HumanTask], Optional[HumanTaskRejection]]:
-    """Return the active record matching this pause, or fail closed for durable waits."""
+) -> tuple[Optional[HumanTask], Optional[TaskResult], Optional[HumanTaskRejection]]:
+    """Resolve the exact durable task, including one interrupted continuation."""
     if not record_store.exists:
-        return None, None
+        return None, None, None
     matching = [
         task
         for task in record_store.tasks()
@@ -454,33 +529,101 @@ def _resolve_durable_task(
         None,
     )
     submitted_id = _submitted_human_task_id(raw_payload)
-    if active is None:
-        rejected_task = matching[0] if matching else None
-        if rejected_task is not None:
+    if active is not None:
+        if submitted_id is None:
             record_store.record_rejection(
                 workflow_id=workflow_id,
-                task_id=rejected_task.id,
-                reason="the task is no longer pending",
+                task_id=active.id,
+                reason="response omits the required durable task id",
             )
-        return None, HumanTaskRejection(
-            message="This workflow is not waiting for a matching human task.",
-            correction_guidance=policy.correction_guidance,
-        )
-    if submitted_id is not None and submitted_id != active.id:
+            return None, None, HumanTaskRejection(
+                message="This response must identify the pending durable human task.",
+                correction_guidance=policy.correction_guidance,
+            )
+        if submitted_id != active.id:
+            record_store.record_rejection(
+                workflow_id=workflow_id,
+                task_id=active.id,
+                reason="response references a different durable task",
+            )
+            return None, None, HumanTaskRejection(
+                message="This response belongs to a different durable human task.",
+                correction_guidance=policy.correction_guidance,
+            )
+        return active, None, None
+
+    if not matching:
+        return None, None, None
+
+    if submitted_id is None:
         record_store.record_rejection(
             workflow_id=workflow_id,
-            task_id=active.id,
-            reason="response references a different durable task",
+            task_id=matching[0].id,
+            reason="response omits the required durable task id",
         )
-        return None, HumanTaskRejection(
-            message="This response belongs to a different durable human task.",
+        return None, None, HumanTaskRejection(
+            message="This response must identify the pending durable human task.",
             correction_guidance=policy.correction_guidance,
         )
-    return active, None
+
+    completed = next(
+        (task for task in matching if task.id == submitted_id and task.status is HumanTaskStatus.COMPLETED),
+        None,
+    )
+    if completed is not None:
+        result = record_store.get_result(completed.id)
+        if result is not None:
+            return completed, result, None
+
+    rejected_task = next((task for task in matching if task.id == submitted_id), matching[0])
+    record_store.record_rejection(
+        workflow_id=workflow_id,
+        task_id=rejected_task.id,
+        reason="the task is no longer pending",
+    )
+    return None, None, HumanTaskRejection(
+        message="This workflow is not waiting for a matching human task.",
+        correction_guidance=policy.correction_guidance,
+    )
+
+
+def _recorded_result_continuation(
+    result: TaskResult, *, policy: HumanTaskPolicy
+) -> tuple[str | HumanTaskRejection, str]:
+    """Restore only the previously validated continuation and agent input."""
+    payload = result.payload
+    continuation = payload.get("continuation")
+    if payload.get("task") != policy.id or not isinstance(continuation, str) or not continuation:
+        return HumanTaskRejection(
+            message="The completed durable human task has an invalid continuation.",
+            correction_guidance=policy.correction_guidance,
+        ), ""
+    feedback = payload.get("feedback")
+    if isinstance(feedback, str) and feedback:
+        return continuation, feedback
+    answers = payload.get("answers")
+    if answers is None:
+        return continuation, ""
+    if not isinstance(answers, Mapping):
+        return HumanTaskRejection(
+            message="The completed durable human task has invalid recorded answers.",
+            correction_guidance=policy.correction_guidance,
+        ), ""
+    lines = []
+    for question, answer in answers.items():
+        if not isinstance(question, str) or not isinstance(answer, list) or not all(
+            isinstance(item, str) for item in answer
+        ):
+            return HumanTaskRejection(
+                message="The completed durable human task has invalid recorded answers.",
+                correction_guidance=policy.correction_guidance,
+            ), ""
+        lines.append(f"{question}: {', '.join(answer)}")
+    return continuation, "\n".join(lines)
 
 
 def _submitted_human_task_id(raw_payload: str | Mapping[str, Any]) -> Optional[str]:
-    """Read an optional durable id without changing the existing #345 payload contract."""
+    """Read a durable id while preserving taskless #345 payloads."""
     if isinstance(raw_payload, str):
         try:
             raw_payload = json.loads(raw_payload)

--- a/src/cafe/ui/human_tasks.py
+++ b/src/cafe/ui/human_tasks.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass
+import json
 from pathlib import Path
 from typing import Any, Optional, Sequence
 
@@ -16,9 +17,15 @@ from cafe.core.human_tasks import (
     HumanTaskPolicyError,
     HumanTaskQuestion,
     HumanTaskRejection,
+    resolve_step_human_task as _resolve_step_human_task,
     resolve_human_task_continuation,
-    resolve_human_task_policy,
     validate_human_task_completion,
+)
+from cafe.core.human_task_records import (
+    HumanTask,
+    HumanTaskCorrelationError,
+    HumanTaskRecordStore,
+    HumanTaskStatus,
 )
 from cafe.core.phase_state_mixin import next_runnable_iteration_number
 from cafe.skills.loader import SkillLoader
@@ -32,31 +39,14 @@ def resolve_step_human_task(
     skill_loader: Optional[SkillLoader] = None,
     iteration: int = 1,
 ) -> tuple[HumanTaskPolicy, HumanTaskBinding]:
-    """Resolve one declared step binding without inferring workflow semantics."""
-    raw_steps = playbook_data.get("steps")
-    if not isinstance(raw_steps, Mapping):
-        raise HumanTaskPolicyError("Playbook has no step declarations")
-    raw_step = raw_steps.get(step_name)
-    if not isinstance(raw_step, Mapping):
-        raise HumanTaskPolicyError(f"Unknown playbook step {step_name!r}")
-    raw_bindings = raw_step.get("human_tasks")
-    if not isinstance(raw_bindings, Sequence) or isinstance(raw_bindings, (str, bytes)):
-        raise HumanTaskPolicyError(
-            f"Step {step_name!r} has no declared human task for trigger {trigger!r}"
-        )
-    bindings = [
-        HumanTaskBinding.model_validate(raw)
-        for raw in raw_bindings
-        if isinstance(raw, Mapping) and raw.get("trigger") == trigger
-    ]
-    if len(bindings) != 1:
-        raise HumanTaskPolicyError(
-            f"Step {step_name!r} requires exactly one human task for trigger {trigger!r}"
-        )
-    skill_name = _select_skill_name(raw_step, iteration)
-    contract = (skill_loader or SkillLoader()).get_workflow_contract(skill_name)
-    policy = resolve_human_task_policy(defaults=contract.human_tasks, binding=bindings[0])
-    return policy, bindings[0]
+    """UI adapter that preserves the existing configurable skill-loader boundary."""
+    return _resolve_step_human_task(
+        playbook_data=playbook_data,
+        step_name=step_name,
+        trigger=trigger,
+        skill_loader=skill_loader or SkillLoader(),
+        iteration=iteration,
+    )
 
 
 def validate_step_human_task_completion(
@@ -111,12 +101,18 @@ def collect_human_task_payload(
     role: Optional[str] = None,
     issue_name: Optional[str] = None,
     agent_name: Optional[str] = None,
+    human_task_id: Optional[str] = None,
 ) -> Optional[dict[str, Any]]:
     """Collect one interactive response in the policy's declared input shape."""
     from cafe.ui.inquirer_prompts import prompt_checkbox, prompt_list, prompt_multiline
 
+    def with_record_id(payload: dict[str, Any]) -> dict[str, Any]:
+        if human_task_id:
+            return {**payload, "human_task_id": human_task_id}
+        return payload
+
     if policy.input_schema == "feedback":
-        return {"task": policy.id, "feedback": prompt_multiline(policy.prompt).strip()}
+        return with_record_id({"task": policy.id, "feedback": prompt_multiline(policy.prompt).strip()})
     if policy.input_schema == "decision":
         choices = [{"name": item.label, "value": item.id} for item in policy.decisions]
         if role and issue_name:
@@ -133,31 +129,31 @@ def collect_human_task_payload(
         feedback = ""
         if selected is not None and selected.requires_feedback:
             feedback = prompt_multiline(policy.prompt).strip()
-        return {
+        return with_record_id({
             "task": policy.id,
             "decision": decision,
             "target": target,
             "feedback": feedback,
-        }
+        })
     if policy.input_schema == "target":
         target = prompt_list(
             policy.prompt,
             [{"name": target, "value": target} for target in policy.allowed_targets],
             default=None,
         )
-        return {"task": policy.id, "target": target}
+        return with_record_id({"task": policy.id, "target": target})
 
     if policy.questions_from_xml:
         if not questions:
             return None
         from cafe.ui.interactive_qa import interactive_qa_answers
 
-        return {
+        return with_record_id({
             "task": policy.id,
             "answers": interactive_qa_answers(
                 list(questions), role=role, issue_name=issue_name, agent_name=agent_name
             ),
-        }
+        })
 
     answers: dict[str, str | list[str]] = {}
     for question in policy.questions:
@@ -168,7 +164,7 @@ def collect_human_task_payload(
         else:
             answer = prompt_multiline(question.prompt).strip()
         answers[question.id] = answer
-    return {"task": policy.id, "answers": answers}
+    return with_record_id({"task": policy.id, "answers": answers})
 
 
 @dataclass(frozen=True)
@@ -192,6 +188,7 @@ def apply_human_task_payload(
 ) -> HumanTaskApplication:
     """Validate and apply one response while retaining a pause on rejection."""
     store = BlackboardStore(issue_dir)
+    record_store = HumanTaskRecordStore(issue_dir)
     try:
         iteration = latest_step_iteration(issue_dir=issue_dir, step_name=from_step)
         questions = _load_dynamic_questions(
@@ -209,7 +206,7 @@ def apply_human_task_payload(
             questions=questions,
             iteration=iteration,
         )
-    except HumanTaskPolicyError as exc:
+    except (HumanTaskPolicyError, LookupError, TypeError) as exc:
         rejection = HumanTaskRejection(
             message=str(exc),
             correction_guidance=(
@@ -221,9 +218,44 @@ def apply_human_task_payload(
             "human_task_configuration_error",
             {"step": from_step, "trigger": trigger, "reason": rejection.message},
         )
+        if record_store.exists:
+            record_store.record_configuration_error(
+                workflow_id=blackboard.workflow_id,
+                step=from_step,
+                iteration=latest_step_iteration(issue_dir=issue_dir, step_name=from_step),
+                trigger=trigger,
+                reason=rejection.message,
+            )
         return HumanTaskApplication(target=None, policy=None, rejection=rejection)
 
+    durable_task, durable_rejection = _resolve_durable_task(
+        record_store=record_store,
+        workflow_id=blackboard.workflow_id,
+        from_step=from_step,
+        trigger=trigger,
+        policy=policy,
+        raw_payload=raw_payload,
+    )
+    if durable_rejection is not None:
+        store.record_event(
+            blackboard,
+            "human_task_rejected",
+            {
+                "step": from_step,
+                "trigger": trigger,
+                "task_id": policy.id,
+                "reason": durable_rejection.message,
+            },
+        )
+        return HumanTaskApplication(target=None, policy=policy, rejection=durable_rejection)
+
     if isinstance(completion, HumanTaskRejection):
+        if durable_task is not None:
+            record_store.record_rejection(
+                workflow_id=blackboard.workflow_id,
+                task_id=durable_task.id,
+                reason=completion.message,
+            )
         store.record_event(
             blackboard,
             "human_task_rejected",
@@ -243,6 +275,12 @@ def apply_human_task_payload(
         completion=completion,
     )
     if isinstance(continuation, HumanTaskRejection):
+        if durable_task is not None:
+            record_store.record_rejection(
+                workflow_id=blackboard.workflow_id,
+                task_id=durable_task.id,
+                reason=continuation.message,
+            )
         store.record_event(
             blackboard,
             "human_task_rejected",
@@ -275,6 +313,12 @@ def apply_human_task_payload(
         else None
     )
     if qualification_rejection is not None:
+        if durable_task is not None:
+            record_store.record_rejection(
+                workflow_id=blackboard.workflow_id,
+                task_id=durable_task.id,
+                reason=qualification_rejection.message,
+            )
         store.record_event(
             blackboard,
             "human_task_rejected",
@@ -288,6 +332,62 @@ def apply_human_task_payload(
         return HumanTaskApplication(
             target=None, policy=policy, rejection=qualification_rejection
         )
+
+    if durable_task is not None:
+        permitted_continuations = set(durable_task.continuations.values())
+        if not permitted_continuations:
+            raw_allowed = durable_task.expected_result.get("allowed_targets", [])
+            if isinstance(raw_allowed, list):
+                permitted_continuations = {item for item in raw_allowed if isinstance(item, str)}
+        if continuation not in permitted_continuations:
+            rejection = HumanTaskRejection(
+                message="This response does not select the pending task's declared continuation.",
+                correction_guidance=policy.correction_guidance,
+            )
+            record_store.record_rejection(
+                workflow_id=blackboard.workflow_id,
+                task_id=durable_task.id,
+                reason=rejection.message,
+            )
+            store.record_event(
+                blackboard,
+                "human_task_rejected",
+                {
+                    "step": from_step,
+                    "trigger": trigger,
+                    "task_id": policy.id,
+                    "reason": rejection.message,
+                },
+            )
+            return HumanTaskApplication(target=None, policy=policy, rejection=rejection)
+        if record_store.get_result(durable_task.id) is not None:
+            rejection = HumanTaskRejection(
+                message="This human task has already completed.",
+                correction_guidance=policy.correction_guidance,
+            )
+            record_store.record_rejection(
+                workflow_id=blackboard.workflow_id,
+                task_id=durable_task.id,
+                reason=rejection.message,
+            )
+            return HumanTaskApplication(target=None, policy=policy, rejection=rejection)
+        try:
+            record_store.complete(
+                workflow_id=blackboard.workflow_id,
+                task_id=durable_task.id,
+                payload=_validated_completion_payload(completion, continuation),
+                source=source,
+            )
+        except HumanTaskCorrelationError as exc:
+            rejection = HumanTaskRejection(
+                message=str(exc), correction_guidance=policy.correction_guidance
+            )
+            record_store.record_rejection(
+                workflow_id=blackboard.workflow_id,
+                task_id=durable_task.id,
+                reason=rejection.message,
+            )
+            return HumanTaskApplication(target=None, policy=policy, rejection=rejection)
 
     agent_input = completion.agent_input()
     if agent_input:
@@ -322,6 +422,90 @@ def apply_human_task_payload(
         },
     )
     return HumanTaskApplication(target="done" if is_done else continuation, policy=policy)
+
+
+def _resolve_durable_task(
+    *,
+    record_store: HumanTaskRecordStore,
+    workflow_id: str,
+    from_step: str,
+    trigger: str,
+    policy: HumanTaskPolicy,
+    raw_payload: str | Mapping[str, Any],
+) -> tuple[Optional[HumanTask], Optional[HumanTaskRejection]]:
+    """Return the active record matching this pause, or fail closed for durable waits."""
+    if not record_store.exists:
+        return None, None
+    matching = [
+        task
+        for task in record_store.tasks()
+        if task.workflow_id == workflow_id
+        and task.step == from_step
+        and task.trigger == trigger
+        and task.policy_id == policy.id
+    ]
+    active = next(
+        (
+            task
+            for task in matching
+            if task.status is HumanTaskStatus.PENDING
+            and record_store.get_wait_state(task.id).released_at is None
+        ),
+        None,
+    )
+    submitted_id = _submitted_human_task_id(raw_payload)
+    if active is None:
+        rejected_task = matching[0] if matching else None
+        if rejected_task is not None:
+            record_store.record_rejection(
+                workflow_id=workflow_id,
+                task_id=rejected_task.id,
+                reason="the task is no longer pending",
+            )
+        return None, HumanTaskRejection(
+            message="This workflow is not waiting for a matching human task.",
+            correction_guidance=policy.correction_guidance,
+        )
+    if submitted_id is not None and submitted_id != active.id:
+        record_store.record_rejection(
+            workflow_id=workflow_id,
+            task_id=active.id,
+            reason="response references a different durable task",
+        )
+        return None, HumanTaskRejection(
+            message="This response belongs to a different durable human task.",
+            correction_guidance=policy.correction_guidance,
+        )
+    return active, None
+
+
+def _submitted_human_task_id(raw_payload: str | Mapping[str, Any]) -> Optional[str]:
+    """Read an optional durable id without changing the existing #345 payload contract."""
+    if isinstance(raw_payload, str):
+        try:
+            raw_payload = json.loads(raw_payload)
+        except json.JSONDecodeError:
+            return None
+    if not isinstance(raw_payload, Mapping):
+        return None
+    value = raw_payload.get("human_task_id")
+    if not isinstance(value, str) or not value.strip():
+        return None
+    return value.strip()
+
+
+def _validated_completion_payload(completion: HumanTaskCompletion, continuation: str) -> dict[str, Any]:
+    """Store the validated, transport-neutral completion rather than raw input."""
+    payload: dict[str, Any] = {"task": completion.task_id, "continuation": continuation}
+    if completion.decision is not None:
+        payload["decision"] = completion.decision
+    if completion.answers is not None:
+        payload["answers"] = {key: list(value) for key, value in completion.answers.items()}
+    if completion.feedback is not None:
+        payload["feedback"] = completion.feedback
+    if completion.target is not None:
+        payload["target"] = completion.target
+    return payload
 
 
 def _validate_packet_contracts_before_confirmation(

--- a/src/cafe/ui/human_tasks.py
+++ b/src/cafe/ui/human_tasks.py
@@ -553,7 +553,10 @@ def _resolve_durable_task(
         return active, None, None
 
     if not matching:
-        return None, None, None
+        return None, None, HumanTaskRejection(
+            message="This response cannot be correlated to a durable human task.",
+            correction_guidance=policy.correction_guidance,
+        )
 
     if submitted_id is None:
         record_store.record_rejection(

--- a/tests/integration/test_human_task_workflow.py
+++ b/tests/integration/test_human_task_workflow.py
@@ -34,13 +34,14 @@ def _materialize_default_task(
     *,
     from_step: str,
     trigger: str,
+    workflow_id: str | None = None,
 ):
     playbook = PlaybookLoader().load("default")
     policy, binding = resolve_step_human_task(
         playbook_data=playbook, step_name=from_step, trigger=trigger
     )
     return HumanTaskRecordStore(issue_dir).materialize(
-        workflow_id=state.workflow_id,
+        workflow_id=workflow_id or state.workflow_id,
         step=from_step,
         iteration=1,
         trigger=trigger,
@@ -371,6 +372,39 @@ def test_taskless_legacy_handoffs_continue_through_both_existing_transports(
         assert result.target == "plan"
         assert not (issue_dir / "human_tasks.json").exists()
         assert store.load_or_create("spec").handoff_contract.to_step == "plan"
+
+
+def test_taskless_payload_rejects_another_workflows_durable_records(tmp_path: Path) -> None:
+    """IT-004: an existing durable envelope cannot become a legacy handoff."""
+    issue_dir = tmp_path / ".cafe" / "issues" / "cross-workflow-envelope"
+    playbook = PlaybookLoader().load("default")
+    store, state = _paused_default_state(
+        issue_dir, from_step="spec", intent=HandoffIntent.CONFIRM_OUTPUT
+    )
+    state.workflow_id = "workflow-A"
+    store.save(state)
+    _materialize_default_task(
+        issue_dir,
+        state,
+        from_step="spec",
+        trigger="confirm_output",
+        workflow_id="workflow-B",
+    )
+
+    result = apply_human_task_payload(
+        issue_dir=issue_dir,
+        playbook_data=playbook,
+        blackboard=state,
+        from_step="spec",
+        trigger="confirm_output",
+        raw_payload={"task": "output-review", "decision": "confirm"},
+        source="command",
+    )
+
+    assert result.target is None
+    assert result.rejection is not None
+    assert store.load_or_create("spec").current_step == "user"
+    assert HumanTaskRecordStore(issue_dir).results() == ()
 
 
 def test_confirmation_rejects_invalid_declared_packet_contract_for_custom_steps(

--- a/tests/integration/test_human_task_workflow.py
+++ b/tests/integration/test_human_task_workflow.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 from pathlib import Path
 
 from cafe.core.blackboard import BlackboardStore, HandoffIntent, HandoffOwner
+from cafe.core.human_task_records import HumanTaskRecordStore, HumanTaskStatus
 from cafe.playbooks.loader import PlaybookLoader
-from cafe.ui.human_tasks import apply_human_task_payload
+from cafe.ui.human_tasks import apply_human_task_payload, resolve_step_human_task
 
 
 def _paused_default_state(issue_dir: Path, *, from_step: str, intent: HandoffIntent):
@@ -22,6 +23,30 @@ def _paused_default_state(issue_dir: Path, *, from_step: str, intent: HandoffInt
         source="test",
     )
     return store, state
+
+
+def _materialize_default_task(
+    issue_dir: Path,
+    state: object,
+    *,
+    from_step: str,
+    trigger: str,
+):
+    playbook = PlaybookLoader().load("default")
+    policy, binding = resolve_step_human_task(
+        playbook_data=playbook, step_name=from_step, trigger=trigger
+    )
+    return HumanTaskRecordStore(issue_dir).materialize(
+        workflow_id=state.workflow_id,
+        step=from_step,
+        iteration=1,
+        trigger=trigger,
+        policy_id=policy.id,
+        prompt=policy.prompt,
+        expected_result=policy.model_dump(mode="json"),
+        continuations=binding.outcomes,
+        assignee_type="user",
+    )
 
 
 def test_default_human_tasks_validate_and_route_all_user_handoff_patterns(tmp_path: Path) -> None:
@@ -107,6 +132,116 @@ def test_invalid_default_human_task_response_keeps_the_user_pause(tmp_path: Path
     assert reloaded.current_step == "user"
     assert reloaded.handoff_contract.to_owner == HandoffOwner.USER
     assert any(event.event_type == "human_task_rejected" for event in reloaded.events)
+
+
+def test_matching_durable_completion_records_one_result_and_declared_continuation(
+    tmp_path: Path,
+) -> None:
+    """IT-002/IT-003: interactive and command responses share durable completion guards."""
+    playbook = PlaybookLoader().load("default")
+    for source in ("interactive", "command"):
+        issue_dir = tmp_path / ".cafe" / "issues" / source
+        store, state = _paused_default_state(
+            issue_dir, from_step="spec", intent=HandoffIntent.CONFIRM_OUTPUT
+        )
+        task = _materialize_default_task(
+            issue_dir, state, from_step="spec", trigger="confirm_output"
+        )
+
+        result = apply_human_task_payload(
+            issue_dir=issue_dir,
+            playbook_data=playbook,
+            blackboard=state,
+            from_step="spec",
+            trigger="confirm_output",
+            raw_payload={
+                "task": "output-review",
+                "decision": "confirm",
+                "human_task_id": task.id,
+            },
+            source=source,
+        )
+
+        records = HumanTaskRecordStore(issue_dir)
+        assert result.target == "plan"
+        assert records.get_task(task.id).status is HumanTaskStatus.COMPLETED
+        assert records.get_wait_state(task.id).released_at is not None
+        assert len(records.results()) == 1
+        assert store.load_or_create("spec").handoff_contract.to_step == "plan"
+
+
+def test_durable_invalid_stale_and_cross_workflow_results_leave_the_pause_intact(
+    tmp_path: Path,
+) -> None:
+    """IT-004: only the matching active task can create progress exactly once."""
+    playbook = PlaybookLoader().load("default")
+    issue_dir = tmp_path / ".cafe" / "issues" / "guarded"
+    store, state = _paused_default_state(
+        issue_dir, from_step="spec", intent=HandoffIntent.CONFIRM_OUTPUT
+    )
+    task = _materialize_default_task(
+        issue_dir, state, from_step="spec", trigger="confirm_output"
+    )
+
+    unrelated = apply_human_task_payload(
+        issue_dir=issue_dir,
+        playbook_data=playbook,
+        blackboard=state,
+        from_step="spec",
+        trigger="confirm_output",
+        raw_payload={
+            "task": "output-review",
+            "decision": "confirm",
+            "human_task_id": "another-workflow-task",
+        },
+        source="command",
+    )
+    HumanTaskRecordStore(issue_dir).cancel(
+        workflow_id=state.workflow_id, task_id=task.id, reason="replaced handoff"
+    )
+    stale = apply_human_task_payload(
+        issue_dir=issue_dir,
+        playbook_data=playbook,
+        blackboard=state,
+        from_step="spec",
+        trigger="confirm_output",
+        raw_payload={"task": "output-review", "decision": "confirm", "human_task_id": task.id},
+        source="interactive",
+    )
+
+    records = HumanTaskRecordStore(issue_dir)
+    assert unrelated.target is None and unrelated.rejection is not None
+    assert stale.target is None and stale.rejection is not None
+    assert store.load_or_create("spec").current_step == "user"
+    assert records.get_task(task.id).status is HumanTaskStatus.CANCELLED
+    assert records.results() == ()
+    assert "rejected" in [event.event_type for event in records.lifecycle_events()]
+
+
+def test_taskless_legacy_handoffs_continue_through_both_existing_transports(
+    tmp_path: Path,
+) -> None:
+    """IT-006: old #345 pauses have no fabricated record but remain completable."""
+    playbook = PlaybookLoader().load("default")
+    for source in ("interactive", "command"):
+        issue_dir = tmp_path / ".cafe" / "issues" / f"legacy-{source}"
+        store, state = _paused_default_state(
+            issue_dir, from_step="spec", intent=HandoffIntent.CONFIRM_OUTPUT
+        )
+
+        result = apply_human_task_payload(
+            issue_dir=issue_dir,
+            playbook_data=playbook,
+            blackboard=state,
+            from_step="spec",
+            trigger="confirm_output",
+            raw_payload={"task": "output-review", "decision": "confirm"},
+            source=source,
+        )
+
+        assert result.target == "plan"
+        assert not (issue_dir / "human_tasks.json").exists()
+        assert store.load_or_create("spec").handoff_contract.to_step == "plan"
 
 
 def test_confirmation_rejects_invalid_declared_packet_contract_for_custom_steps(

--- a/tests/integration/test_human_task_workflow.py
+++ b/tests/integration/test_human_task_workflow.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from cafe.core.blackboard import BlackboardStore, HandoffIntent, HandoffOwner
 from cafe.core.human_task_records import HumanTaskRecordStore, HumanTaskStatus
 from cafe.playbooks.loader import PlaybookLoader
@@ -169,6 +171,88 @@ def test_matching_durable_completion_records_one_result_and_declared_continuatio
         assert records.get_wait_state(task.id).released_at is not None
         assert len(records.results()) == 1
         assert store.load_or_create("spec").handoff_contract.to_step == "plan"
+
+
+def test_completed_durable_result_recovers_the_declared_continuation_after_a_restart(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """IT-001/IT-003: a persisted result can finish its interrupted continuation."""
+    issue_dir = tmp_path / ".cafe" / "issues" / "restart-after-result"
+    playbook = PlaybookLoader().load("default")
+    store, state = _paused_default_state(
+        issue_dir, from_step="spec", intent=HandoffIntent.CONFIRM_OUTPUT
+    )
+    task = _materialize_default_task(
+        issue_dir, state, from_step="spec", trigger="confirm_output"
+    )
+    payload = {
+        "task": "output-review",
+        "decision": "confirm",
+        "human_task_id": task.id,
+    }
+
+    with monkeypatch.context() as crashing:
+        crashing.setattr(
+            BlackboardStore,
+            "set_current_step",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("interrupted")),
+        )
+        with pytest.raises(RuntimeError, match="interrupted"):
+            apply_human_task_payload(
+                issue_dir=issue_dir,
+                playbook_data=playbook,
+                blackboard=state,
+                from_step="spec",
+                trigger="confirm_output",
+                raw_payload=payload,
+                source="command",
+            )
+
+    restarted = store.load_or_create("spec", playbook_id="default")
+    records = HumanTaskRecordStore(issue_dir)
+    assert restarted.current_step == "user"
+    assert records.get_task(task.id).status is HumanTaskStatus.COMPLETED
+
+    recovered = apply_human_task_payload(
+        issue_dir=issue_dir,
+        playbook_data=playbook,
+        blackboard=restarted,
+        from_step="spec",
+        trigger="confirm_output",
+        raw_payload=payload,
+        source="command",
+    )
+
+    assert recovered.target == "plan"
+    assert store.load_or_create("spec").handoff_contract.to_step == "plan"
+    assert len(HumanTaskRecordStore(issue_dir).results()) == 1
+
+
+def test_durable_command_requires_the_matching_task_identifier(tmp_path: Path) -> None:
+    """IT-004: a command cannot bind an unlabelled response to a later task."""
+    issue_dir = tmp_path / ".cafe" / "issues" / "required-command-id"
+    playbook = PlaybookLoader().load("default")
+    store, state = _paused_default_state(
+        issue_dir, from_step="spec", intent=HandoffIntent.CONFIRM_OUTPUT
+    )
+    task = _materialize_default_task(
+        issue_dir, state, from_step="spec", trigger="confirm_output"
+    )
+
+    result = apply_human_task_payload(
+        issue_dir=issue_dir,
+        playbook_data=playbook,
+        blackboard=state,
+        from_step="spec",
+        trigger="confirm_output",
+        raw_payload={"task": "output-review", "decision": "confirm"},
+        source="command",
+    )
+
+    assert result.target is None
+    assert result.rejection is not None
+    assert HumanTaskRecordStore(issue_dir).get_task(task.id).status is HumanTaskStatus.PENDING
+    assert store.load_or_create("spec").current_step == "user"
 
 
 def test_durable_invalid_stale_and_cross_workflow_results_leave_the_pause_intact(

--- a/tests/integration/test_human_task_workflow.py
+++ b/tests/integration/test_human_task_workflow.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from cafe.core.blackboard import BlackboardStore, HandoffIntent, HandoffOwner
@@ -183,17 +184,29 @@ def test_durable_invalid_stale_and_cross_workflow_results_leave_the_pause_intact
         issue_dir, state, from_step="spec", trigger="confirm_output"
     )
 
+    invalid = apply_human_task_payload(
+        issue_dir=issue_dir,
+        playbook_data=playbook,
+        blackboard=state,
+        from_step="spec",
+        trigger="confirm_output",
+        raw_payload={"task": "output-review", "decision": "unknown", "human_task_id": task.id},
+        source="command",
+    )
+
     unrelated = apply_human_task_payload(
         issue_dir=issue_dir,
         playbook_data=playbook,
         blackboard=state,
         from_step="spec",
         trigger="confirm_output",
-        raw_payload={
-            "task": "output-review",
-            "decision": "confirm",
-            "human_task_id": "another-workflow-task",
-        },
+        raw_payload=json.dumps(
+            {
+                "task": "output-review",
+                "decision": "confirm",
+                "human_task_id": "another-workflow-task",
+            }
+        ),
         source="command",
     )
     HumanTaskRecordStore(issue_dir).cancel(
@@ -210,12 +223,44 @@ def test_durable_invalid_stale_and_cross_workflow_results_leave_the_pause_intact
     )
 
     records = HumanTaskRecordStore(issue_dir)
+    assert invalid.target is None and invalid.rejection is not None
     assert unrelated.target is None and unrelated.rejection is not None
     assert stale.target is None and stale.rejection is not None
     assert store.load_or_create("spec").current_step == "user"
     assert records.get_task(task.id).status is HumanTaskStatus.CANCELLED
     assert records.results() == ()
     assert "rejected" in [event.event_type for event in records.lifecycle_events()]
+
+    duplicate_dir = tmp_path / ".cafe" / "issues" / "duplicate"
+    duplicate_store, duplicate_state = _paused_default_state(
+        duplicate_dir, from_step="spec", intent=HandoffIntent.CONFIRM_OUTPUT
+    )
+    duplicate_task = _materialize_default_task(
+        duplicate_dir, duplicate_state, from_step="spec", trigger="confirm_output"
+    )
+    completed = apply_human_task_payload(
+        issue_dir=duplicate_dir,
+        playbook_data=playbook,
+        blackboard=duplicate_state,
+        from_step="spec",
+        trigger="confirm_output",
+        raw_payload={"task": "output-review", "decision": "confirm", "human_task_id": duplicate_task.id},
+        source="command",
+    )
+    duplicate = apply_human_task_payload(
+        issue_dir=duplicate_dir,
+        playbook_data=playbook,
+        blackboard=duplicate_state,
+        from_step="spec",
+        trigger="confirm_output",
+        raw_payload={"task": "output-review", "decision": "confirm", "human_task_id": duplicate_task.id},
+        source="command",
+    )
+
+    assert completed.target == "plan"
+    assert duplicate.target is None and duplicate.rejection is not None
+    assert len(HumanTaskRecordStore(duplicate_dir).results()) == 1
+    assert duplicate_store.load_or_create("spec").current_step == "plan"
 
 
 def test_taskless_legacy_handoffs_continue_through_both_existing_transports(

--- a/tests/unit/test_cli_shared_human_tasks.py
+++ b/tests/unit/test_cli_shared_human_tasks.py
@@ -97,38 +97,46 @@ def test_interactive_handoff_forwards_the_active_durable_task_id(
     assert target == "plan"
 
 
-def test_interactive_handoff_recovers_a_persisted_completion_after_interruption(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+@pytest.mark.parametrize(
+    ("trigger", "response"),
+    [
+        ("need_clarification", {"feedback": "Preserve the legacy handoff."}),
+        (
+            "no_changes_needed",
+            {"decision": "disagree", "feedback": "Cover the interrupted restart."},
+        ),
+    ],
+)
+def test_interactive_handoff_recovers_a_persisted_same_step_completion_after_interruption(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    trigger: str,
+    response: dict[str, str],
 ) -> None:
-    """IT-001/IT-002: the public interactive path resumes a stored completion."""
-    issue_dir = tmp_path / ".cafe" / "issues" / "interrupted-interactive"
+    """IT-001/IT-002: restart resumes a stored same-step response without prompting."""
+    issue_dir = tmp_path / ".cafe" / "issues" / f"interrupted-{trigger}"
     playbook = PlaybookLoader().load("default")
+    phase_dir = issue_dir / "develop" / "iteration_001"
+    phase_dir.mkdir(parents=True)
+    (phase_dir / "context.json").write_text('{"end_time": "complete"}', encoding="utf-8")
     store = BlackboardStore(issue_dir)
-    blackboard = store.load_or_create("spec", playbook_id="default")
+    blackboard = store.load_or_create("develop", playbook_id="default")
     store.set_current_step(blackboard, "user")
-    store.update_handoff_contract(
-        blackboard,
-        from_step="spec",
-        to_owner=HandoffOwner.USER,
-        to_step="user",
-        intent=HandoffIntent.CONFIRM_OUTPUT,
-        source="test",
-    )
     policy, binding = resolve_step_human_task(
-        playbook_data=playbook, step_name="spec", trigger="confirm_output"
+        playbook_data=playbook, step_name="develop", trigger=trigger
     )
     task = HumanTaskRecordStore(issue_dir).materialize(
         workflow_id=blackboard.workflow_id,
-        step="spec",
+        step="develop",
         iteration=1,
-        trigger="confirm_output",
+        trigger=trigger,
         policy_id=policy.id,
         prompt=policy.prompt,
         expected_result=policy.model_dump(mode="json"),
         continuations=binding.outcomes,
         assignee_type="user",
     )
-    payload = {"task": policy.id, "decision": "confirm", "human_task_id": task.id}
+    payload = {"task": policy.id, **response, "human_task_id": task.id}
     monkeypatch.setattr(
         "cafe.ui.human_tasks.collect_human_task_payload", lambda *_args, **_kwargs: payload
     )
@@ -141,31 +149,34 @@ def test_interactive_handoff_recovers_a_persisted_completion_after_interruption(
         )
         with pytest.raises(RuntimeError, match="interrupted"):
             cli_shared._handle_declared_human_task_handoff(
-                issue_name="interrupted-interactive",
+                issue_name=f"interrupted-{trigger}",
                 issue_dir=issue_dir,
                 blackboard=blackboard,
-                from_step="spec",
+                from_step="develop",
                 summary="",
                 playbook_data=playbook,
-                trigger="confirm_output",
+                trigger=trigger,
             )
 
-    restarted = store.load_or_create("spec", playbook_id="default")
+    restarted = store.load_or_create("develop", playbook_id="default")
     monkeypatch.setattr(
         "cafe.ui.human_tasks.collect_human_task_payload",
         lambda *_args, **_kwargs: pytest.fail("recovery must not re-prompt the participant"),
     )
     target = cli_shared._handle_declared_human_task_handoff(
-        issue_name="interrupted-interactive",
+        issue_name=f"interrupted-{trigger}",
         issue_dir=issue_dir,
         blackboard=restarted,
-        from_step="spec",
+        from_step="develop",
         summary="",
         playbook_data=playbook,
-        trigger="confirm_output",
+        trigger=trigger,
     )
 
     records = HumanTaskRecordStore(issue_dir)
-    assert target == "plan"
+    assert target == "develop"
     assert len(records.results()) == 1
-    assert store.load_or_create("spec").handoff_contract.to_step == "plan"
+    assert (
+        issue_dir / "develop" / "iteration_002" / "user_input.md"
+    ).read_text(encoding="utf-8") == response["feedback"]
+    assert store.load_or_create("develop").handoff_contract.to_step == "develop"

--- a/tests/unit/test_cli_shared_human_tasks.py
+++ b/tests/unit/test_cli_shared_human_tasks.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from cafe.core.blackboard import BlackboardStore
+from cafe.core.blackboard import BlackboardStore, HandoffIntent, HandoffOwner
+from cafe.core.human_task_records import HumanTaskRecordStore
 from cafe.playbooks.loader import PlaybookLoader
 from cafe.ui import cli_shared
+from cafe.ui.human_tasks import resolve_step_human_task
 
 
 def test_no_change_handoff_shows_implementation_output_before_decision(
@@ -38,3 +40,56 @@ def test_no_change_handoff_shows_implementation_output_before_decision(
 
     assert displayed == [output_file]
     assert target == "pr"
+
+
+def test_interactive_handoff_forwards_the_active_durable_task_id(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """IT-002: the production interactive caller binds its payload to the active wait."""
+    issue_dir = tmp_path / ".cafe" / "issues" / "durable-interactive"
+    playbook = PlaybookLoader().load("default")
+    store = BlackboardStore(issue_dir)
+    blackboard = store.load_or_create("spec", playbook_id="default")
+    store.set_current_step(blackboard, "user")
+    store.update_handoff_contract(
+        blackboard,
+        from_step="spec",
+        to_owner=HandoffOwner.USER,
+        to_step="user",
+        intent=HandoffIntent.CONFIRM_OUTPUT,
+        source="test",
+    )
+    policy, binding = resolve_step_human_task(
+        playbook_data=playbook, step_name="spec", trigger="confirm_output"
+    )
+    task = HumanTaskRecordStore(issue_dir).materialize(
+        workflow_id=blackboard.workflow_id,
+        step="spec",
+        iteration=1,
+        trigger="confirm_output",
+        policy_id=policy.id,
+        prompt=policy.prompt,
+        expected_result=policy.model_dump(mode="json"),
+        continuations=binding.outcomes,
+        assignee_type="user",
+    )
+    captured: dict[str, object] = {}
+
+    def collect(policy, **kwargs):
+        captured.update(kwargs)
+        return {"task": policy.id, "decision": "confirm", "human_task_id": kwargs["human_task_id"]}
+
+    monkeypatch.setattr("cafe.ui.human_tasks.collect_human_task_payload", collect)
+
+    target = cli_shared._handle_declared_human_task_handoff(
+        issue_name="durable-interactive",
+        issue_dir=issue_dir,
+        blackboard=blackboard,
+        from_step="spec",
+        summary="",
+        playbook_data=playbook,
+        trigger="confirm_output",
+    )
+
+    assert captured["human_task_id"] == task.id
+    assert target == "plan"

--- a/tests/unit/test_cli_shared_human_tasks.py
+++ b/tests/unit/test_cli_shared_human_tasks.py
@@ -180,3 +180,92 @@ def test_interactive_handoff_recovers_a_persisted_same_step_completion_after_int
         issue_dir / "develop" / "iteration_002" / "user_input.md"
     ).read_text(encoding="utf-8") == response["feedback"]
     assert store.load_or_create("develop").handoff_contract.to_step == "develop"
+
+
+def test_interactive_handoff_recovers_dynamic_answers_from_completed_iteration(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """IT-001/IT-002: dynamic answers resume from their completed task iteration."""
+    issue_dir = tmp_path / ".cafe" / "issues" / "interrupted-dynamic-answers"
+    playbook = PlaybookLoader().load("default")
+    phase_dir = issue_dir / "spec" / "iteration_001"
+    phase_dir.mkdir(parents=True)
+    (phase_dir / "context.json").write_text('{"end_time": "complete"}', encoding="utf-8")
+    (phase_dir / "questions.xml").write_text(
+        (
+            "<questions>\n"
+            "  <question id=\"scope\"><title>Scope?</title><options><option>Small</option>"
+            "</options></question>\n"
+            "</questions>"
+        ),
+        encoding="utf-8",
+    )
+    store = BlackboardStore(issue_dir)
+    blackboard = store.load_or_create("spec", playbook_id="default")
+    store.set_current_step(blackboard, "user")
+    policy, binding = resolve_step_human_task(
+        playbook_data=playbook, step_name="spec", trigger="need_clarification"
+    )
+    assert policy.questions_from_xml
+    task = HumanTaskRecordStore(issue_dir).materialize(
+        workflow_id=blackboard.workflow_id,
+        step="spec",
+        iteration=1,
+        trigger="need_clarification",
+        policy_id=policy.id,
+        prompt=policy.prompt,
+        expected_result=policy.model_dump(mode="json"),
+        continuations=binding.outcomes,
+        assignee_type="user",
+    )
+    payload = {
+        "task": policy.id,
+        "answers": {"scope": "Small"},
+        "human_task_id": task.id,
+    }
+    monkeypatch.setattr(
+        "cafe.ui.human_tasks.collect_human_task_payload", lambda *_args, **_kwargs: payload
+    )
+
+    with monkeypatch.context() as crashing:
+        crashing.setattr(
+            BlackboardStore,
+            "set_current_step",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("interrupted")),
+        )
+        with pytest.raises(RuntimeError, match="interrupted"):
+            cli_shared._handle_declared_human_task_handoff(
+                issue_name="interrupted-dynamic-answers",
+                issue_dir=issue_dir,
+                blackboard=blackboard,
+                from_step="spec",
+                summary="",
+                playbook_data=playbook,
+                trigger="need_clarification",
+            )
+    persisted_input = issue_dir / "spec" / "iteration_002" / "user_input.md"
+    assert persisted_input.read_text(encoding="utf-8") == "scope: Small"
+    assert not (persisted_input.parent / "questions.xml").exists()
+
+    restarted = store.load_or_create("spec", playbook_id="default")
+    monkeypatch.setattr(
+        "cafe.ui.human_tasks.collect_human_task_payload",
+        lambda *_args, **_kwargs: pytest.fail("recovery must not re-prompt the participant"),
+    )
+    target = cli_shared._handle_declared_human_task_handoff(
+        issue_name="interrupted-dynamic-answers",
+        issue_dir=issue_dir,
+        blackboard=restarted,
+        from_step="spec",
+        summary="",
+        playbook_data=playbook,
+        trigger="need_clarification",
+    )
+
+    records = HumanTaskRecordStore(issue_dir)
+    assert target == "spec"
+    assert len(records.results()) == 1
+    assert (issue_dir / "spec" / "iteration_002" / "user_input.md").read_text(
+        encoding="utf-8"
+    ) == "scope: Small"
+    assert store.load_or_create("spec").handoff_contract.to_step == "spec"

--- a/tests/unit/test_cli_shared_human_tasks.py
+++ b/tests/unit/test_cli_shared_human_tasks.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from cafe.core.blackboard import BlackboardStore, HandoffIntent, HandoffOwner
 from cafe.core.human_task_records import HumanTaskRecordStore
 from cafe.playbooks.loader import PlaybookLoader
@@ -93,3 +95,77 @@ def test_interactive_handoff_forwards_the_active_durable_task_id(
 
     assert captured["human_task_id"] == task.id
     assert target == "plan"
+
+
+def test_interactive_handoff_recovers_a_persisted_completion_after_interruption(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """IT-001/IT-002: the public interactive path resumes a stored completion."""
+    issue_dir = tmp_path / ".cafe" / "issues" / "interrupted-interactive"
+    playbook = PlaybookLoader().load("default")
+    store = BlackboardStore(issue_dir)
+    blackboard = store.load_or_create("spec", playbook_id="default")
+    store.set_current_step(blackboard, "user")
+    store.update_handoff_contract(
+        blackboard,
+        from_step="spec",
+        to_owner=HandoffOwner.USER,
+        to_step="user",
+        intent=HandoffIntent.CONFIRM_OUTPUT,
+        source="test",
+    )
+    policy, binding = resolve_step_human_task(
+        playbook_data=playbook, step_name="spec", trigger="confirm_output"
+    )
+    task = HumanTaskRecordStore(issue_dir).materialize(
+        workflow_id=blackboard.workflow_id,
+        step="spec",
+        iteration=1,
+        trigger="confirm_output",
+        policy_id=policy.id,
+        prompt=policy.prompt,
+        expected_result=policy.model_dump(mode="json"),
+        continuations=binding.outcomes,
+        assignee_type="user",
+    )
+    payload = {"task": policy.id, "decision": "confirm", "human_task_id": task.id}
+    monkeypatch.setattr(
+        "cafe.ui.human_tasks.collect_human_task_payload", lambda *_args, **_kwargs: payload
+    )
+
+    with monkeypatch.context() as crashing:
+        crashing.setattr(
+            BlackboardStore,
+            "set_current_step",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("interrupted")),
+        )
+        with pytest.raises(RuntimeError, match="interrupted"):
+            cli_shared._handle_declared_human_task_handoff(
+                issue_name="interrupted-interactive",
+                issue_dir=issue_dir,
+                blackboard=blackboard,
+                from_step="spec",
+                summary="",
+                playbook_data=playbook,
+                trigger="confirm_output",
+            )
+
+    restarted = store.load_or_create("spec", playbook_id="default")
+    monkeypatch.setattr(
+        "cafe.ui.human_tasks.collect_human_task_payload",
+        lambda *_args, **_kwargs: pytest.fail("recovery must not re-prompt the participant"),
+    )
+    target = cli_shared._handle_declared_human_task_handoff(
+        issue_name="interrupted-interactive",
+        issue_dir=issue_dir,
+        blackboard=restarted,
+        from_step="spec",
+        summary="",
+        playbook_data=playbook,
+        trigger="confirm_output",
+    )
+
+    records = HumanTaskRecordStore(issue_dir)
+    assert target == "plan"
+    assert len(records.results()) == 1
+    assert store.load_or_create("spec").handoff_contract.to_step == "plan"

--- a/tests/unit/test_human_task_records.py
+++ b/tests/unit/test_human_task_records.py
@@ -55,7 +55,7 @@ def test_versioned_records_round_trip_with_assignment_wait_and_result(tmp_path: 
     assert reloaded.get_assignment(task.id).assignee_type == "user"
     assert wait_state.task_id == task.id
     assert wait_state.released_at is not None
-    assert loaded_result is result
+    assert loaded_result == result
     assert loaded_result.payload["feedback"] == "Keep old handoffs working."
 
 
@@ -120,7 +120,7 @@ def test_terminal_lifecycle_transitions_preserve_the_first_result(tmp_path: Path
             source="command",
         )
 
-    assert repeated is first
+    assert repeated == first
     assert len(store.results()) == 1
     assert store.get_task(cancelled.id).status is HumanTaskStatus.CANCELLED
     assert store.active_wait_state("workflow-one") is None

--- a/tests/unit/test_human_task_records.py
+++ b/tests/unit/test_human_task_records.py
@@ -1,0 +1,167 @@
+"""Invariant coverage for durable human-task workflow records."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from cafe.core.human_task_records import (
+    HumanTaskCorrelationError,
+    HumanTaskRecordSchemaError,
+    HumanTaskRecordStore,
+    HumanTaskStatus,
+)
+
+
+def _materialize(store: HumanTaskRecordStore, *, iteration: int = 1):
+    return store.materialize(
+        workflow_id="workflow-one",
+        step="develop",
+        iteration=iteration,
+        trigger="need_clarification",
+        policy_id="clarification-feedback",
+        prompt="Describe the compatibility requirement.",
+        expected_result={"input_schema": "feedback", "required": True},
+        continuations={"submit": "develop"},
+        assignee_type="user",
+    )
+
+
+def test_versioned_records_round_trip_with_assignment_wait_and_result(tmp_path: Path) -> None:
+    """UT-001: one task keeps its durable identity and completion context."""
+    store = HumanTaskRecordStore(tmp_path / "issue")
+    task = _materialize(store)
+
+    result = store.complete(
+        workflow_id="workflow-one",
+        task_id=task.id,
+        payload={"feedback": "Keep old handoffs working."},
+        source="command",
+    )
+
+    reloaded = HumanTaskRecordStore(tmp_path / "issue")
+    loaded_task = reloaded.get_task(task.id)
+    wait_state = reloaded.get_wait_state(task.id)
+    loaded_result = reloaded.get_result(task.id)
+
+    assert loaded_task.id == task.id
+    assert loaded_task.workflow_id == "workflow-one"
+    assert loaded_task.step == "develop"
+    assert loaded_task.iteration == 1
+    assert loaded_task.policy_id == "clarification-feedback"
+    assert loaded_task.status is HumanTaskStatus.COMPLETED
+    assert reloaded.get_assignment(task.id).assignee_type == "user"
+    assert wait_state.task_id == task.id
+    assert wait_state.released_at is not None
+    assert loaded_result is result
+    assert loaded_result.payload["feedback"] == "Keep old handoffs working."
+
+
+def test_materialization_is_idempotent_per_handoff_key(tmp_path: Path) -> None:
+    """UT-002: retries reuse one active task, while a new iteration is distinct."""
+    store = HumanTaskRecordStore(tmp_path / "issue")
+
+    first = _materialize(store)
+    retry = _materialize(store)
+    next_iteration = _materialize(store, iteration=2)
+
+    assert retry.id == first.id
+    assert store.active_wait_state("workflow-one").task_id == first.id
+    assert next_iteration.id != first.id
+    assert len(store.tasks()) == 2
+
+
+def test_completion_requires_the_matching_workflow_and_pending_task(tmp_path: Path) -> None:
+    """UT-003: a cross-workflow result cannot release the active wait state."""
+    store = HumanTaskRecordStore(tmp_path / "issue")
+    task = _materialize(store)
+
+    with pytest.raises(HumanTaskCorrelationError):
+        store.complete(
+            workflow_id="workflow-two",
+            task_id=task.id,
+            payload={"feedback": "unrelated"},
+            source="command",
+        )
+
+    assert store.get_task(task.id).status is HumanTaskStatus.PENDING
+    assert store.active_wait_state("workflow-one").task_id == task.id
+    assert store.results() == ()
+
+
+def test_terminal_lifecycle_transitions_preserve_the_first_result(tmp_path: Path) -> None:
+    """UT-004: repeat, stale, and cancelled completion attempts create no progress."""
+    store = HumanTaskRecordStore(tmp_path / "issue")
+    completed = _materialize(store)
+    first = store.complete(
+        workflow_id="workflow-one",
+        task_id=completed.id,
+        payload={"feedback": "first"},
+        source="interactive",
+    )
+    repeated = store.complete(
+        workflow_id="workflow-one",
+        task_id=completed.id,
+        payload={"feedback": "second"},
+        source="interactive",
+    )
+    cancelled = _materialize(store, iteration=2)
+    store.cancel(
+        workflow_id="workflow-one", task_id=cancelled.id, reason="workflow ended"
+    )
+
+    with pytest.raises(HumanTaskCorrelationError):
+        store.complete(
+            workflow_id="workflow-one",
+            task_id=cancelled.id,
+            payload={"feedback": "late"},
+            source="command",
+        )
+
+    assert repeated is first
+    assert len(store.results()) == 1
+    assert store.get_task(cancelled.id).status is HumanTaskStatus.CANCELLED
+    assert store.active_wait_state("workflow-one") is None
+
+
+def test_lifecycle_and_configuration_errors_are_auditable_without_an_actionable_wait(
+    tmp_path: Path,
+) -> None:
+    """UT-006: rejected and configuration-error evidence does not create progress."""
+    store = HumanTaskRecordStore(tmp_path / "issue")
+    task = _materialize(store)
+
+    store.record_rejection(
+        workflow_id="workflow-one", task_id=task.id, reason="response is invalid"
+    )
+    store.record_configuration_error(
+        workflow_id="workflow-one",
+        step="develop",
+        iteration=2,
+        trigger="need_clarification",
+        reason="no matching policy",
+    )
+
+    event_types = [event.event_type for event in store.lifecycle_events()]
+    assert "created" in event_types
+    assert "rejected" in event_types
+    assert "configuration_error" in event_types
+    assert store.get_task(task.id).status is HumanTaskStatus.PENDING
+    assert store.active_wait_state("workflow-one").task_id == task.id
+    assert len(store.results()) == 0
+
+
+def test_future_record_schema_fails_closed_without_rewriting_data(tmp_path: Path) -> None:
+    """UT-005: unsupported task records are rejected rather than migrated blindly."""
+    issue_dir = tmp_path / "issue"
+    issue_dir.mkdir()
+    path = issue_dir / "human_tasks.json"
+    raw = {"schema_version": 999, "workflow_id": "future", "tasks": []}
+    path.write_text(json.dumps(raw), encoding="utf-8")
+
+    with pytest.raises(HumanTaskRecordSchemaError):
+        HumanTaskRecordStore(issue_dir).tasks()
+
+    assert json.loads(path.read_text(encoding="utf-8")) == raw

--- a/tests/unit/test_human_task_records.py
+++ b/tests/unit/test_human_task_records.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import multiprocessing
+import os
 from pathlib import Path
 
 import pytest
@@ -27,6 +29,30 @@ def _materialize(store: HumanTaskRecordStore, *, iteration: int = 1):
         continuations={"submit": "develop"},
         assignee_type="user",
     )
+
+
+def _materialize_in_process(issue_dir: str, barrier, results) -> None:
+    """Exercise the store through a separate process sharing one handoff."""
+    try:
+        barrier.wait(timeout=5)
+        results.put(("ok", _materialize(HumanTaskRecordStore(Path(issue_dir))).id))
+    except BaseException as exc:
+        results.put(("error", repr(exc)))
+
+
+def _complete_in_process(issue_dir: str, task_id: str, barrier, results) -> None:
+    """Race two external completion attempts against the same durable task."""
+    try:
+        barrier.wait(timeout=5)
+        result = HumanTaskRecordStore(Path(issue_dir)).complete(
+            workflow_id="workflow-one",
+            task_id=task_id,
+            payload={"feedback": "concurrent completion"},
+            source="command",
+        )
+        results.put(("ok", result.id))
+    except BaseException as exc:
+        results.put(("error", repr(exc)))
 
 
 def test_versioned_records_round_trip_with_assignment_wait_and_result(tmp_path: Path) -> None:
@@ -71,6 +97,56 @@ def test_materialization_is_idempotent_per_handoff_key(tmp_path: Path) -> None:
     assert store.active_wait_state("workflow-one").task_id == first.id
     assert next_iteration.id != first.id
     assert len(store.tasks()) == 2
+
+
+@pytest.mark.skipif(os.name == "nt", reason="the durable record lock is POSIX file based")
+def test_record_transitions_are_idempotent_across_concurrent_processes(tmp_path: Path) -> None:
+    """UT-002/UT-004: concurrent workers create and complete exactly one record."""
+    context = multiprocessing.get_context("fork")
+    issue_dir = tmp_path / "issue"
+    worker_count = 8
+
+    create_barrier = context.Barrier(worker_count)
+    create_results = context.Queue()
+    creators = [
+        context.Process(
+            target=_materialize_in_process,
+            args=(str(issue_dir), create_barrier, create_results),
+        )
+        for _ in range(worker_count)
+    ]
+    for process in creators:
+        process.start()
+    created = [create_results.get(timeout=10) for _ in creators]
+    for process in creators:
+        process.join(timeout=10)
+
+    assert all(process.exitcode == 0 for process in creators)
+    assert all(status == "ok" for status, _value in created)
+    assert len({value for _status, value in created}) == 1
+    task = HumanTaskRecordStore(issue_dir).tasks()[0]
+
+    complete_barrier = context.Barrier(worker_count)
+    complete_results = context.Queue()
+    completers = [
+        context.Process(
+            target=_complete_in_process,
+            args=(str(issue_dir), task.id, complete_barrier, complete_results),
+        )
+        for _ in range(worker_count)
+    ]
+    for process in completers:
+        process.start()
+    completed = [complete_results.get(timeout=10) for _ in completers]
+    for process in completers:
+        process.join(timeout=10)
+
+    records = HumanTaskRecordStore(issue_dir)
+    assert all(process.exitcode == 0 for process in completers)
+    assert all(status == "ok" for status, _value in completed)
+    assert len({value for _status, value in completed}) == 1
+    assert len(records.tasks()) == 1
+    assert len(records.results()) == 1
 
 
 def test_completion_requires_the_matching_workflow_and_pending_task(tmp_path: Path) -> None:

--- a/tests/unit/test_ui_human_tasks.py
+++ b/tests/unit/test_ui_human_tasks.py
@@ -16,6 +16,7 @@ from cafe.core.blackboard import (
     HandoffOwner,
 )
 from cafe.core.human_tasks import HumanTaskPolicy
+from cafe.core.human_task_records import HumanTaskRecordStore, HumanTaskStatus
 from cafe.skills.loader import SkillLoader
 from cafe.ui.human_tasks import (
     _validate_packet_contracts_before_confirmation,
@@ -357,6 +358,68 @@ def test_command_completion_uses_the_same_policy_and_declared_destination(tmp_pa
     assert reloaded.current_step == "plan"
     assert reloaded.handoff_contract.to_owner == HandoffOwner.AGENT
     assert reloaded.handoff_contract.to_step == "plan"
+
+
+def test_command_completion_binds_the_current_durable_task_before_routing(tmp_path: Path) -> None:
+    """IT-003: command input cannot bypass the active task/wait correlation."""
+    issue_dir = tmp_path / ".cafe" / "issues" / "durable-command"
+    store = BlackboardStore(issue_dir)
+    blackboard = store.load_or_create("spec", playbook_id="default")
+    store.set_current_step(blackboard, "user")
+    store.update_handoff_contract(
+        blackboard,
+        from_step="spec",
+        to_owner=HandoffOwner.USER,
+        to_step="user",
+        intent=HandoffIntent.CONFIRM_OUTPUT,
+        source="test",
+    )
+    playbook = {
+        "steps": {
+            "spec": {
+                "skill": "cafe-spec",
+                "human_tasks": [
+                    {
+                        "trigger": "confirm_output",
+                        "task_id": "output-review",
+                        "outcomes": {"confirm": "plan", "revise": "spec"},
+                    }
+                ],
+            },
+            "plan": {"skill": "cafe-plan"},
+        }
+    }
+    policy, binding = resolve_step_human_task(
+        playbook_data=playbook, step_name="spec", trigger="confirm_output"
+    )
+    task = HumanTaskRecordStore(issue_dir).materialize(
+        workflow_id=blackboard.workflow_id,
+        step="spec",
+        iteration=1,
+        trigger="confirm_output",
+        policy_id=policy.id,
+        prompt=policy.prompt,
+        expected_result=policy.model_dump(mode="json"),
+        continuations=binding.outcomes,
+        assignee_type="user",
+    )
+
+    result = apply_human_task_payload(
+        issue_dir=issue_dir,
+        playbook_data=playbook,
+        blackboard=blackboard,
+        from_step="spec",
+        trigger="confirm_output",
+        raw_payload={
+            "task": "output-review",
+            "decision": "confirm",
+            "human_task_id": task.id,
+        },
+        source="command",
+    )
+
+    assert result.target == "plan"
+    assert HumanTaskRecordStore(issue_dir).get_task(task.id).status is HumanTaskStatus.COMPLETED
 
 
 def test_cross_step_revision_feedback_is_written_for_the_selected_target(tmp_path: Path) -> None:

--- a/tests/unit/test_workflow_models.py
+++ b/tests/unit/test_workflow_models.py
@@ -287,7 +287,7 @@ def test_blackboard_store_records_artifacts_events_and_decisions(tmp_path: Path)
 
     reloaded = store.load_or_create("spec")
     assert reloaded.current_step == "plan"
-    assert reloaded.schema_version == 1
+    assert reloaded.schema_version == 2
     assert reloaded.handoff_summary == "developer owns the next step"
     assert reloaded.artifacts["spec"].path == "spec/output.md"
     assert reloaded.artifacts["spec"].version == 1

--- a/tests/unit/test_workflow_models.py
+++ b/tests/unit/test_workflow_models.py
@@ -216,6 +216,23 @@ def test_blackboard_load_or_create_persists_current_step_and_playbook(tmp_path: 
     assert loaded.playbook_id == "default"
 
 
+def test_blackboard_migrates_a_legacy_state_to_a_stable_workflow_id(tmp_path: Path) -> None:
+    """UT-005: old taskless workflow state gains identity without a task record."""
+    issue_dir = tmp_path / ".cafe" / "issues" / "legacy"
+    issue_dir.mkdir(parents=True)
+    (issue_dir / "blackboard.json").write_text(
+        json.dumps({"schema_version": 1, "current_step": "user", "playbook_id": "default"}),
+        encoding="utf-8",
+    )
+
+    state = BlackboardStore(issue_dir).load_or_create("spec", playbook_id="default")
+    persisted = json.loads((issue_dir / "blackboard.json").read_text(encoding="utf-8"))
+
+    assert state.workflow_id
+    assert persisted["workflow_id"] == state.workflow_id
+    assert not (issue_dir / "human_tasks.json").exists()
+
+
 def test_alignment_checkpoint_baton_must_be_user_owned_user_target(tmp_path: Path) -> None:
     issue_dir = tmp_path / ".cafe" / "issues" / "issue-align-baton"
     store = BlackboardStore(issue_dir)

--- a/tests/unit/test_workflow_runtime.py
+++ b/tests/unit/test_workflow_runtime.py
@@ -15,8 +15,10 @@ from cafe.core.blackboard import (
     OperationMonitoring,
     OperationRisk,
 )
+from cafe.core.human_task_records import HumanTaskRecordStore
 from cafe.core.workflow_models import BatonRejected, StepExecutionResult
 from cafe.core.workflow_runtime import BlackboardWorkflowRuntime
+from cafe.playbooks.loader import PlaybookLoader
 
 _OPERATION_DECISION = {
     "risk": "low",
@@ -1733,6 +1735,71 @@ def test_runtime_pauses_ready_for_review_with_confirm_output_intent(tmp_path: Pa
     assert blackboard.handoff_contract is not None
     assert blackboard.handoff_contract.to_owner == HandoffOwner.USER
     assert blackboard.handoff_contract.intent == HandoffIntent.CONFIRM_OUTPUT
+
+
+def test_runtime_materializes_one_declared_task_and_recovers_it_after_restart(tmp_path: Path) -> None:
+    """IT-001: pause/restart preserves the exact durable task and wait state."""
+    issue_dir = tmp_path / ".cafe" / "issues" / "durable-restart"
+    playbook = PlaybookLoader().load("default")
+
+    def executor(step_name: str, step_def: dict, state: object) -> StepExecutionResult:
+        return StepExecutionResult(
+            response="ready_for_review",
+            artifacts={},
+            status_code="ready_for_review",
+            auto_continue=False,
+        )
+
+    runtime = BlackboardWorkflowRuntime(issue_dir=issue_dir, playbook=playbook, executor=executor)
+    paused = runtime.run(start_step="spec")
+    state = BlackboardStore(issue_dir).load_or_create("spec")
+    records = HumanTaskRecordStore(issue_dir)
+    task = records.tasks()[0]
+    wait = records.get_wait_state(task.id)
+
+    recovered = BlackboardWorkflowRuntime(
+        issue_dir=issue_dir, playbook=playbook, executor=executor
+    ).run(max_transitions=2)
+    restored = HumanTaskRecordStore(issue_dir)
+
+    assert paused.completed is False
+    assert recovered.completed is False
+    assert restored.tasks()[0].id == task.id
+    assert restored.get_wait_state(task.id) == wait
+    assert state.workflow_id == task.workflow_id
+
+
+def test_runtime_records_non_actionable_configuration_error_for_bad_task_binding(
+    tmp_path: Path,
+) -> None:
+    """IT-005: an unresolved declared task never creates an actionable wait."""
+    issue_dir = tmp_path / ".cafe" / "issues" / "durable-config-error"
+    playbook = {
+        "playbook": {"id": "default"},
+        "steps": {
+            "spec": {
+                "skill": "cafe-spec",
+                "human_tasks": [],
+                "on": {"confirm_output": "spec"},
+            }
+        },
+    }
+
+    def executor(step_name: str, step_def: dict, state: object) -> StepExecutionResult:
+        return StepExecutionResult(
+            response="ready_for_review",
+            artifacts={},
+            status_code="ready_for_review",
+            auto_continue=False,
+        )
+
+    BlackboardWorkflowRuntime(issue_dir=issue_dir, playbook=playbook, executor=executor).run(
+        start_step="spec"
+    )
+
+    records = HumanTaskRecordStore(issue_dir)
+    assert records.tasks() == ()
+    assert "configuration_error" in [event.event_type for event in records.lifecycle_events()]
 
 
 def test_runtime_pauses_brief_ready_for_review_with_confirm_output_intent(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Implements issue #396's durable HumanTask foundation. New user-owned handoffs now persist identifiable human work, survive workflow restarts, and resume only from a validated result correlated to the matching task and workflow. Existing #345 interactive and non-interactive handoffs remain compatible, including legacy waits without a task record.

## Changes

- Added versioned standard-library JSON records for `HumanTask`, `Assignment`, `WaitState`, and `TaskResult`, with stable workflow/task correlation, lifecycle evidence, idempotent transitions, and fail-closed schema handling.
- Added stable workflow identity migration and runtime materialization/recovery so each declared user-owned pause reuses exactly one pending task and wait state.
- Routed interactive and `--user-input` completion through the existing #345 validation authority, then guarded result persistence and declared-continuation updates against invalid, stale, duplicate, cancelled, and cross-workflow results.
- Closed the durable-store correlation gap: when a task store exists but has no task matching the current workflow, step, trigger, and policy, payloads are rejected and the user pause remains intact instead of falling through to legacy taskless handling.
- Preserved the taskless legacy #345 completion path for in-progress handoffs when no durable record file exists, and documented storage, migration, lifecycle, and compatibility behavior in `docs/human-task-runtime.md`.
- Added and expanded unit/integration coverage for record round trips, migration, restart recovery, both completion transports, lifecycle guards, configuration failures, legacy compatibility, interrupted dynamic answers, and cross-workflow durable-task isolation.

Commit series:

- `ff9b20bd` — specify durable task records
- `463d5ca2` — persist durable task records
- `8c771c2d` — cover durable task journeys
- `63e8a6ef` — bind durable tasks to handoffs
- `fde0d273` — document durable task migration
- `c1e76a04` — recover durable task completions
- `14c6aab3` — recover interactive task completion
- `3f61e55e` — recover interrupted same-step input
- `2f62f560` — cover recovered dynamic answers
- `1e160627` — reject unmatched durable task

## Test Plan

- `./scripts/test-coverage.sh` — passed as the repository-defined full verification suite on clean `1e160627f4bfe173411436c8bc05fb5d9954ca8e`.
- `./.venv/bin/python -m pytest tests/unit/test_human_task_records.py tests/unit/test_ui_human_tasks.py tests/unit/test_cli_shared_human_tasks.py tests/integration/test_human_task_workflow.py -q` — 39 passed.
- `./.venv/bin/python -m pytest tests/integration/test_human_task_workflow.py -q` — 11 passed.
- `./.venv/bin/python -m ruff check tests/unit/test_cli_shared_human_tasks.py` — passed.
- `cafe verification check --output-file ./.cafe/issues/issue396/develop/iteration_006/output.md --require-scope full` — valid clean-HEAD full-suite receipt.