### PR TITLE
Release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.1] - 2026-08-18
+
+### Added
+
+- Added an agent-neutral repository bootstrap that installs CAFE into an
+  isolated user environment and synchronizes bundled workflow skills without a
+  vendor-specific plugin.
+- Added an AI-readable installation contract and surfaced it at the beginning
+  of the README.
+
+### Changed
+
+- Global helper skill synchronization now targets only detected agent CLIs by
+  default. Explicit `--cli` selections still create the requested destination.
+- Generated Python bytecode is excluded from skill fingerprints and installed
+  copies to prevent unnecessary synchronization.
+
+### Fixed
+
+- Removed the stale HumanTask confirmation gate that still required legacy
+  model-authored downstream contracts after structural context packets became
+  authoritative.
+- Added rollback protection so a failed bootstrap cannot replace a working
+  CAFE launcher with an incomplete installation.
+
+See [the v0.3.1 release notes](docs/releases/v0.3.1.md) for installation and
+upgrade details.
+
 ## [0.3.0] - 2026-08-18
 
 This release opens the v0.3 development cycle. Roadmap capabilities assigned

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,89 @@
+# Install CAFE with a CLI Agent
+
+CAFE can be installed by any CLI agent that can inspect repository files and
+run local commands. The user does not need to install a Codex, Claude, or other
+vendor-specific plugin.
+
+## What to tell your agent
+
+Send this request to your CLI agent:
+
+```text
+Install the latest stable CAFE release from https://github.com/luyotw/cafe.
+Follow INSTALL.md. I authorize the user-scoped changes described there.
+Do not use sudo, do not modify system Python, and do not change my shell profile.
+```
+
+The authorization covers only the isolated CAFE environment, one user launcher,
+and the detected user-level skill directories. It does not authorize changes
+to system packages, provider credentials, unrelated launchers, or project files.
+
+## Instructions for the CLI agent
+
+1. Verify that the source is `https://github.com/luyotw/cafe` and resolve its
+   latest stable release. Do not install an unreviewed fork or a moving branch.
+2. Check out that exact release tag into a temporary or user-approved location.
+   Inspect this file and `scripts/bootstrap-cafe.py` before execution. Do not use
+   a `curl | sh` or equivalent remote-code pipeline.
+3. Confirm that Python 3.10 or newer is available. Stop and explain the missing
+   prerequisite instead of installing system packages or using `sudo`.
+4. Show the deterministic plan without changing files:
+
+   ```bash
+   python3 scripts/bootstrap-cafe.py --dry-run
+   ```
+
+5. If the user's request already authorizes the documented user-scoped changes,
+   install non-interactively:
+
+   ```bash
+   python3 scripts/bootstrap-cafe.py --yes
+   ```
+
+   Otherwise, obtain authorization before running this command.
+6. Report the installed CAFE version, launcher path, skill synchronization
+   result, and any missing prerequisite. Never request or modify provider API
+   keys as part of this installation.
+
+On Windows, use an available Python 3.10+ launcher to run the same Python script.
+
+## What the bootstrap changes
+
+The bootstrap:
+
+- creates a versioned virtual environment under
+  `~/.local/share/cafe-engine/environments/`;
+- creates a CAFE-managed launcher in `~/.local/bin/`;
+- verifies the installed package before publishing that launcher;
+- runs `cafe skill sync-global`, which copies the bundled
+  `use-cafe-workflow`, `write-cafe-playbook`, and `write-cafe-phase` skills to
+  user directories for detected Claude, Codex, Copilot, Cursor, and Gemini
+  installations; and
+- removes only the previous isolated environment recorded in CAFE's own install
+  manifest after a successful upgrade.
+
+The bootstrap does not use `sudo`, modify system Python, edit a shell profile,
+install an agent CLI, or configure provider authentication. It refuses to
+replace an existing `cafe` launcher that it does not manage.
+
+If `~/.local/bin` is not on `PATH`, the installation remains usable through the
+reported absolute launcher path. A CLI agent must ask separately before editing
+a shell profile.
+
+## Manual installation
+
+Developers who manage their own Python environment can still install the
+published package or a trusted source checkout directly:
+
+```bash
+pip install cafe-engine
+```
+
+```bash
+git clone https://github.com/luyotw/cafe.git
+cd cafe
+pip install -e .
+```
+
+Run `cafe skill sync-global` after a manual installation to install the bundled
+workflow helper skills for all supported CLI agents.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ CAFE (CLI Agent Flow Engine) is an AI-driven development workflow automation sys
 
 CAFE is actively evolving—we're continuously iterating based on real-world usage and feedback to improve stability, usability, and integration with various AI agents.
 
