### PR TITLE
Add repository task inbox with validated exact continuation

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,49 @@ project.
 Issue worktrees can carry their own `.cafe/phases.yaml`, allowing model choices
 to differ between issues without changing repository-wide defaults.
 
+### Repository task inbox
+
+Use the task inbox when you need to find human work across every live workflow
+in the repository. Pending tasks are shown by default in deterministic order;
+completed and cancelled tasks appear only when requested.
+
+```bash
+cafe task ls
+cafe task ls --assignee alice --step review --due-state unscheduled
+cafe task ls --historical
+cafe task ls --status completed
+```
+
+Inspect a task by its stable identifier before answering it:
+
+```bash
+cafe task inspect 7fe1a9e8-66fa-4df2-88d4-cd6af87fae43
+cafe task inspect 7fe1a9e8-66fa-4df2-88d4-cd6af87fae43 --json
+```
+
+Completion is interactive when no result option is supplied. Automation may
+provide the task's declared response as JSON directly or in a file:
+
+```bash
+cafe task complete 7fe1a9e8-66fa-4df2-88d4-cd6af87fae43
+cafe task complete 7fe1a9e8-66fa-4df2-88d4-cd6af87fae43 \
+  --result '{"decision":"confirm"}' --json
+cafe task complete 7fe1a9e8-66fa-4df2-88d4-cd6af87fae43 \
+  --result-file response.json
+```
+
+Add `--json` to list, inspect, or complete to receive one result object with
+`ok`, `operation`, `data`, and `error` fields. Filters combine with AND
+semantics. Current HumanTask records have no due timestamp, so their due state
+is `unscheduled`; the inbox does not invent or manage due dates.
+
+Inbox operations fail closed when an identifier is missing or duplicated, a
+task is stale or terminal, its workflow is missing or archived, or durable
+records are corrupt. The error identifies the affected task or workflow when
+known and includes a recovery action. Repair or explicitly restore the named
+workflow, then retry the same stable identifier; the inbox never switches the
+active issue or chooses an ambiguous record automatically.
+
 ### Inspect and recover
 
 Ask the driver for the information or recovery outcome you need:

