### PR TITLE
Add typed capability manifests and fail-closed host dispatch

### DIFF
--- a/src/cafe/core/capabilities.py
+++ b/src/cafe/core/capabilities.py
@@ -2,16 +2,16 @@
 
 from __future__ import annotations
 
-import json
-import subprocess
 import hashlib
+import json
 import re
+import subprocess
 import sys
 import uuid
 import webbrowser
-from enum import Enum
-from datetime import datetime
 from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
 from pathlib import Path
 from types import MappingProxyType
 from typing import Any, Dict, List, Literal, Mapping, Optional, Sequence, Tuple
@@ -57,6 +57,16 @@ class ValueSchema(StrictCapabilityModel):
     @classmethod
     def freeze_enum(cls, value: Any) -> Any:
         return tuple(value) if isinstance(value, list) else value
+
+    @model_validator(mode="after")
+    def enum_values_match_declared_type(self) -> "ValueSchema":
+        if self.enum is None:
+            return self
+        python_types = {"string": str, "integer": int, "boolean": bool}
+        expected = python_types[self.type]
+        if any(type(value) is not expected for value in self.enum):
+            raise ValueError("enum values must match the declared type")
+        return self
 
 
 class ObjectSchema(StrictCapabilityModel):
@@ -335,7 +345,7 @@ def load_capability_registry(
             try:
                 manifest = CapabilityManifest.model_validate(data)
             except ValidationError as exc:
-                raise CapabilityRegistryError(f"Invalid capability manifest {path}") from exc
+                raise CapabilityRegistryError(f"Invalid capability manifest {path}: {exc}") from exc
             cap_id = manifest.id
             if cap_id in merged:
                 raise CapabilityRegistryError(
@@ -802,10 +812,17 @@ def validation_rejection_receipt(
     capability: str,
     code: str,
     raw_request: Optional[Mapping[str, Any]] = None,
+    rejected_value: Any = None,
+    rejection_source: Optional[Mapping[str, Any]] = None,
+    error_detail: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Build a correlated fail-closed receipt when typed evaluation cannot start."""
     request_boundary: Dict[str, Any] = dict(raw_request) if raw_request is not None else {}
-    fingerprint_payload = {"capability": capability, "request": request_boundary}
+    fingerprint_payload = {
+        "capability": capability,
+        "request": request_boundary,
+        "rejected_value": rejected_value,
+    }
     canonical = json.dumps(
         fingerprint_payload,
         sort_keys=True,
@@ -837,6 +854,11 @@ def validation_rejection_receipt(
                 "explanation": "The request could not be authorized.",
             },
             "outcome": "validation_rejection",
+            "rejection": {
+                "source": dict(rejection_source) if rejection_source is not None else {},
+                "rejected_value": rejected_value,
+                "error_detail": error_detail or code,
+            },
         }
     )
     return receipt

--- a/src/cafe/core/capabilities.py
+++ b/src/cafe/core/capabilities.py
@@ -144,6 +144,35 @@ def _is_effect_subset(requested: CapabilityEffects, allowed: CapabilityEffects) 
     )
 
 
+def _resolve_boundary_tokens(
+    manifest: CapabilityManifest, request: ExecutionRequest
+) -> tuple[CapabilityEffects, Mapping[str, Tuple[str, ...]]]:
+    replacements: Dict[str, str] = {}
+    if manifest.id == CAPABILITY_PR_PUBLISH_ID:
+        output = str(request.args.get("output") or "")
+        output_path = Path(output)
+        if output_path.is_absolute() or ".." in output_path.parts:
+            return CapabilityEffects(writes=(), network_destinations=(), browser_open=()), {}
+        replacements["request_output"] = output
+        parts = output_path.parts
+        try:
+            issue_index = parts.index("issues")
+            replacements["issue_dir"] = str(Path(*parts[: issue_index + 2]))
+        except (ValueError, IndexError):
+            replacements["issue_dir"] = ""
+
+    def expand(values: Sequence[str]) -> Tuple[str, ...]:
+        return tuple(replacements.get(value, value) for value in values if replacements.get(value, value))
+
+    effects = CapabilityEffects(
+        writes=expand(manifest.effects.writes),
+        network_destinations=manifest.effects.network_destinations,
+        browser_open=manifest.effects.browser_open,
+    )
+    permissions = {key: expand(values) for key, values in manifest.permissions.items()}
+    return effects, permissions
+
+
 def evaluate_capability_request(
     registry: Mapping[str, CapabilityManifest], raw_request: Mapping[str, Any]
 ) -> CapabilityEvaluation:
@@ -153,15 +182,16 @@ def evaluate_capability_request(
     if not isinstance(manifest, CapabilityManifest):
         raise CapabilityRegistryError(f"Unknown capability {request.capability!r}")
     fingerprint = canonical_request_fingerprint(request)
+    allowed_effects, allowed_permissions = _resolve_boundary_tokens(manifest, request)
 
     reason = _validate_request_arguments(request, manifest)
-    if reason is None and not _is_effect_subset(request.effects, manifest.effects):
+    if reason is None and not _is_effect_subset(request.effects, allowed_effects):
         reason = "effect_not_allowed"
     if reason is None and not set(request.credentials).issubset(manifest.credentials):
         reason = "credential_not_allowed"
     if reason is None:
         for permission, values in request.permissions.items():
-            allowed = manifest.permissions.get(permission)
+            allowed = allowed_permissions.get(permission)
             if allowed is None or not set(values).issubset(allowed):
                 reason = "permission_not_allowed"
                 break
@@ -189,7 +219,7 @@ def evaluate_capability_request(
         decision=decision,
         reason_code=reason,
         explanation=explanation,
-        allowed_effects=manifest.effects,
+        allowed_effects=allowed_effects,
     )
 
 
@@ -617,6 +647,187 @@ def run_pr_publish_capability(
     return PrPublishRun(receipt=receipt, pr_synced_event=pr_synced, error_message=None)
 
 
+class CapabilityExecutionError(RuntimeError):
+    def __init__(
+        self, category: str, code: str, outputs: Optional[Dict[str, Any]] = None
+    ) -> None:
+        super().__init__(code)
+        self.category = category
+        self.code = code
+        self.outputs = outputs or {}
+
+
+def _normalize_legacy_pr_request(request: Mapping[str, Any]) -> Dict[str, Any]:
+    normalized = dict(request)
+    if str(normalized.get("capability") or "") != CAPABILITY_PR_PUBLISH_ID:
+        return normalized
+    legacy_permissions = normalized.get("permissions")
+    if not isinstance(legacy_permissions, Mapping):
+        legacy_permissions = {}
+    args = normalized.get("args") if isinstance(normalized.get("args"), Mapping) else {}
+    writes = list(legacy_permissions.get("writes") or [str(args.get("output") or "")])
+    network = list(legacy_permissions.get("network") or ["github.com", "api.github.com"])
+    normalized.setdefault(
+        "effects",
+        {"writes": [value for value in writes if value], "network_destinations": network},
+    )
+    if isinstance(normalized.get("effects"), Mapping):
+        normalized["effects"] = {"browser_open": [], **dict(normalized["effects"])}
+    normalized.setdefault("credentials", ["gh"])
+    normalized["permissions"] = {"network": network, "writes": writes}
+    return normalized
+
+
+def _manifest_digest(manifest: CapabilityManifest) -> str:
+    payload = json.dumps(
+        manifest.model_dump(mode="json"), sort_keys=True, separators=(",", ":")
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _audited_receipt(
+    *,
+    correlation_id: str,
+    evaluation: CapabilityEvaluation,
+    success: bool,
+    category: Optional[str],
+    code: Optional[str],
+    outputs: Dict[str, Any],
+    outcome: str,
+) -> Dict[str, Any]:
+    receipt = _base_receipt(
+        correlation_id=correlation_id,
+        capability=evaluation.request.capability,
+        success=success,
+        category=category,
+        code=code,
+        inputs=dict(evaluation.request.args),
+        outputs=outputs,
+    )
+    receipt.update(
+        {
+            "request_fingerprint": evaluation.fingerprint,
+            "manifest": {
+                "id": evaluation.manifest.id,
+                "version": evaluation.manifest.version,
+                "digest": _manifest_digest(evaluation.manifest),
+            },
+            "requested_effects": evaluation.request.effects.model_dump(mode="json"),
+            "allowed_effects": evaluation.allowed_effects.model_dump(mode="json"),
+            "decision": {
+                "outcome": evaluation.decision.value,
+                "reason_code": evaluation.reason_code,
+                "explanation": evaluation.explanation,
+            },
+            "outcome": outcome,
+        }
+    )
+    return receipt
+
+
+def _non_dispatch_run(
+    *,
+    correlation_id: str,
+    capability: str,
+    fingerprint: str,
+    code: str,
+    decision: PolicyDecision,
+    outcome: str,
+    inputs: Dict[str, Any],
+    evaluation: Optional[CapabilityEvaluation] = None,
+) -> PrPublishRun:
+    if evaluation is not None:
+        receipt = _audited_receipt(
+            correlation_id=correlation_id,
+            evaluation=evaluation,
+            success=False,
+            category=VALIDATION_ERROR,
+            code=code,
+            outputs={},
+            outcome=outcome,
+        )
+    else:
+        receipt = _base_receipt(
+            correlation_id=correlation_id,
+            capability=capability,
+            success=False,
+            category=VALIDATION_ERROR,
+            code=code,
+            inputs=inputs,
+            outputs={},
+        )
+        receipt.update(
+            {
+                "request_fingerprint": fingerprint,
+                "manifest": None,
+                "requested_effects": {},
+                "allowed_effects": {},
+                "decision": {
+                    "outcome": decision.value,
+                    "reason_code": code,
+                    "explanation": "The request could not be authorized.",
+                },
+                "outcome": outcome,
+            }
+        )
+    return PrPublishRun(receipt=receipt, pr_synced_event=None, error_message=code)
+
+
+def _validate_typed_outputs(outputs: Mapping[str, Any], schema: ObjectSchema) -> Optional[str]:
+    if not set(schema.required).issubset(outputs):
+        return "missing_output"
+    if not set(outputs).issubset(schema.properties):
+        return "undeclared_output"
+    python_types = {"string": str, "integer": int, "boolean": bool}
+    for key, value in outputs.items():
+        field = schema.properties[key]
+        if type(value) is not python_types[field.type]:
+            return "output_type_invalid"
+        if field.enum is not None and value not in field.enum:
+            return "output_value_invalid"
+    return None
+
+
+def _sync_pr_adapter(
+    *,
+    repo_root: Path,
+    request: ExecutionRequest,
+    manifest: CapabilityManifest,
+    output_file: Path,
+    timeout_sec: float,
+) -> tuple[Dict[str, Any], Optional[Dict[str, Any]]]:
+    legacy_definition = {
+        "id": manifest.id,
+        "script_ref": manifest.implementation,
+        "args_schema": manifest.arguments.model_dump(mode="json"),
+        "expected_outputs": manifest.outputs.model_dump(mode="json"),
+    }
+    run = run_pr_publish_capability(
+        repo_root=repo_root,
+        registry={manifest.id: legacy_definition},
+        publish_request={"capability": manifest.id, "args": dict(request.args)},
+        pr_markdown_file=output_file,
+        timeout_sec=timeout_sec,
+    )
+    if not run.receipt.get("success"):
+        raise CapabilityExecutionError(
+            str(run.receipt.get("category") or VALIDATION_ERROR),
+            str(run.receipt.get("code") or "execution_failed"),
+            dict(run.receipt.get("outputs") or {}),
+        )
+    return dict(run.receipt.get("outputs") or {}), run.pr_synced_event
+
+
+def _unimplemented_browser_adapter(**_kwargs: Any) -> tuple[Dict[str, Any], None]:
+    raise CapabilityExecutionError(VALIDATION_ERROR, "unsupported_implementation")
+
+
+HOST_CAPABILITY_ADAPTERS: Mapping[str, Any] = {
+    "sync_pr": _sync_pr_adapter,
+    "open_current_pr": _unimplemented_browser_adapter,
+}
+
+
 def run_capability_request(
     *,
     repo_root: Path,
@@ -625,34 +836,124 @@ def run_capability_request(
     output_file: Path,
     timeout_sec: float = 600.0,
 ) -> PrPublishRun:
-    """Execute one trusted capability request or return a validation receipt.
+    """Evaluate and dispatch one request through the host-owned adapter allow-list."""
+    correlation_id = uuid.uuid4().hex[:20]
+    raw_request = _normalize_legacy_pr_request(capability_request)
+    cap_id = str(raw_request.get("capability") or "").strip()
+    raw_fingerprint = hashlib.sha256(
+        json.dumps(raw_request, sort_keys=True, default=str).encode("utf-8")
+    ).hexdigest()
 
-    The generic entry point intentionally only dispatches allow-listed
-    implementations. Unknown or not-yet-implemented capability ids become
-    validation receipts and never execute host-side scripts.
-    """
-    cap_id = str(capability_request.get("capability") or "").strip()
-    if cap_id == CAPABILITY_PR_PUBLISH_ID:
-        return run_pr_publish_capability(
-            repo_root=repo_root,
-            registry=registry,
-            publish_request=capability_request,
-            pr_markdown_file=output_file,
-            timeout_sec=timeout_sec,
+    raw_manifest = registry.get(cap_id)
+    if raw_manifest is None:
+        return _non_dispatch_run(
+            correlation_id=correlation_id,
+            capability=cap_id or "unknown",
+            fingerprint=raw_fingerprint,
+            code="unknown_capability",
+            decision=PolicyDecision.DENY,
+            outcome="validation_rejection",
+            inputs=_receipt_inputs(raw_request.get("args")),
+        )
+    if not isinstance(raw_manifest, CapabilityManifest):
+        return _non_dispatch_run(
+            correlation_id=correlation_id,
+            capability=cap_id or "unknown",
+            fingerprint=raw_fingerprint,
+            code="unsupported_capability",
+            decision=PolicyDecision.DENY,
+            outcome="validation_rejection",
+            inputs=_receipt_inputs(raw_request.get("args")),
         )
 
-    definition = registry.get(cap_id)
-    code = "unknown_capability" if definition is None else "unsupported_capability"
-    receipt = _base_receipt(
-        correlation_id=uuid.uuid4().hex[:20],
-        capability=cap_id or "unknown",
-        success=False,
-        category=VALIDATION_ERROR,
-        code=code,
-        inputs=_receipt_inputs(capability_request.get("args")),
-        outputs={},
+    try:
+        request = ExecutionRequest.model_validate(raw_request)
+    except ValidationError:
+        return _non_dispatch_run(
+            correlation_id=correlation_id,
+            capability=cap_id or "unknown",
+            fingerprint=raw_fingerprint,
+            code="malformed_request",
+            decision=PolicyDecision.DENY,
+            outcome="validation_rejection",
+            inputs=_receipt_inputs(raw_request.get("args")),
+        )
+
+    manifest = raw_manifest
+
+    evaluation = evaluate_capability_request(registry, raw_request)
+    if evaluation.decision != PolicyDecision.ALLOW:
+        outcome = (
+            "approval_required"
+            if evaluation.decision == PolicyDecision.REQUIRE_APPROVAL
+            else "policy_denied"
+        )
+        return _non_dispatch_run(
+            correlation_id=correlation_id,
+            capability=request.capability,
+            fingerprint=evaluation.fingerprint,
+            code=evaluation.reason_code,
+            decision=evaluation.decision,
+            outcome=outcome,
+            inputs=dict(request.args),
+            evaluation=evaluation,
+        )
+
+    adapter = HOST_CAPABILITY_ADAPTERS.get(manifest.implementation)
+    if adapter is None:
+        return _non_dispatch_run(
+            correlation_id=correlation_id,
+            capability=request.capability,
+            fingerprint=evaluation.fingerprint,
+            code="unsupported_implementation",
+            decision=PolicyDecision.DENY,
+            outcome="validation_rejection",
+            inputs=dict(request.args),
+            evaluation=evaluation,
+        )
+
+    try:
+        outputs, event = adapter(
+            repo_root=repo_root,
+            request=request,
+            manifest=manifest,
+            output_file=output_file,
+            timeout_sec=timeout_sec,
+        )
+    except CapabilityExecutionError as exc:
+        receipt = _audited_receipt(
+            correlation_id=correlation_id,
+            evaluation=evaluation,
+            success=False,
+            category=exc.category,
+            code=exc.code,
+            outputs=exc.outputs,
+            outcome="execution_failure",
+        )
+        return PrPublishRun(receipt=receipt, pr_synced_event=None, error_message=exc.code)
+    output_error = _validate_typed_outputs(outputs, manifest.outputs)
+    if output_error:
+        receipt = _audited_receipt(
+            correlation_id=correlation_id,
+            evaluation=evaluation,
+            success=False,
+            category=OUTPUT_CONTRACT_ERROR,
+            code=output_error,
+            outputs=outputs,
+            outcome="execution_failure",
+        )
+        return PrPublishRun(receipt=receipt, pr_synced_event=None, error_message=output_error)
+
+    receipt = _audited_receipt(
+        correlation_id=correlation_id,
+        evaluation=evaluation,
+        success=True,
+        category=None,
+        code=None,
+        outputs=outputs,
+        outcome="success",
     )
-    return PrPublishRun(receipt=receipt, pr_synced_event=None, error_message=code)
+    return PrPublishRun(receipt=receipt, pr_synced_event=event, error_message=None)
 
 
 def capability_receipt_hook_event(receipt: Mapping[str, Any]) -> Dict[str, Any]:

--- a/src/cafe/core/capabilities.py
+++ b/src/cafe/core/capabilities.py
@@ -822,6 +822,7 @@ def validation_rejection_receipt(
         "capability": capability,
         "request": request_boundary,
         "rejected_value": rejected_value,
+        "rejection_source": dict(rejection_source) if rejection_source is not None else None,
     }
     canonical = json.dumps(
         fingerprint_payload,

--- a/src/cafe/core/capabilities.py
+++ b/src/cafe/core/capabilities.py
@@ -5,16 +5,20 @@ from __future__ import annotations
 import json
 import subprocess
 import uuid
+from enum import Enum
 from datetime import datetime
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
+from types import MappingProxyType
+from typing import Any, Dict, List, Literal, Mapping, Optional, Sequence, Tuple
 
 import yaml
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
 from cafe.skills.loader import SkillLoader
 
 CAPABILITY_PR_PUBLISH_ID = "cafe.pr.publish"
+CAPABILITY_BROWSER_OPEN_ID = "cafe.browser.open"
 
 # Failure categories surfaced on capability receipts (distinct from validation_error).
 SCRIPT_EXIT_ERROR = "script_exit_error"
@@ -27,6 +31,53 @@ class CapabilityRegistryError(ValueError):
     """Raised when capability definitions cannot be loaded."""
 
 
+class StrictCapabilityModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class ValueSchema(StrictCapabilityModel):
+    type: Literal["string", "integer", "boolean"]
+    enum: Optional[Tuple[Any, ...]] = None
+
+
+class ObjectSchema(StrictCapabilityModel):
+    required: Tuple[str, ...]
+    properties: Mapping[str, ValueSchema]
+
+    @model_validator(mode="after")
+    def required_fields_are_declared(self) -> "ObjectSchema":
+        if not set(self.required).issubset(self.properties):
+            raise ValueError("required fields must be declared in properties")
+        return self
+
+
+class CapabilityEffects(StrictCapabilityModel):
+    writes: Tuple[str, ...]
+    network_destinations: Tuple[str, ...]
+    browser_open: Tuple[str, ...] = ()
+
+
+class CapabilityManifest(StrictCapabilityModel):
+    id: str = Field(min_length=1)
+    version: int = Field(ge=1)
+    implementation: Literal["sync_pr", "open_current_pr"]
+    arguments: ObjectSchema
+    outputs: ObjectSchema
+    effects: CapabilityEffects
+    credentials: Tuple[str, ...]
+    permissions: Mapping[str, Tuple[str, ...]]
+    idempotency: Literal["safe", "update_in_place", "unsafe"]
+    risk: Literal["low", "medium", "high"]
+    approval: Literal["not_required", "required"]
+    policy: Literal["allow", "deny"]
+
+    @model_validator(mode="after")
+    def reject_contradictory_policy(self) -> "CapabilityManifest":
+        if self.approval == "required" and self.policy == "deny":
+            raise ValueError("approval-required capability cannot also be policy denied")
+        return self
+
+
 def _package_capabilities_dir() -> Path:
     return Path(__file__).resolve().parents[1] / "data" / "capabilities"
 
@@ -36,12 +87,14 @@ def default_capability_definition_dirs(repo_root: Path) -> List[Path]:
     return [repo_root / "data" / "capabilities", _package_capabilities_dir()]
 
 
-def load_capability_registry(capabilities_dirs: Sequence[Path]) -> Dict[str, Dict[str, Any]]:
+def load_capability_registry(
+    capabilities_dirs: Sequence[Path],
+) -> Mapping[str, CapabilityManifest]:
     """Load all *.yaml / *.yml / *.json capability definitions.
 
     Duplicate ``id`` values across files are rejected with both paths listed.
     """
-    merged: Dict[str, Tuple[Dict[str, Any], Path]] = {}
+    merged: Dict[str, Tuple[CapabilityManifest, Path]] = {}
     for base in capabilities_dirs:
         if not base.is_dir():
             continue
@@ -62,15 +115,17 @@ def load_capability_registry(capabilities_dirs: Sequence[Path]) -> Dict[str, Dic
                 raise CapabilityRegistryError(f"Invalid capability document {path}") from exc
             if not isinstance(data, dict):
                 raise CapabilityRegistryError(f"Capability root must be a mapping: {path}")
-            cap_id = str(data.get("id") or "").strip()
-            if not cap_id:
-                raise CapabilityRegistryError(f"Capability missing id: {path}")
+            try:
+                manifest = CapabilityManifest.model_validate(data)
+            except ValidationError as exc:
+                raise CapabilityRegistryError(f"Invalid capability manifest {path}") from exc
+            cap_id = manifest.id
             if cap_id in merged:
                 raise CapabilityRegistryError(
                     f"Duplicate capability id {cap_id!r}: {merged[cap_id][1]} and {path}"
                 )
-            merged[cap_id] = (data, path)
-    return {key: value[0] for key, value in merged.items()}
+            merged[cap_id] = (manifest, path)
+    return MappingProxyType({key: value[0] for key, value in merged.items()})
 
 
 def _schema_required(schema: Mapping[str, Any], *, label: str) -> List[str]:

--- a/src/cafe/core/capabilities.py
+++ b/src/cafe/core/capabilities.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+import hashlib
 import uuid
 from enum import Enum
 from datetime import datetime
@@ -76,6 +77,120 @@ class CapabilityManifest(StrictCapabilityModel):
         if self.approval == "required" and self.policy == "deny":
             raise ValueError("approval-required capability cannot also be policy denied")
         return self
+
+
+class ExecutionRequest(StrictCapabilityModel):
+    capability: str = Field(min_length=1)
+    args: Mapping[str, Any]
+    effects: CapabilityEffects
+    credentials: Tuple[str, ...]
+    permissions: Mapping[str, Tuple[str, ...]]
+
+
+class PolicyDecision(str, Enum):
+    ALLOW = "allow"
+    REQUIRE_APPROVAL = "require_approval"
+    DENY = "deny"
+
+
+@dataclass(frozen=True)
+class CapabilityEvaluation:
+    request: ExecutionRequest
+    manifest: CapabilityManifest
+    fingerprint: str
+    decision: PolicyDecision
+    reason_code: str
+    explanation: str
+    allowed_effects: CapabilityEffects
+
+
+def canonical_request_fingerprint(request: ExecutionRequest) -> str:
+    """Hash the canonical security-relevant request boundary."""
+    payload = request.model_dump(mode="json")
+    effects = payload["effects"]
+    for key in ("writes", "network_destinations", "browser_open"):
+        effects[key] = sorted(effects[key])
+    payload["credentials"] = sorted(payload["credentials"])
+    payload["permissions"] = {
+        key: sorted(values) for key, values in sorted(payload["permissions"].items())
+    }
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _validate_request_arguments(
+    request: ExecutionRequest, manifest: CapabilityManifest
+) -> Optional[str]:
+    declared = manifest.arguments.properties
+    if not set(manifest.arguments.required).issubset(request.args):
+        return "missing_argument"
+    if not set(request.args).issubset(declared):
+        return "argument_not_allowed"
+    python_types = {"string": str, "integer": int, "boolean": bool}
+    for key, value in request.args.items():
+        field = declared[key]
+        expected = python_types[field.type]
+        if type(value) is not expected:
+            return "argument_type_invalid"
+        if field.enum is not None and value not in field.enum:
+            return "argument_not_allowed"
+    return None
+
+
+def _is_effect_subset(requested: CapabilityEffects, allowed: CapabilityEffects) -> bool:
+    return all(
+        set(getattr(requested, field)).issubset(getattr(allowed, field))
+        for field in ("writes", "network_destinations", "browser_open")
+    )
+
+
+def evaluate_capability_request(
+    registry: Mapping[str, CapabilityManifest], raw_request: Mapping[str, Any]
+) -> CapabilityEvaluation:
+    """Return one explicit, fail-closed policy decision for a parsed request."""
+    request = ExecutionRequest.model_validate(raw_request)
+    manifest = registry.get(request.capability)
+    if not isinstance(manifest, CapabilityManifest):
+        raise CapabilityRegistryError(f"Unknown capability {request.capability!r}")
+    fingerprint = canonical_request_fingerprint(request)
+
+    reason = _validate_request_arguments(request, manifest)
+    if reason is None and not _is_effect_subset(request.effects, manifest.effects):
+        reason = "effect_not_allowed"
+    if reason is None and not set(request.credentials).issubset(manifest.credentials):
+        reason = "credential_not_allowed"
+    if reason is None:
+        for permission, values in request.permissions.items():
+            allowed = manifest.permissions.get(permission)
+            if allowed is None or not set(values).issubset(allowed):
+                reason = "permission_not_allowed"
+                break
+
+    if reason is not None:
+        decision = PolicyDecision.DENY
+        explanation = "The request exceeds its registered capability boundary."
+    elif manifest.policy == "deny":
+        decision = PolicyDecision.DENY
+        reason = "policy_denied"
+        explanation = "The registered policy denies this capability."
+    elif manifest.approval == "required":
+        decision = PolicyDecision.REQUIRE_APPROVAL
+        reason = "approval_required"
+        explanation = "The registered policy requires approval before execution."
+    else:
+        decision = PolicyDecision.ALLOW
+        reason = "policy_allowed"
+        explanation = "The request is within the registered capability boundary."
+
+    return CapabilityEvaluation(
+        request=request,
+        manifest=manifest,
+        fingerprint=fingerprint,
+        decision=decision,
+        reason_code=reason,
+        explanation=explanation,
+        allowed_effects=manifest.effects,
+    )
 
 
 def _package_capabilities_dir() -> Path:

--- a/src/cafe/core/capabilities.py
+++ b/src/cafe/core/capabilities.py
@@ -18,7 +18,15 @@ from typing import Any, Dict, List, Literal, Mapping, Optional, Sequence, Tuple
 from urllib.parse import urlparse
 
 import yaml
-from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    ValidationError,
+    field_serializer,
+    field_validator,
+    model_validator,
+)
 
 from cafe.skills.loader import SkillLoader
 from cafe.utils.github import GitHubOps
@@ -38,29 +46,49 @@ class CapabilityRegistryError(ValueError):
 
 
 class StrictCapabilityModel(BaseModel):
-    model_config = ConfigDict(extra="forbid", frozen=True)
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
 
 
 class ValueSchema(StrictCapabilityModel):
     type: Literal["string", "integer", "boolean"]
     enum: Optional[Tuple[Any, ...]] = None
 
+    @field_validator("enum", mode="before")
+    @classmethod
+    def freeze_enum(cls, value: Any) -> Any:
+        return tuple(value) if isinstance(value, list) else value
+
 
 class ObjectSchema(StrictCapabilityModel):
     required: Tuple[str, ...]
     properties: Mapping[str, ValueSchema]
 
+    @field_validator("required", mode="before")
+    @classmethod
+    def freeze_required(cls, value: Any) -> Any:
+        return tuple(value) if isinstance(value, list) else value
+
     @model_validator(mode="after")
     def required_fields_are_declared(self) -> "ObjectSchema":
         if not set(self.required).issubset(self.properties):
             raise ValueError("required fields must be declared in properties")
+        object.__setattr__(self, "properties", MappingProxyType(dict(self.properties)))
         return self
+
+    @field_serializer("properties")
+    def serialize_properties(self, value: Mapping[str, ValueSchema]) -> Dict[str, ValueSchema]:
+        return dict(value)
 
 
 class CapabilityEffects(StrictCapabilityModel):
     writes: Tuple[str, ...]
     network_destinations: Tuple[str, ...]
     browser_open: Tuple[str, ...] = ()
+
+    @field_validator("writes", "network_destinations", "browser_open", mode="before")
+    @classmethod
+    def freeze_effects(cls, value: Any) -> Any:
+        return tuple(value) if isinstance(value, list) else value
 
 
 class CapabilityManifest(StrictCapabilityModel):
@@ -77,11 +105,32 @@ class CapabilityManifest(StrictCapabilityModel):
     approval: Literal["not_required", "required"]
     policy: Literal["allow", "deny"]
 
+    @field_validator("credentials", mode="before")
+    @classmethod
+    def freeze_credentials(cls, value: Any) -> Any:
+        return tuple(value) if isinstance(value, list) else value
+
+    @field_validator("permissions", mode="before")
+    @classmethod
+    def freeze_permissions(cls, value: Any) -> Any:
+        if not isinstance(value, Mapping):
+            return value
+        return {
+            key: tuple(items) if isinstance(items, list) else items for key, items in value.items()
+        }
+
     @model_validator(mode="after")
     def reject_contradictory_policy(self) -> "CapabilityManifest":
         if self.approval == "required" and self.policy == "deny":
             raise ValueError("approval-required capability cannot also be policy denied")
+        object.__setattr__(self, "permissions", MappingProxyType(dict(self.permissions)))
         return self
+
+    @field_serializer("permissions")
+    def serialize_permissions(
+        self, value: Mapping[str, Tuple[str, ...]]
+    ) -> Dict[str, Tuple[str, ...]]:
+        return dict(value)
 
 
 class ExecutionRequest(StrictCapabilityModel):
@@ -90,6 +139,20 @@ class ExecutionRequest(StrictCapabilityModel):
     effects: CapabilityEffects
     credentials: Tuple[str, ...]
     permissions: Mapping[str, Tuple[str, ...]]
+
+    @field_validator("credentials", mode="before")
+    @classmethod
+    def freeze_credentials(cls, value: Any) -> Any:
+        return tuple(value) if isinstance(value, list) else value
+
+    @field_validator("permissions", mode="before")
+    @classmethod
+    def freeze_permissions(cls, value: Any) -> Any:
+        if not isinstance(value, Mapping):
+            return value
+        return {
+            key: tuple(items) if isinstance(items, list) else items for key, items in value.items()
+        }
 
 
 class PolicyDecision(str, Enum):
@@ -142,9 +205,9 @@ def _validate_request_arguments(
     return None
 
 
-def _is_effect_subset(requested: CapabilityEffects, allowed: CapabilityEffects) -> bool:
+def _matches_effect_boundary(requested: CapabilityEffects, allowed: CapabilityEffects) -> bool:
     return all(
-        set(getattr(requested, field)).issubset(getattr(allowed, field))
+        set(getattr(requested, field)) == set(getattr(allowed, field))
         for field in ("writes", "network_destinations", "browser_open")
     )
 
@@ -192,16 +255,18 @@ def evaluate_capability_request(
     allowed_effects, allowed_permissions = _resolve_boundary_tokens(manifest, request)
 
     reason = _validate_request_arguments(request, manifest)
-    if reason is None and not _is_effect_subset(request.effects, allowed_effects):
+    if reason is None and not _matches_effect_boundary(request.effects, allowed_effects):
         reason = "effect_not_allowed"
-    if reason is None and not set(request.credentials).issubset(manifest.credentials):
+    if reason is None and set(request.credentials) != set(manifest.credentials):
         reason = "credential_not_allowed"
     if reason is None:
-        for permission, values in request.permissions.items():
-            allowed = allowed_permissions.get(permission)
-            if allowed is None or not set(values).issubset(allowed):
-                reason = "permission_not_allowed"
-                break
+        if set(request.permissions) != set(allowed_permissions):
+            reason = "permission_not_allowed"
+        else:
+            for permission, values in request.permissions.items():
+                if set(values) != set(allowed_permissions[permission]):
+                    reason = "permission_not_allowed"
+                    break
 
     if reason is not None:
         decision = PolicyDecision.DENY
@@ -666,20 +731,24 @@ def _normalize_legacy_pr_request(request: Mapping[str, Any]) -> Dict[str, Any]:
     normalized = dict(request)
     if str(normalized.get("capability") or "") != CAPABILITY_PR_PUBLISH_ID:
         return normalized
-    legacy_permissions = normalized.get("permissions")
-    if not isinstance(legacy_permissions, Mapping):
-        legacy_permissions = {}
-    args = normalized.get("args") if isinstance(normalized.get("args"), Mapping) else {}
-    writes = list(legacy_permissions.get("writes") or [str(args.get("output") or "")])
-    network = list(legacy_permissions.get("network") or ["github.com", "api.github.com"])
-    normalized.setdefault(
-        "effects",
-        {"writes": [value for value in writes if value], "network_destinations": network},
-    )
-    if isinstance(normalized.get("effects"), Mapping):
-        normalized["effects"] = {"browser_open": [], **dict(normalized["effects"])}
-    normalized.setdefault("credentials", ["gh"])
-    normalized["permissions"] = {"network": network, "writes": writes}
+    if "effects" not in normalized:
+        args = normalized.get("args") if isinstance(normalized.get("args"), Mapping) else {}
+        output = str(args.get("output") or "")
+        output_parts = Path(output).parts
+        try:
+            issue_index = output_parts.index("issues")
+            issue_dir = str(Path(*output_parts[: issue_index + 2]))
+        except (ValueError, IndexError):
+            issue_dir = ""
+        writes = [value for value in (output, ".git", issue_dir) if value]
+        network = ["github.com", "api.github.com"]
+        normalized["effects"] = {
+            "browser_open": [],
+            "writes": writes,
+            "network_destinations": network,
+        }
+        normalized["credentials"] = ["gh"]
+        normalized["permissions"] = {"network": network, "writes": writes}
     return normalized
 
 
@@ -723,6 +792,51 @@ def _audited_receipt(
                 "explanation": evaluation.explanation,
             },
             "outcome": outcome,
+        }
+    )
+    return receipt
+
+
+def validation_rejection_receipt(
+    *,
+    capability: str,
+    code: str,
+    raw_request: Optional[Mapping[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Build a correlated fail-closed receipt when typed evaluation cannot start."""
+    request_boundary: Dict[str, Any] = dict(raw_request) if raw_request is not None else {}
+    fingerprint_payload = {"capability": capability, "request": request_boundary}
+    canonical = json.dumps(
+        fingerprint_payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        default=str,
+    )
+    requested_effects = request_boundary.get("effects")
+    receipt = _base_receipt(
+        correlation_id=uuid.uuid4().hex[:20],
+        capability=capability,
+        success=False,
+        category=VALIDATION_ERROR,
+        code=code,
+        inputs=_receipt_inputs(request_boundary.get("args")),
+        outputs={},
+    )
+    receipt.update(
+        {
+            "request_fingerprint": hashlib.sha256(canonical.encode("utf-8")).hexdigest(),
+            "manifest": None,
+            "requested_effects": (
+                dict(requested_effects) if isinstance(requested_effects, Mapping) else {}
+            ),
+            "allowed_effects": {},
+            "decision": {
+                "outcome": PolicyDecision.DENY.value,
+                "reason_code": code,
+                "explanation": "The request could not be authorized.",
+            },
+            "outcome": "validation_rejection",
         }
     )
     return receipt

--- a/src/cafe/core/capabilities.py
+++ b/src/cafe/core/capabilities.py
@@ -167,7 +167,9 @@ def _resolve_boundary_tokens(
             replacements["issue_dir"] = ""
 
     def expand(values: Sequence[str]) -> Tuple[str, ...]:
-        return tuple(replacements.get(value, value) for value in values if replacements.get(value, value))
+        return tuple(
+            replacements.get(value, value) for value in values if replacements.get(value, value)
+        )
 
     effects = CapabilityEffects(
         writes=expand(manifest.effects.writes),
@@ -653,9 +655,7 @@ def run_pr_publish_capability(
 
 
 class CapabilityExecutionError(RuntimeError):
-    def __init__(
-        self, category: str, code: str, outputs: Optional[Dict[str, Any]] = None
-    ) -> None:
+    def __init__(self, category: str, code: str, outputs: Optional[Dict[str, Any]] = None) -> None:
         super().__init__(code)
         self.category = category
         self.code = code
@@ -684,9 +684,7 @@ def _normalize_legacy_pr_request(request: Mapping[str, Any]) -> Dict[str, Any]:
 
 
 def _manifest_digest(manifest: CapabilityManifest) -> str:
-    payload = json.dumps(
-        manifest.model_dump(mode="json"), sort_keys=True, separators=(",", ":")
-    )
+    payload = json.dumps(manifest.model_dump(mode="json"), sort_keys=True, separators=(",", ":"))
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 

--- a/src/cafe/core/capabilities.py
+++ b/src/cafe/core/capabilities.py
@@ -5,18 +5,23 @@ from __future__ import annotations
 import json
 import subprocess
 import hashlib
+import re
+import sys
 import uuid
+import webbrowser
 from enum import Enum
 from datetime import datetime
 from dataclasses import dataclass
 from pathlib import Path
 from types import MappingProxyType
 from typing import Any, Dict, List, Literal, Mapping, Optional, Sequence, Tuple
+from urllib.parse import urlparse
 
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
 from cafe.skills.loader import SkillLoader
+from cafe.utils.github import GitHubOps
 
 CAPABILITY_PR_PUBLISH_ID = "cafe.pr.publish"
 CAPABILITY_BROWSER_OPEN_ID = "cafe.browser.open"
@@ -818,13 +823,82 @@ def _sync_pr_adapter(
     return dict(run.receipt.get("outputs") or {}), run.pr_synced_event
 
 
-def _unimplemented_browser_adapter(**_kwargs: Any) -> tuple[Dict[str, Any], None]:
-    raise CapabilityExecutionError(VALIDATION_ERROR, "unsupported_implementation")
+def _current_repo_slug(repo_root: Path) -> str:
+    try:
+        result = subprocess.run(
+            ["git", "config", "--get", "remote.origin.url"],
+            cwd=str(repo_root),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError as exc:
+        raise CapabilityExecutionError(VALIDATION_ERROR, "repo_resolution_failed") from exc
+    if result.returncode != 0:
+        raise CapabilityExecutionError(VALIDATION_ERROR, "repo_resolution_failed")
+    remote = str(result.stdout or "").strip()
+    match = re.fullmatch(
+        r"(?:https://github\.com/|git@github\.com:|ssh://git@github\.com/)([^/]+/[^/]+?)(?:\.git)?",
+        remote,
+    )
+    if match is None:
+        raise CapabilityExecutionError(VALIDATION_ERROR, "repo_resolution_failed")
+    return match.group(1)
+
+
+def _canonical_current_pr_url(url: str, repo_slug: str) -> bool:
+    parsed = urlparse(url)
+    if parsed.scheme != "https" or parsed.netloc != "github.com":
+        return False
+    expected = repo_slug.split("/")
+    parts = [part for part in parsed.path.split("/") if part]
+    return (
+        len(expected) == 2
+        and len(parts) == 4
+        and parts[:2] == expected
+        and parts[2] == "pull"
+        and parts[3].isdigit()
+        and not parsed.params
+        and not parsed.query
+        and not parsed.fragment
+    )
+
+
+def _open_current_pr_adapter(
+    *,
+    repo_root: Path,
+    request: ExecutionRequest,
+    manifest: CapabilityManifest,
+    output_file: Path,
+    timeout_sec: float,
+) -> tuple[Dict[str, Any], Optional[Dict[str, Any]]]:
+    del manifest, output_file, timeout_sec
+    if request.args != {"target_ref": "current_pr"}:
+        raise CapabilityExecutionError(VALIDATION_ERROR, "target_not_allowed")
+    try:
+        resolved_url = GitHubOps().get_current_pr_url()
+        repo_slug = _current_repo_slug(repo_root)
+    except Exception as exc:
+        if isinstance(exc, CapabilityExecutionError):
+            raise
+        raise CapabilityExecutionError(VALIDATION_ERROR, "target_resolution_failed") from exc
+    if not _canonical_current_pr_url(resolved_url, repo_slug):
+        raise CapabilityExecutionError(VALIDATION_ERROR, "resolved_target_not_allowed")
+    if not sys.stdin.isatty():
+        return {"opened": False}, None
+    try:
+        webbrowser.open(resolved_url)
+    except Exception as exc:
+        raise CapabilityExecutionError("adapter_error", "browser_open_failed") from exc
+    return {"opened": True, "url": resolved_url}, {
+        "type": "pr_link_opened",
+        "url": resolved_url,
+    }
 
 
 HOST_CAPABILITY_ADAPTERS: Mapping[str, Any] = {
     "sync_pr": _sync_pr_adapter,
-    "open_current_pr": _unimplemented_browser_adapter,
+    "open_current_pr": _open_current_pr_adapter,
 }
 
 

--- a/src/cafe/core/hooks/native.py
+++ b/src/cafe/core/hooks/native.py
@@ -3,8 +3,6 @@
 from __future__ import annotations
 
 import json
-import uuid
-from datetime import datetime
 from pathlib import Path
 from typing import Any, Optional
 
@@ -1136,7 +1134,6 @@ class GitHubPRCreator(NoOpHook):
             CAPABILITY_PR_PUBLISH_ID,
             SCRIPT_EXIT_ERROR,
             TIMEOUT_ERROR,
-            VALIDATION_ERROR,
             CapabilityRegistryError,
             capability_receipt_hook_event,
             default_capability_definition_dirs,
@@ -1180,33 +1177,53 @@ class GitHubPRCreator(NoOpHook):
             if isinstance(blackboard_state, BlackboardState) and isinstance(issue_dir, Path):
                 BlackboardStore(issue_dir).append_capability_receipt(blackboard_state, receipt)
 
+        request_file = (
+            capability_request_file
+            if isinstance(capability_request_file, Path)
+            else publish_request_file if isinstance(publish_request_file, Path) else None
+        )
         try:
             request_payload = self._load_publish_request(
-                publish_request_file=(
-                    capability_request_file
-                    if isinstance(capability_request_file, Path)
-                    else publish_request_file if isinstance(publish_request_file, Path) else None
-                ),
+                publish_request_file=request_file,
                 repo_root=repo_root,
             )
             requests = self._normalize_capability_requests(request_payload)
-        except RuntimeError:
+        except RuntimeError as exc:
+            rejected_value: Any = None
+            if isinstance(request_file, Path):
+                try:
+                    rejected_value = request_file.resolve().read_text(encoding="utf-8")
+                except OSError:
+                    pass
             receipt = validation_rejection_receipt(
                 capability=fallback_capability,
                 code="request_load_error",
+                rejected_value=rejected_value,
+                rejection_source={
+                    "kind": "request_artifact",
+                    "path": str(request_file.resolve()) if isinstance(request_file, Path) else None,
+                },
+                error_detail=str(exc),
             )
             persist_receipt(receipt)
             return HookResult(events=[capability_receipt_hook_event(receipt)])
 
+        definition_dirs = default_capability_definition_dirs(repo_root)
         try:
-            registry = load_capability_registry(default_capability_definition_dirs(repo_root))
-        except CapabilityRegistryError:
+            registry = load_capability_registry(definition_dirs)
+        except CapabilityRegistryError as exc:
             events: list[dict[str, Any]] = []
             for request in requests:
                 receipt = validation_rejection_receipt(
                     capability=str(request.get("capability") or fallback_capability),
                     code="registry_load_error",
                     raw_request=request,
+                    rejected_value=request,
+                    rejection_source={
+                        "kind": "capability_registry",
+                        "paths": [str(path) for path in definition_dirs],
+                    },
+                    error_detail=str(exc),
                 )
                 persist_receipt(receipt)
                 events.append(capability_receipt_hook_event(receipt))

--- a/src/cafe/core/hooks/native.py
+++ b/src/cafe/core/hooks/native.py
@@ -1142,6 +1142,7 @@ class GitHubPRCreator(NoOpHook):
             default_capability_definition_dirs,
             load_capability_registry,
             run_capability_request,
+            validation_rejection_receipt,
         )
 
         phase = kwargs.get("phase")
@@ -1190,16 +1191,10 @@ class GitHubPRCreator(NoOpHook):
             )
             requests = self._normalize_capability_requests(request_payload)
         except RuntimeError:
-            receipt = {
-                "capability": fallback_capability,
-                "correlation_id": uuid.uuid4().hex[:20],
-                "success": False,
-                "category": VALIDATION_ERROR,
-                "code": "request_load_error",
-                "inputs": {},
-                "outputs": {},
-                "finished_at": datetime.now().astimezone().isoformat(),
-            }
+            receipt = validation_rejection_receipt(
+                capability=fallback_capability,
+                code="request_load_error",
+            )
             persist_receipt(receipt)
             return HookResult(events=[capability_receipt_hook_event(receipt)])
 
@@ -1208,16 +1203,11 @@ class GitHubPRCreator(NoOpHook):
         except CapabilityRegistryError:
             events: list[dict[str, Any]] = []
             for request in requests:
-                receipt = {
-                    "capability": str(request.get("capability") or fallback_capability),
-                    "correlation_id": uuid.uuid4().hex[:20],
-                    "success": False,
-                    "category": VALIDATION_ERROR,
-                    "code": "registry_load_error",
-                    "inputs": self._request_inputs_for_receipt(request),
-                    "outputs": {},
-                    "finished_at": datetime.now().astimezone().isoformat(),
-                }
+                receipt = validation_rejection_receipt(
+                    capability=str(request.get("capability") or fallback_capability),
+                    code="registry_load_error",
+                    raw_request=request,
+                )
                 persist_receipt(receipt)
                 events.append(capability_receipt_hook_event(receipt))
             return HookResult(events=events)

--- a/src/cafe/core/hooks/native.py
+++ b/src/cafe/core/hooks/native.py
@@ -336,11 +336,15 @@ class UserInputCollector(NoOpHook):
             prev_data = phase._load_previous_iteration_data() or {}
             # Show diff again after returning from chat/edit, but never print full output.
             if delta_displayed:
+
                 def redisplay_callback() -> None:
                     self._display_previous_iteration_delta(phase, previous_output_file)
+
             else:
+
                 def redisplay_callback() -> None:
                     self._display_previous_output(phase, step_name, previous_output_file)
+
             choice = phase._ask_user_for_review_decision(
                 self._resolve_review_item_name(step_name),
                 agent_name=agent_name,
@@ -555,8 +559,7 @@ def _declares_no_changes_task(step_def: Any) -> bool:
     if not isinstance(tasks, (list, tuple)):
         return False
     return any(
-        isinstance(task, dict) and task.get("trigger") == "no_changes_needed"
-        for task in tasks
+        isinstance(task, dict) and task.get("trigger") == "no_changes_needed" for task in tasks
     )
 
 
@@ -637,9 +640,7 @@ class InitialInputProviderResolver(NoOpHook):
             assert output_file is not None
             output_file.parent.mkdir(parents=True, exist_ok=True)
             formatter = kwargs.get("initial_input_output_formatter") or (
-                legacy_adapter._format_initial_requirements
-                if legacy_adapter is not None
-                else None
+                legacy_adapter._format_initial_requirements if legacy_adapter is not None else None
             )
             content = formatter(result.content) if callable(formatter) else result.content
             if legacy_empty_seed:
@@ -648,9 +649,7 @@ class InitialInputProviderResolver(NoOpHook):
                 output_file.write_text(f"{content.rstrip()}\n", encoding="utf-8")
 
         context_updates = (
-            {"user_input": result.content}
-            if binding.get("prompt_context") == "user_input"
-            else {}
+            {"user_input": result.content} if binding.get("prompt_context") == "user_input" else {}
         )
         return HookResult(
             context_updates=context_updates,
@@ -677,11 +676,14 @@ class InitialInputProviderResolver(NoOpHook):
             return False
         if MANUAL_TEXT_PROVIDER not in {str(provider) for provider in providers}:
             return False
-        if self._resolve_prefilled_input(
-            phase=phase,
-            step_name=step_name,
-            context=context,
-        ) is not None:
+        if (
+            self._resolve_prefilled_input(
+                phase=phase,
+                step_name=step_name,
+                context=context,
+            )
+            is not None
+        ):
             return False
         configured_provider, _issue_id = load_initial_input_selection(
             self._load_issue_config(phase)
@@ -1158,11 +1160,9 @@ class GitHubPRCreator(NoOpHook):
         output_file = kwargs.get("output_file")
         if phase is None or not isinstance(output_file, Path) or not output_file.exists():
             return HookResult()
-        if (
-            CAPABILITY_PR_PUBLISH_ID
-            in _effective_capability_ids(step_name=step_name, step_def=step_def)
-            and self._is_local_pr_mode(phase)
-        ):
+        if CAPABILITY_PR_PUBLISH_ID in _effective_capability_ids(
+            step_name=step_name, step_def=step_def
+        ) and self._is_local_pr_mode(phase):
             return HookResult()
 
         repo_root = self._resolve_repo_root(phase)

--- a/src/cafe/core/hooks/native.py
+++ b/src/cafe/core/hooks/native.py
@@ -3,9 +3,7 @@
 from __future__ import annotations
 
 import json
-import sys
 import uuid
-import webbrowser
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Optional
@@ -1469,18 +1467,41 @@ class PRLinkOpener(NoOpHook):
         ):
             return HookResult()
 
+        from cafe.core.blackboard import BlackboardStore
+        from cafe.core.capabilities import (
+            CAPABILITY_BROWSER_OPEN_ID,
+            CapabilityRegistryError,
+            default_capability_definition_dirs,
+            load_capability_registry,
+            run_capability_request,
+        )
+
+        repo_root = GitHubPRCreator._resolve_repo_root(phase) if phase is not None else Path.cwd()
         try:
-            pr_url = GitHubOps().get_current_pr_url()
-        except GitHubError:
-            return HookResult()
-        except Exception:
+            registry = load_capability_registry(default_capability_definition_dirs(repo_root))
+            run = run_capability_request(
+                repo_root=repo_root,
+                registry=registry,
+                capability_request={
+                    "capability": CAPABILITY_BROWSER_OPEN_ID,
+                    "args": {"target_ref": "current_pr"},
+                    "effects": {
+                        "browser_open": ["current_pr"],
+                        "writes": [],
+                        "network_destinations": [],
+                    },
+                    "credentials": [],
+                    "permissions": {},
+                },
+                output_file=Path(kwargs.get("output_file") or repo_root),
+            )
+        except (CapabilityRegistryError, OSError, ValueError):
             return HookResult()
 
-        if sys.stdin.isatty():
-            try:
-                webbrowser.open(pr_url)
-            except Exception:
-                return HookResult()
-            return HookResult(events=[{"type": "pr_link_opened", "url": pr_url}])
-
+        blackboard_state = kwargs.get("blackboard_state")
+        issue_dir = getattr(phase, "issue_dir", None)
+        if isinstance(blackboard_state, BlackboardState) and isinstance(issue_dir, Path):
+            BlackboardStore(issue_dir).append_capability_receipt(blackboard_state, run.receipt)
+        if run.receipt.get("success") and run.pr_synced_event is not None:
+            return HookResult(events=[run.pr_synced_event])
         return HookResult()

--- a/src/cafe/core/hooks/native.py
+++ b/src/cafe/core/hooks/native.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 from pathlib import Path
 from typing import Any, Optional
@@ -1190,21 +1191,24 @@ class GitHubPRCreator(NoOpHook):
             requests = self._normalize_capability_requests(request_payload)
         except RuntimeError as exc:
             rejected_value: Any = None
+            rejection_source: dict[str, Any] = {
+                "kind": "request_artifact",
+                "path": str(request_file.resolve()) if isinstance(request_file, Path) else None,
+            }
             if isinstance(request_file, Path):
                 try:
-                    rejected_value = request_file.resolve().read_text(
-                        encoding="utf-8", errors="replace"
-                    )
+                    rejected_bytes = request_file.resolve().read_bytes()
+                    rejection_source["content_sha256"] = hashlib.sha256(
+                        rejected_bytes
+                    ).hexdigest()
+                    rejected_value = rejected_bytes.decode("utf-8", errors="replace")
                 except OSError:
                     pass
             receipt = validation_rejection_receipt(
                 capability=fallback_capability,
                 code="request_load_error",
                 rejected_value=rejected_value,
-                rejection_source={
-                    "kind": "request_artifact",
-                    "path": str(request_file.resolve()) if isinstance(request_file, Path) else None,
-                },
+                rejection_source=rejection_source,
                 error_detail=str(exc),
             )
             persist_receipt(receipt)

--- a/src/cafe/core/hooks/native.py
+++ b/src/cafe/core/hooks/native.py
@@ -1192,7 +1192,9 @@ class GitHubPRCreator(NoOpHook):
             rejected_value: Any = None
             if isinstance(request_file, Path):
                 try:
-                    rejected_value = request_file.resolve().read_text(encoding="utf-8")
+                    rejected_value = request_file.resolve().read_text(
+                        encoding="utf-8", errors="replace"
+                    )
                 except OSError:
                     pass
             receipt = validation_rejection_receipt(
@@ -1334,6 +1336,12 @@ class GitHubPRCreator(NoOpHook):
             raise RuntimeError(f"PR publish request not found: {request_file}")
         try:
             payload = json.loads(request_file.read_text(encoding="utf-8"))
+        except UnicodeError as exc:
+            raise RuntimeError(
+                f"PR publish request is not valid UTF-8: {request_file}"
+            ) from exc
+        except OSError as exc:
+            raise RuntimeError(f"PR publish request cannot be read: {request_file}") from exc
         except json.JSONDecodeError as exc:
             raise RuntimeError(f"PR publish request is invalid JSON: {request_file}") from exc
         if not isinstance(payload, dict):

--- a/src/cafe/data/capabilities/cafe.browser.open.yaml
+++ b/src/cafe/data/capabilities/cafe.browser.open.yaml
@@ -1,0 +1,30 @@
+id: cafe.browser.open
+version: 1
+implementation: open_current_pr
+arguments:
+  required:
+    - target_ref
+  properties:
+    target_ref:
+      type: string
+      enum:
+        - current_pr
+outputs:
+  required:
+    - opened
+  properties:
+    opened:
+      type: boolean
+    url:
+      type: string
+effects:
+  writes: []
+  network_destinations: []
+  browser_open:
+    - current_pr
+credentials: []
+permissions: {}
+idempotency: safe
+risk: low
+approval: not_required
+policy: allow

--- a/src/cafe/data/capabilities/cafe.pr.publish.yaml
+++ b/src/cafe/data/capabilities/cafe.pr.publish.yaml
@@ -1,7 +1,7 @@
 id: cafe.pr.publish
-script_ref: sync_pr
-idempotency_hint: update_in_place
-args_schema:
+version: 1
+implementation: sync_pr
+arguments:
   required:
     - output
   properties:
@@ -9,7 +9,7 @@ args_schema:
       type: string
     base:
       type: string
-expected_outputs:
+outputs:
   required:
     - pr_url
     - pr_number
@@ -20,3 +20,26 @@ expected_outputs:
       type: string
     action:
       type: string
+effects:
+  writes:
+    - request_output
+    - .git
+    - issue_dir
+  network_destinations:
+    - github.com
+    - api.github.com
+  browser_open: []
+credentials:
+  - gh
+permissions:
+  network:
+    - github.com
+    - api.github.com
+  writes:
+    - request_output
+    - .git
+    - issue_dir
+idempotency: update_in_place
+risk: medium
+approval: not_required
+policy: allow

--- a/src/cafe/phases/generic_workflow_step.py
+++ b/src/cafe/phases/generic_workflow_step.py
@@ -2051,6 +2051,7 @@ class GenericWorkflowStepExecutor(Phase):
                 "browser_open": [],
                 "network_destinations": ["github.com", "api.github.com"],
                 "writes": [
+                    self._repo_relative_path(output_file),
                     ".git",
                     self._repo_relative_path(self.issue_dir),
                 ],
@@ -2059,6 +2060,7 @@ class GenericWorkflowStepExecutor(Phase):
             "permissions": {
                 "network": ["github.com", "api.github.com"],
                 "writes": [
+                    self._repo_relative_path(output_file),
                     ".git",
                     self._repo_relative_path(self.issue_dir),
                 ],

--- a/src/cafe/phases/generic_workflow_step.py
+++ b/src/cafe/phases/generic_workflow_step.py
@@ -502,6 +502,7 @@ class GenericWorkflowStepExecutor(Phase):
             and self._should_validate_checklist(status_code)
         ):
             resolved_user_input = self._get_resolved_iteration_user_input(step_name)
+
             def validate_completion():
                 return self._validate_and_retry_checklist_completion(
                     agent_name=agent_name,
@@ -511,6 +512,7 @@ class GenericWorkflowStepExecutor(Phase):
                     allowed_tools=allowed_tools,
                     max_retries=3,
                 )
+
             response, validated_status, validation_passed = (
                 self._preserve_hybrid_control_files(
                     validate_completion,

--- a/src/cafe/phases/generic_workflow_step.py
+++ b/src/cafe/phases/generic_workflow_step.py
@@ -2011,10 +2011,29 @@ class GenericWorkflowStepExecutor(Phase):
         output_file: Path,
         capability_id: str,
     ) -> Dict[str, Any]:
+        if capability_id == "cafe.browser.open":
+            return {
+                "capability": capability_id,
+                "args": {"target_ref": "current_pr"},
+                "effects": {
+                    "browser_open": ["current_pr"],
+                    "writes": [],
+                    "network_destinations": [],
+                },
+                "credentials": [],
+                "permissions": {},
+            }
+
         if capability_id != CAPABILITY_PR_PUBLISH_ID:
             return {
                 "capability": capability_id,
                 "args": {},
+                "effects": {
+                    "browser_open": [],
+                    "writes": [],
+                    "network_destinations": [],
+                },
+                "credentials": [],
                 "permissions": {},
             }
 
@@ -2026,6 +2045,15 @@ class GenericWorkflowStepExecutor(Phase):
                 "output": self._repo_relative_path(output_file),
                 "base": resolved_base,
             },
+            "effects": {
+                "browser_open": [],
+                "network_destinations": ["github.com", "api.github.com"],
+                "writes": [
+                    ".git",
+                    self._repo_relative_path(self.issue_dir),
+                ],
+            },
+            "credentials": ["gh"],
             "permissions": {
                 "network": ["github.com", "api.github.com"],
                 "writes": [

--- a/tests/integration/test_long_running_operation_workflow.py
+++ b/tests/integration/test_long_running_operation_workflow.py
@@ -634,7 +634,9 @@ def test_high_risk_explicit_stop_and_recovery_journey_preserves_policy(
         except ProcessLookupError:
             pass
 
-    deadline = time.time() + 2
+    # The monitor allows its child the full two-second graceful shutdown window
+    # before escalating to SIGKILL, so the observer must wait longer than that.
+    deadline = time.time() + 5
     while command_alive() and time.time() < deadline:
         time.sleep(0.02)
     try:

--- a/tests/integration/test_pr_e2e_with_mock.py
+++ b/tests/integration/test_pr_e2e_with_mock.py
@@ -53,12 +53,20 @@ def test_pr_publish_generic_journey_preserves_outputs_and_correlates_receipt(
             "effects": {
                 "browser_open": [],
                 "network_destinations": ["github.com", "api.github.com"],
-                "writes": [".git", ".cafe/issues/demo"],
+                "writes": [
+                    ".cafe/issues/demo/pr/iteration_001/output.md",
+                    ".git",
+                    ".cafe/issues/demo",
+                ],
             },
             "credentials": ["gh"],
             "permissions": {
                 "network": ["github.com", "api.github.com"],
-                "writes": [".git", ".cafe/issues/demo"],
+                "writes": [
+                    ".cafe/issues/demo/pr/iteration_001/output.md",
+                    ".git",
+                    ".cafe/issues/demo",
+                ],
             },
         },
         output_file=output_file,

--- a/tests/integration/test_pr_e2e_with_mock.py
+++ b/tests/integration/test_pr_e2e_with_mock.py
@@ -22,6 +22,60 @@ from cafe.skills.native_bridge import NativeSkillBridge
 from cafe.utils.phase_config import PhaseStepModelResolution
 
 
+def test_pr_publish_generic_journey_preserves_outputs_and_correlates_receipt(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import cafe.core.capabilities as cap_mod
+
+    output_file = tmp_path / ".cafe/issues/demo/pr/iteration_001/output.md"
+    output_file.parent.mkdir(parents=True)
+    output_file.write_text("# PR\n", encoding="utf-8")
+
+    class Result:
+        returncode = 0
+        stderr = ""
+        stdout = (
+            '{"action":"created","pr_number":"42",'
+            '"pr_url":"https://github.com/acme/widgets/pull/42"}\n'
+        )
+
+    monkeypatch.setattr(cap_mod.subprocess, "run", lambda *_args, **_kwargs: Result())
+    registry = cap_mod.load_capability_registry([cap_mod._package_capabilities_dir()])
+    run = cap_mod.run_capability_request(
+        repo_root=tmp_path,
+        registry=registry,
+        capability_request={
+            "capability": "cafe.pr.publish",
+            "args": {
+                "output": ".cafe/issues/demo/pr/iteration_001/output.md",
+                "base": "main",
+            },
+            "effects": {
+                "browser_open": [],
+                "network_destinations": ["github.com", "api.github.com"],
+                "writes": [".git", ".cafe/issues/demo"],
+            },
+            "credentials": ["gh"],
+            "permissions": {
+                "network": ["github.com", "api.github.com"],
+                "writes": [".git", ".cafe/issues/demo"],
+            },
+        },
+        output_file=output_file,
+    )
+
+    assert run.receipt["success"] is True
+    assert run.receipt["outputs"] == {
+        "pr_url": "https://github.com/acme/widgets/pull/42",
+        "pr_number": "42",
+        "action": "created",
+    }
+    assert run.receipt["request_fingerprint"]
+    assert run.receipt["manifest"]["id"] == "cafe.pr.publish"
+    assert run.receipt["decision"]["outcome"] == "allow"
+    assert run.receipt["outcome"] == "success"
+
+
 def _load_default_playbook() -> dict:
     return PlaybookLoader().load("default")
 
@@ -192,11 +246,14 @@ def test_declared_pr_feedback_source_records_and_delivers_each_comment_once(
     assert second.events == []
 
     phase.git_ops.reset_mock()
-    assert _find_external_resume_step(
-        issue_dir=issue_dir,
-        playbook_data=playbook,
-        git_ops=phase.git_ops,
-    ) == "develop"
+    assert (
+        _find_external_resume_step(
+            issue_dir=issue_dir,
+            playbook_data=playbook,
+            git_ops=phase.git_ops,
+        )
+        == "develop"
+    )
     assert len(ledger.pending(target_step="develop")) == 2
     phase.git_ops.get_current_branch.assert_not_called()
 
@@ -249,9 +306,7 @@ def test_declared_pr_feedback_source_records_and_delivers_each_comment_once(
         )
 
     paused_playbook = json.loads(json.dumps(playbook))
-    paused_playbook["steps"]["develop"]["hooks"] = {
-        "before_execute": ["PauseBeforeAgent"]
-    }
+    paused_playbook["steps"]["develop"]["hooks"] = {"before_execute": ["PauseBeforeAgent"]}
     paused_manager = AgentManager()
     paused_executor = GenericWorkflowStepExecutor(
         issue_dir=issue_dir,

--- a/tests/integration/test_workflow_e2e.py
+++ b/tests/integration/test_workflow_e2e.py
@@ -77,6 +77,72 @@ def _write_pr_done_baton(issue_dir: Path) -> None:
     )
 
 
+def test_host_capability_journeys_share_fail_closed_dispatch_and_receipts(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import cafe.core.capabilities as cap_mod
+
+    registry = cap_mod.load_capability_registry([cap_mod._package_capabilities_dir()])
+    browser = registry[cap_mod.CAPABILITY_BROWSER_OPEN_ID]
+    calls: list[str] = []
+    monkeypatch.setattr(
+        cap_mod,
+        "HOST_CAPABILITY_ADAPTERS",
+        {
+            "open_current_pr": lambda **_kwargs: (
+                calls.append("browser") or {"opened": True, "url": "https://example.test"},
+                None,
+            )
+        },
+    )
+    request = {
+        "capability": cap_mod.CAPABILITY_BROWSER_OPEN_ID,
+        "args": {"target_ref": "current_pr"},
+        "effects": {
+            "browser_open": ["current_pr"],
+            "writes": [],
+            "network_destinations": [],
+        },
+        "credentials": [],
+        "permissions": {},
+    }
+
+    allowed = cap_mod.run_capability_request(
+        repo_root=tmp_path,
+        registry=registry,
+        capability_request=request,
+        output_file=tmp_path / "output.md",
+    )
+    tampered = cap_mod.run_capability_request(
+        repo_root=tmp_path,
+        registry=registry,
+        capability_request={**request, "url": "https://evil.test"},
+        output_file=tmp_path / "output.md",
+    )
+    approval = cap_mod.run_capability_request(
+        repo_root=tmp_path,
+        registry={browser.id: browser.model_copy(update={"approval": "required"})},
+        capability_request=request,
+        output_file=tmp_path / "output.md",
+    )
+    denied = cap_mod.run_capability_request(
+        repo_root=tmp_path,
+        registry={browser.id: browser.model_copy(update={"policy": "deny"})},
+        capability_request=request,
+        output_file=tmp_path / "output.md",
+    )
+
+    assert calls == ["browser"]
+    assert allowed.receipt["outcome"] == "success"
+    assert tampered.receipt["outcome"] == "validation_rejection"
+    assert approval.receipt["outcome"] == "approval_required"
+    assert denied.receipt["outcome"] == "policy_denied"
+    assert {approval.receipt["decision"]["outcome"], denied.receipt["decision"]["outcome"]} == {
+        "require_approval",
+        "deny",
+    }
+
+
 class _BatonWritingAgentManager:
     """Test-double agent boundary that writes the workflow's public baton."""
 

--- a/tests/unit/test_capability_registry.py
+++ b/tests/unit/test_capability_registry.py
@@ -24,7 +24,9 @@ def _manifest(capability_id: str = "demo.echo", **overrides: object) -> dict[str
     manifest: dict[str, object] = {
         "id": capability_id,
         "version": 1,
-        "implementation": "sync_pr" if capability_id == CAPABILITY_PR_PUBLISH_ID else "open_current_pr",
+        "implementation": (
+            "sync_pr" if capability_id == CAPABILITY_PR_PUBLISH_ID else "open_current_pr"
+        ),
         "arguments": {
             "required": ["target_ref"],
             "properties": {"target_ref": {"type": "string", "enum": ["current_pr"]}},
@@ -171,9 +173,7 @@ def test_policy_denies_broadened_request(
 
 
 def test_policy_decision_is_total_for_allow_approval_and_deny() -> None:
-    allowed = evaluate_capability_request(
-        {"demo.echo": _typed_manifest()}, _browser_request()
-    )
+    allowed = evaluate_capability_request({"demo.echo": _typed_manifest()}, _browser_request())
     approval = evaluate_capability_request(
         {"demo.echo": _typed_manifest(approval="required")}, _browser_request()
     )
@@ -282,9 +282,10 @@ def test_enriched_blackboard_receipt_remains_backward_readable(tmp_path: Path) -
     )
 
     loaded = store.load_or_create("develop")
-    assert loaded.capability_receipts[-2:] == [enriched, {
-        "capability": "legacy", "success": True, "correlation_id": "old"
-    }]
+    assert loaded.capability_receipts[-2:] == [
+        enriched,
+        {"capability": "legacy", "success": True, "correlation_id": "old"},
+    ]
 
 
 def test_current_pr_browser_adapter_opens_only_resolved_repository_pr(

--- a/tests/unit/test_capability_registry.py
+++ b/tests/unit/test_capability_registry.py
@@ -60,6 +60,22 @@ def test_load_registry_returns_typed_complete_manifests(tmp_path: Path) -> None:
     with pytest.raises(TypeError):
         registry["new"] = registry["demo.echo"]  # type: ignore[index]
 
+    manifest = registry["demo.echo"]
+    with pytest.raises(TypeError):
+        manifest.arguments.properties["other"] = manifest.arguments.properties["target_ref"]  # type: ignore[index]
+    with pytest.raises(TypeError):
+        manifest.permissions["network"] = ("example.test",)  # type: ignore[index]
+
+
+def test_load_registry_rejects_coerced_manifest_scalars(tmp_path: Path) -> None:
+    cap_dir = tmp_path / "caps"
+    cap_dir.mkdir()
+    malformed = _manifest(version=True)
+    (cap_dir / "demo.yaml").write_text(yaml.safe_dump(malformed), encoding="utf-8")
+
+    with pytest.raises(CapabilityRegistryError):
+        load_capability_registry([cap_dir])
+
 
 @pytest.mark.parametrize(
     "field",
@@ -170,6 +186,40 @@ def test_policy_denies_broadened_request(
     )
     assert evaluation.decision == PolicyDecision.DENY
     assert evaluation.reason_code == reason_code
+
+
+@pytest.mark.parametrize(
+    "request_update",
+    [
+        {
+            "effects": {
+                "writes": [],
+                "network_destinations": [],
+                "browser_open": [],
+            }
+        },
+        {"credentials": []},
+        {"permissions": {}},
+    ],
+)
+def test_policy_denies_requests_that_omit_fixed_adapter_authority(
+    request_update: dict[str, object],
+) -> None:
+    manifest = _typed_manifest(
+        credentials=("browser",),
+        permissions={"browser": ("current_pr",)},
+    )
+    request = _browser_request(
+        **{
+            "credentials": ["browser"],
+            "permissions": {"browser": ["current_pr"]},
+            **request_update,
+        }
+    )
+
+    evaluation = evaluate_capability_request({"demo.echo": manifest}, request)
+
+    assert evaluation.decision == PolicyDecision.DENY
 
 
 def test_policy_decision_is_total_for_allow_approval_and_deny() -> None:

--- a/tests/unit/test_capability_registry.py
+++ b/tests/unit/test_capability_registry.py
@@ -6,6 +6,7 @@ import pytest
 import yaml
 
 from cafe.core.capabilities import (
+    CAPABILITY_BROWSER_OPEN_ID,
     CAPABILITY_PR_PUBLISH_ID,
     CapabilityManifest,
     CapabilityRegistryError,
@@ -284,6 +285,80 @@ def test_enriched_blackboard_receipt_remains_backward_readable(tmp_path: Path) -
     assert loaded.capability_receipts[-2:] == [enriched, {
         "capability": "legacy", "success": True, "correlation_id": "old"
     }]
+
+
+def test_current_pr_browser_adapter_opens_only_resolved_repository_pr(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import cafe.core.capabilities as cap_mod
+
+    registry = load_capability_registry([cap_mod._package_capabilities_dir()])
+    monkeypatch.setattr(cap_mod.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(
+        cap_mod.GitHubOps,
+        "get_current_pr_url",
+        lambda _self: "https://github.com/acme/widgets/pull/42",
+    )
+    opened: list[str] = []
+    monkeypatch.setattr(cap_mod.webbrowser, "open", opened.append)
+    monkeypatch.setattr(
+        cap_mod,
+        "_current_repo_slug",
+        lambda _repo_root: "acme/widgets",
+    )
+
+    run = run_capability_request(
+        repo_root=tmp_path,
+        registry=registry,
+        capability_request={
+            "capability": CAPABILITY_BROWSER_OPEN_ID,
+            "args": {"target_ref": "current_pr"},
+            "effects": {
+                "browser_open": ["current_pr"],
+                "writes": [],
+                "network_destinations": [],
+            },
+            "credentials": [],
+            "permissions": {},
+        },
+        output_file=tmp_path / "output.md",
+    )
+
+    assert run.receipt["success"] is True
+    assert opened == ["https://github.com/acme/widgets/pull/42"]
+
+
+@pytest.mark.parametrize(
+    "resolved_url",
+    [
+        "http://github.com/acme/widgets/pull/42",
+        "https://evil.test/acme/widgets/pull/42",
+        "https://github.com/acme/other/pull/42",
+        "https://github.com/acme/widgets/issues/42",
+        "https://github.com/acme/widgets/pull/not-a-number",
+    ],
+)
+def test_current_pr_browser_adapter_rejects_noncanonical_resolution(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, resolved_url: str
+) -> None:
+    import cafe.core.capabilities as cap_mod
+
+    registry = load_capability_registry([cap_mod._package_capabilities_dir()])
+    monkeypatch.setattr(cap_mod.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(cap_mod.GitHubOps, "get_current_pr_url", lambda _self: resolved_url)
+    monkeypatch.setattr(cap_mod, "_current_repo_slug", lambda _repo_root: "acme/widgets")
+    opened: list[str] = []
+    monkeypatch.setattr(cap_mod.webbrowser, "open", opened.append)
+
+    run = run_capability_request(
+        repo_root=tmp_path,
+        registry=registry,
+        capability_request=_browser_request(capability=CAPABILITY_BROWSER_OPEN_ID),
+        output_file=tmp_path / "output.md",
+    )
+
+    assert run.receipt["success"] is False
+    assert opened == []
 
 
 def test_load_registry_duplicate_ids(tmp_path: Path) -> None:

--- a/tests/unit/test_capability_registry.py
+++ b/tests/unit/test_capability_registry.py
@@ -9,6 +9,10 @@ from cafe.core.capabilities import (
     CAPABILITY_PR_PUBLISH_ID,
     CapabilityManifest,
     CapabilityRegistryError,
+    ExecutionRequest,
+    PolicyDecision,
+    canonical_request_fingerprint,
+    evaluate_capability_request,
     load_capability_registry,
     run_capability_request,
     run_pr_publish_capability,
@@ -89,6 +93,98 @@ def test_load_registry_rejects_extra_and_unsupported_implementation(tmp_path: Pa
 
     with pytest.raises(CapabilityRegistryError):
         load_capability_registry([cap_dir])
+
+
+def _typed_manifest(**overrides: object) -> CapabilityManifest:
+    return CapabilityManifest.model_validate(_manifest(**overrides))
+
+
+def _browser_request(**overrides: object) -> dict[str, object]:
+    request: dict[str, object] = {
+        "capability": "demo.echo",
+        "args": {"target_ref": "current_pr"},
+        "effects": {
+            "writes": [],
+            "network_destinations": [],
+            "browser_open": ["current_pr"],
+        },
+        "credentials": [],
+        "permissions": {},
+    }
+    request.update(overrides)
+    return request
+
+
+def test_execution_request_is_strict_and_fingerprint_covers_security_boundary() -> None:
+    first = ExecutionRequest.model_validate(_browser_request())
+    reordered = ExecutionRequest.model_validate(
+        {
+            "permissions": {},
+            "credentials": [],
+            "effects": {
+                "browser_open": ["current_pr"],
+                "network_destinations": [],
+                "writes": [],
+            },
+            "args": {"target_ref": "current_pr"},
+            "capability": "demo.echo",
+        }
+    )
+    assert canonical_request_fingerprint(first) == canonical_request_fingerprint(reordered)
+
+    changed = ExecutionRequest.model_validate(
+        _browser_request(effects={"writes": [], "network_destinations": [], "browser_open": []})
+    )
+    assert canonical_request_fingerprint(first) != canonical_request_fingerprint(changed)
+
+    with pytest.raises(ValueError):
+        ExecutionRequest.model_validate({**_browser_request(), "script": "./owned.sh"})
+
+
+@pytest.mark.parametrize(
+    ("request_update", "reason_code"),
+    [
+        ({"args": {"target_ref": "https://evil.test"}}, "argument_not_allowed"),
+        (
+            {
+                "effects": {
+                    "writes": ["../outside"],
+                    "network_destinations": [],
+                    "browser_open": ["current_pr"],
+                }
+            },
+            "effect_not_allowed",
+        ),
+        ({"credentials": ["admin-token"]}, "credential_not_allowed"),
+        ({"permissions": {"network": ["evil.test"]}}, "permission_not_allowed"),
+    ],
+)
+def test_policy_denies_broadened_request(
+    request_update: dict[str, object], reason_code: str
+) -> None:
+    evaluation = evaluate_capability_request(
+        {"demo.echo": _typed_manifest()}, _browser_request(**request_update)
+    )
+    assert evaluation.decision == PolicyDecision.DENY
+    assert evaluation.reason_code == reason_code
+
+
+def test_policy_decision_is_total_for_allow_approval_and_deny() -> None:
+    allowed = evaluate_capability_request(
+        {"demo.echo": _typed_manifest()}, _browser_request()
+    )
+    approval = evaluate_capability_request(
+        {"demo.echo": _typed_manifest(approval="required")}, _browser_request()
+    )
+    denied = evaluate_capability_request(
+        {"demo.echo": _typed_manifest(policy="deny")}, _browser_request()
+    )
+
+    assert allowed.decision == PolicyDecision.ALLOW
+    assert approval.decision == PolicyDecision.REQUIRE_APPROVAL
+    assert denied.decision == PolicyDecision.DENY
+    assert allowed.fingerprint
+    assert allowed.allowed_effects == allowed.request.effects
 
 
 def test_load_registry_duplicate_ids(tmp_path: Path) -> None:

--- a/tests/unit/test_capability_registry.py
+++ b/tests/unit/test_capability_registry.py
@@ -78,6 +78,35 @@ def test_load_registry_rejects_coerced_manifest_scalars(tmp_path: Path) -> None:
 
 
 @pytest.mark.parametrize(
+    ("declared_type", "enum_value"),
+    [
+        ("integer", True),
+        ("integer", "1"),
+        ("boolean", 1),
+        ("boolean", "true"),
+        ("string", 1),
+        ("string", True),
+    ],
+)
+def test_load_registry_rejects_enum_values_with_wrong_declared_type(
+    tmp_path: Path, declared_type: str, enum_value: object
+) -> None:
+    cap_dir = tmp_path / "caps"
+    cap_dir.mkdir()
+    malformed = _manifest()
+    malformed["arguments"] = {
+        "required": ["target_ref"],
+        "properties": {
+            "target_ref": {"type": declared_type, "enum": [enum_value]},
+        },
+    }
+    (cap_dir / "demo.yaml").write_text(yaml.safe_dump(malformed), encoding="utf-8")
+
+    with pytest.raises(CapabilityRegistryError):
+        load_capability_registry([cap_dir])
+
+
+@pytest.mark.parametrize(
     "field",
     [
         "version",

--- a/tests/unit/test_capability_registry.py
+++ b/tests/unit/test_capability_registry.py
@@ -187,6 +187,105 @@ def test_policy_decision_is_total_for_allow_approval_and_deny() -> None:
     assert allowed.allowed_effects == allowed.request.effects
 
 
+def test_dispatch_gate_records_approval_without_calling_adapter(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import cafe.core.capabilities as cap_mod
+
+    monkeypatch.setattr(
+        cap_mod,
+        "HOST_CAPABILITY_ADAPTERS",
+        {"open_current_pr": lambda **_kwargs: (_ for _ in ()).throw(AssertionError())},
+    )
+    run = run_capability_request(
+        repo_root=tmp_path,
+        registry={"demo.echo": _typed_manifest(approval="required")},
+        capability_request=_browser_request(),
+        output_file=tmp_path / "output.md",
+    )
+
+    assert run.receipt["success"] is False
+    assert run.receipt["decision"]["outcome"] == "require_approval"
+    assert run.receipt["outcome"] == "approval_required"
+    assert run.receipt["request_fingerprint"]
+    assert run.receipt["requested_effects"]["browser_open"] == ["current_pr"]
+
+
+def test_dispatch_gate_records_policy_denial_without_calling_adapter(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import cafe.core.capabilities as cap_mod
+
+    monkeypatch.setattr(
+        cap_mod,
+        "HOST_CAPABILITY_ADAPTERS",
+        {"open_current_pr": lambda **_kwargs: (_ for _ in ()).throw(AssertionError())},
+    )
+    run = run_capability_request(
+        repo_root=tmp_path,
+        registry={"demo.echo": _typed_manifest(policy="deny")},
+        capability_request=_browser_request(),
+        output_file=tmp_path / "output.md",
+    )
+
+    assert run.receipt["decision"]["outcome"] == "deny"
+    assert run.receipt["outcome"] == "policy_denied"
+
+
+def test_dispatch_success_requires_output_contract(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import cafe.core.capabilities as cap_mod
+
+    manifest = _typed_manifest(
+        outputs={
+            "required": ["opened"],
+            "properties": {"opened": {"type": "boolean"}},
+        }
+    )
+    monkeypatch.setattr(
+        cap_mod,
+        "HOST_CAPABILITY_ADAPTERS",
+        {"open_current_pr": lambda **_kwargs: ({"opened": "yes"}, None)},
+    )
+    run = run_capability_request(
+        repo_root=tmp_path,
+        registry={"demo.echo": manifest},
+        capability_request=_browser_request(),
+        output_file=tmp_path / "output.md",
+    )
+
+    assert run.receipt["success"] is False
+    assert run.receipt["outcome"] == "execution_failure"
+    assert run.receipt["category"] == "output_contract_error"
+
+
+def test_enriched_blackboard_receipt_remains_backward_readable(tmp_path: Path) -> None:
+    from cafe.core.blackboard import BlackboardStore
+
+    issue_dir = tmp_path / "issue"
+    store = BlackboardStore(issue_dir)
+    state = store.load_or_create("develop")
+    enriched = {
+        "capability": "demo.echo",
+        "success": False,
+        "correlation_id": "new",
+        "request_fingerprint": "abc",
+        "manifest": {"id": "demo.echo", "version": 1},
+        "decision": {"outcome": "deny", "reason_code": "policy_denied"},
+        "outcome": "policy_denied",
+    }
+    store.append_capability_receipt(state, enriched)
+    store.append_capability_receipt(
+        state, {"capability": "legacy", "success": True, "correlation_id": "old"}
+    )
+
+    loaded = store.load_or_create("develop")
+    assert loaded.capability_receipts[-2:] == [enriched, {
+        "capability": "legacy", "success": True, "correlation_id": "old"
+    }]
+
+
 def test_load_registry_duplicate_ids(tmp_path: Path) -> None:
     cap_dir = tmp_path / "caps"
     cap_dir.mkdir()

--- a/tests/unit/test_capability_registry.py
+++ b/tests/unit/test_capability_registry.py
@@ -7,6 +7,7 @@ import yaml
 
 from cafe.core.capabilities import (
     CAPABILITY_PR_PUBLISH_ID,
+    CapabilityManifest,
     CapabilityRegistryError,
     load_capability_registry,
     run_capability_request,
@@ -14,15 +15,86 @@ from cafe.core.capabilities import (
 )
 
 
+def _manifest(capability_id: str = "demo.echo", **overrides: object) -> dict[str, object]:
+    manifest: dict[str, object] = {
+        "id": capability_id,
+        "version": 1,
+        "implementation": "sync_pr" if capability_id == CAPABILITY_PR_PUBLISH_ID else "open_current_pr",
+        "arguments": {
+            "required": ["target_ref"],
+            "properties": {"target_ref": {"type": "string", "enum": ["current_pr"]}},
+        },
+        "outputs": {"required": [], "properties": {}},
+        "effects": {
+            "writes": [],
+            "network_destinations": [],
+            "browser_open": ["current_pr"],
+        },
+        "credentials": [],
+        "permissions": {},
+        "idempotency": "safe",
+        "risk": "low",
+        "approval": "not_required",
+        "policy": "allow",
+    }
+    manifest.update(overrides)
+    return manifest
+
+
+def test_load_registry_returns_typed_complete_manifests(tmp_path: Path) -> None:
+    cap_dir = tmp_path / "caps"
+    cap_dir.mkdir()
+    (cap_dir / "demo.yaml").write_text(yaml.safe_dump(_manifest()), encoding="utf-8")
+
+    registry = load_capability_registry([cap_dir])
+
+    assert isinstance(registry["demo.echo"], CapabilityManifest)
+    assert registry["demo.echo"].implementation == "open_current_pr"
+    with pytest.raises(TypeError):
+        registry["new"] = registry["demo.echo"]  # type: ignore[index]
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "version",
+        "implementation",
+        "arguments",
+        "outputs",
+        "effects",
+        "credentials",
+        "permissions",
+        "idempotency",
+        "risk",
+        "approval",
+        "policy",
+    ],
+)
+def test_load_registry_rejects_incomplete_manifest(tmp_path: Path, field: str) -> None:
+    cap_dir = tmp_path / "caps"
+    cap_dir.mkdir()
+    data = _manifest()
+    data.pop(field)
+    (cap_dir / "demo.yaml").write_text(yaml.safe_dump(data), encoding="utf-8")
+
+    with pytest.raises(CapabilityRegistryError):
+        load_capability_registry([cap_dir])
+
+
+def test_load_registry_rejects_extra_and_unsupported_implementation(tmp_path: Path) -> None:
+    cap_dir = tmp_path / "caps"
+    cap_dir.mkdir()
+    malformed = _manifest(implementation="repo_script", executable="./run.sh")
+    (cap_dir / "demo.yaml").write_text(yaml.safe_dump(malformed), encoding="utf-8")
+
+    with pytest.raises(CapabilityRegistryError):
+        load_capability_registry([cap_dir])
+
+
 def test_load_registry_duplicate_ids(tmp_path: Path) -> None:
     cap_dir = tmp_path / "caps"
     cap_dir.mkdir()
-    one = {
-        "id": "dup",
-        "script_ref": "sync_pr",
-        "args_schema": {"required": []},
-        "expected_outputs": {"required": ["pr_url", "pr_number"]},
-    }
+    one = _manifest("dup")
     two = dict(one)
     (cap_dir / "a.yaml").write_text(yaml.safe_dump(one), encoding="utf-8")
     (cap_dir / "b.yaml").write_text(yaml.safe_dump(two), encoding="utf-8")

--- a/tests/unit/test_generic_workflow_step.py
+++ b/tests/unit/test_generic_workflow_step.py
@@ -1580,11 +1580,19 @@ def test_generic_workflow_step_writes_pr_publish_request_contract(
         "base": "v02",
     }
     assert publish_request["permissions"]["network"] == ["github.com", "api.github.com"]
-    assert publish_request["permissions"]["writes"] == [".git", ".cafe/issues/issue-pr-contract"]
+    assert publish_request["permissions"]["writes"] == [
+        ".cafe/issues/issue-pr-contract/pr/iteration_001/output.md",
+        ".git",
+        ".cafe/issues/issue-pr-contract",
+    ]
     assert publish_request["effects"] == {
         "browser_open": [],
         "network_destinations": ["github.com", "api.github.com"],
-        "writes": [".git", ".cafe/issues/issue-pr-contract"],
+        "writes": [
+            ".cafe/issues/issue-pr-contract/pr/iteration_001/output.md",
+            ".git",
+            ".cafe/issues/issue-pr-contract",
+        ],
     }
     assert publish_request["credentials"] == ["gh"]
 

--- a/tests/unit/test_generic_workflow_step.py
+++ b/tests/unit/test_generic_workflow_step.py
@@ -1581,9 +1581,15 @@ def test_generic_workflow_step_writes_pr_publish_request_contract(
     }
     assert publish_request["permissions"]["network"] == ["github.com", "api.github.com"]
     assert publish_request["permissions"]["writes"] == [".git", ".cafe/issues/issue-pr-contract"]
+    assert publish_request["effects"] == {
+        "browser_open": [],
+        "network_destinations": ["github.com", "api.github.com"],
+        "writes": [".git", ".cafe/issues/issue-pr-contract"],
+    }
+    assert publish_request["credentials"] == ["gh"]
 
 
-def test_generic_workflow_step_writes_declared_capability_request_for_non_pr_step(
+def test_generic_workflow_step_writes_exact_current_pr_browser_request(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
@@ -1598,7 +1604,7 @@ def test_generic_workflow_step_writes_declared_capability_request_for_non_pr_ste
                 "role": "developer",
                 "output_artifact": "code",
                 "allowed_tools": ["Read"],
-                "capability_requests": ["demo.unknown"],
+                "capability_requests": ["cafe.browser.open"],
                 "valid_intents": ["confirmed"],
                 "on": {"await_agent": "_done"},
             }
@@ -1632,8 +1638,14 @@ def test_generic_workflow_step_writes_declared_capability_request_for_non_pr_ste
         )
     )
     assert capability_request == {
-        "capability": "demo.unknown",
-        "args": {},
+        "capability": "cafe.browser.open",
+        "args": {"target_ref": "current_pr"},
+        "effects": {
+            "browser_open": ["current_pr"],
+            "writes": [],
+            "network_destinations": [],
+        },
+        "credentials": [],
         "permissions": {},
     }
     assert not (issue_dir / "publish" / "iteration_001" / "publish_request.json").exists()
@@ -1689,8 +1701,28 @@ def test_generic_workflow_step_writes_multi_capability_request_contract(
     )
     assert capability_request == {
         "requests": [
-            {"capability": "demo.first", "args": {}, "permissions": {}},
-            {"capability": "demo.second", "args": {}, "permissions": {}},
+            {
+                "capability": "demo.first",
+                "args": {},
+                "effects": {
+                    "browser_open": [],
+                    "writes": [],
+                    "network_destinations": [],
+                },
+                "credentials": [],
+                "permissions": {},
+            },
+            {
+                "capability": "demo.second",
+                "args": {},
+                "effects": {
+                    "browser_open": [],
+                    "writes": [],
+                    "network_destinations": [],
+                },
+                "credentials": [],
+                "permissions": {},
+            },
         ]
     }
     assert not (issue_dir / "publish" / "iteration_001" / "publish_request.json").exists()

--- a/tests/unit/test_generic_workflow_step.py
+++ b/tests/unit/test_generic_workflow_step.py
@@ -37,6 +37,7 @@ def LongRunningOperationArtifact(**kwargs):
         **kwargs,
     )
 
+
 from cafe.core.hooks import HookResult
 from cafe.core.downstream_contract import ContractValidationError
 from cafe.core.resume_user_input import CONTINUE_USER_INPUT
@@ -380,9 +381,7 @@ def test_generic_step_forwards_declared_read_only_guard_on_checklist_retry(
         def execute(self, *args, continuation=None, **kwargs):
             result = super().execute(*args, **kwargs)
             checklist.write_text(
-                "[ ] complete task\n"
-                if self.execute_call_count == 1
-                else "[x] complete task\n",
+                "[ ] complete task\n" if self.execute_call_count == 1 else "[x] complete task\n",
                 encoding="utf-8",
             )
             return result
@@ -1318,7 +1317,8 @@ def test_generic_workflow_step_executor_installs_workflow_common_and_phase_skill
         "write(./.cafe/issues/issue-review-skill/review/iteration_001/output.md)" in allowed_tools
     )
     assert (
-        "write(./.cafe/issues/issue-review-skill/review/iteration_001/checklist.md)" in allowed_tools
+        "write(./.cafe/issues/issue-review-skill/review/iteration_001/checklist.md)"
+        in allowed_tools
     )
     assert "edit(./.cafe/issues/issue-review-skill/blackboard.json)" not in allowed_tools
     assert "edit(./.cafe/issues/issue-review-skill/next_step.txt)" in allowed_tools
@@ -3876,9 +3876,7 @@ def test_cold_takeover_reports_absent_when_no_operation_has_started(
     assert untrusted_snapshot["operation"] == {"state": "unknown"}
 
 
-def test_cold_takeover_rejects_untrusted_operation_evidence(
-    tmp_path: Path, monkeypatch
-) -> None:
+def test_cold_takeover_rejects_untrusted_operation_evidence(tmp_path: Path, monkeypatch) -> None:
     """UT-011 — takeover state uses the runtime's operation trust boundary."""
     monkeypatch.chdir(tmp_path)
     issue_dir = tmp_path / ".cafe" / "issues" / "issue-takeover-trust"
@@ -5131,9 +5129,7 @@ def test_persisted_packet_decision_rejects_missing_effective_inputs(tmp_path: Pa
     """UT-004: an interrupted iteration cannot replace a lost packet decision."""
     iteration_dir = tmp_path / "develop" / "iteration_001"
     iteration_dir.mkdir(parents=True)
-    (iteration_dir / "iteration.json").write_text(
-        json.dumps({"iteration": 1}), encoding="utf-8"
-    )
+    (iteration_dir / "iteration.json").write_text(json.dumps({"iteration": 1}), encoding="utf-8")
 
     with pytest.raises(ValueError, match="context packet decision"):
         GenericWorkflowStepExecutor._load_persisted_effective_inputs(
@@ -5267,7 +5263,12 @@ Prepare packet inputs.
 
     assert reloaded_context["spec_file"] == reloaded_context["spec_file_path"]
     assert reloaded_context["input_loading_modes"] == "spec_file=packet, spec_file_path=packet"
-    assert json.loads((iteration_dir / "iteration.json").read_text(encoding="utf-8"))["effective_inputs"] == persisted
+    assert (
+        json.loads((iteration_dir / "iteration.json").read_text(encoding="utf-8"))[
+            "effective_inputs"
+        ]
+        == persisted
+    )
 
 
 def test_primary_and_backup_reject_persisted_full_active_packet_binding(
@@ -5371,14 +5372,29 @@ def test_persisted_packet_binding_must_match_declared_authority_and_envelope(
     _write_valid_spec_contract(source)
     other.write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
     contract = SkillWorkflowContract.model_validate(
-        {"prompt_inputs": [
-            {"artifacts": ["spec"], "placeholder": "spec_file", "load_policy": [{"mode": "packet", "contract_kind": "spec"}]},
-            {"artifacts": ["spec"], "placeholder": "spec_file_path", "load_policy": [{"mode": "packet", "contract_kind": "spec"}]},
-        ]}
+        {
+            "prompt_inputs": [
+                {
+                    "artifacts": ["spec"],
+                    "placeholder": "spec_file",
+                    "load_policy": [{"mode": "packet", "contract_kind": "spec"}],
+                },
+                {
+                    "artifacts": ["spec"],
+                    "placeholder": "spec_file_path",
+                    "load_policy": [{"mode": "packet", "contract_kind": "spec"}],
+                },
+            ]
+        }
     )
     iteration_dir = tmp_path / "develop" / "iteration_001"
     effective = resolve_effective_prompt_inputs(
-        contract, {"spec": source}, step="develop", iteration=1, feedback=False, packet_dir=iteration_dir
+        contract,
+        {"spec": source},
+        step="develop",
+        iteration=1,
+        feedback=False,
+        packet_dir=iteration_dir,
     )
     (iteration_dir / "iteration.json").write_text(
         json.dumps({"effective_inputs": effective}), encoding="utf-8"
@@ -5423,9 +5439,11 @@ def test_persisted_packet_binding_must_match_declared_authority_and_envelope(
 
     tampered_packet = json.loads(original_packet)
     tampered_packet["contract"]["bytes"] = "agent-substituted contract"
-    tampered_packet["contract"]["sha256"] = __import__("hashlib").sha256(
-        tampered_packet["contract"]["bytes"].encode("utf-8")
-    ).hexdigest()
+    tampered_packet["contract"]["sha256"] = (
+        __import__("hashlib")
+        .sha256(tampered_packet["contract"]["bytes"].encode("utf-8"))
+        .hexdigest()
+    )
     packet_path.write_text(json.dumps(tampered_packet), encoding="utf-8")
     (iteration_dir / "iteration.json").write_text(json.dumps(original), encoding="utf-8")
     with pytest.raises(ValueError, match="context packet decision"):
@@ -5470,9 +5488,12 @@ def test_persisted_packet_decision_fails_closed_on_tampered_runtime_fields(
     iteration_dir = tmp_path / "develop" / "iteration_001"
     iteration_dir.mkdir(parents=True)
     binding = {
-        "requested_mode": "packet", "mode": "full_fallback", "path": "spec.md",
+        "requested_mode": "packet",
+        "mode": "full_fallback",
+        "path": "spec.md",
         "source": {"artifact_name": "spec", "artifact_version": 1},
-        "reason": "packet_invalid", "fallback_reason": "packet_invalid",
+        "reason": "packet_invalid",
+        "fallback_reason": "packet_invalid",
         "detail": "context packet validation failed",
     }
     binding[field] = value

--- a/tests/unit/test_native_user_input_hook.py
+++ b/tests/unit/test_native_user_input_hook.py
@@ -19,7 +19,6 @@ from cafe.core.workflow_models import StepExecutionResult
 from cafe.phases.generic_phase import GenericPhaseExecution
 from cafe.phases.generic_workflow_step import GenericWorkflowStepExecutor
 
-
 PUBLISH_STEP = {
     "capability_requests": ["cafe.pr.publish"],
     "behavior": {"publish_confirmation": True},
@@ -1108,7 +1107,7 @@ def test_github_pr_creator_load_failures_persist_correlated_rejection_receipts(
     tmp_path: Path, failure: str
 ) -> None:
     from cafe.core.blackboard import BlackboardStore
-    from cafe.core.capabilities import CapabilityRegistryError
+    from cafe.core.capabilities import CapabilityRegistryError, default_capability_definition_dirs
 
     issue_dir = tmp_path / ".cafe" / "issues" / "demo"
     phase_dir = issue_dir / "publish"
@@ -1155,6 +1154,61 @@ def test_github_pr_creator_load_failures_persist_correlated_rejection_receipts(
     assert receipt["allowed_effects"] == {}
     assert receipt["decision"]["outcome"] == "deny"
     assert receipt["outcome"] == "validation_rejection"
+    assert receipt["rejection"]["error_detail"]
+    if failure == "request":
+        assert receipt["rejection"]["source"] == {
+            "kind": "request_artifact",
+            "path": str(capability_request_file.resolve()),
+        }
+        assert receipt["rejection"]["rejected_value"] == "not-json"
+    else:
+        assert receipt["rejection"]["source"] == {
+            "kind": "capability_registry",
+            "paths": [str(path) for path in default_capability_definition_dirs(tmp_path)],
+        }
+        assert receipt["rejection"]["rejected_value"] == {
+            "capability": "demo.echo",
+            "args": {"target_ref": "current_pr"},
+        }
+        assert "invalid registry" in receipt["rejection"]["error_detail"]
+
+
+def test_github_pr_creator_malformed_request_fingerprint_tracks_rejected_artifact(
+    tmp_path: Path,
+) -> None:
+    from cafe.core.blackboard import BlackboardStore
+
+    issue_dir = tmp_path / ".cafe" / "issues" / "demo"
+    phase_dir = issue_dir / "publish"
+    output_file = phase_dir / "iteration_001" / "output.md"
+    capability_request_file = phase_dir / "iteration_001" / "capability_request.json"
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    output_file.write_text("# Publish\n", encoding="utf-8")
+    phase = _FakePhase(phase_dir=phase_dir, iteration=1)
+    phase.git_ops = MagicMock()
+    phase.git_ops.get_repo_root.return_value = tmp_path
+    store = BlackboardStore(issue_dir)
+    blackboard_state = store.load_or_create("publish")
+    hook = GitHubPRCreator()
+    fingerprints: list[str] = []
+
+    for malformed in ("not-json", "also-not-json"):
+        capability_request_file.write_text(malformed, encoding="utf-8")
+        hook.run(
+            stage="publish_output",
+            phase=phase,
+            step_name="publish",
+            step_def={"capability_requests": ["demo.echo"]},
+            output_file=output_file,
+            capability_request_file=capability_request_file,
+            blackboard_state=blackboard_state,
+            status_code=PhaseStatusCode.CONFIRMED,
+        )
+        fingerprints.append(
+            store.load_or_create("publish").capability_receipts[-1]["request_fingerprint"]
+        )
+
+    assert fingerprints[0] != fingerprints[1]
 
 
 def test_github_pr_creator_publish_output_records_all_multi_capability_receipts(

--- a/tests/unit/test_native_user_input_hook.py
+++ b/tests/unit/test_native_user_input_hook.py
@@ -1103,6 +1103,60 @@ def test_github_pr_creator_publish_output_rejects_unknown_generic_capability_wit
     assert loaded.capability_receipts[-1]["success"] is False
 
 
+@pytest.mark.parametrize("failure", ["request", "registry"])
+def test_github_pr_creator_load_failures_persist_correlated_rejection_receipts(
+    tmp_path: Path, failure: str
+) -> None:
+    from cafe.core.blackboard import BlackboardStore
+    from cafe.core.capabilities import CapabilityRegistryError
+
+    issue_dir = tmp_path / ".cafe" / "issues" / "demo"
+    phase_dir = issue_dir / "publish"
+    output_file = phase_dir / "iteration_001" / "output.md"
+    capability_request_file = phase_dir / "iteration_001" / "capability_request.json"
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    output_file.write_text("# Publish\n", encoding="utf-8")
+    capability_request_file.write_text(
+        (
+            "not-json"
+            if failure == "request"
+            else json.dumps({"capability": "demo.echo", "args": {"target_ref": "current_pr"}})
+        ),
+        encoding="utf-8",
+    )
+    phase = _FakePhase(phase_dir=phase_dir, iteration=1)
+    phase.git_ops = MagicMock()
+    phase.git_ops.get_repo_root.return_value = tmp_path
+    store = BlackboardStore(issue_dir)
+    blackboard_state = store.load_or_create("publish")
+
+    hook = GitHubPRCreator()
+    registry_patch = patch(
+        "cafe.core.capabilities.load_capability_registry",
+        side_effect=CapabilityRegistryError("invalid registry"),
+    )
+    with registry_patch:
+        result = hook.run(
+            stage="publish_output",
+            phase=phase,
+            step_name="publish",
+            step_def={"capability_requests": ["demo.echo"]},
+            output_file=output_file,
+            capability_request_file=capability_request_file,
+            blackboard_state=blackboard_state,
+            status_code=PhaseStatusCode.CONFIRMED,
+        )
+
+    receipt = store.load_or_create("publish").capability_receipts[-1]
+    assert result.events[0]["type"] == "capability_receipt"
+    assert receipt["request_fingerprint"]
+    assert receipt["manifest"] is None
+    assert "requested_effects" in receipt
+    assert receipt["allowed_effects"] == {}
+    assert receipt["decision"]["outcome"] == "deny"
+    assert receipt["outcome"] == "validation_rejection"
+
+
 def test_github_pr_creator_publish_output_records_all_multi_capability_receipts(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_native_user_input_hook.py
+++ b/tests/unit/test_native_user_input_hook.py
@@ -911,9 +911,10 @@ def test_pr_link_opener_opens_current_pr_url_when_confirmed() -> None:
     hook = PRLinkOpener()
 
     with (
-        patch("cafe.core.hooks.native.GitHubOps") as mock_github_ops,
-        patch("cafe.core.hooks.native.webbrowser.open") as mock_open,
-        patch("cafe.core.hooks.native.sys.stdin.isatty", return_value=True),
+        patch("cafe.core.capabilities.GitHubOps") as mock_github_ops,
+        patch("cafe.core.capabilities.webbrowser.open") as mock_open,
+        patch("cafe.core.capabilities.sys.stdin.isatty", return_value=True),
+        patch("cafe.core.capabilities._current_repo_slug", return_value="test/repo"),
     ):
         mock_github_ops.return_value.get_current_pr_url.return_value = (
             "https://github.com/test/repo/pull/123"
@@ -933,9 +934,10 @@ def test_pr_link_opener_skips_browser_in_non_interactive() -> None:
     hook = PRLinkOpener()
 
     with (
-        patch("cafe.core.hooks.native.GitHubOps") as mock_github_ops,
-        patch("cafe.core.hooks.native.webbrowser.open") as mock_open,
-        patch("cafe.core.hooks.native.sys.stdin.isatty", return_value=False),
+        patch("cafe.core.capabilities.GitHubOps") as mock_github_ops,
+        patch("cafe.core.capabilities.webbrowser.open") as mock_open,
+        patch("cafe.core.capabilities.sys.stdin.isatty", return_value=False),
+        patch("cafe.core.capabilities._current_repo_slug", return_value="test/repo"),
     ):
         mock_github_ops.return_value.get_current_pr_url.return_value = (
             "https://github.com/test/repo/pull/123"
@@ -953,8 +955,9 @@ def test_pr_link_opener_noops_when_pr_url_unavailable() -> None:
     hook = PRLinkOpener()
 
     with (
-        patch("cafe.core.hooks.native.GitHubOps") as mock_github_ops,
-        patch("cafe.core.hooks.native.webbrowser.open") as mock_open,
+        patch("cafe.core.capabilities.GitHubOps") as mock_github_ops,
+        patch("cafe.core.capabilities.webbrowser.open") as mock_open,
+        patch("cafe.core.capabilities._current_repo_slug", return_value="test/repo"),
     ):
         mock_github_ops.return_value.get_current_pr_url.side_effect = Exception("no pr")
 
@@ -970,11 +973,12 @@ def test_pr_link_opener_noops_when_browser_open_fails() -> None:
     hook = PRLinkOpener()
 
     with (
-        patch("cafe.core.hooks.native.GitHubOps") as mock_github_ops,
+        patch("cafe.core.capabilities.GitHubOps") as mock_github_ops,
         patch(
-            "cafe.core.hooks.native.webbrowser.open", side_effect=Exception("blocked")
+            "cafe.core.capabilities.webbrowser.open", side_effect=Exception("blocked")
         ) as mock_open,
-        patch("cafe.core.hooks.native.sys.stdin.isatty", return_value=True),
+        patch("cafe.core.capabilities.sys.stdin.isatty", return_value=True),
+        patch("cafe.core.capabilities._current_repo_slug", return_value="test/repo"),
     ):
         mock_github_ops.return_value.get_current_pr_url.return_value = (
             "https://github.com/test/repo/pull/123"
@@ -1424,10 +1428,10 @@ def test_github_pr_creator_publish_output_fails_safe_without_explicit_true(
     assert result.events == []
 
 
-def test_github_pr_creator_publish_ignores_untrusted_script_field_in_request(
+def test_github_pr_creator_publish_rejects_untrusted_script_field_before_dispatch(
     tmp_path: Path,
 ) -> None:
-    """Registry-resolved script is used; agent-supplied script path must not change dispatch."""
+    """Agent-supplied executable authority invalidates the request."""
     issue_dir = tmp_path / ".cafe" / "issues" / "demo"
     _enable_remote_pr(issue_dir)
     phase_dir = issue_dir / "pr"
@@ -1462,7 +1466,7 @@ def test_github_pr_creator_publish_ignores_untrusted_script_field_in_request(
 
     hook = GitHubPRCreator()
     with patch("cafe.core.capabilities.subprocess.run", return_value=completed) as mock_run:
-        hook.run(
+        result = hook.run(
             stage="publish_output",
             phase=phase,
             step_name="pr",
@@ -1472,8 +1476,10 @@ def test_github_pr_creator_publish_ignores_untrusted_script_field_in_request(
             status_code=PhaseStatusCode.CONFIRMED,
         )
 
-    cmd = mock_run.call_args.args[0]
-    assert cmd[1] == str(hook._resolve_sync_script(tmp_path))
+    mock_run.assert_not_called()
+    assert result.events[-1]["type"] == "capability_receipt"
+    assert result.events[-1]["success"] is False
+    assert result.events[-1]["code"] == "malformed_request"
 
 
 def test_pr_comment_poster_posts_todo_comment_only_when_confirmed_and_complete(

--- a/tests/unit/test_native_user_input_hook.py
+++ b/tests/unit/test_native_user_input_hook.py
@@ -1,6 +1,7 @@
 """Tests for workflow user-input hooks."""
 
 import json
+from contextlib import nullcontext
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -1102,7 +1103,9 @@ def test_github_pr_creator_publish_output_rejects_unknown_generic_capability_wit
     assert loaded.capability_receipts[-1]["success"] is False
 
 
-@pytest.mark.parametrize("failure", ["request", "registry"])
+@pytest.mark.parametrize(
+    "failure", ["request_json", "request_encoding", "request_read", "registry"]
+)
 def test_github_pr_creator_load_failures_persist_correlated_rejection_receipts(
     tmp_path: Path, failure: str
 ) -> None:
@@ -1115,14 +1118,14 @@ def test_github_pr_creator_load_failures_persist_correlated_rejection_receipts(
     capability_request_file = phase_dir / "iteration_001" / "capability_request.json"
     output_file.parent.mkdir(parents=True, exist_ok=True)
     output_file.write_text("# Publish\n", encoding="utf-8")
-    capability_request_file.write_text(
-        (
-            "not-json"
-            if failure == "request"
-            else json.dumps({"capability": "demo.echo", "args": {"target_ref": "current_pr"}})
-        ),
-        encoding="utf-8",
-    )
+    valid_request = {"capability": "demo.echo", "args": {"target_ref": "current_pr"}}
+    if failure == "request_encoding":
+        capability_request_file.write_bytes(b"{\xff}")
+    else:
+        capability_request_file.write_text(
+            "not-json" if failure == "request_json" else json.dumps(valid_request),
+            encoding="utf-8",
+        )
     phase = _FakePhase(phase_dir=phase_dir, iteration=1)
     phase.git_ops = MagicMock()
     phase.git_ops.get_repo_root.return_value = tmp_path
@@ -1134,7 +1137,12 @@ def test_github_pr_creator_load_failures_persist_correlated_rejection_receipts(
         "cafe.core.capabilities.load_capability_registry",
         side_effect=CapabilityRegistryError("invalid registry"),
     )
-    with registry_patch:
+    read_patch = (
+        patch("pathlib.Path.read_text", side_effect=PermissionError("request unreadable"))
+        if failure == "request_read"
+        else nullcontext()
+    )
+    with registry_patch, read_patch:
         result = hook.run(
             stage="publish_output",
             phase=phase,
@@ -1155,12 +1163,17 @@ def test_github_pr_creator_load_failures_persist_correlated_rejection_receipts(
     assert receipt["decision"]["outcome"] == "deny"
     assert receipt["outcome"] == "validation_rejection"
     assert receipt["rejection"]["error_detail"]
-    if failure == "request":
+    if failure.startswith("request_"):
         assert receipt["rejection"]["source"] == {
             "kind": "request_artifact",
             "path": str(capability_request_file.resolve()),
         }
-        assert receipt["rejection"]["rejected_value"] == "not-json"
+        if failure == "request_json":
+            assert receipt["rejection"]["rejected_value"] == "not-json"
+        elif failure == "request_encoding":
+            assert receipt["rejection"]["rejected_value"] == "{\ufffd}"
+        else:
+            assert receipt["rejection"]["rejected_value"] is None
     else:
         assert receipt["rejection"]["source"] == {
             "kind": "capability_registry",

--- a/tests/unit/test_native_user_input_hook.py
+++ b/tests/unit/test_native_user_input_hook.py
@@ -1,5 +1,6 @@
 """Tests for workflow user-input hooks."""
 
+import hashlib
 import json
 from contextlib import nullcontext
 from pathlib import Path
@@ -1142,7 +1143,12 @@ def test_github_pr_creator_load_failures_persist_correlated_rejection_receipts(
         if failure == "request_read"
         else nullcontext()
     )
-    with registry_patch, read_patch:
+    bytes_patch = (
+        patch("pathlib.Path.read_bytes", side_effect=PermissionError("request unreadable"))
+        if failure == "request_read"
+        else nullcontext()
+    )
+    with registry_patch, read_patch, bytes_patch:
         result = hook.run(
             stage="publish_output",
             phase=phase,
@@ -1164,10 +1170,15 @@ def test_github_pr_creator_load_failures_persist_correlated_rejection_receipts(
     assert receipt["outcome"] == "validation_rejection"
     assert receipt["rejection"]["error_detail"]
     if failure.startswith("request_"):
-        assert receipt["rejection"]["source"] == {
+        expected_source = {
             "kind": "request_artifact",
             "path": str(capability_request_file.resolve()),
         }
+        if failure != "request_read":
+            expected_source["content_sha256"] = hashlib.sha256(
+                capability_request_file.read_bytes()
+            ).hexdigest()
+        assert receipt["rejection"]["source"] == expected_source
         if failure == "request_json":
             assert receipt["rejection"]["rejected_value"] == "not-json"
         elif failure == "request_encoding":
@@ -1219,6 +1230,88 @@ def test_github_pr_creator_malformed_request_fingerprint_tracks_rejected_artifac
         )
         fingerprints.append(
             store.load_or_create("publish").capability_receipts[-1]["request_fingerprint"]
+        )
+
+    assert fingerprints[0] != fingerprints[1]
+
+
+def test_github_pr_creator_unreadable_request_fingerprint_tracks_source_path(
+    tmp_path: Path,
+) -> None:
+    from cafe.core.blackboard import BlackboardStore
+
+    issue_dir = tmp_path / ".cafe" / "issues" / "demo"
+    phase_dir = issue_dir / "publish"
+    output_file = phase_dir / "iteration_001" / "output.md"
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    output_file.write_text("# Publish\n", encoding="utf-8")
+    phase = _FakePhase(phase_dir=phase_dir, iteration=1)
+    phase.git_ops = MagicMock()
+    phase.git_ops.get_repo_root.return_value = tmp_path
+    store = BlackboardStore(issue_dir)
+    blackboard_state = store.load_or_create("publish")
+    hook = GitHubPRCreator()
+    fingerprints: list[str] = []
+
+    with (
+        patch("pathlib.Path.read_text", side_effect=PermissionError("request unreadable")),
+        patch("pathlib.Path.read_bytes", side_effect=PermissionError("request unreadable")),
+    ):
+        for filename in ("first.json", "second.json"):
+            request_file = output_file.parent / filename
+            request_file.write_text("same request", encoding="utf-8")
+            hook.run(
+                stage="publish_output",
+                phase=phase,
+                step_name="publish",
+                step_def={"capability_requests": ["demo.echo"]},
+                output_file=output_file,
+                capability_request_file=request_file,
+                blackboard_state=blackboard_state,
+                status_code=PhaseStatusCode.CONFIRMED,
+            )
+            fingerprints.append(
+                blackboard_state.capability_receipts[-1]["request_fingerprint"]
+            )
+
+    assert fingerprints[0] != fingerprints[1]
+
+
+def test_github_pr_creator_invalid_utf8_fingerprint_tracks_original_bytes(
+    tmp_path: Path,
+) -> None:
+    from cafe.core.blackboard import BlackboardStore
+
+    issue_dir = tmp_path / ".cafe" / "issues" / "demo"
+    phase_dir = issue_dir / "publish"
+    output_file = phase_dir / "iteration_001" / "output.md"
+    capability_request_file = output_file.parent / "capability_request.json"
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    output_file.write_text("# Publish\n", encoding="utf-8")
+    phase = _FakePhase(phase_dir=phase_dir, iteration=1)
+    phase.git_ops = MagicMock()
+    phase.git_ops.get_repo_root.return_value = tmp_path
+    store = BlackboardStore(issue_dir)
+    blackboard_state = store.load_or_create("publish")
+    hook = GitHubPRCreator()
+    fingerprints: list[str] = []
+
+    for malformed in (b"{\xff}", b"{\xfe}"):
+        capability_request_file.write_bytes(malformed)
+        hook.run(
+            stage="publish_output",
+            phase=phase,
+            step_name="publish",
+            step_def={"capability_requests": ["demo.echo"]},
+            output_file=output_file,
+            capability_request_file=capability_request_file,
+            blackboard_state=blackboard_state,
+            status_code=PhaseStatusCode.CONFIRMED,
+        )
+        fingerprints.append(
+            store.load_or_create("publish").capability_receipts[-1][
+                "request_fingerprint"
+            ]
         )
 
     assert fingerprints[0] != fingerprints[1]

--- a/tests/unit/test_native_user_input_hook.py
+++ b/tests/unit/test_native_user_input_hook.py
@@ -551,9 +551,7 @@ def test_github_issue_fetcher_fetches_configured_issue_noninteractively(tmp_path
 
     assert "Restore legacy input" in output_file.read_text(encoding="utf-8")
     assert result.context_updates == {"user_input": "**Issue Title:** Restore legacy input"}
-    assert result.events == [
-        {"type": "user_input_collected", "step": "spec", "source": "github"}
-    ]
+    assert result.events == [{"type": "user_input_collected", "step": "spec", "source": "github"}]
     mock_prompt_method.assert_not_called()
     mock_prompt_manual.assert_not_called()
     mock_fetch_issue.assert_called_once_with(346)
@@ -583,9 +581,7 @@ def test_github_only_provider_prompts_for_issue_id_interactively(tmp_path: Path)
         initial_input_fetch_github_issue=fetch,
     )
 
-    assert output_file.read_text(encoding="utf-8") == (
-        "**Issue Title:** Gather requirements\n"
-    )
+    assert output_file.read_text(encoding="utf-8") == ("**Issue Title:** Gather requirements\n")
     assert result.context_updates == {"user_input": "**Issue Title:** Gather requirements"}
     prompt.assert_called_once_with()
     fetch.assert_called_once_with(346)
@@ -643,9 +639,7 @@ def test_initial_input_provider_delivers_prefilled_manual_text_to_custom_entry_s
         context={"user_input": "Summarize the incoming customer report."},
     )
 
-    assert output_file.read_text(encoding="utf-8") == (
-        "Summarize the incoming customer report.\n"
-    )
+    assert output_file.read_text(encoding="utf-8") == ("Summarize the incoming customer report.\n")
     assert result.context_updates == {"user_input": "Summarize the incoming customer report."}
     assert result.events == [
         {"type": "initial_input_resolved", "step": "intake", "provider": "manual_text"}
@@ -721,9 +715,7 @@ def test_builtin_initial_input_preserves_legacy_requirements_seed(
     assert output_file.read_text(encoding="utf-8") == (
         "# Initial Requirements\n\nPreserve the established workflow kickoff.\n"
     )
-    assert result.context_updates == {
-        "user_input": "Preserve the established workflow kickoff."
-    }
+    assert result.context_updates == {"user_input": "Preserve the established workflow kickoff."}
 
 
 def test_builtin_initial_input_seeds_empty_legacy_requirements_non_interactively(


### PR DESCRIPTION
## Summary
- Added the issue #400 capability-policy hardening work end-to-end: typed capability manifests, strict request boundary checks, explicit `allow`/`require_approval`/`deny` decisions, allow-listed host dispatch, and correlated receipts for all outcomes.
- The PR preserves existing PR publishing behavior while proving a bounded generic capability path through `cafe.browser.open` with only current-PR resolution authority.

## Changes
- Completed typed capability contracts and registry validation in `src/cafe/core/capabilities.py`, including manifest loading, conflict detection, implementation allow-list enforcement, argument/effect normalization, and subset boundary checks.
- Implemented a fail-closed policy evaluator that returns a single total decision plus reason and prevents dispatch on malformed, conflicting, unsupported, broadened, tampered, or indeterminate requests.
- Routed execution through a request → policy → dispatch → receipt pipeline with stable request fingerprints and audit fields for request, manifest, decision, and outcome.
- Migrated PR publishing to the shared capability lifecycle while keeping the existing `pr_synced` user outcome contract and successful PR result compatibility.
- Added `cafe.browser.open` as the non-PR generic-path demonstration with strict `current_pr` target-only contract and no caller-selected URL/origin/network/credential/permission authority.
- Closed remaining request-load rejection regression in fingerprint correlation for unreadable and invalid-byte artifact variants.
- Kept all checks and tests aligned with the original issue-400 acceptance criteria, including full-suite and coverage validation.
- Added related commits for reference:
  - `ed289581` correlate rejected request artifacts
  - `771bdca9` close capability request load gaps
  - `1a542d8a` close capability audit gaps
  - `b38b625a` close capability authorization gaps
  - `257bffd9` stabilize operation shutdown assertion
  - `4b42a7d1` cover capability policy user journeys
  - `064ecd69` route host capabilities through policy boundary
  - `7255d64b` gate capability dispatch with audit receipts
  - `06f7f1e8` enforce fail-closed capability policy
  - `f735f6c7` add typed capability manifest registry

## Test Plan
- `cafe verification check --output-file ./.cafe/issues/issue400/develop/iteration_005/output.md --require-scope full`
  - Verified full scope including repository-defined `./scripts/test-coverage.sh` and integration coverage against a clean tracked HEAD.
- `pytest tests/unit/test_capability_registry.py tests/unit/test_generic_workflow_step.py tests/unit/test_native_user_input_hook.py`
  - Covers manifest schema, policy/fingerprint, and native dispatch outcome cases in unit scope.
- `pytest tests/integration/test_pr_e2e_with_mock.py tests/integration/test_workflow_e2e.py`
  - Covers compatibility, fail-closed paths, approval/deny outcomes, and bounded `cafe.browser.open` request behavior.