+To install CAFE, see [INSTALL.md](INSTALL.md), or ask your CLI agent to follow it.
+
 ![image](https://github.com/luyotw/cafe/blob/main/images/cafe-flow.png)
 
 ---
@@ -107,13 +109,31 @@ Support for more CLI agent tools is planned for the future. Stay tuned!
 
 ## Installation
 
-### From PyPI
+### Ask Your CLI Agent (Recommended)
+
+CAFE does not require a vendor-specific plugin. Ask any CLI agent that can
+inspect repository files and run local commands to install it for you:
+
+```text
+Install the latest stable CAFE release from https://github.com/luyotw/cafe.
+Follow INSTALL.md. I authorize the user-scoped changes described there.
+Do not use sudo, do not modify system Python, and do not change my shell profile.
+```
+
+The repository bootstrap installs CAFE in an isolated user environment and
+synchronizes the bundled workflow skills for detected Claude, Codex, Copilot,
+Cursor, and Gemini installations. See [INSTALL.md](INSTALL.md) for the exact
+safety boundaries and agent instructions.
+
+### Manual Installation
+
+From PyPI:
 
 ```bash
 pip install cafe-engine
 ```
 
-### From Source
+From source:
 
 ```bash
 # Clone repository
@@ -205,10 +225,12 @@ Configured and CLI-provided directories must exist before the workflow starts.
 
 ### Global Workflow Helper Skills
 
-Every `cafe` CLI startup performs a fast per-machine fingerprint check and
-automatically installs or updates bundled workflow helper skills when their
-sources changed or an installed copy is missing. This covers fresh machines,
-new checkouts, and package upgrades without a manual sync command.
+Every `cafe` CLI startup detects supported agent installations, performs a fast
+per-machine fingerprint check, and installs or updates bundled workflow helper
+skills when their sources changed or an installed copy is missing. Detection
+uses an agent executable on `PATH` or existing vendor state other than copies
+managed only by CAFE. This covers fresh machines, new checkouts, and package
+upgrades without creating directories for agents that are not installed.
 
 The fingerprint and installed copies are local to each machine. Multiple
 machines can develop CAFE concurrently: each one syncs from its current local
@@ -234,7 +256,8 @@ cafe skill sync-global
 ```
 
 The default sync copies `use-cafe-workflow`, `write-cafe-playbook`, and
-`write-cafe-phase`, including their references and scripts, to:
+`write-cafe-phase`, including their references and scripts, to the detected
+subset of:
 
 - `~/.claude/skills/`
 - `~/.codex/skills/`
@@ -243,7 +266,8 @@ The default sync copies `use-cafe-workflow`, `write-cafe-playbook`, and
 - `~/.gemini/skills/`
 
 The command is safe to rerun: it reports each destination as installed,
-updated, or unchanged. Limit the sync to selected CLIs with repeatable options:
+updated, or unchanged. Explicit `--cli` targets bypass detection and may create
+the selected vendor directory:
 
 ```bash
 cafe skill sync-global --cli codex --cli cursor

--- a/docs/releases/v0.3.1.md
+++ b/docs/releases/v0.3.1.md
@@ -1,0 +1,54 @@
+# CAFE v0.3.1 release notes
+
+## Release scope
+
+CAFE v0.3.1 is a patch release that restores structural context-packet
+confirmation and adds a vendor-neutral installation path for CLI agent users.
+It does not change playbook, artifact, or durable HumanTask schemas.
+
+## Agent-driven installation
+
+Users can now ask any CLI agent with local command access to install CAFE by
+following the repository's `INSTALL.md`. The bootstrap installs CAFE into a
+versioned virtual environment under the user's home directory, publishes one
+managed launcher, verifies the installed package, and synchronizes the bundled
+workflow helper skills.
+
+The bootstrap does not use `sudo`, modify system Python, edit shell profiles,
+or configure provider credentials. It refuses to replace launchers that it does
+not manage and restores the previous launcher if publishing the new install
+cannot complete.
+
+## Detected CLI synchronization
+
+Default global skill synchronization no longer creates directories for every
+supported agent. It targets an agent only when its executable is available on
+`PATH` or its user directory contains vendor state beyond CAFE's managed skill
+copies. Use an explicit target when preinstalling skills for an unavailable
+agent:
+
+```bash
+cafe skill sync-global --cli codex
+```
+
+Python bytecode and `__pycache__` directories are excluded from fingerprints
+and installed skill copies, preventing generated files from causing redundant
+updates.
+
+## HumanTask confirmation fix
+
+HumanTask output confirmation no longer re-applies the retired downstream
+contract validator. Spec and plan confirmation now advances normally, while
+the consuming runtime remains responsible for deriving and validating the
+structural context packet.
+
+## Upgrade
+
+Existing installations can upgrade normally. Run the explicit sync command if
+a prior startup warning reported a damaged managed copy:
+
+```bash
+cafe skill sync-global
+```
+
+No workflow-state migration is required for this patch release.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cafe-engine"
-version = "0.3.0"
+version = "0.3.1"
 description = "CLI Agent Flow Engine - Automated development workflow with AI agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/bootstrap-cafe.py
+++ b/scripts/bootstrap-cafe.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""Run the CAFE bootstrap directly from a trusted source checkout."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPOSITORY_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPOSITORY_ROOT / "src"))
+
+from cafe.install.bootstrap import main  # noqa: E402,I001
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(["--source", str(REPOSITORY_ROOT), *sys.argv[1:]]))

--- a/src/cafe/install/__init__.py
+++ b/src/cafe/install/__init__.py
@@ -1,0 +1,1 @@
+"""User-scoped CAFE installation helpers."""

--- a/src/cafe/install/bootstrap.py
+++ b/src/cafe/install/bootstrap.py
@@ -1,0 +1,425 @@
+"""Install CAFE from a trusted source checkout into an isolated user environment."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional, Sequence
+
+MINIMUM_PYTHON = (3, 10)
+MANAGED_WINDOWS_LAUNCHER = "REM Managed by the CAFE repository bootstrap"
+
+
+class BootstrapError(RuntimeError):
+    """Raised when the bootstrap cannot make a safe user-scoped installation."""
+
+
+@dataclass(frozen=True)
+class BootstrapPlan:
+    """Resolved locations for one bootstrap attempt."""
+
+    source: Path
+    install_root: Path
+    environments_dir: Path
+    environment: Path
+    bin_dir: Path
+    launcher: Path
+    cafe_executable: Path
+
+
+def _default_install_root(home_dir: Path) -> Path:
+    configured = os.getenv("XDG_DATA_HOME")
+    data_home = Path(configured).expanduser() if configured else home_dir / ".local" / "share"
+    return data_home / "cafe-engine"
+
+
+def _default_bin_dir(home_dir: Path) -> Path:
+    configured = os.getenv("XDG_BIN_HOME")
+    return Path(configured).expanduser() if configured else home_dir / ".local" / "bin"
+
+
+def _environment_executable(environment: Path) -> Path:
+    if os.name == "nt":
+        return environment / "Scripts" / "cafe.exe"
+    return environment / "bin" / "cafe"
+
+
+def _launcher_path(bin_dir: Path) -> Path:
+    return bin_dir / ("cafe.cmd" if os.name == "nt" else "cafe")
+
+
+def create_plan(
+    *,
+    source: Path,
+    home_dir: Optional[Path] = None,
+    install_root: Optional[Path] = None,
+    bin_dir: Optional[Path] = None,
+    generation: Optional[str] = None,
+) -> BootstrapPlan:
+    """Resolve all paths without writing to disk."""
+    resolved_home = (home_dir or Path.home()).expanduser().resolve()
+    resolved_source = source.expanduser().resolve()
+    resolved_root = (install_root or _default_install_root(resolved_home)).expanduser().resolve()
+    resolved_bin = (bin_dir or _default_bin_dir(resolved_home)).expanduser().resolve()
+    environments_dir = resolved_root / "environments"
+    if generation is None:
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        generation = f"env-{timestamp}-{uuid.uuid4().hex[:8]}"
+    if not re.fullmatch(r"env-[A-Za-z0-9._-]+", generation):
+        raise BootstrapError("The generated environment name is invalid")
+    environment = environments_dir / generation
+    return BootstrapPlan(
+        source=resolved_source,
+        install_root=resolved_root,
+        environments_dir=environments_dir,
+        environment=environment,
+        bin_dir=resolved_bin,
+        launcher=_launcher_path(resolved_bin),
+        cafe_executable=_environment_executable(environment),
+    )
+
+
+def _validate_source(source: Path) -> None:
+    pyproject = source / "pyproject.toml"
+    package = source / "src" / "cafe"
+    if not pyproject.is_file() or not package.is_dir():
+        raise BootstrapError(
+            "Run this bootstrap from a CAFE source checkout containing pyproject.toml and src/cafe"
+        )
+    metadata = pyproject.read_text(encoding="utf-8")
+    if re.search(r'^name\s*=\s*["\']cafe-engine["\']\s*$', metadata, re.MULTILINE) is None:
+        raise BootstrapError("The source checkout is not the cafe-engine project")
+
+
+def _validate_python() -> None:
+    if sys.version_info < MINIMUM_PYTHON:
+        required = ".".join(str(part) for part in MINIMUM_PYTHON)
+        current = f"{sys.version_info.major}.{sys.version_info.minor}"
+        raise BootstrapError(f"CAFE requires Python {required}+; this interpreter is {current}")
+
+
+def _is_managed_posix_launcher(launcher: Path, environments_dir: Path) -> bool:
+    if not launcher.is_symlink():
+        return False
+    target = (launcher.parent / os.readlink(launcher)).resolve(strict=False)
+    try:
+        relative = target.relative_to(environments_dir.resolve())
+    except ValueError:
+        return False
+    return len(relative.parts) == 3 and relative.parts[-2:] == ("bin", "cafe")
+
+
+def _is_managed_windows_launcher(launcher: Path) -> bool:
+    if not launcher.is_file():
+        return False
+    try:
+        first_line = launcher.read_text(encoding="utf-8").splitlines()[0]
+    except (IndexError, OSError, UnicodeError):
+        return False
+    return first_line == f"@{MANAGED_WINDOWS_LAUNCHER}"
+
+
+def _validate_launcher(plan: BootstrapPlan) -> None:
+    if plan.bin_dir.exists() and not plan.bin_dir.is_dir():
+        raise BootstrapError(f"Launcher directory is not a directory: {plan.bin_dir}")
+    if not plan.launcher.exists() and not plan.launcher.is_symlink():
+        return
+    managed = (
+        _is_managed_windows_launcher(plan.launcher)
+        if os.name == "nt"
+        else _is_managed_posix_launcher(plan.launcher, plan.environments_dir)
+    )
+    if not managed:
+        raise BootstrapError(
+            f"Refusing to replace an existing launcher not managed by CAFE: {plan.launcher}"
+        )
+
+
+def _run(
+    command: Sequence[str],
+    *,
+    capture_output: bool = False,
+    cwd: Optional[Path] = None,
+    env: Optional[dict[str, str]] = None,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        list(command),
+        check=True,
+        text=True,
+        capture_output=capture_output,
+        cwd=cwd,
+        env=env,
+    )
+
+
+def _install_environment(plan: BootstrapPlan) -> str:
+    _run([sys.executable, "-m", "venv", str(plan.environment)])
+    environment_python = _environment_python(plan.environment)
+    _run(
+        [
+            str(environment_python),
+            "-m",
+            "pip",
+            "install",
+            "--disable-pip-version-check",
+            "--no-cache-dir",
+            "--no-input",
+            str(plan.source),
+        ]
+    )
+    _run([str(environment_python), "-m", "pip", "check"])
+    if not plan.cafe_executable.is_file():
+        raise BootstrapError(f"The installed CAFE executable is missing: {plan.cafe_executable}")
+    cli_env = os.environ.copy()
+    cli_env.update(
+        {
+            "CAFE_SKIP_ENTRYPOINT_CHECK": "1",
+            "CAFE_SKIP_GLOBAL_SKILL_SYNC": "1",
+            "CAFE_SKIP_UPDATE_CHECK": "1",
+        }
+    )
+    version = _run(
+        [str(plan.cafe_executable), "version"],
+        capture_output=True,
+        cwd=plan.install_root,
+        env=cli_env,
+    ).stdout.strip()
+    if not version.startswith("CAFE version "):
+        raise BootstrapError(f"Unexpected version response from installed CAFE: {version}")
+    sync_env = cli_env.copy()
+    sync_env.pop("CAFE_SKIP_GLOBAL_SKILL_SYNC")
+    _run(
+        [str(plan.cafe_executable), "skill", "sync-global"],
+        cwd=plan.install_root,
+        env=sync_env,
+    )
+    return version.removeprefix("CAFE version ")
+
+
+def _environment_python(environment: Path) -> Path:
+    if os.name == "nt":
+        return environment / "Scripts" / "python.exe"
+    return environment / "bin" / "python"
+
+
+def _publish_launcher(plan: BootstrapPlan) -> Optional[Path]:
+    plan.bin_dir.mkdir(parents=True, exist_ok=True)
+    temporary = plan.bin_dir / f".cafe-{uuid.uuid4().hex}.tmp"
+    backup: Optional[Path] = None
+    try:
+        if os.name == "nt":
+            content = (
+                f"@{MANAGED_WINDOWS_LAUNCHER}\r\n"
+                f'@"{plan.cafe_executable}" %*\r\n'
+            )
+            temporary.write_text(content, encoding="utf-8")
+        else:
+            temporary.symlink_to(plan.cafe_executable)
+        if plan.launcher.exists() or plan.launcher.is_symlink():
+            backup = plan.bin_dir / f".cafe-launcher-{uuid.uuid4().hex}.backup"
+            plan.launcher.replace(backup)
+        try:
+            temporary.replace(plan.launcher)
+        except Exception:
+            if backup is not None:
+                backup.replace(plan.launcher)
+            raise
+    finally:
+        if temporary.exists() or temporary.is_symlink():
+            temporary.unlink()
+    return backup
+
+
+def _rollback_launcher(plan: BootstrapPlan, backup: Optional[Path]) -> None:
+    if plan.launcher.exists() or plan.launcher.is_symlink():
+        plan.launcher.unlink()
+    if backup is not None and (backup.exists() or backup.is_symlink()):
+        backup.replace(plan.launcher)
+
+
+def _remove_launcher_backup(backup: Optional[Path]) -> None:
+    if backup is not None and (backup.exists() or backup.is_symlink()):
+        backup.unlink()
+
+
+def _manifest_path(plan: BootstrapPlan) -> Path:
+    return plan.install_root / "install.json"
+
+
+def _read_previous_environment(plan: BootstrapPlan) -> Optional[Path]:
+    manifest = _manifest_path(plan)
+    try:
+        data = json.loads(manifest.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError, UnicodeError):
+        return None
+    value = data.get("environment") if isinstance(data, dict) else None
+    return Path(value) if isinstance(value, str) else None
+
+
+def _write_manifest(plan: BootstrapPlan, version: str) -> None:
+    manifest = _manifest_path(plan)
+    temporary = manifest.with_name(f".{manifest.name}.{uuid.uuid4().hex}.tmp")
+    data = {
+        "version": 1,
+        "cafe_version": version,
+        "environment": str(plan.environment),
+        "launcher": str(plan.launcher),
+        "source": str(plan.source),
+    }
+    try:
+        temporary.write_text(
+            json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        temporary.replace(manifest)
+    finally:
+        if temporary.exists():
+            temporary.unlink()
+
+
+def _remove_previous_environment(previous: Optional[Path], plan: BootstrapPlan) -> None:
+    if previous is None or previous == plan.environment:
+        return
+    resolved = previous.expanduser().resolve()
+    if resolved.parent != plan.environments_dir.resolve() or not resolved.name.startswith("env-"):
+        return
+    if resolved.is_dir() and not resolved.is_symlink():
+        shutil.rmtree(resolved)
+
+
+def _bin_dir_is_on_path(bin_dir: Path) -> bool:
+    for entry in os.getenv("PATH", "").split(os.pathsep):
+        if not entry:
+            continue
+        try:
+            if Path(entry).expanduser().resolve() == bin_dir.resolve():
+                return True
+        except OSError:
+            continue
+    return False
+
+
+def print_plan(plan: BootstrapPlan) -> None:
+    """Print the complete user-scoped mutation plan."""
+    print("CAFE user installation plan")
+    print(f"  Source: {plan.source}")
+    print(f"  Isolated environment: {plan.environment}")
+    print(f"  Launcher: {plan.launcher}")
+    print("  Global skills: detected Claude, Codex, Copilot, Cursor, and Gemini CLIs")
+    print("  System packages and shell profiles will not be modified.")
+
+
+def install(plan: BootstrapPlan) -> str:
+    """Install, verify, sync skills, and publish the user launcher."""
+    _validate_python()
+    _validate_source(plan.source)
+    _validate_launcher(plan)
+    if plan.environment.exists() or plan.environment.is_symlink():
+        raise BootstrapError(f"Generated environment already exists: {plan.environment}")
+
+    previous = _read_previous_environment(plan)
+    plan.environments_dir.mkdir(parents=True, exist_ok=True)
+    launcher_backup: Optional[Path] = None
+    try:
+        version = _install_environment(plan)
+        launcher_backup = _publish_launcher(plan)
+        try:
+            _write_manifest(plan, version)
+        except Exception:
+            _rollback_launcher(plan, launcher_backup)
+            launcher_backup = None
+            raise
+    except Exception:
+        if plan.environment.is_dir() and not plan.environment.is_symlink():
+            shutil.rmtree(plan.environment)
+        raise
+
+    try:
+        _remove_launcher_backup(launcher_backup)
+    except OSError as exc:
+        print(f"Warning: could not remove the launcher backup: {exc}", file=sys.stderr)
+    try:
+        _remove_previous_environment(previous, plan)
+    except OSError as exc:
+        print(f"Warning: could not remove the previous CAFE environment: {exc}", file=sys.stderr)
+    return version
+
+
+def _confirm() -> bool:
+    if not sys.stdin.isatty():
+        raise BootstrapError(
+            "Non-interactive installation requires --yes after the user authorizes the plan"
+        )
+    return input("Continue with this user-scoped installation? [y/N] ").strip().lower() in {
+        "y",
+        "yes",
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Install CAFE and its workflow skills into user-scoped locations.",
+    )
+    parser.add_argument(
+        "--source",
+        type=Path,
+        default=Path.cwd(),
+        help="Trusted CAFE source checkout (default: current directory)",
+    )
+    parser.add_argument("--install-root", type=Path, help=argparse.SUPPRESS)
+    parser.add_argument("--bin-dir", type=Path, help=argparse.SUPPRESS)
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Show the plan without writing files"
+    )
+    parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="Run non-interactively after the user has authorized the displayed plan",
+    )
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = _parser().parse_args(argv)
+    plan = create_plan(
+        source=args.source,
+        install_root=args.install_root,
+        bin_dir=args.bin_dir,
+    )
+    try:
+        _validate_python()
+        _validate_source(plan.source)
+        _validate_launcher(plan)
+        print_plan(plan)
+        if args.dry_run:
+            return 0
+        if not args.yes and not _confirm():
+            print("Installation cancelled.")
+            return 0
+        version = install(plan)
+    except (BootstrapError, OSError, subprocess.CalledProcessError) as exc:
+        print(f"Installation failed: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"Installed CAFE {version}.")
+    print(f"Launcher: {plan.launcher}")
+    if not _bin_dir_is_on_path(plan.bin_dir):
+        print(
+            f"Warning: {plan.bin_dir} is not on PATH. Use the launcher by its full path or "
+            "ask before updating the shell profile.",
+            file=sys.stderr,
+        )
+    print("Bundled workflow skills were synchronized for detected CLI agents.")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/src/cafe/skills/global_installer.py
+++ b/src/cafe/skills/global_installer.py
@@ -29,6 +29,13 @@ GLOBAL_CLI_SKILL_DIRS = {
     "cursor": Path(".cursor/skills"),
     "gemini": Path(".gemini/skills"),
 }
+GLOBAL_CLI_EXECUTABLES = {
+    "claude": ("claude",),
+    "codex": ("codex",),
+    "copilot": ("copilot",),
+    "cursor": ("cursor-agent",),
+    "gemini": ("gemini",),
+}
 
 GlobalSkillSyncStatus = Literal["installed", "updated", "unchanged", "failed"]
 AUTO_SYNC_STATE_VERSION = 1
@@ -92,6 +99,7 @@ class _ResolvedGlobalSkillSync:
     home_dir: Path
     skill_names: list[str]
     cli_names: list[str]
+    default_cli_selection: bool
 
 
 @dataclass
@@ -122,9 +130,8 @@ def _normalize_unique(values: list[str]) -> list[str]:
     return list(dict.fromkeys(values))
 
 
-def _validate_cli_names(cli_names: Optional[list[str]]) -> list[str]:
-    requested = list(GLOBAL_CLI_SKILL_DIRS) if cli_names is None else cli_names
-    names = _normalize_unique(requested)
+def _validate_cli_names(cli_names: list[str]) -> list[str]:
+    names = _normalize_unique(cli_names)
     if not names:
         raise GlobalSkillSyncError("At least one CLI is required")
     for name in names:
@@ -132,6 +139,35 @@ def _validate_cli_names(cli_names: Optional[list[str]]) -> list[str]:
             supported = ", ".join(GLOBAL_CLI_SKILL_DIRS)
             raise GlobalSkillSyncError(f"Unsupported CLI '{name}'; choose from: {supported}")
     return names
+
+
+def _has_existing_agent_state(home_dir: Path, cli: str) -> bool:
+    """Detect vendor state while ignoring directories created only by CAFE."""
+    skills_root = home_dir / GLOBAL_CLI_SKILL_DIRS[cli]
+    agent_root = skills_root.parent
+    if agent_root.is_symlink() or (agent_root.exists() and not agent_root.is_dir()):
+        return True
+    if not agent_root.is_dir():
+        return False
+    for child in agent_root.iterdir():
+        if child != skills_root:
+            return True
+    if not skills_root.is_dir():
+        return False
+    return any(child.name not in DEFAULT_GLOBAL_SKILLS for child in skills_root.iterdir())
+
+
+def detect_global_skill_clis(*, home_dir: Optional[Path] = None) -> list[str]:
+    """Return supported agent CLIs evidenced by PATH or existing vendor state."""
+    resolved_home = (home_dir or _default_home_dir()).expanduser().resolve()
+    detected: list[str] = []
+    for cli in GLOBAL_CLI_SKILL_DIRS:
+        executable_found = any(
+            shutil.which(name) is not None for name in GLOBAL_CLI_EXECUTABLES[cli]
+        )
+        if executable_found or _has_existing_agent_state(resolved_home, cli):
+            detected.append(cli)
+    return detected
 
 
 def _validate_sources(source_root: Path, skill_names: Optional[list[str]]) -> list[str]:
@@ -166,7 +202,10 @@ def _file_digest(path: Path) -> str:
 def _tree_manifest(root: Path) -> list[tuple[str, str, str]]:
     manifest: list[tuple[str, str, str]] = []
     for path in sorted(root.rglob("*"), key=lambda item: item.relative_to(root).as_posix()):
-        relative = path.relative_to(root).as_posix()
+        relative_path = path.relative_to(root)
+        if "__pycache__" in relative_path.parts or path.suffix in {".pyc", ".pyo"}:
+            continue
+        relative = relative_path.as_posix()
         if path.is_symlink():
             manifest.append((relative, "symlink", os.readlink(path)))
         elif path.is_dir():
@@ -243,9 +282,7 @@ def _build_auto_sync_state(
 
 
 def _is_complete_default_sync(request: _ResolvedGlobalSkillSync) -> bool:
-    return request.skill_names == list(DEFAULT_GLOBAL_SKILLS) and request.cli_names == list(
-        GLOBAL_CLI_SKILL_DIRS
-    )
+    return request.skill_names == list(DEFAULT_GLOBAL_SKILLS) and request.default_cli_selection
 
 
 def _expected_auto_sync_state(
@@ -322,7 +359,12 @@ def _stage_directory_replacement(
     had_destination = destination.exists() or destination.is_symlink()
 
     try:
-        shutil.copytree(source, staged, symlinks=True)
+        shutil.copytree(
+            source,
+            staged,
+            symlinks=True,
+            ignore=shutil.ignore_patterns("__pycache__", "*.pyc", "*.pyo"),
+        )
     except Exception:
         shutil.rmtree(workspace, ignore_errors=True)
         raise
@@ -404,7 +446,12 @@ def _resolve_global_skill_sync(
         source_root=resolved_source_root,
         home_dir=resolved_home_dir,
         skill_names=_validate_sources(resolved_source_root, skill_names),
-        cli_names=_validate_cli_names(cli_names),
+        cli_names=(
+            detect_global_skill_clis(home_dir=resolved_home_dir)
+            if cli_names is None
+            else _validate_cli_names(cli_names)
+        ),
+        default_cli_selection=cli_names is None,
     )
 
 
@@ -543,7 +590,7 @@ def sync_global_skills(
     skill_names: Optional[list[str]] = None,
     cli_names: Optional[list[str]] = None,
 ) -> GlobalSkillSyncSummary:
-    """Install or update bundled skills in selected user-level CLI directories.
+    """Install or update bundled skills in detected or selected user CLI directories.
 
     Sources always come from CAFE's bundled skill catalog, not project or global
     overrides. Validation completes before acquiring one per-machine batch lock,
@@ -556,6 +603,12 @@ def sync_global_skills(
         skill_names=skill_names,
         cli_names=cli_names,
     )
+    if not request.cli_names:
+        return GlobalSkillSyncSummary(
+            source_root=request.source_root,
+            home_dir=request.home_dir,
+            results=[],
+        )
     with _global_skill_sync_lock(
         request.home_dir,
         timeout_seconds=EXPLICIT_SYNC_LOCK_TIMEOUT_SECONDS,
@@ -588,6 +641,8 @@ def auto_sync_global_skills(
         source_root=source_root,
         home_dir=home_dir,
     )
+    if not request.cli_names:
+        return None
     try:
         with _global_skill_sync_lock(
             request.home_dir,

--- a/src/cafe/ui/commands/catalog.py
+++ b/src/cafe/ui/commands/catalog.py
@@ -250,6 +250,11 @@ def _print_skill_import_summary(summary: SkillImportSummary) -> None:
 
 def _print_global_skill_sync_summary(summary: GlobalSkillSyncSummary) -> None:
     """Print user-level CLI skill installation and update results."""
+    if not summary.results:
+        console.print(
+            "[yellow]No supported CLI agents detected. Use --cli to target one explicitly.[/yellow]"
+        )
+        return
     console.print(
         f"[green]Synced {len(summary.results)} installation(s)[/green]: "
         f"{summary.installed_count} installed, {summary.updated_count} updated, "
@@ -334,10 +339,13 @@ def skill_sync_global(
     cli_names: Optional[list[str]] = typer.Option(
         None,
         "--cli",
-        help="Target CLI; repeat for multiple (claude, codex, copilot, cursor, gemini)",
+        help=(
+            "Target CLI instead of auto-detection; repeat for multiple "
+            "(claude, codex, copilot, cursor, gemini)"
+        ),
     ),
 ) -> None:
-    """Install or update bundled CAFE helper skills in user-level CLI directories."""
+    """Install helper skills for detected CLIs or explicit --cli targets."""
     try:
         summary = sync_global_skills(
             skill_names=skills or None,

--- a/src/cafe/ui/human_tasks.py
+++ b/src/cafe/ui/human_tasks.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+import json
 from collections.abc import Mapping
 from dataclasses import dataclass
-import json
 from pathlib import Path
 from typing import Any, Optional, Sequence
 
@@ -15,7 +15,13 @@ from cafe.core.blackboard import (
     HandoffIntent,
     HandoffOwner,
 )
-from cafe.core.downstream_contract import ContractValidationError, extract_downstream_contract
+from cafe.core.human_task_records import (
+    HumanTask,
+    HumanTaskCorrelationError,
+    HumanTaskRecordStore,
+    HumanTaskStatus,
+    TaskResult,
+)
 from cafe.core.human_tasks import (
     HumanTaskBinding,
     HumanTaskCompletion,
@@ -23,16 +29,11 @@ from cafe.core.human_tasks import (
     HumanTaskPolicyError,
     HumanTaskQuestion,
     HumanTaskRejection,
-    resolve_step_human_task as _resolve_step_human_task,
     resolve_human_task_continuation,
     validate_human_task_completion,
 )
-from cafe.core.human_task_records import (
-    HumanTask,
-    HumanTaskCorrelationError,
-    HumanTaskRecordStore,
-    HumanTaskStatus,
-    TaskResult,
+from cafe.core.human_tasks import (
+    resolve_step_human_task as _resolve_step_human_task,
 )
 from cafe.core.phase_state_mixin import next_runnable_iteration_number
 from cafe.core.workflow_feedback import WorkflowFeedbackError, WorkflowFeedbackLedger
@@ -373,53 +374,6 @@ def _apply_human_task_payload(
             )
             return HumanTaskApplication(target=None, policy=policy, rejection=continuation)
 
-    selected_decision = next(
-        (
-            item
-            for item in policy.decisions
-            if durable_result is None and item.id == completion.decision
-        ),
-        None,
-    )
-    is_correction = selected_decision is not None and selected_decision.correction
-    qualification_rejection = (
-        _validate_packet_contracts_before_confirmation(
-            playbook_data=playbook_data,
-            blackboard=blackboard,
-            issue_dir=issue_dir,
-            producer_step=from_step,
-            correction_guidance=policy.correction_guidance,
-        )
-        if (
-            durable_result is None
-            and
-            trigger == "confirm_output"
-            and continuation != from_step
-            and not is_correction
-        )
-        else None
-    )
-    if qualification_rejection is not None:
-        if durable_task is not None:
-            record_store.record_rejection(
-                workflow_id=blackboard.workflow_id,
-                task_id=durable_task.id,
-                reason=qualification_rejection.message,
-            )
-        store.record_event(
-            blackboard,
-            "human_task_rejected",
-            {
-                "step": from_step,
-                "trigger": trigger,
-                "task_id": policy.id,
-                "reason": qualification_rejection.message,
-            },
-        )
-        return HumanTaskApplication(
-            target=None, policy=policy, rejection=qualification_rejection
-        )
-
     feedback = (
         durable_result.payload.get("feedback", "")
         if durable_result is not None
@@ -734,64 +688,6 @@ def _validated_completion_payload(completion: HumanTaskCompletion, continuation:
     if completion.target is not None:
         payload["target"] = completion.target
     return payload
-
-
-def _validate_packet_contracts_before_confirmation(
-    *,
-    playbook_data: Mapping[str, Any],
-    blackboard: Any,
-    issue_dir: Path,
-    producer_step: str,
-    correction_guidance: str,
-) -> Optional[HumanTaskRejection]:
-    """Reject confirmation when a declared packet consumer lacks a valid source contract."""
-    raw_steps = playbook_data.get("steps")
-    if not isinstance(raw_steps, Mapping):
-        return None
-    producer = raw_steps.get(producer_step)
-    if not isinstance(producer, Mapping):
-        return None
-    artifact_name = producer.get("output_artifact")
-    if not isinstance(artifact_name, str):
-        return None
-    artifact = getattr(blackboard, "artifacts", {}).get(artifact_name)
-    # Legacy callers that only exercise routing have no produced artifact to
-    # qualify. Runtime confirmation always records the producer output first.
-    if artifact is None:
-        return None
-    source_path = getattr(artifact, "path", None)
-    for consumer_step, consumer in raw_steps.items():
-        if not isinstance(consumer_step, str) or not isinstance(consumer, Mapping):
-            continue
-        input_artifacts = consumer.get("input_artifacts")
-        if (
-            not isinstance(input_artifacts, Sequence)
-            or isinstance(input_artifacts, (str, bytes))
-            or artifact_name not in input_artifacts
-        ):
-            continue
-        consumer_iteration = next_runnable_iteration_number(issue_dir / consumer_step)
-        skill_name = _select_skill_name(consumer, consumer_iteration)
-        contract = SkillLoader().get_workflow_contract(skill_name)
-        packet_kinds = {
-            policy.contract_kind
-            for mapping in contract.prompt_inputs
-            if artifact_name in mapping.artifacts
-            for policy in mapping.load_policy
-            if policy.mode == "packet" and policy.contract_kind in {"spec", "plan"}
-        }
-        for kind in sorted(packet_kinds):
-            try:
-                extract_downstream_contract(str(source_path or ""), kind=kind)
-            except ContractValidationError as exc:
-                return HumanTaskRejection(
-                    message=(
-                        f"Cannot confirm {producer_step} -> {consumer_step} packet relation "
-                        f"for {artifact_name!r}: {exc}"
-                    ),
-                    correction_guidance=correction_guidance,
-                )
-    return None
 
 
 def _write_next_iteration_user_input(*, issue_dir: Path, step_name: str, text: str) -> None:

--- a/tests/integration/test_human_task_workflow.py
+++ b/tests/integration/test_human_task_workflow.py
@@ -475,52 +475,33 @@ def test_taskless_payload_rejects_another_workflows_durable_records(tmp_path: Pa
     assert HumanTaskRecordStore(issue_dir).results() == ()
 
 
-def test_confirmation_rejects_invalid_declared_packet_contract_for_custom_steps(
+def test_plan_confirmation_accepts_structural_packet_source_without_legacy_contract(
     tmp_path: Path,
 ) -> None:
-    """A packet consumer blocks confirmation before any fallback can be recorded."""
+    """Plan confirmation leaves structural packet construction to the consumer runtime."""
     issue_dir = tmp_path / ".cafe" / "issues" / "packet-confirmation"
     store, state = _paused_default_state(
-        issue_dir, from_step="producer", intent=HandoffIntent.CONFIRM_OUTPUT
+        issue_dir, from_step="plan", intent=HandoffIntent.CONFIRM_OUTPUT
     )
-    output = issue_dir / "producer" / "iteration_001" / "output.md"
+    output = issue_dir / "plan" / "iteration_001" / "plan.md"
     output.parent.mkdir(parents=True)
-    output.write_text("# incomplete source\n", encoding="utf-8")
-    store.set_artifact(state, "spec", str(output))
-    playbook = {
-        "steps": {
-            "producer": {
-                "skill": "cafe-spec",
-                "output_artifact": "spec",
-                "human_tasks": [
-                    {
-                        "trigger": "confirm_output",
-                        "task_id": "output-review",
-                        "outcomes": {"confirm": "consumer", "revise": "producer"},
-                    }
-                ],
-            },
-            "consumer": {"skill": "cafe-develop", "input_artifacts": ["spec"]},
-        }
-    }
+    output.write_text("# Implementation Plan\n\n- [ ] Implement the fix.\n", encoding="utf-8")
+    store.set_artifact(state, "plan", str(output))
+    playbook = PlaybookLoader().load("default")
 
     result = apply_human_task_payload(
         issue_dir=issue_dir,
         playbook_data=playbook,
         blackboard=state,
-        from_step="producer",
+        from_step="plan",
         trigger="confirm_output",
         raw_payload={"task": "output-review", "decision": "confirm"},
         source="integration",
     )
 
-    assert result.target is None
-    assert result.rejection is not None
-    assert "producer -> consumer" in result.rejection.message
-    assert "Downstream Contract" in result.rejection.message
-    reloaded = store.load_or_create("producer")
-    assert reloaded.current_step == "user"
-    assert not any("fallback" in event.event_type for event in reloaded.events)
+    assert result.target == "develop"
+    assert result.rejection is None
+    assert store.load_or_create("plan").current_step == "develop"
 
 
 def test_tdd_no_change_agreement_skips_review_to_pr(tmp_path: Path) -> None:

--- a/tests/unit/test_bootstrap_install.py
+++ b/tests/unit/test_bootstrap_install.py
@@ -1,0 +1,226 @@
+"""Tests for the repository-owned, agent-neutral installation bootstrap."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from cafe.install import bootstrap
+from cafe.install.bootstrap import BootstrapError, create_plan, install
+
+
+def _source_checkout(tmp_path: Path) -> Path:
+    source = tmp_path / "source"
+    (source / "src" / "cafe").mkdir(parents=True)
+    (source / "pyproject.toml").write_text(
+        '[project]\nname = "cafe-engine"\n',
+        encoding="utf-8",
+    )
+    return source
+
+
+def _plan(tmp_path: Path, source: Path, generation: str = "env-test"):
+    return create_plan(
+        source=source,
+        home_dir=tmp_path / "home",
+        install_root=tmp_path / "install",
+        bin_dir=tmp_path / "bin",
+        generation=generation,
+    )
+
+
+def test_create_plan_is_user_scoped_and_side_effect_free(tmp_path: Path) -> None:
+    source = _source_checkout(tmp_path)
+
+    plan = _plan(tmp_path, source)
+
+    assert plan.environment == tmp_path / "install" / "environments" / "env-test"
+    assert plan.launcher == tmp_path / "bin" / "cafe"
+    assert plan.cafe_executable == plan.environment / "bin" / "cafe"
+    assert not plan.install_root.exists()
+    assert not plan.bin_dir.exists()
+
+
+def test_install_publishes_managed_launcher_manifest_and_replaces_previous_generation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = _source_checkout(tmp_path)
+    previous_plan = _plan(tmp_path, source, "env-previous")
+    previous_plan.cafe_executable.parent.mkdir(parents=True)
+    previous_plan.cafe_executable.write_text("old", encoding="utf-8")
+    previous_plan.bin_dir.mkdir(parents=True)
+    previous_plan.launcher.symlink_to(previous_plan.cafe_executable)
+    previous_manifest = {
+        "environment": str(previous_plan.environment),
+        "cafe_version": "0.2.0",
+    }
+    previous_plan.install_root.mkdir(parents=True, exist_ok=True)
+    (previous_plan.install_root / "install.json").write_text(
+        json.dumps(previous_manifest), encoding="utf-8"
+    )
+    plan = _plan(tmp_path, source, "env-current")
+
+    def fake_install_environment(current_plan):
+        current_plan.cafe_executable.parent.mkdir(parents=True)
+        current_plan.cafe_executable.write_text("new", encoding="utf-8")
+        return "0.3.0"
+
+    monkeypatch.setattr(bootstrap, "_install_environment", fake_install_environment)
+
+    version = install(plan)
+
+    assert version == "0.3.0"
+    assert plan.launcher.resolve() == plan.cafe_executable
+    manifest = json.loads((plan.install_root / "install.json").read_text(encoding="utf-8"))
+    assert manifest["cafe_version"] == "0.3.0"
+    assert manifest["environment"] == str(plan.environment)
+    assert not previous_plan.environment.exists()
+
+
+def test_environment_install_verifies_package_then_synchronizes_all_skills(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = _source_checkout(tmp_path)
+    plan = _plan(tmp_path, source)
+    commands: list[tuple[list[str], dict[str, object]]] = []
+
+    def fake_run(command, **kwargs):
+        command_list = list(command)
+        commands.append((command_list, kwargs))
+        if command_list[1:3] == ["-m", "venv"]:
+            plan.cafe_executable.parent.mkdir(parents=True)
+            plan.cafe_executable.write_text("installed", encoding="utf-8")
+            environment_python = plan.environment / "bin" / "python"
+            environment_python.write_text("python", encoding="utf-8")
+        stdout = "CAFE version 0.3.0\n" if command_list[-1] == "version" else ""
+        return subprocess.CompletedProcess(command_list, 0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(bootstrap, "_run", fake_run)
+
+    version = bootstrap._install_environment(plan)
+
+    assert version == "0.3.0"
+    assert [command[-2:] for command, _ in commands][-1] == ["skill", "sync-global"]
+    assert "--no-cache-dir" in commands[1][0]
+    version_kwargs = commands[-2][1]
+    assert version_kwargs["cwd"] == plan.install_root
+    assert version_kwargs["env"]["CAFE_SKIP_ENTRYPOINT_CHECK"] == "1"
+    assert version_kwargs["env"]["CAFE_SKIP_GLOBAL_SKILL_SYNC"] == "1"
+    sync_kwargs = commands[-1][1]
+    assert "CAFE_SKIP_GLOBAL_SKILL_SYNC" not in sync_kwargs["env"]
+
+
+def test_install_refuses_to_replace_foreign_launcher(tmp_path: Path) -> None:
+    source = _source_checkout(tmp_path)
+    plan = _plan(tmp_path, source)
+    plan.bin_dir.mkdir(parents=True)
+    plan.launcher.write_text("#!/bin/sh\n", encoding="utf-8")
+
+    with pytest.raises(BootstrapError, match="not managed by CAFE"):
+        install(plan)
+
+    assert not plan.environment.exists()
+    assert plan.launcher.read_text(encoding="utf-8") == "#!/bin/sh\n"
+
+
+def test_failed_install_removes_only_the_new_generation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = _source_checkout(tmp_path)
+    plan = _plan(tmp_path, source)
+
+    def fail_install(current_plan):
+        current_plan.environment.mkdir(parents=True)
+        (current_plan.environment / "partial").write_text("partial", encoding="utf-8")
+        raise BootstrapError("verification failed")
+
+    monkeypatch.setattr(bootstrap, "_install_environment", fail_install)
+
+    with pytest.raises(BootstrapError, match="verification failed"):
+        install(plan)
+
+    assert not plan.environment.exists()
+    assert not plan.launcher.exists()
+
+
+def test_manifest_failure_restores_previous_launcher_and_environment(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = _source_checkout(tmp_path)
+    previous_plan = _plan(tmp_path, source, "env-previous")
+    previous_plan.cafe_executable.parent.mkdir(parents=True)
+    previous_plan.cafe_executable.write_text("old", encoding="utf-8")
+    previous_plan.bin_dir.mkdir(parents=True)
+    previous_plan.launcher.symlink_to(previous_plan.cafe_executable)
+    previous_plan.install_root.mkdir(parents=True, exist_ok=True)
+    (previous_plan.install_root / "install.json").write_text(
+        json.dumps({"environment": str(previous_plan.environment)}), encoding="utf-8"
+    )
+    plan = _plan(tmp_path, source, "env-current")
+
+    def fake_install_environment(current_plan):
+        current_plan.cafe_executable.parent.mkdir(parents=True)
+        current_plan.cafe_executable.write_text("new", encoding="utf-8")
+        return "0.3.0"
+
+    monkeypatch.setattr(bootstrap, "_install_environment", fake_install_environment)
+    monkeypatch.setattr(
+        bootstrap,
+        "_write_manifest",
+        lambda *_: (_ for _ in ()).throw(OSError("manifest unavailable")),
+    )
+
+    with pytest.raises(OSError, match="manifest unavailable"):
+        install(plan)
+
+    assert previous_plan.environment.exists()
+    assert previous_plan.launcher.resolve() == previous_plan.cafe_executable
+    assert not plan.environment.exists()
+
+
+def test_noninteractive_main_requires_explicit_authorization(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    source = _source_checkout(tmp_path)
+
+    with patch("sys.stdin.isatty", return_value=False):
+        result = bootstrap.main(
+            [
+                "--source",
+                str(source),
+                "--install-root",
+                str(tmp_path / "install"),
+                "--bin-dir",
+                str(tmp_path / "bin"),
+            ]
+        )
+
+    assert result == 1
+    assert "requires --yes" in capsys.readouterr().err
+    assert not (tmp_path / "install").exists()
+
+
+def test_dry_run_validates_and_prints_plan_without_writing(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    source = _source_checkout(tmp_path)
+
+    result = bootstrap.main(
+        [
+            "--source",
+            str(source),
+            "--install-root",
+            str(tmp_path / "install"),
+            "--bin-dir",
+            str(tmp_path / "bin"),
+            "--dry-run",
+        ]
+    )
+
+    assert result == 0
+    assert "CAFE user installation plan" in capsys.readouterr().out
+    assert not (tmp_path / "install").exists()

--- a/tests/unit/test_cli_catalog_commands.py
+++ b/tests/unit/test_cli_catalog_commands.py
@@ -76,19 +76,21 @@ def test_skill_sync_global_installs_bundled_helper_skills(
     monkeypatch.chdir(tmp_path)
     home_dir = tmp_path / "home"
 
-    with patch(
-        "cafe.skills.global_installer._default_home_dir",
-        return_value=home_dir,
+    with (
+        patch("cafe.skills.global_installer._default_home_dir", return_value=home_dir),
+        patch(
+            "cafe.skills.global_installer.shutil.which",
+            side_effect=lambda executable: (
+                "/test-bin/codex" if executable == "codex" else None
+            ),
+        ),
     ):
         result = runner.invoke(app, ["skill", "sync-global"])
 
     assert result.exit_code == 0
-    assert "Synced 15 installation(s)" in result.stdout
-    assert (home_dir / ".claude/skills/use-cafe-workflow/SKILL.md").is_file()
+    assert "Synced 3 installation(s)" in result.stdout
     assert (home_dir / ".codex/skills/write-cafe-playbook/SKILL.md").is_file()
-    assert (home_dir / ".copilot/skills/write-cafe-phase/SKILL.md").is_file()
-    assert (home_dir / ".cursor/skills/use-cafe-workflow/SKILL.md").is_file()
-    assert (home_dir / ".gemini/skills/write-cafe-playbook/SKILL.md").is_file()
+    assert not (home_dir / ".claude").exists()
 
 
 def test_skill_sync_global_can_limit_target_clis(tmp_path: Path, monkeypatch) -> None:
@@ -109,6 +111,23 @@ def test_skill_sync_global_can_limit_target_clis(tmp_path: Path, monkeypatch) ->
     assert (home_dir / ".codex/skills/use-cafe-workflow/SKILL.md").is_file()
     assert (home_dir / ".cursor/skills/use-cafe-workflow/SKILL.md").is_file()
     assert not (home_dir / ".claude").exists()
+
+
+def test_skill_sync_global_reports_when_no_cli_is_detected(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    home_dir = tmp_path / "home"
+
+    with (
+        patch("cafe.skills.global_installer._default_home_dir", return_value=home_dir),
+        patch("cafe.skills.global_installer.shutil.which", return_value=None),
+    ):
+        result = runner.invoke(app, ["skill", "sync-global"])
+
+    assert result.exit_code == 0
+    assert "No supported CLI agents detected" in result.stdout
+    assert not home_dir.exists()
 
 
 def test_playbook_validate_reports_warning_and_strict_failure(tmp_path: Path, monkeypatch) -> None:

--- a/tests/unit/test_global_skill_installer.py
+++ b/tests/unit/test_global_skill_installer.py
@@ -18,6 +18,7 @@ from cafe.skills.global_installer import (
     GlobalSkillSyncError,
     GlobalSkillSyncSummary,
     auto_sync_global_skills,
+    detect_global_skill_clis,
     sync_global_skills,
 )
 
@@ -28,6 +29,20 @@ EXPECTED_CLI_ROOTS = {
     "cursor": Path(".cursor/skills"),
     "gemini": Path(".gemini/skills"),
 }
+
+
+@pytest.fixture(autouse=True)
+def _detect_supported_clis_on_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    executable_names = {
+        executable
+        for names in global_installer.GLOBAL_CLI_EXECUTABLES.values()
+        for executable in names
+    }
+    monkeypatch.setattr(
+        global_installer.shutil,
+        "which",
+        lambda executable: f"/test-bin/{executable}" if executable in executable_names else None,
+    )
 
 
 def _write_skill(source_root: Path, name: str, body: str) -> None:
@@ -45,6 +60,71 @@ def _write_skill(source_root: Path, name: str, body: str) -> None:
 def _write_default_sources(source_root: Path) -> None:
     for name in DEFAULT_GLOBAL_SKILLS:
         _write_skill(source_root, name, f"{name} v1")
+
+
+def test_detect_global_skill_clis_uses_path_or_existing_non_cafe_state(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home_dir = tmp_path / "home"
+    managed_only = home_dir / ".claude/skills/use-cafe-workflow"
+    managed_only.mkdir(parents=True)
+    (managed_only / "SKILL.md").write_text("managed", encoding="utf-8")
+    gemini_config = home_dir / ".gemini/settings.json"
+    gemini_config.parent.mkdir(parents=True)
+    gemini_config.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(
+        global_installer.shutil,
+        "which",
+        lambda executable: "/test-bin/codex" if executable == "codex" else None,
+    )
+
+    detected = detect_global_skill_clis(home_dir=home_dir)
+
+    assert detected == ["codex", "gemini"]
+
+
+def test_default_sync_skips_undetected_clis_but_explicit_target_creates_one(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source_root = tmp_path / "bundled-skills"
+    home_dir = tmp_path / "home"
+    _write_default_sources(source_root)
+    monkeypatch.setattr(
+        global_installer.shutil,
+        "which",
+        lambda executable: "/test-bin/codex" if executable == "codex" else None,
+    )
+
+    detected = sync_global_skills(source_root=source_root, home_dir=home_dir)
+
+    assert detected.installed_count == 3
+    assert (home_dir / ".codex/skills/use-cafe-workflow/SKILL.md").is_file()
+    assert not (home_dir / ".claude").exists()
+
+    explicit = sync_global_skills(
+        source_root=source_root,
+        home_dir=home_dir,
+        cli_names=["cursor"],
+    )
+
+    assert explicit.installed_count == 3
+    assert (home_dir / ".cursor/skills/use-cafe-workflow/SKILL.md").is_file()
+
+
+def test_default_sync_is_a_noop_when_no_supported_cli_is_detected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source_root = tmp_path / "bundled-skills"
+    home_dir = tmp_path / "home"
+    _write_default_sources(source_root)
+    monkeypatch.setattr(global_installer.shutil, "which", lambda _: None)
+
+    explicit = sync_global_skills(source_root=source_root, home_dir=home_dir)
+    automatic = auto_sync_global_skills(source_root=source_root, home_dir=home_dir)
+
+    assert explicit.results == []
+    assert automatic is None
+    assert not home_dir.exists()
 
 
 def test_sync_global_skills_installs_updates_and_detects_unchanged(tmp_path: Path) -> None:
@@ -83,6 +163,27 @@ def test_sync_global_skills_installs_updates_and_detects_unchanged(tmp_path: Pat
     )
 
     unchanged = sync_global_skills(source_root=source_root, home_dir=home_dir)
+    assert unchanged.unchanged_count == 15
+    assert unchanged.changed_count == 0
+
+
+def test_sync_global_skills_ignores_generated_python_bytecode(tmp_path: Path) -> None:
+    source_root = tmp_path / "bundled-skills"
+    home_dir = tmp_path / "home"
+    _write_default_sources(source_root)
+    generated = source_root / "use-cafe-workflow" / "scripts" / "__pycache__"
+    generated.mkdir(parents=True)
+    bytecode = generated / "helper.cpython-312.pyc"
+    bytecode.write_bytes(b"first generated version")
+
+    installed = sync_global_skills(source_root=source_root, home_dir=home_dir)
+
+    assert installed.installed_count == 15
+    assert not (home_dir / ".codex/skills/use-cafe-workflow/scripts/__pycache__").exists()
+
+    bytecode.write_bytes(b"second generated version")
+    unchanged = sync_global_skills(source_root=source_root, home_dir=home_dir)
+
     assert unchanged.unchanged_count == 15
     assert unchanged.changed_count == 0
 
@@ -411,6 +512,9 @@ def test_auto_sync_lock_contention_is_safe_across_processes(tmp_path: Path) -> N
     source_root = tmp_path / "bundled-skills"
     home_dir = tmp_path / "home"
     _write_default_sources(source_root)
+    codex_config = home_dir / ".codex/config.toml"
+    codex_config.parent.mkdir(parents=True)
+    codex_config.write_text("model = 'test'\n", encoding="utf-8")
     code = (
         "from pathlib import Path; import sys; "
         "from cafe.skills.global_installer import auto_sync_global_skills; "

--- a/tests/unit/test_ui_human_tasks.py
+++ b/tests/unit/test_ui_human_tasks.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from types import SimpleNamespace
 
 import pytest
 
@@ -15,88 +14,14 @@ from cafe.core.blackboard import (
     HandoffIntent,
     HandoffOwner,
 )
-from cafe.core.human_tasks import HumanTaskPolicy
 from cafe.core.human_task_records import HumanTaskRecordStore, HumanTaskStatus
+from cafe.core.human_tasks import HumanTaskPolicy
 from cafe.skills.loader import SkillLoader
 from cafe.ui.human_tasks import (
-    _validate_packet_contracts_before_confirmation,
     apply_human_task_payload,
     collect_human_task_payload,
     resolve_step_human_task,
 )
-
-
-def test_packet_confirmation_uses_next_runnable_consumer_iteration_for_contract_validation(
-    tmp_path: Path, monkeypatch
-) -> None:
-    """IT-001: confirmation uses the consumer's next runnable skill contract."""
-    builtin_root = tmp_path / "builtin"
-    for name, prompt_inputs in (
-        ("first-consumer", "  prompt_inputs: []\n"),
-        (
-            "current-consumer",
-            """  prompt_inputs:
-    - artifacts: [spec]
-      placeholder: spec_file
-      load_policy:
-        - when: {}
-          mode: packet
-          contract_kind: spec
-""",
-        ),
-    ):
-        skill_dir = builtin_root / "skills" / name
-        skill_dir.mkdir(parents=True)
-        (skill_dir / "SKILL.md").write_text(
-            "---\n"
-            f"name: {name}\n"
-            "description: test skill\n"
-            "workflow:\n"
-            f"{prompt_inputs}"
-            "---\n",
-            encoding="utf-8",
-        )
-    loader = SkillLoader(
-        project_root=tmp_path / "project",
-        global_root=tmp_path / "global",
-        builtin_root=builtin_root,
-    )
-    monkeypatch.setattr("cafe.ui.human_tasks.SkillLoader", lambda: loader)
-    invalid_spec = tmp_path / "spec.md"
-    invalid_spec.write_text("# Missing downstream contract\n", encoding="utf-8")
-
-    rejection = _validate_packet_contracts_before_confirmation(
-        playbook_data={
-            "steps": {
-                "spec": {"output_artifact": "spec"},
-                "develop": {
-                    "input_artifacts": ["spec"],
-                    "skill": {"1": "first-consumer", "2": "current-consumer"},
-                },
-            }
-        },
-        blackboard=SimpleNamespace(artifacts={"spec": SimpleNamespace(path=invalid_spec)}),
-        issue_dir=_iteration_history(tmp_path, producer=1, consumer=1),
-        producer_step="spec",
-        correction_guidance="repair the contract",
-    )
-
-    assert rejection is not None
-    assert "spec -> develop" in rejection.message
-
-
-def _iteration_history(tmp_path: Path, *, producer: int, consumer: int) -> Path:
-    """Create completed producer and consumer iteration histories."""
-    issue_dir = tmp_path / ".cafe" / "issues" / "demo"
-    for step_name, count in (("spec", producer), ("develop", consumer)):
-        for iteration in range(1, count + 1):
-            iteration_dir = issue_dir / step_name / f"iteration_{iteration:03d}"
-            iteration_dir.mkdir(parents=True)
-            (iteration_dir / "iteration.json").write_text(
-                json.dumps({"iteration": iteration, "end_time": "done"}),
-                encoding="utf-8",
-            )
-    return issue_dir
 
 
 def test_custom_step_resolves_its_skill_owned_human_task(tmp_path: Path) -> None:
@@ -726,10 +651,10 @@ def test_cross_step_revision_feedback_replaces_pending_input_without_state(
 
 
 @pytest.mark.parametrize("requires_target", [True, False], ids=["targeted", "fixed-outcome"])
-def test_revision_bypasses_packet_confirmation_gate(
+def test_revision_route_is_independent_of_downstream_packet_preparation(
     tmp_path: Path, monkeypatch, requires_target: bool
 ) -> None:
-    """A correction route remains available when its source packet is invalid."""
+    """A correction route remains available before consumer context preparation."""
     builtin_root = tmp_path / "builtin"
     review_skill = builtin_root / "skills" / "targeted-review"
     review_skill.mkdir(parents=True)
@@ -841,10 +766,10 @@ workflow:
     ) == "Repair the invalid packet."
 
 
-def test_feedback_required_approval_still_qualifies_packet(
+def test_feedback_required_approval_does_not_revalidate_packet_contract(
     tmp_path: Path, monkeypatch
 ) -> None:
-    """Input requirements do not turn an approval into a correction route."""
+    """A reasoned approval leaves packet construction to the consumer runtime."""
     builtin_root = tmp_path / "builtin"
     review_skill = builtin_root / "skills" / "reasoned-approval"
     review_skill.mkdir(parents=True)
@@ -936,8 +861,9 @@ workflow:
         source="command",
     )
 
-    assert result.rejection is not None
-    assert "Cannot confirm" in result.rejection.message
+    assert result.rejection is None
+    assert result.target == "closeout"
+    assert store.load_or_create("review").current_step == "closeout"
 
 
 def test_confirmation_does_not_overwrite_unfinished_producer_input(tmp_path: Path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -66,7 +66,7 @@ wheels = [
 
 [[package]]
 name = "cafe-engine"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- restore HumanTask confirmation after structural context packets
- add the agent-neutral user bootstrap and installation contract
- synchronize helper skills only for detected CLI agents
- release CAFE v0.3.1

## Verification

- `./scripts/release-check.sh`
- 2855 passed, 1 skipped, 1 xfailed
- clean wheel install verified cafe-engine 0.3.1