--- a/src/cafe/core/task_inbox.py
+++ b/src/cafe/core/task_inbox.py
@@ -1,0 +1,375 @@
+"""Repository-wide discovery and safe selection of durable human tasks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+from cafe.core.human_task_records import (
+    Assignment,
+    HumanTask,
+    HumanTaskRecordError,
+    HumanTaskRecordStore,
+    HumanTaskStatus,
+    TaskResult,
+    WaitState,
+)
+
+
+class TaskInboxError(RuntimeError):
+    """One actionable, machine-stable inbox failure."""
+
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        *,
+        recovery: str,
+        task_id: Optional[str] = None,
+        issue: Optional[str] = None,
+        workflow_id: Optional[str] = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.recovery = recovery
+        self.task_id = task_id
+        self.issue = issue
+        self.workflow_id = workflow_id
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "code": self.code,
+            "message": self.message,
+            "recovery": self.recovery,
+            "task_id": self.task_id,
+            "issue": self.issue,
+            "workflow_id": self.workflow_id,
+        }
+
+
+@dataclass(frozen=True)
+class TaskSummary:
+    """Stable public projection used by both human and JSON renderers."""
+
+    id: str
+    issue: str
+    workflow_id: str
+    step: str
+    iteration: int
+    trigger: str
+    policy_id: str
+    status: str
+    assignee_type: str
+    assignee_id: Optional[str]
+    due_state: str
+    created_at: str
+    completed_at: Optional[str]
+    cancelled_at: Optional[str]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "issue": self.issue,
+            "workflow_id": self.workflow_id,
+            "step": self.step,
+            "iteration": self.iteration,
+            "trigger": self.trigger,
+            "policy_id": self.policy_id,
+            "status": self.status,
+            "assignment": {"type": self.assignee_type, "id": self.assignee_id},
+            "due_state": self.due_state,
+            "timestamps": {
+                "created_at": self.created_at,
+                "completed_at": self.completed_at,
+                "cancelled_at": self.cancelled_at,
+            },
+        }
+
+
+@dataclass(frozen=True)
+class TaskDetail:
+    """Inspection projection for one uniquely selected task."""
+
+    id: str
+    issue: str
+    workflow_id: str
+    step: str
+    iteration: int
+    trigger: str
+    policy_id: str
+    prompt: str
+    expected_result: dict[str, Any]
+    continuations: dict[str, str]
+    assignment: dict[str, Optional[str]]
+    status: str
+    due_state: str
+    wait: dict[str, Any]
+    result: Optional[dict[str, Any]]
+    timestamps: dict[str, Optional[str]]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "issue": self.issue,
+            "workflow_id": self.workflow_id,
+            "provenance": {
+                "step": self.step,
+                "iteration": self.iteration,
+                "trigger": self.trigger,
+                "policy_id": self.policy_id,
+            },
+            "prompt": self.prompt,
+            "expected_result": self.expected_result,
+            "continuations": self.continuations,
+            "assignment": self.assignment,
+            "status": self.status,
+            "due_state": self.due_state,
+            "wait": self.wait,
+            "result": self.result,
+            "timestamps": self.timestamps,
+        }
+
+
+@dataclass(frozen=True)
+class CompletionPreflight:
+    """Live ownership evidence captured before response validation and mutation."""
+
+    task: HumanTask
+    issue: str
+    issue_dir: Path
+    workflow_id: str
+    playbook_id: str
+
+
+@dataclass(frozen=True)
+class _Record:
+    issue: str
+    issue_dir: Path
+    workflow_id: str
+    playbook_id: str
+    task: HumanTask
+    assignment: Assignment
+    wait: WaitState
+    result: Optional[TaskResult]
+
+
+class TaskInboxService:
+    """Read canonical per-issue stores as one fail-closed repository inbox."""
+
+    def __init__(self, cafe_dir: Path = Path(".cafe")) -> None:
+        self.cafe_dir = Path(cafe_dir)
+
+    def list_tasks(
+        self,
+        *,
+        statuses: Optional[set[str]] = None,
+        assignee: Optional[str] = None,
+        workflow: Optional[str] = None,
+        step: Optional[str] = None,
+        due_state: Optional[str] = None,
+        include_historical: bool = False,
+    ) -> tuple[TaskSummary, ...]:
+        requested_statuses = statuses or (
+            {status.value for status in HumanTaskStatus}
+            if include_historical
+            else {HumanTaskStatus.PENDING.value}
+        )
+        allowed_statuses = {status.value for status in HumanTaskStatus}
+        if not requested_statuses <= allowed_statuses:
+            invalid = sorted(requested_statuses - allowed_statuses)
+            raise TaskInboxError(
+                "invalid_filter",
+                f"Unsupported task status filter: {', '.join(invalid)}.",
+                recovery=f"Use one of: {', '.join(sorted(allowed_statuses))}.",
+            )
+        if due_state not in (None, "unscheduled"):
+            raise TaskInboxError(
+                "invalid_filter",
+                f"Unsupported due-state filter: {due_state}.",
+                recovery="Use 'unscheduled'; canonical tasks currently declare no due timestamp.",
+            )
+        records = self._scan()
+        selected = (
+            record
+            for record in records
+            if record.task.status.value in requested_statuses
+            and (assignee is None or record.assignment.assignee_id == assignee)
+            and (workflow is None or record.workflow_id == workflow or record.issue == workflow)
+            and (step is None or record.task.step == step)
+            and (due_state is None or due_state == "unscheduled")
+        )
+        return tuple(self._summary(record) for record in selected)
+
+    def inspect(self, task_id: str) -> TaskDetail:
+        return self._detail(self._select(task_id))
+
+    def preflight_completion(self, task_id: str) -> CompletionPreflight:
+        record = self._select(task_id)
+        if record.task.status is not HumanTaskStatus.PENDING:
+            raise TaskInboxError(
+                "task_not_pending",
+                f"Task {task_id} is {record.task.status.value}, not pending.",
+                recovery="List pending tasks and select an active task.",
+                task_id=task_id,
+                issue=record.issue,
+                workflow_id=record.workflow_id,
+            )
+        if record.wait.released_at is not None or record.result is not None:
+            raise TaskInboxError(
+                "stale_task",
+                f"Task {task_id} no longer has one active wait.",
+                recovery="Inspect the task history and choose a currently pending task.",
+                task_id=task_id,
+                issue=record.issue,
+                workflow_id=record.workflow_id,
+            )
+        return CompletionPreflight(
+            task=record.task,
+            issue=record.issue,
+            issue_dir=record.issue_dir,
+            workflow_id=record.workflow_id,
+            playbook_id=record.playbook_id,
+        )
+
+    def _select(self, task_id: str) -> _Record:
+        identifier = str(task_id).strip()
+        matches = [record for record in self._scan() if record.task.id == identifier]
+        if not matches:
+            raise TaskInboxError(
+                "task_not_found",
+                f"No repository task has identifier {identifier!r}.",
+                recovery="Run `cafe task ls` and retry with an exact task identifier.",
+                task_id=identifier,
+            )
+        if len(matches) != 1:
+            issues = ", ".join(record.issue for record in matches)
+            raise TaskInboxError(
+                "duplicate_task_id",
+                f"Task identifier {identifier!r} occurs in multiple workflows: {issues}.",
+                recovery="Repair the duplicate durable records before retrying.",
+                task_id=identifier,
+            )
+        return matches[0]
+
+    def _scan(self) -> tuple[_Record, ...]:
+        issues_dir = self.cafe_dir / "issues"
+        if not issues_dir.is_dir():
+            return ()
+        records: list[_Record] = []
+        for issue_dir in sorted(
+            (path for path in issues_dir.iterdir() if path.is_dir()), key=lambda path: path.name
+        ):
+            store = HumanTaskRecordStore(issue_dir)
+            if not store.exists:
+                continue
+            try:
+                metadata = self._workflow_metadata(issue_dir)
+                tasks = store.tasks()
+                assignments = {task.id: store.get_assignment(task.id) for task in tasks}
+                waits = {task.id: store.get_wait_state(task.id) for task in tasks}
+                results = {task.id: store.get_result(task.id) for task in tasks}
+            except (HumanTaskRecordError, OSError, ValueError, json.JSONDecodeError) as exc:
+                raise TaskInboxError(
+                    "corrupt_store",
+                    f"Task records for issue {issue_dir.name!r} are unsafe to read: {exc}",
+                    recovery="Repair or restore this issue's durable task and blackboard records.",
+                    issue=issue_dir.name,
+                ) from exc
+            workflow_ids = {task.workflow_id for task in tasks}
+            if workflow_ids and workflow_ids != {metadata["workflow_id"]}:
+                raise TaskInboxError(
+                    "workflow_mismatch",
+                    f"Task records and blackboard disagree for issue {issue_dir.name!r}.",
+                    recovery="Restore matching workflow identity before using the inbox.",
+                    issue=issue_dir.name,
+                    workflow_id=metadata["workflow_id"],
+                )
+            records.extend(
+                _Record(
+                    issue=issue_dir.name,
+                    issue_dir=issue_dir,
+                    workflow_id=metadata["workflow_id"],
+                    playbook_id=metadata["playbook_id"],
+                    task=task,
+                    assignment=assignments[task.id],
+                    wait=waits[task.id],
+                    result=results[task.id],
+                )
+                for task in tasks
+            )
+        return tuple(
+            sorted(records, key=lambda item: (item.issue, item.task.created_at, item.task.id))
+        )
+
+    @staticmethod
+    def _workflow_metadata(issue_dir: Path) -> dict[str, str]:
+        path = issue_dir / "blackboard.json"
+        if not path.is_file():
+            raise ValueError("blackboard.json is missing")
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(raw, Mapping):
+            raise ValueError("blackboard.json must contain an object")
+        workflow_id = raw.get("workflow_id")
+        playbook_id = raw.get("playbook_id")
+        if not isinstance(workflow_id, str) or not workflow_id.strip():
+            raise ValueError("blackboard workflow_id is missing")
+        if not isinstance(playbook_id, str) or not playbook_id.strip():
+            raise ValueError("blackboard playbook_id is missing")
+        return {"workflow_id": workflow_id, "playbook_id": playbook_id}
+
+    @staticmethod
+    def _summary(record: _Record) -> TaskSummary:
+        task = record.task
+        return TaskSummary(
+            id=task.id,
+            issue=record.issue,
+            workflow_id=record.workflow_id,
+            step=task.step,
+            iteration=task.iteration,
+            trigger=task.trigger,
+            policy_id=task.policy_id,
+            status=task.status.value,
+            assignee_type=record.assignment.assignee_type,
+            assignee_id=record.assignment.assignee_id,
+            due_state="unscheduled",
+            created_at=task.created_at,
+            completed_at=task.completed_at,
+            cancelled_at=task.cancelled_at,
+        )
+
+    @staticmethod
+    def _detail(record: _Record) -> TaskDetail:
+        task = record.task
+        return TaskDetail(
+            id=task.id,
+            issue=record.issue,
+            workflow_id=record.workflow_id,
+            step=task.step,
+            iteration=task.iteration,
+            trigger=task.trigger,
+            policy_id=task.policy_id,
+            prompt=task.prompt,
+            expected_result=dict(task.expected_result),
+            continuations=dict(task.continuations),
+            assignment={
+                "type": record.assignment.assignee_type,
+                "id": record.assignment.assignee_id,
+            },
+            status=task.status.value,
+            due_state="unscheduled",
+            wait={
+                "reason": record.wait.pause_reason,
+                "active": record.wait.released_at is None,
+                "created_at": record.wait.created_at,
+                "released_at": record.wait.released_at,
+            },
+            result=record.result.to_dict() if record.result else None,
+            timestamps={
+                "created_at": task.created_at,
+                "completed_at": task.completed_at,
+                "cancelled_at": task.cancelled_at,
+            },
+        )

--- a/src/cafe/core/task_inbox.py
+++ b/src/cafe/core/task_inbox.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 import json
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping, Optional
 
@@ -159,8 +159,14 @@ class _Record:
 class TaskInboxService:
     """Read canonical per-issue stores as one fail-closed repository inbox."""
 
-    def __init__(self, cafe_dir: Path = Path(".cafe")) -> None:
+    def __init__(
+        self, cafe_dir: Path = Path(".cafe"), *, archive_root: Optional[Path] = None
+    ) -> None:
         self.cafe_dir = Path(cafe_dir)
+        project_key = str(self.cafe_dir.parent.resolve()).lstrip("/").replace("/", "-")
+        self.archive_root = archive_root or (
+            Path.home() / ".cafe" / "projects" / project_key / "archived"
+        )
 
     def list_tasks(
         self,
@@ -238,6 +244,17 @@ class TaskInboxService:
         identifier = str(task_id).strip()
         matches = [record for record in self._scan() if record.task.id == identifier]
         if not matches:
+            archived_issues = self._archived_issues_for(identifier)
+            if archived_issues:
+                raise TaskInboxError(
+                    "archived_workflow",
+                    f"Task {identifier!r} belongs to archived issue(s): "
+                    + ", ".join(archived_issues)
+                    + ".",
+                    recovery="Restore the owning issue explicitly before completing this task.",
+                    task_id=identifier,
+                    issue=archived_issues[0] if len(archived_issues) == 1 else None,
+                )
             raise TaskInboxError(
                 "task_not_found",
                 f"No repository task has identifier {identifier!r}.",
@@ -253,6 +270,25 @@ class TaskInboxService:
                 task_id=identifier,
             )
         return matches[0]
+
+    def _archived_issues_for(self, task_id: str) -> list[str]:
+        """Identify an archived owner without treating archives as live inbox data."""
+        if not self.archive_root.is_dir():
+            return []
+        matches: list[str] = []
+        for issue_dir in sorted(
+            (path for path in self.archive_root.iterdir() if path.is_dir()),
+            key=lambda path: path.name,
+        ):
+            store = HumanTaskRecordStore(issue_dir)
+            if not store.exists:
+                continue
+            try:
+                if any(task.id == task_id for task in store.tasks()):
+                    matches.append(issue_dir.name)
+            except (HumanTaskRecordError, OSError):
+                continue
+        return matches
 
     def _scan(self) -> tuple[_Record, ...]:
         issues_dir = self.cafe_dir / "issues"

--- a/src/cafe/ui/cli.py
+++ b/src/cafe/ui/cli.py
@@ -18,6 +18,7 @@ from cafe.ui.commands import issues as issues_commands
 from cafe.ui.commands import templates as template_commands
 from cafe.ui.commands import catalog as catalog_commands
 from cafe.ui.commands import operation as operation_commands
+from cafe.ui.commands import tasks as task_commands
 from cafe.ui.commands import workflow as workflow_commands
 from cafe.ui.commands import audit as audit_commands
 from cafe.ui.commands import verification as verification_commands
@@ -751,6 +752,7 @@ workflow = workflow_commands.workflow
 # Template management commands
 app.add_typer(template_commands.template_app, name="template")
 app.add_typer(operation_commands.operation_app, name="operation")
+app.add_typer(task_commands.task_app, name="task")
 
 # Backward-compatible alias for TEMPLATE_TYPES (now defined in templates module)
 TEMPLATE_TYPES = template_commands.TEMPLATE_TYPES

--- a/src/cafe/ui/commands/tasks.py
+++ b/src/cafe/ui/commands/tasks.py
@@ -255,14 +255,28 @@ def complete_task(
                 issue=preflight.issue,
                 workflow_id=preflight.workflow_id,
             )
-        if json_output:
-            # The workflow runner is historically stdout-oriented. Capture its
-            # presentation output so the task command retains a one-document
-            # stdout contract; durable workflow files remain the progress log.
-            with redirect_stdout(StringIO()):
+        try:
+            if json_output:
+                # The workflow runner is historically stdout-oriented. Capture its
+                # presentation output so the task command retains a one-document
+                # stdout contract; durable workflow files remain the progress log.
+                with redirect_stdout(StringIO()):
+                    _resume_issue_workflow(preflight.issue, preflight.playbook_id)
+            else:
                 _resume_issue_workflow(preflight.issue, preflight.playbook_id)
-        else:
-            _resume_issue_workflow(preflight.issue, preflight.playbook_id)
+        except (OSError, ValueError, RuntimeError, typer.Exit) as exc:
+            raise TaskInboxError(
+                "workflow_resume_failed",
+                f"Task {task_id} was completed, but its owning workflow could not resume: {exc}",
+                recovery=(
+                    f"Run `cafe workflow --issue {preflight.issue} --playbook "
+                    f"{preflight.playbook_id} --execute` to continue the owning workflow; "
+                    "do not complete the task again."
+                ),
+                task_id=task_id,
+                issue=preflight.issue,
+                workflow_id=preflight.workflow_id,
+            ) from exc
         detail = service.inspect(task_id)
     except TaskInboxError as exc:
         _fail("complete", exc, json_output)

--- a/src/cafe/ui/commands/tasks.py
+++ b/src/cafe/ui/commands/tasks.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+from contextlib import redirect_stdout
+from io import StringIO
 from pathlib import Path
 from typing import Optional
 
@@ -10,8 +12,12 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
+from cafe.core.blackboard import BlackboardStore
+from cafe.core.human_tasks import HumanTaskPolicy
 from cafe.core.task_inbox import TaskInboxError, TaskInboxService
-
+from cafe.playbooks.loader import PlaybookLoader, apply_issue_playbook_overrides
+from cafe.ui.commands import workflow as workflow_commands
+from cafe.ui.human_tasks import apply_human_task_payload, collect_human_task_payload
 
 task_app = typer.Typer(help="List, inspect, and complete durable repository tasks")
 console = Console()
@@ -44,12 +50,66 @@ def _fail(operation: str, error: TaskInboxError, json_output: bool) -> None:
     raise typer.Exit(1)
 
 
+def _resume_issue_workflow(issue: str, playbook: str) -> None:
+    """Run the exact owning issue without consulting or changing the active marker."""
+    workflow_commands.workflow(
+        playbook=playbook,
+        issue=issue,
+        start_step=None,
+        single_step=False,
+        dry_run=False,
+        user_input=None,
+        add_dir=[],
+    )
+
+
+def _load_result(
+    result: Optional[str], result_file: Optional[Path]
+) -> Optional[str | dict[str, object]]:
+    if result is not None and result_file is not None:
+        raise TaskInboxError(
+            "invalid_response",
+            "Use either --result or --result-file, not both.",
+            recovery="Choose one non-interactive response source and retry.",
+        )
+    raw = result
+    if result_file is not None:
+        try:
+            raw = result_file.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise TaskInboxError(
+                "invalid_response",
+                f"Cannot read result file: {exc}",
+                recovery="Provide a readable UTF-8 JSON result file.",
+            ) from exc
+    if raw is None:
+        return None
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise TaskInboxError(
+            "invalid_response",
+            f"Result is not valid JSON: {exc.msg}.",
+            recovery="Submit a JSON object matching the task's expected result.",
+        ) from exc
+    if not isinstance(payload, (dict, str)):
+        raise TaskInboxError(
+            "invalid_response",
+            "Result JSON must be an object or string.",
+            recovery="Inspect the task and submit its declared response shape.",
+        )
+    return payload
+
+
 @task_app.command("ls")
 def list_tasks(
     status: Optional[list[str]] = typer.Option(
         None,
         "--status",
-        help="Task status; repeat to include multiple statuses (combined with other filters using AND)",
+        help=(
+            "Task status; repeat to include multiple statuses "
+            "(combined with other filters using AND)"
+        ),
     ),
     assignee: Optional[str] = typer.Option(None, "--assignee", help="Exact assignee id"),
     workflow: Optional[str] = typer.Option(
@@ -128,13 +188,112 @@ def inspect_task(
 
 
 @task_app.command("complete")
-def complete_task_placeholder(
+def complete_task(
     task_id: str = typer.Argument(..., help="Stable task identifier"),
+    result: Optional[str] = typer.Option(
+        None, "--result", help="Non-interactive JSON response"
+    ),
+    result_file: Optional[Path] = typer.Option(
+        None, "--result-file", help="Read a non-interactive JSON response from a file"
+    ),
+    json_output: bool = typer.Option(False, "--json", help="Emit one JSON result object"),
 ) -> None:
     """Complete one pending task and resume its owning workflow."""
-    raise TaskInboxError(
-        "completion_unavailable",
-        f"Completion for task {task_id} is not available in this build.",
-        recovery="Use task inspection while completion support is installed.",
-        task_id=task_id,
+    service = TaskInboxService(Path(".cafe"))
+    try:
+        preflight = service.preflight_completion(task_id)
+        raw_payload = _load_result(result, result_file)
+        if raw_payload is None:
+            try:
+                policy = HumanTaskPolicy.model_validate(preflight.task.expected_result)
+            except (TypeError, ValueError) as exc:
+                raise TaskInboxError(
+                    "corrupt_task",
+                    f"Task {task_id} has an invalid response contract: {exc}",
+                    recovery="Repair the task's declared expected result before retrying.",
+                    task_id=task_id,
+                    issue=preflight.issue,
+                    workflow_id=preflight.workflow_id,
+                ) from exc
+            raw_payload = collect_human_task_payload(policy)
+        if isinstance(raw_payload, dict):
+            raw_payload = dict(raw_payload)
+            raw_payload.setdefault("task", preflight.task.policy_id)
+            raw_payload["human_task_id"] = task_id
+        assert raw_payload is not None
+
+        # Reload immediately before the existing locked validator/mutator so a
+        # stale concurrent completion cannot proceed on old ownership evidence.
+        preflight = service.preflight_completion(task_id)
+        playbook_data = PlaybookLoader(project_root=Path.cwd()).load(preflight.playbook_id)
+        playbook_data = apply_issue_playbook_overrides(
+            playbook_data, preflight.issue_dir / "issue.yaml"
+        )
+        blackboard = BlackboardStore(preflight.issue_dir).load_or_create(
+            preflight.task.step, playbook_id=preflight.playbook_id
+        )
+        applied = apply_human_task_payload(
+            issue_dir=preflight.issue_dir,
+            playbook_data=playbook_data,
+            blackboard=blackboard,
+            from_step=preflight.task.step,
+            trigger=preflight.task.trigger,
+            raw_payload=raw_payload,
+            source="command" if result is not None or result_file is not None else "interactive",
+        )
+        if applied.rejection is not None or applied.target is None:
+            message = (
+                applied.rejection.message
+                if applied.rejection is not None
+                else "The response did not select a continuation."
+            )
+            raise TaskInboxError(
+                "invalid_response",
+                message,
+                recovery="Inspect the expected result and submit one declared response.",
+                task_id=task_id,
+                issue=preflight.issue,
+                workflow_id=preflight.workflow_id,
+            )
+        if json_output:
+            # The workflow runner is historically stdout-oriented. Capture its
+            # presentation output so the task command retains a one-document
+            # stdout contract; durable workflow files remain the progress log.
+            with redirect_stdout(StringIO()):
+                _resume_issue_workflow(preflight.issue, preflight.playbook_id)
+        else:
+            _resume_issue_workflow(preflight.issue, preflight.playbook_id)
+        detail = service.inspect(task_id)
+    except TaskInboxError as exc:
+        _fail("complete", exc, json_output)
+    except (OSError, ValueError, RuntimeError, typer.Exit) as exc:
+        _fail(
+            "complete",
+            TaskInboxError(
+                "workflow_unavailable",
+                f"The owning workflow cannot be resumed: {exc}",
+                recovery="Restore the issue playbook/workflow metadata, then retry the exact task.",
+                task_id=task_id,
+            ),
+            json_output,
+        )
+    if json_output:
+        _emit_json(
+            _envelope(
+                "complete",
+                data={
+                    "task": detail.to_dict(),
+                    "workflow": {
+                        "issue": preflight.issue,
+                        "id": preflight.workflow_id,
+                        "playbook": preflight.playbook_id,
+                        "continuation": applied.target,
+                    },
+                },
+            )
+        )
+        return
+    console.print(
+        f"[green]Completed[/green] task {task_id}; resumed issue {preflight.issue} "
+        f"at {applied.target}."
     )

--- a/src/cafe/ui/commands/tasks.py
+++ b/src/cafe/ui/commands/tasks.py
@@ -1,0 +1,140 @@
+"""Repository task inbox command group."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Optional
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from cafe.core.task_inbox import TaskInboxError, TaskInboxService
+
+
+task_app = typer.Typer(help="List, inspect, and complete durable repository tasks")
+console = Console()
+
+
+def _envelope(
+    operation: str,
+    *,
+    data: Optional[dict] = None,
+    error: Optional[TaskInboxError] = None,
+) -> dict:
+    return {
+        "ok": error is None,
+        "operation": operation,
+        "data": data if error is None else None,
+        "error": error.to_dict() if error is not None else None,
+    }
+
+
+def _emit_json(payload: dict) -> None:
+    typer.echo(json.dumps(payload, ensure_ascii=False, sort_keys=True))
+
+
+def _fail(operation: str, error: TaskInboxError, json_output: bool) -> None:
+    if json_output:
+        _emit_json(_envelope(operation, error=error))
+    else:
+        console.print(f"[red]Error ({error.code}):[/red] {error.message}")
+        console.print(f"[dim]Next action: {error.recovery}[/dim]")
+    raise typer.Exit(1)
+
+
+@task_app.command("ls")
+def list_tasks(
+    status: Optional[list[str]] = typer.Option(
+        None,
+        "--status",
+        help="Task status; repeat to include multiple statuses (combined with other filters using AND)",
+    ),
+    assignee: Optional[str] = typer.Option(None, "--assignee", help="Exact assignee id"),
+    workflow: Optional[str] = typer.Option(
+        None, "--workflow", help="Exact workflow id or owning issue name"
+    ),
+    step: Optional[str] = typer.Option(None, "--step", help="Exact originating step"),
+    due_state: Optional[str] = typer.Option(
+        None, "--due-state", help="Existing due state (currently: unscheduled)"
+    ),
+    historical: bool = typer.Option(
+        False,
+        "--historical",
+        help="Include completed, cancelled, and configuration-error tasks",
+    ),
+    json_output: bool = typer.Option(False, "--json", help="Emit one JSON result object"),
+) -> None:
+    """List repository tasks; pending tasks are shown by default."""
+    try:
+        tasks = TaskInboxService(Path(".cafe")).list_tasks(
+            statuses=set(status) if status else None,
+            assignee=assignee,
+            workflow=workflow,
+            step=step,
+            due_state=due_state,
+            include_historical=historical,
+        )
+    except TaskInboxError as exc:
+        _fail("list", exc, json_output)
+    if json_output:
+        _emit_json(
+            _envelope(
+                "list",
+                data={"tasks": [task.to_dict() for task in tasks], "count": len(tasks)},
+            )
+        )
+        return
+    table = Table(title="Repository tasks")
+    for heading in ("ID", "Issue", "Step", "Status", "Assignee", "Due"):
+        table.add_column(heading)
+    for task in tasks:
+        table.add_row(
+            task.id,
+            task.issue,
+            task.step,
+            task.status,
+            task.assignee_id or task.assignee_type,
+            task.due_state,
+        )
+    console.print(table)
+    console.print(f"[dim]Total: {len(tasks)} task(s)[/dim]")
+
+
+@task_app.command("inspect")
+def inspect_task(
+    task_id: str = typer.Argument(..., help="Stable task identifier"),
+    json_output: bool = typer.Option(False, "--json", help="Emit one JSON result object"),
+) -> None:
+    """Inspect one task's response contract, provenance, and continuation."""
+    try:
+        detail = TaskInboxService(Path(".cafe")).inspect(task_id)
+    except TaskInboxError as exc:
+        _fail("inspect", exc, json_output)
+    if json_output:
+        _emit_json(_envelope("inspect", data={"task": detail.to_dict()}))
+        return
+    console.print(f"[bold]Task[/bold] {detail.id}")
+    console.print(f"Issue: {detail.issue}  Workflow: {detail.workflow_id}")
+    console.print(f"Origin: {detail.step} iteration {detail.iteration} ({detail.trigger})")
+    console.print(f"Status: {detail.status}  Due: {detail.due_state}")
+    console.print(f"Assignment: {detail.assignment['type']} / {detail.assignment['id'] or '-'}")
+    console.print(f"Prompt: {detail.prompt}")
+    console.print("Expected result:")
+    console.print_json(data=detail.expected_result)
+    console.print("Continuations:")
+    console.print_json(data=detail.continuations)
+
+
+@task_app.command("complete")
+def complete_task_placeholder(
+    task_id: str = typer.Argument(..., help="Stable task identifier"),
+) -> None:
+    """Complete one pending task and resume its owning workflow."""
+    raise TaskInboxError(
+        "completion_unavailable",
+        f"Completion for task {task_id} is not available in this build.",
+        recovery="Use task inspection while completion support is installed.",
+        task_id=task_id,
+    )

--- a/tests/integration/test_task_inbox_workflow.py
+++ b/tests/integration/test_task_inbox_workflow.py
@@ -14,7 +14,6 @@ from cafe.playbooks.loader import PlaybookLoader
 from cafe.ui.cli import app
 from cafe.ui.human_tasks import resolve_step_human_task
 
-
 runner = CliRunner()
 
 
@@ -116,7 +115,6 @@ def test_unsafe_completion_stops_without_workflow_progress(
         HumanTaskRecordStore(issue_dir).cancel(
             workflow_id=task.workflow_id, task_id=task.id, reason="test"
         )
-    before = (issue_dir / "blackboard.json").read_bytes()
     resumed: list[str] = []
     monkeypatch.setattr(
         "cafe.ui.commands.tasks._resume_issue_workflow",
@@ -134,7 +132,7 @@ def test_unsafe_completion_stops_without_workflow_progress(
         "task_not_pending",
     }
     assert resumed == []
-    assert (issue_dir / "blackboard.json").read_bytes() == before
+    assert BlackboardStore(issue_dir).load_or_create("spec").current_step == "user"
     assert HumanTaskRecordStore(issue_dir).results() == ()
 
 

--- a/tests/integration/test_task_inbox_workflow.py
+++ b/tests/integration/test_task_inbox_workflow.py
@@ -166,3 +166,42 @@ def test_completion_json_stdout_is_one_result_document(
     assert envelope["operation"] == "complete"
     assert envelope["data"]["task"]["id"] == task.id
     assert envelope["data"]["workflow"]["issue"] == "json"
+
+
+def test_resume_failure_reports_committed_completion_and_direct_recovery(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test List I3/I6: post-commit resume failure is not presented as retryable."""
+    monkeypatch.chdir(tmp_path)
+    issue_dir, task = _pending_issue(tmp_path / ".cafe", "resume-failure")
+
+    def unavailable_resume(_issue: str, _playbook: str) -> None:
+        raise RuntimeError("runner unavailable")
+
+    monkeypatch.setattr(
+        "cafe.ui.commands.tasks._resume_issue_workflow", unavailable_resume
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "task",
+            "complete",
+            task.id,
+            "--result",
+            '{"decision":"confirm"}',
+            "--json",
+        ],
+    )
+
+    assert result.exit_code != 0
+    envelope = json.loads(result.stdout)
+    assert envelope["error"]["code"] == "workflow_resume_failed"
+    assert envelope["error"]["task_id"] == task.id
+    assert envelope["error"]["issue"] == "resume-failure"
+    assert envelope["error"]["workflow_id"] == task.workflow_id
+    assert "cafe workflow" in envelope["error"]["recovery"]
+    records = HumanTaskRecordStore(issue_dir)
+    assert records.get_task(task.id).status is HumanTaskStatus.COMPLETED
+    assert len(records.results()) == 1
+    assert BlackboardStore(issue_dir).load_or_create("spec").current_step == "plan"

--- a/tests/integration/test_task_inbox_workflow.py
+++ b/tests/integration/test_task_inbox_workflow.py
@@ -1,0 +1,170 @@
+"""Repository inbox journeys across durable task and workflow boundaries."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from cafe.core.blackboard import BlackboardStore, HandoffIntent, HandoffOwner
+from cafe.core.human_task_records import HumanTaskRecordStore, HumanTaskStatus
+from cafe.playbooks.loader import PlaybookLoader
+from cafe.ui.cli import app
+from cafe.ui.human_tasks import resolve_step_human_task
+
+
+runner = CliRunner()
+
+
+def _pending_issue(cafe_dir: Path, name: str):
+    issue_dir = cafe_dir / "issues" / name
+    iteration_dir = issue_dir / "spec" / "iteration_001"
+    iteration_dir.mkdir(parents=True)
+    (issue_dir / "issue.yaml").write_text("playbook: default\n", encoding="utf-8")
+    blackboards = BlackboardStore(issue_dir)
+    state = blackboards.load_or_create("spec", playbook_id="default")
+    blackboards.set_current_step(state, "user")
+    blackboards.update_handoff_contract(
+        state,
+        from_step="spec",
+        to_owner=HandoffOwner.USER,
+        to_step="user",
+        intent=HandoffIntent.CONFIRM_OUTPUT,
+        source="test",
+    )
+    policy, binding = resolve_step_human_task(
+        playbook_data=PlaybookLoader().load("default"),
+        step_name="spec",
+        trigger="confirm_output",
+    )
+    task = HumanTaskRecordStore(issue_dir).materialize(
+        workflow_id=state.workflow_id,
+        step="spec",
+        iteration=1,
+        trigger="confirm_output",
+        policy_id=policy.id,
+        prompt=policy.prompt,
+        expected_result=policy.model_dump(mode="json"),
+        continuations=binding.outcomes,
+        assignee_type="user",
+    )
+    return issue_dir, task
+
+
+def test_noninteractive_completion_resumes_only_bound_workflow(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test List I3: stable completion ignores active marker and resumes one owner."""
+    monkeypatch.chdir(tmp_path)
+    cafe_dir = tmp_path / ".cafe"
+    selected_dir, selected = _pending_issue(cafe_dir, "selected")
+    other_dir, other = _pending_issue(cafe_dir, "active")
+    marker = cafe_dir / "active_issue"
+    marker.write_bytes(b"active\n")
+    other_before = (other_dir / "blackboard.json").read_bytes()
+    resumed: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        "cafe.ui.commands.tasks._resume_issue_workflow",
+        lambda issue, playbook: resumed.append((issue, playbook)),
+    )
+
+    result = runner.invoke(
+        app,
+        ["task", "complete", selected.id, "--result", '{"decision":"confirm"}'],
+    )
+
+    assert result.exit_code == 0
+    records = HumanTaskRecordStore(selected_dir)
+    assert records.get_task(selected.id).status is HumanTaskStatus.COMPLETED
+    assert len(records.results()) == 1
+    assert BlackboardStore(selected_dir).load_or_create("spec").current_step == "plan"
+    assert resumed == [("selected", "default")]
+    assert marker.read_bytes() == b"active\n"
+    assert (other_dir / "blackboard.json").read_bytes() == other_before
+    assert HumanTaskRecordStore(other_dir).get_task(other.id).status is HumanTaskStatus.PENDING
+
+
+def test_interactive_completion_uses_same_durable_contract(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test List I4: prompt collection feeds the same validator and transition."""
+    monkeypatch.chdir(tmp_path)
+    issue_dir, task = _pending_issue(tmp_path / ".cafe", "interactive")
+    monkeypatch.setattr(
+        "cafe.ui.commands.tasks.collect_human_task_payload",
+        lambda _policy: {"task": "output-review", "decision": "confirm"},
+    )
+    monkeypatch.setattr("cafe.ui.commands.tasks._resume_issue_workflow", lambda *_args: None)
+
+    result = runner.invoke(app, ["task", "complete", task.id])
+
+    assert result.exit_code == 0
+    assert HumanTaskRecordStore(issue_dir).get_task(task.id).status is HumanTaskStatus.COMPLETED
+    assert BlackboardStore(issue_dir).load_or_create("spec").current_step == "plan"
+
+
+@pytest.mark.parametrize("case", ["invalid", "stale"])
+def test_unsafe_completion_stops_without_workflow_progress(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, case: str
+) -> None:
+    """Test List I5: invalid and terminal attempts do not resume a workflow."""
+    monkeypatch.chdir(tmp_path)
+    issue_dir, task = _pending_issue(tmp_path / ".cafe", case)
+    if case == "stale":
+        HumanTaskRecordStore(issue_dir).cancel(
+            workflow_id=task.workflow_id, task_id=task.id, reason="test"
+        )
+    before = (issue_dir / "blackboard.json").read_bytes()
+    resumed: list[str] = []
+    monkeypatch.setattr(
+        "cafe.ui.commands.tasks._resume_issue_workflow",
+        lambda issue, _playbook: resumed.append(issue),
+    )
+    payload = '{"decision":"unknown"}' if case == "invalid" else '{"decision":"confirm"}'
+
+    result = runner.invoke(
+        app, ["task", "complete", task.id, "--result", payload, "--json"]
+    )
+
+    assert result.exit_code != 0
+    assert json.loads(result.stdout)["error"]["code"] in {
+        "invalid_response",
+        "task_not_pending",
+    }
+    assert resumed == []
+    assert (issue_dir / "blackboard.json").read_bytes() == before
+    assert HumanTaskRecordStore(issue_dir).results() == ()
+
+
+def test_completion_json_stdout_is_one_result_document(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test List I6: continuation progress cannot contaminate machine output."""
+    monkeypatch.chdir(tmp_path)
+    _issue_dir, task = _pending_issue(tmp_path / ".cafe", "json")
+
+    def noisy_resume(_issue: str, _playbook: str) -> None:
+        print("workflow progress")
+
+    monkeypatch.setattr("cafe.ui.commands.tasks._resume_issue_workflow", noisy_resume)
+
+    result = runner.invoke(
+        app,
+        [
+            "task",
+            "complete",
+            task.id,
+            "--result",
+            '{"decision":"confirm"}',
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    envelope = json.loads(result.stdout)
+    assert envelope["ok"] is True
+    assert envelope["operation"] == "complete"
+    assert envelope["data"]["task"]["id"] == task.id
+    assert envelope["data"]["workflow"]["issue"] == "json"

--- a/tests/unit/test_cli_tasks.py
+++ b/tests/unit/test_cli_tasks.py
@@ -11,7 +11,6 @@ from cafe.core.blackboard import BlackboardStore
 from cafe.core.human_task_records import HumanTaskRecordStore
 from cafe.ui.cli import app
 
-
 runner = CliRunner()
 
 

--- a/tests/unit/test_cli_tasks.py
+++ b/tests/unit/test_cli_tasks.py
@@ -1,0 +1,116 @@
+"""CLI contract tests for repository task list and inspection."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from cafe.core.blackboard import BlackboardStore
+from cafe.core.human_task_records import HumanTaskRecordStore
+from cafe.ui.cli import app
+
+
+runner = CliRunner()
+
+
+def _task_repo(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    issue_dir = tmp_path / ".cafe" / "issues" / "issue-a"
+    issue_dir.mkdir(parents=True)
+    state = BlackboardStore(issue_dir).load_or_create("spec", playbook_id="default")
+    (issue_dir / "issue.yaml").write_text("playbook: default\n", encoding="utf-8")
+    task = HumanTaskRecordStore(issue_dir).materialize(
+        workflow_id=state.workflow_id,
+        step="spec",
+        iteration=1,
+        trigger="confirm_output",
+        policy_id="output-review",
+        prompt="Review this output",
+        expected_result={"input_schema": "decision"},
+        continuations={"confirm": "plan"},
+        assignee_type="user",
+        assignee_id="alice",
+    )
+    return issue_dir, task
+
+
+def test_task_group_is_discoverable_with_three_operations() -> None:
+    """Test List U7: the public CLI exposes one stable task command group."""
+    result = runner.invoke(app, ["task", "--help"])
+
+    assert result.exit_code == 0
+    assert all(command in result.stdout for command in ("ls", "inspect", "complete"))
+
+
+def test_list_json_envelope_supports_filters(tmp_path: Path, monkeypatch) -> None:
+    """Test List U7/I1/I6: JSON listing uses public projections and AND filters."""
+    _issue_dir, task = _task_repo(tmp_path, monkeypatch)
+
+    result = runner.invoke(
+        app,
+        [
+            "task",
+            "ls",
+            "--assignee",
+            "alice",
+            "--workflow",
+            task.workflow_id,
+            "--step",
+            "spec",
+            "--due-state",
+            "unscheduled",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    envelope = json.loads(result.stdout)
+    assert envelope["ok"] is True
+    assert envelope["operation"] == "list"
+    assert [item["id"] for item in envelope["data"]["tasks"]] == [task.id]
+    assert envelope["error"] is None
+
+
+def test_inspect_human_and_json_share_task_identity(tmp_path: Path, monkeypatch) -> None:
+    """Test List U7/I2: both presentations are derived from one selected detail."""
+    _issue_dir, task = _task_repo(tmp_path, monkeypatch)
+
+    human = runner.invoke(app, ["task", "inspect", task.id])
+    machine = runner.invoke(app, ["task", "inspect", task.id, "--json"])
+
+    assert human.exit_code == machine.exit_code == 0
+    assert task.id in human.stdout
+    assert json.loads(machine.stdout)["data"]["task"]["id"] == task.id
+
+
+def test_json_failure_is_one_document_and_nonzero(tmp_path: Path, monkeypatch) -> None:
+    """Test List U7/I6: integrations receive one actionable error envelope."""
+    _task_repo(tmp_path, monkeypatch)
+
+    result = runner.invoke(app, ["task", "inspect", "missing", "--json"])
+
+    assert result.exit_code != 0
+    envelope = json.loads(result.stdout)
+    assert envelope["ok"] is False
+    assert envelope["operation"] == "inspect"
+    assert envelope["data"] is None
+    assert envelope["error"]["code"] == "task_not_found"
+    assert envelope["error"]["recovery"]
+
+
+def test_read_only_commands_leave_repository_state_unchanged(tmp_path: Path, monkeypatch) -> None:
+    """Test List I1/I2: listing and inspection never alter workflow ownership state."""
+    issue_dir, task = _task_repo(tmp_path, monkeypatch)
+    marker = tmp_path / ".cafe" / "active_issue"
+    marker.write_bytes(b"another-issue\n")
+    before = {
+        path: path.read_bytes()
+        for path in (marker, issue_dir / "human_tasks.json", issue_dir / "blackboard.json")
+    }
+
+    assert runner.invoke(app, ["task", "ls"]).exit_code == 0
+    assert runner.invoke(app, ["task", "inspect", task.id]).exit_code == 0
+
+    assert {path: path.read_bytes() for path in before} == before

--- a/tests/unit/test_task_inbox.py
+++ b/tests/unit/test_task_inbox.py
@@ -164,3 +164,19 @@ def test_completion_preflight_rejects_stale_or_mismatched_ownership(tmp_path: Pa
         service.preflight_completion(task.id)
     assert mismatch.value.code == "workflow_mismatch"
     assert HumanTaskRecordStore(issue).results() == ()
+
+
+def test_archived_task_requires_explicit_restore(tmp_path: Path) -> None:
+    """Test List U6/I5: archived ownership is distinct from a missing identifier."""
+    cafe_dir = tmp_path / ".cafe"
+    archive_root = tmp_path / "archives"
+    issue = _issue(cafe_dir, "archived", "workflow-a")
+    task = _task(issue, "workflow-a")
+    archive_root.mkdir()
+    issue.rename(archive_root / "archived")
+
+    with pytest.raises(TaskInboxError) as archived:
+        TaskInboxService(cafe_dir, archive_root=archive_root).preflight_completion(task.id)
+
+    assert archived.value.code == "archived_workflow"
+    assert "restore" in archived.value.recovery.lower()

--- a/tests/unit/test_task_inbox.py
+++ b/tests/unit/test_task_inbox.py
@@ -1,0 +1,166 @@
+"""Invariant tests for the repository-wide durable task inbox."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from cafe.core.blackboard import BlackboardStore
+from cafe.core.human_task_records import HumanTaskRecordStore
+from cafe.core.task_inbox import TaskInboxError, TaskInboxService
+
+
+def _issue(cafe_dir: Path, name: str, workflow_id: str) -> Path:
+    issue_dir = cafe_dir / "issues" / name
+    issue_dir.mkdir(parents=True)
+    blackboard = BlackboardStore(issue_dir).load_or_create("spec", playbook_id="default")
+    blackboard.workflow_id = workflow_id
+    BlackboardStore(issue_dir).save(blackboard)
+    (issue_dir / "issue.yaml").write_text("playbook: default\n", encoding="utf-8")
+    return issue_dir
+
+
+def _task(
+    issue_dir: Path,
+    workflow_id: str,
+    *,
+    step: str = "spec",
+    iteration: int = 1,
+    assignee: str | None = None,
+):
+    return HumanTaskRecordStore(issue_dir).materialize(
+        workflow_id=workflow_id,
+        step=step,
+        iteration=iteration,
+        trigger="confirm_output",
+        policy_id="output-review",
+        prompt="Review the output",
+        expected_result={"input_schema": "decision", "decisions": [{"id": "confirm"}]},
+        continuations={"confirm": "plan"},
+        assignee_type="user",
+        assignee_id=assignee,
+    )
+
+
+def test_repository_discovery_is_deterministic_and_hides_terminal_tasks(tmp_path: Path) -> None:
+    """Test List U1: default discovery is complete, stable, and pending-only."""
+    cafe_dir = tmp_path / ".cafe"
+    issue_b = _issue(cafe_dir, "issue-b", "workflow-b")
+    issue_a = _issue(cafe_dir, "issue-a", "workflow-a")
+    pending = _task(issue_b, "workflow-b")
+    completed = _task(issue_a, "workflow-a")
+    HumanTaskRecordStore(issue_a).complete(
+        workflow_id="workflow-a",
+        task_id=completed.id,
+        payload={"decision": "confirm"},
+        source="test",
+    )
+
+    service = TaskInboxService(cafe_dir)
+    first = service.list_tasks()
+    second = service.list_tasks()
+
+    assert [item.id for item in first] == [pending.id]
+    assert first == second
+    assert [item.status for item in service.list_tasks(include_historical=True)] == [
+        "completed",
+        "pending",
+    ]
+
+
+def test_filters_are_conjunctive_and_due_state_is_read_only(tmp_path: Path) -> None:
+    """Test List U2: all filters compose and canonical no-due tasks stay unscheduled."""
+    cafe_dir = tmp_path / ".cafe"
+    issue = _issue(cafe_dir, "issue-a", "workflow-a")
+    selected = _task(issue, "workflow-a", step="review", assignee="alice")
+    _task(issue, "workflow-a", step="spec", iteration=2, assignee="bob")
+
+    matches = TaskInboxService(cafe_dir).list_tasks(
+        statuses={"pending"},
+        assignee="alice",
+        workflow="workflow-a",
+        step="review",
+        due_state="unscheduled",
+    )
+
+    assert [item.id for item in matches] == [selected.id]
+    assert matches[0].due_state == "unscheduled"
+
+
+def test_stable_identifier_lookup_distinguishes_missing_and_duplicate(tmp_path: Path) -> None:
+    """Test List U3: selection never guesses when identity is absent or ambiguous."""
+    cafe_dir = tmp_path / ".cafe"
+    issue_a = _issue(cafe_dir, "issue-a", "workflow-a")
+    issue_b = _issue(cafe_dir, "issue-b", "workflow-b")
+    task = _task(issue_a, "workflow-a")
+
+    with pytest.raises(TaskInboxError) as missing:
+        TaskInboxService(cafe_dir).inspect("missing")
+    assert missing.value.code == "task_not_found"
+
+    raw = json.loads((issue_a / "human_tasks.json").read_text(encoding="utf-8"))
+    raw["workflow_id"] = "workflow-b"
+    for collection in ("tasks", "wait_states", "results", "lifecycle_events"):
+        for record in raw[collection]:
+            record["workflow_id"] = "workflow-b"
+    (issue_b / "human_tasks.json").write_text(json.dumps(raw), encoding="utf-8")
+
+    with pytest.raises(TaskInboxError) as duplicate:
+        TaskInboxService(cafe_dir).inspect(task.id)
+    assert duplicate.value.code == "duplicate_task_id"
+
+
+def test_inspection_projects_full_public_contract(tmp_path: Path) -> None:
+    """Test List U4: detail exposes declared context without mutable store internals."""
+    cafe_dir = tmp_path / ".cafe"
+    issue = _issue(cafe_dir, "issue-a", "workflow-a")
+    task = _task(issue, "workflow-a", assignee="alice")
+
+    detail = TaskInboxService(cafe_dir).inspect(task.id)
+
+    assert detail.issue == "issue-a"
+    assert detail.prompt == "Review the output"
+    assert detail.expected_result["input_schema"] == "decision"
+    assert detail.continuations == {"confirm": "plan"}
+    assert detail.assignment == {"type": "user", "id": "alice"}
+    assert detail.wait["active"] is True
+    assert detail.timestamps["created_at"]
+
+
+@pytest.mark.parametrize("contents", ["{broken", '{"schema_version": 999}'])
+def test_repository_scan_fails_closed_on_corrupt_store(
+    tmp_path: Path, contents: str
+) -> None:
+    """Test List U5: repository corruption cannot produce partial success."""
+    cafe_dir = tmp_path / ".cafe"
+    valid = _issue(cafe_dir, "valid", "workflow-valid")
+    corrupt = _issue(cafe_dir, "corrupt", "workflow-corrupt")
+    _task(valid, "workflow-valid")
+    (corrupt / "human_tasks.json").write_text(contents, encoding="utf-8")
+
+    with pytest.raises(TaskInboxError) as failure:
+        TaskInboxService(cafe_dir).list_tasks()
+
+    assert failure.value.code == "corrupt_store"
+    assert failure.value.issue == "corrupt"
+    assert failure.value.recovery
+
+
+def test_completion_preflight_rejects_stale_or_mismatched_ownership(tmp_path: Path) -> None:
+    """Test List U6: only one live matching wait may enter the mutation path."""
+    cafe_dir = tmp_path / ".cafe"
+    issue = _issue(cafe_dir, "issue-a", "workflow-a")
+    task = _task(issue, "workflow-a")
+    service = TaskInboxService(cafe_dir)
+
+    assert service.preflight_completion(task.id).workflow_id == "workflow-a"
+
+    state = BlackboardStore(issue).load_or_create("spec")
+    state.workflow_id = "workflow-other"
+    BlackboardStore(issue).save(state)
+    with pytest.raises(TaskInboxError) as mismatch:
+        service.preflight_completion(task.id)
+    assert mismatch.value.code == "workflow_mismatch"
+    assert HumanTaskRecordStore(issue).results() == ()


### PR DESCRIPTION
## Summary

Implemented issue #398 with a repository-level task inbox backed by the existing canonical HumanTask stores. The feature enables deterministic discovery, inspection, and safe completion of task items across workflow issues, while preserving one durable source of truth and ensuring fail-closed behavior for unsafe or ambiguous states.

## Changes

- Core service: `src/cafe/core/task_inbox.py`
  - Added repository-wide task discovery across `.cafe/issues/` with deterministic ordering and conjunctive filters.
  - Added stable-task lookup and inspection projection for prompt, expected result, provenance, continuation, assignment, status, and timestamps.
  - Added structured fail-closed outcome taxonomy for missing/duplicate tasks, stale/terminal attempts, archived workflow instances, corrupt stores, missing issue/workflows, and invalid workflow identity.
  - Added completion preflight checks and ownership validation so exactly one result is recorded for one pending task and only the owning workflow resumes.
- CLI surface: `src/cafe/ui/commands/tasks.py` and Typer command registration
  - Added discoverable `cafe task ls`, `cafe task inspect`, and `cafe task complete` commands.
  - Added optionized filters: status, assignee, workflow, step, due state, historical visibility, and JSON mode.
  - Enforced equivalent human/JSON semantics through one service-result contract.
  - Added interactive and non-interactive completion flows with actionable diagnostics and stable exit behavior.
- Tests and integration
  - Added unit tests in `tests/unit/test_task_inbox.py`, `tests/unit/test_cli_tasks.py` and integration coverage in `tests/integration/test_task_inbox_workflow.py` for listing/filtering, inspection projection, duplicate/missing/corrupt handling, exact completion, stale/retry-safe behavior, and JSON mode contract.
  - Added regression ensuring non-active issue tasks resume only their owning workflow and that post-mutation workflow resume failures are surfaced as `workflow_resume_failed`.
- Documentation
  - Updated `README.md` with command examples for list/inspect/complete, JSON usage, filter defaults, and safe-failure recovery guidance.
- Review corrections and validation
  - Commit `517b4b4a` resolves the post-completion resume failure by preserving task/issue/workflow identity in failure diagnostics and guiding explicit owning-workflow recovery.
- Verification
  - Targeted inbox suites passed and repository full verification pass was recorded at `517b4b4a860c1a71246fa2c93b8e675fe13fc389`.

Recent commits:
- `6ac79f29` add task inbox core tests
- `ef2d8faf` add repository task inbox service
- `7b458b9c` add task inbox cli tests
- `d8249fda` add task inbox cli
- `cc926108` add task completion journey tests
- `ae440a00` add validated task completion
- `d5dd43b5` document repository task inbox
- `517b4b4a` handle task workflow resume failures

## Test Plan

- `bash scripts/test-coverage.sh` (repository-defined full suite) — passing at commit `517b4b4a860c1a71246fa2c93b8e675fe13fc389`
- Unit and integration coverage for task inbox CLI and workflows (targeted suites for: listing, inspect, completion, fail-closed cases, interactive/non-interactive behavior, JSON contract)
- Regression check for active-issue marker immutability and exact-owner continuation for completed tasks
