### PR TITLE
Implement exact-request capability approval with expiry-boundary validation

### DIFF
--- a/src/cafe/core/capabilities.py
+++ b/src/cafe/core/capabilities.py
@@ -151,6 +151,21 @@ class ExecutionRequest(StrictCapabilityModel):
     permissions: Mapping[str, Tuple[str, ...]]
     expires_at: Optional[str] = None
 
+    @field_validator("expires_at")
+    @classmethod
+    def validate_expires_at(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        if not value.strip():
+            raise ValueError("expires_at must be a timezone-aware ISO 8601 timestamp")
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError as exc:
+            raise ValueError("expires_at must be a timezone-aware ISO 8601 timestamp") from exc
+        if parsed.tzinfo is None:
+            raise ValueError("expires_at must include a timezone")
+        return value
+
     @field_validator("credentials", mode="before")
     @classmethod
     def freeze_credentials(cls, value: Any) -> Any:

--- a/src/cafe/core/capabilities.py
+++ b/src/cafe/core/capabilities.py
@@ -17,7 +17,7 @@ from types import MappingProxyType
 from typing import Any, Dict, List, Literal, Mapping, Optional, Sequence, Tuple
 from urllib.parse import urlparse
 
-import yaml
+import yaml  # type: ignore[import-untyped]
 from pydantic import (
     BaseModel,
     ConfigDict,
@@ -742,7 +742,8 @@ def _normalize_legacy_pr_request(request: Mapping[str, Any]) -> Dict[str, Any]:
     if str(normalized.get("capability") or "") != CAPABILITY_PR_PUBLISH_ID:
         return normalized
     if "effects" not in normalized:
-        args = normalized.get("args") if isinstance(normalized.get("args"), Mapping) else {}
+        raw_args = normalized.get("args")
+        args = raw_args if isinstance(raw_args, Mapping) else {}
         output = str(args.get("output") or "")
         output_parts = Path(output).parts
         try:
@@ -1088,8 +1089,6 @@ def run_capability_request(
             inputs=_receipt_inputs(raw_request.get("args")),
         )
 
-    manifest = raw_manifest
-
     evaluation = evaluate_capability_request(registry, raw_request)
     if evaluation.decision != PolicyDecision.ALLOW:
         outcome = (
@@ -1104,6 +1103,39 @@ def run_capability_request(
             code=evaluation.reason_code,
             decision=evaluation.decision,
             outcome=outcome,
+            inputs=dict(request.args),
+            evaluation=evaluation,
+        )
+
+    return dispatch_revalidated_capability_request(
+        repo_root=repo_root,
+        evaluation=evaluation,
+        output_file=output_file,
+        timeout_sec=timeout_sec,
+        correlation_id=correlation_id,
+    )
+
+
+def dispatch_revalidated_capability_request(
+    *,
+    repo_root: Path,
+    evaluation: CapabilityEvaluation,
+    output_file: Path,
+    timeout_sec: float = 600.0,
+    correlation_id: Optional[str] = None,
+) -> PrPublishRun:
+    """Dispatch one exact evaluation after its caller has established authorization."""
+    correlation_id = correlation_id or uuid.uuid4().hex[:20]
+    request = evaluation.request
+    manifest = evaluation.manifest
+    if evaluation.decision not in {PolicyDecision.ALLOW, PolicyDecision.REQUIRE_APPROVAL}:
+        return _non_dispatch_run(
+            correlation_id=correlation_id,
+            capability=request.capability,
+            fingerprint=evaluation.fingerprint,
+            code=evaluation.reason_code,
+            decision=evaluation.decision,
+            outcome="policy_denied",
             inputs=dict(request.args),
             evaluation=evaluation,
         )

--- a/src/cafe/core/capabilities.py
+++ b/src/cafe/core/capabilities.py
@@ -149,6 +149,7 @@ class ExecutionRequest(StrictCapabilityModel):
     effects: CapabilityEffects
     credentials: Tuple[str, ...]
     permissions: Mapping[str, Tuple[str, ...]]
+    expires_at: Optional[str] = None
 
     @field_validator("credentials", mode="before")
     @classmethod

--- a/src/cafe/core/capability_approvals.py
+++ b/src/cafe/core/capability_approvals.py
@@ -80,6 +80,9 @@ class CapabilityApprovalService:
                 f"current policy does not require approval: {evaluation.reason_code}"
             )
         fingerprint = canonical_request_fingerprint(request)
+        existing = self._find_request(fingerprint, _manifest_digest(manifest))
+        if existing is not None:
+            return existing
         snapshot = {
             "kind": CAPABILITY_APPROVAL_TRIGGER,
             "state": "pending",
@@ -130,6 +133,19 @@ class CapabilityApprovalService:
                 f"capability:{self.workflow_id}:{self.step}:{request.capability}:{fingerprint}"
             ),
         )
+
+    def _find_request(self, fingerprint: str, manifest_digest: str) -> Optional[HumanTask]:
+        if not self.store.exists:
+            return None
+        matches = [
+            task
+            for task in self.store.tasks()
+            if task.workflow_id == self.workflow_id
+            and task.capability_approval is not None
+            and task.capability_approval.get("fingerprint") == fingerprint
+            and task.capability_approval.get("manifest_digest") == manifest_digest
+        ]
+        return max(matches, key=lambda task: task.created_at) if matches else None
 
     def inspect(self, task_id: str) -> dict[str, Any]:
         task = self.store.get_task(task_id)
@@ -426,12 +442,16 @@ class CapabilityApprovalService:
         return {
             "workflow_id": self.workflow_id,
             "task_id": task_id,
+            "capability": current["capability"],
             "request_fingerprint": current["fingerprint"],
             "request": current["request"],
             "approval": current.get("decision"),
             "revalidation": current.get("revalidation"),
             "attempt": current.get("attempt"),
             "outcome": outcome,
+            "success": outcome == "succeeded",
+            "category": None if outcome == "succeeded" else "capability_approval",
+            "code": None if outcome == "succeeded" else outcome,
             "executed": False,
             "recovery": recovery,
             "recorded_at": self._now().astimezone().isoformat(),

--- a/src/cafe/core/capability_approvals.py
+++ b/src/cafe/core/capability_approvals.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Mapping, Optional
@@ -73,6 +74,7 @@ class CapabilityApprovalService:
         request: ExecutionRequest,
         manifest: CapabilityManifest,
         expires_at: Optional[str] = None,
+        correlation_id: Optional[str] = None,
     ) -> HumanTask:
         evaluation = evaluate_capability_request({manifest.id: manifest}, request.model_dump())
         if evaluation.decision is not PolicyDecision.REQUIRE_APPROVAL:
@@ -83,10 +85,12 @@ class CapabilityApprovalService:
         existing = self._find_request(fingerprint, _manifest_digest(manifest))
         if existing is not None:
             return existing
+        correlation_id = correlation_id or uuid.uuid4().hex[:20]
         snapshot = {
             "kind": CAPABILITY_APPROVAL_TRIGGER,
             "state": "pending",
             "workflow_id": self.workflow_id,
+            "correlation_id": correlation_id,
             "fingerprint": fingerprint,
             "request": _json(request),
             "manifest": _json(manifest),
@@ -122,6 +126,7 @@ class CapabilityApprovalService:
                     "workflow_id",
                     "task_id",
                     "request_fingerprint",
+                    "correlation_id",
                 ],
                 "decisions": ["approve", "deny"],
                 "request_fingerprint": fingerprint,
@@ -134,7 +139,13 @@ class CapabilityApprovalService:
             ),
         )
 
-    def _find_request(self, fingerprint: str, manifest_digest: str) -> Optional[HumanTask]:
+    def _find_request(
+        self,
+        fingerprint: str,
+        manifest_digest: Optional[str] = None,
+        *,
+        states: Optional[set[str]] = None,
+    ) -> Optional[HumanTask]:
         if not self.store.exists:
             return None
         matches = [
@@ -143,7 +154,12 @@ class CapabilityApprovalService:
             if task.workflow_id == self.workflow_id
             and task.capability_approval is not None
             and task.capability_approval.get("fingerprint") == fingerprint
-            and task.capability_approval.get("manifest_digest") == manifest_digest
+            and (
+                manifest_digest is None
+                or task.capability_approval.get("manifest_digest") == manifest_digest
+            )
+            and (states is not None or task.capability_approval.get("state") != "policy_rejected")
+            and (states is None or str(task.capability_approval.get("state")) in states)
         ]
         return max(matches, key=lambda task: task.created_at) if matches else None
 
@@ -172,8 +188,6 @@ class CapabilityApprovalService:
     def record_decision(self, task_id: str, payload: object) -> dict[str, Any]:
         with self.store.transaction():
             current = self.inspect(task_id)
-            if current["state"] != "pending":
-                return current
             if not isinstance(payload, Mapping):
                 raise CapabilityApprovalError("capability approval must be structured JSON")
             required = {
@@ -181,6 +195,7 @@ class CapabilityApprovalService:
                 "workflow_id",
                 "task_id",
                 "request_fingerprint",
+                "correlation_id",
             }
             if not required.issubset(payload):
                 raise CapabilityApprovalError("capability approval correlation is incomplete")
@@ -190,15 +205,19 @@ class CapabilityApprovalService:
                 payload.get("workflow_id") != self.workflow_id
                 or payload.get("task_id") != task_id
                 or payload.get("request_fingerprint") != current["fingerprint"]
+                or payload.get("correlation_id") != current["correlation_id"]
             ):
                 raise CapabilityApprovalError(
                     "capability approval does not match the exact request"
                 )
+            if current["state"] != "pending":
+                return current
             now = self._now().astimezone().isoformat()
             current["state"] = "approved" if payload["decision"] == "approve" else "denied"
             current["decision"] = {
                 "outcome": payload["decision"],
                 "source": "capability_approval",
+                "correlation_id": current["correlation_id"],
                 "recorded_at": now,
             }
             if current["state"] == "denied":
@@ -244,10 +263,48 @@ class CapabilityApprovalService:
         )
         return current
 
+    def terminalize_policy_failure(
+        self,
+        *,
+        request: ExecutionRequest,
+        reason_code: str,
+        evidence: Mapping[str, Any],
+    ) -> Optional[dict[str, Any]]:
+        """Consume an approved exact request when current policy is unavailable."""
+        with self.store.transaction():
+            task = self._find_request(
+                canonical_request_fingerprint(request),
+                states={"approved", "policy_rejected"},
+            )
+            if task is None:
+                return None
+            current = self.inspect(task.id)
+            if current["state"] == "policy_rejected":
+                receipt = current.get("receipt")
+                return dict(receipt) if isinstance(receipt, Mapping) else None
+            if current["state"] != "approved":
+                return None
+            current["revalidation"] = {
+                "outcome": "error",
+                "reason_code": reason_code,
+                "checked_at": self._now().astimezone().isoformat(),
+                **_json(evidence),
+            }
+            current["state"] = "policy_rejected"
+            return self._finish(
+                task.id,
+                current,
+                outcome="policy_rejected",
+                executed=False,
+                recovery="Restore a verifiable policy and create a new approval task.",
+                event_type="capability_policy_rejected",
+            )
+
     def resume(
         self,
         task_id: str,
         *,
+        correlation_id: str,
         request: ExecutionRequest,
         registry: Mapping[str, CapabilityManifest],
         repo_root: Path,
@@ -258,6 +315,7 @@ class CapabilityApprovalService:
         with self.store.transaction():
             return self._resume_locked(
                 task_id,
+                correlation_id=correlation_id,
                 request=request,
                 registry=registry,
                 repo_root=repo_root,
@@ -269,6 +327,7 @@ class CapabilityApprovalService:
         self,
         task_id: str,
         *,
+        correlation_id: str,
         request: ExecutionRequest,
         registry: Mapping[str, CapabilityManifest],
         repo_root: Path,
@@ -276,6 +335,8 @@ class CapabilityApprovalService:
         timeout_sec: float,
     ) -> dict[str, Any]:
         current = self.inspect(task_id)
+        if correlation_id != current["correlation_id"]:
+            raise CapabilityApprovalError("capability resume does not match the host request")
         if current["state"] in TERMINAL_STATES:
             receipt = current.get("receipt")
             if isinstance(receipt, Mapping):
@@ -369,6 +430,7 @@ class CapabilityApprovalService:
             evaluation=evaluation,
             output_file=output_file,
             timeout_sec=timeout_sec,
+            correlation_id=str(current["correlation_id"]),
         )
         succeeded = bool(run.receipt.get("success"))
         current["state"] = "succeeded" if succeeded else "failed"
@@ -471,6 +533,7 @@ class CapabilityApprovalService:
     ) -> dict[str, Any]:
         return {
             "workflow_id": self.workflow_id,
+            "correlation_id": current["correlation_id"],
             "task_id": task_id,
             "capability": current["capability"],
             "request_fingerprint": current["fingerprint"],

--- a/src/cafe/core/capability_approvals.py
+++ b/src/cafe/core/capability_approvals.py
@@ -7,10 +7,12 @@ from pathlib import Path
 from typing import Any, Callable, Mapping, Optional
 
 from cafe.core.capabilities import (
+    CapabilityEvaluation,
     CapabilityManifest,
     ExecutionRequest,
     PolicyDecision,
     canonical_request_fingerprint,
+    dispatch_revalidated_capability_request,
     evaluate_capability_request,
 )
 from cafe.core.human_task_records import HumanTask, HumanTaskRecordStore, HumanTaskStatus
@@ -177,9 +179,7 @@ class CapabilityApprovalService:
                     "capability approval does not match the exact request"
                 )
             now = self._now().astimezone().isoformat()
-            current["state"] = (
-                "approved" if payload["decision"] == "approve" else "denied"
-            )
+            current["state"] = "approved" if payload["decision"] == "approve" else "denied"
             current["decision"] = {
                 "outcome": payload["decision"],
                 "source": "capability_approval",
@@ -220,6 +220,188 @@ class CapabilityApprovalService:
             terminal_status=HumanTaskStatus.CANCELLED,
         )
         return current
+
+    def resume(
+        self,
+        task_id: str,
+        *,
+        request: ExecutionRequest,
+        registry: Mapping[str, CapabilityManifest],
+        repo_root: Path,
+        output_file: Path,
+        timeout_sec: float = 600.0,
+    ) -> dict[str, Any]:
+        """Resume only the approved unchanged request behind its one-attempt fence."""
+        current = self.inspect(task_id)
+        if current["state"] in TERMINAL_STATES:
+            receipt = current.get("receipt")
+            if isinstance(receipt, Mapping):
+                return dict(receipt)
+            raise CapabilityApprovalError("terminal capability approval has no receipt")
+        if current["state"] == "attempt_started":
+            current["state"] = "uncertain"
+            current["attempt"] = {
+                **dict(current.get("attempt") or {}),
+                "state": "uncertain",
+                "finished_at": self._now().astimezone().isoformat(),
+            }
+            return self._finish(
+                task_id,
+                current,
+                outcome="uncertain",
+                executed=True,
+                recovery=(
+                    "Inspect the host system and reconcile manually; automatic retry is disabled."
+                ),
+                event_type="capability_attempt_uncertain",
+            )
+        if current["state"] != "approved":
+            raise CapabilityApprovalError("matching capability approval is still required")
+
+        fingerprint = canonical_request_fingerprint(request)
+        if fingerprint != current["fingerprint"]:
+            current["state"] = "tampered"
+            return self._finish(
+                task_id,
+                current,
+                outcome="tampered",
+                executed=False,
+                recovery="Evaluate the changed request and create a new approval task.",
+                event_type="capability_request_tampered",
+            )
+
+        try:
+            evaluation = evaluate_capability_request(registry, request.model_dump(mode="json"))
+        except Exception as exc:
+            current["revalidation"] = {
+                "outcome": "error",
+                "reason_code": type(exc).__name__,
+                "checked_at": self._now().astimezone().isoformat(),
+            }
+            current["state"] = "policy_rejected"
+            return self._finish(
+                task_id,
+                current,
+                outcome="policy_rejected",
+                executed=False,
+                recovery="Restore a verifiable policy and create a new approval task.",
+                event_type="capability_policy_rejected",
+            )
+
+        current["revalidation"] = self._revalidation_record(evaluation)
+        if evaluation.decision is PolicyDecision.DENY or not self._same_reviewed_boundary(
+            current, evaluation.manifest
+        ):
+            current["state"] = "policy_rejected"
+            return self._finish(
+                task_id,
+                current,
+                outcome="policy_rejected",
+                executed=False,
+                recovery="Evaluate the current request and policy through a new approval task.",
+                event_type="capability_policy_rejected",
+            )
+
+        self.store.update_capability_approval(
+            workflow_id=self.workflow_id,
+            task_id=task_id,
+            metadata=current,
+            event_type="capability_policy_revalidated",
+        )
+        started_at = self._now().astimezone().isoformat()
+        current["state"] = "attempt_started"
+        current["attempt"] = {"state": "started", "started_at": started_at}
+        self.store.update_capability_approval(
+            workflow_id=self.workflow_id,
+            task_id=task_id,
+            metadata=current,
+            event_type="capability_attempt_started",
+        )
+
+        run = dispatch_revalidated_capability_request(
+            repo_root=repo_root,
+            evaluation=evaluation,
+            output_file=output_file,
+            timeout_sec=timeout_sec,
+        )
+        succeeded = bool(run.receipt.get("success"))
+        current["state"] = "succeeded" if succeeded else "failed"
+        current["attempt"] = {
+            **dict(current["attempt"]),
+            "state": "finished",
+            "finished_at": self._now().astimezone().isoformat(),
+            "outcome": "succeeded" if succeeded else "failed",
+        }
+        return self._finish(
+            task_id,
+            current,
+            outcome=current["state"],
+            executed=True,
+            recovery=(
+                "No recovery is required."
+                if succeeded
+                else "Inspect the recorded failure; automatic retry is disabled."
+            ),
+            event_type="capability_attempt_finished",
+            execution_receipt=run.receipt,
+        )
+
+    def _finish(
+        self,
+        task_id: str,
+        current: dict[str, Any],
+        *,
+        outcome: str,
+        executed: bool,
+        recovery: str,
+        event_type: str,
+        execution_receipt: Optional[Mapping[str, Any]] = None,
+    ) -> dict[str, Any]:
+        receipt = self._terminal_receipt(
+            task_id=task_id,
+            current=current,
+            outcome=outcome,
+            recovery=recovery,
+        )
+        receipt["executed"] = executed
+        if execution_receipt is not None:
+            receipt["execution"] = dict(execution_receipt)
+        current["receipt"] = receipt
+        self.store.update_capability_approval(
+            workflow_id=self.workflow_id,
+            task_id=task_id,
+            metadata=current,
+            event_type=event_type,
+        )
+        return receipt
+
+    def _revalidation_record(self, evaluation: CapabilityEvaluation) -> dict[str, Any]:
+        return {
+            "outcome": evaluation.decision.value,
+            "reason_code": evaluation.reason_code,
+            "manifest_digest": _manifest_digest(evaluation.manifest),
+            "checked_at": self._now().astimezone().isoformat(),
+        }
+
+    @staticmethod
+    def _same_reviewed_boundary(current: Mapping[str, Any], manifest: CapabilityManifest) -> bool:
+        reviewed = current.get("manifest")
+        if not isinstance(reviewed, Mapping):
+            return False
+        live = manifest.model_dump(mode="json")
+        security_fields = {
+            "id",
+            "version",
+            "implementation",
+            "arguments",
+            "outputs",
+            "effects",
+            "credentials",
+            "permissions",
+            "idempotency",
+            "risk",
+        }
+        return all(reviewed.get(field) == live.get(field) for field in security_fields)
 
     def _is_expired(self, current: Mapping[str, Any]) -> bool:
         raw = current.get("expires_at")

--- a/src/cafe/core/capability_approvals.py
+++ b/src/cafe/core/capability_approvals.py
@@ -73,7 +73,6 @@ class CapabilityApprovalService:
         *,
         request: ExecutionRequest,
         manifest: CapabilityManifest,
-        expires_at: Optional[str] = None,
         correlation_id: Optional[str] = None,
     ) -> HumanTask:
         evaluation = evaluate_capability_request({manifest.id: manifest}, request.model_dump())
@@ -102,7 +101,7 @@ class CapabilityApprovalService:
             "credentials": list(request.credentials),
             "permissions": _json(request.permissions),
             "expected_outputs": list(manifest.outputs.required),
-            "expires_at": expires_at,
+            "expires_at": request.expires_at,
             "decision": None,
             "revalidation": None,
             "attempt": None,

--- a/src/cafe/core/capability_approvals.py
+++ b/src/cafe/core/capability_approvals.py
@@ -1,0 +1,264 @@
+"""Durable approval lifecycle for one exact trusted-host capability request."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Mapping, Optional
+
+from cafe.core.capabilities import (
+    CapabilityManifest,
+    ExecutionRequest,
+    PolicyDecision,
+    canonical_request_fingerprint,
+    evaluate_capability_request,
+)
+from cafe.core.human_task_records import HumanTask, HumanTaskRecordStore, HumanTaskStatus
+
+CAPABILITY_APPROVAL_TRIGGER = "capability_approval"
+CAPABILITY_APPROVAL_POLICY_ID = "capability-approval"
+TERMINAL_STATES = {
+    "denied",
+    "cancelled",
+    "expired",
+    "tampered",
+    "policy_rejected",
+    "succeeded",
+    "failed",
+    "uncertain",
+}
+
+
+class CapabilityApprovalError(ValueError):
+    """An approval input cannot safely advance its exact request."""
+
+
+def _now_iso() -> str:
+    return datetime.now().astimezone().isoformat()
+
+
+def _json(value: Any) -> Any:
+    if hasattr(value, "model_dump"):
+        return value.model_dump(mode="json")
+    if isinstance(value, Mapping):
+        return {str(key): _json(item) for key, item in value.items()}
+    if isinstance(value, (tuple, list)):
+        return [_json(item) for item in value]
+    return value
+
+
+class CapabilityApprovalService:
+    """Coordinate durable human authorization for an immutable execution request."""
+
+    def __init__(
+        self,
+        *,
+        issue_dir: Path,
+        workflow_id: str,
+        step: str,
+        iteration: int,
+        now: Optional[Callable[[], datetime]] = None,
+    ) -> None:
+        self.store = HumanTaskRecordStore(issue_dir)
+        self.workflow_id = workflow_id
+        self.step = step
+        self.iteration = iteration
+        self._now = now or (lambda: datetime.now(timezone.utc))
+
+    def request_approval(
+        self,
+        *,
+        request: ExecutionRequest,
+        manifest: CapabilityManifest,
+        expires_at: Optional[str] = None,
+    ) -> HumanTask:
+        evaluation = evaluate_capability_request({manifest.id: manifest}, request.model_dump())
+        if evaluation.decision is not PolicyDecision.REQUIRE_APPROVAL:
+            raise CapabilityApprovalError(
+                f"current policy does not require approval: {evaluation.reason_code}"
+            )
+        fingerprint = canonical_request_fingerprint(request)
+        snapshot = {
+            "kind": CAPABILITY_APPROVAL_TRIGGER,
+            "state": "pending",
+            "workflow_id": self.workflow_id,
+            "fingerprint": fingerprint,
+            "request": _json(request),
+            "manifest": _json(manifest),
+            "manifest_digest": _manifest_digest(manifest),
+            "capability": request.capability,
+            "risk": manifest.risk,
+            "argument_summary": _json(request.args),
+            "effects": _json(request.effects),
+            "credentials": list(request.credentials),
+            "permissions": _json(request.permissions),
+            "expected_outputs": list(manifest.outputs.required),
+            "expires_at": expires_at,
+            "decision": None,
+            "revalidation": None,
+            "attempt": None,
+            "receipt": None,
+        }
+        prompt = (
+            f"Capability approval: {request.capability} ({manifest.risk} risk). "
+            "Review the exact request and material effects before deciding."
+        )
+        return self.store.materialize(
+            workflow_id=self.workflow_id,
+            step=self.step,
+            iteration=self.iteration,
+            trigger=CAPABILITY_APPROVAL_TRIGGER,
+            policy_id=CAPABILITY_APPROVAL_POLICY_ID,
+            prompt=prompt,
+            expected_result={
+                "input_schema": "capability_approval",
+                "required": [
+                    "decision",
+                    "workflow_id",
+                    "task_id",
+                    "request_fingerprint",
+                ],
+                "decisions": ["approve", "deny"],
+                "request_fingerprint": fingerprint,
+            },
+            continuations={"approve": self.step, "deny": self.step},
+            assignee_type="user",
+            capability_approval=snapshot,
+            handoff_key=(
+                f"capability:{self.workflow_id}:{self.step}:{request.capability}:{fingerprint}"
+            ),
+        )
+
+    def inspect(self, task_id: str) -> dict[str, Any]:
+        task = self.store.get_task(task_id)
+        if task.capability_approval is None:
+            raise CapabilityApprovalError("task is not a capability approval")
+        current = dict(task.capability_approval)
+        if current["state"] in {"pending", "approved"} and self._is_expired(current):
+            current["state"] = "expired"
+            current["receipt"] = self._terminal_receipt(
+                task_id=task_id,
+                current=current,
+                outcome="expired",
+                recovery="Create a new capability request and approval task.",
+            )
+            self.store.transition_capability_approval(
+                workflow_id=self.workflow_id,
+                task_id=task_id,
+                metadata=current,
+                event_type="capability_approval_expired",
+                terminal_status=HumanTaskStatus.CANCELLED,
+            )
+        return current
+
+    def record_decision(self, task_id: str, payload: object) -> dict[str, Any]:
+        with self.store.transaction():
+            current = self.inspect(task_id)
+            if current["state"] != "pending":
+                return current
+            if not isinstance(payload, Mapping):
+                raise CapabilityApprovalError("capability approval must be structured JSON")
+            required = {
+                "decision",
+                "workflow_id",
+                "task_id",
+                "request_fingerprint",
+            }
+            if not required.issubset(payload):
+                raise CapabilityApprovalError("capability approval correlation is incomplete")
+            if payload.get("decision") not in {"approve", "deny"}:
+                raise CapabilityApprovalError("decision must be approve or deny")
+            if (
+                payload.get("workflow_id") != self.workflow_id
+                or payload.get("task_id") != task_id
+                or payload.get("request_fingerprint") != current["fingerprint"]
+            ):
+                raise CapabilityApprovalError(
+                    "capability approval does not match the exact request"
+                )
+            now = self._now().astimezone().isoformat()
+            current["state"] = (
+                "approved" if payload["decision"] == "approve" else "denied"
+            )
+            current["decision"] = {
+                "outcome": payload["decision"],
+                "source": "capability_approval",
+                "recorded_at": now,
+            }
+            self.store.transition_capability_approval(
+                workflow_id=self.workflow_id,
+                task_id=task_id,
+                metadata=current,
+                event_type="capability_approval_decided",
+                terminal_status=HumanTaskStatus.COMPLETED,
+                result_payload=dict(payload),
+            )
+            return current
+
+    def cancel(self, task_id: str, *, reason: str) -> dict[str, Any]:
+        current = self.inspect(task_id)
+        if current["state"] != "pending":
+            return current
+        current["state"] = "cancelled"
+        current["decision"] = {
+            "outcome": "cancel",
+            "source": "capability_approval",
+            "reason": str(reason),
+            "recorded_at": self._now().astimezone().isoformat(),
+        }
+        current["receipt"] = self._terminal_receipt(
+            task_id=task_id,
+            current=current,
+            outcome="cancelled",
+            recovery="Create a new capability request if execution is still required.",
+        )
+        self.store.transition_capability_approval(
+            workflow_id=self.workflow_id,
+            task_id=task_id,
+            metadata=current,
+            event_type="capability_approval_cancelled",
+            terminal_status=HumanTaskStatus.CANCELLED,
+        )
+        return current
+
+    def _is_expired(self, current: Mapping[str, Any]) -> bool:
+        raw = current.get("expires_at")
+        if not isinstance(raw, str) or not raw.strip():
+            return False
+        try:
+            expires_at = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        except ValueError as exc:
+            raise CapabilityApprovalError("approval expiry is invalid") from exc
+        if expires_at.tzinfo is None:
+            raise CapabilityApprovalError("approval expiry must include a timezone")
+        return self._now().astimezone(timezone.utc) >= expires_at.astimezone(timezone.utc)
+
+    def _terminal_receipt(
+        self,
+        *,
+        task_id: str,
+        current: Mapping[str, Any],
+        outcome: str,
+        recovery: str,
+    ) -> dict[str, Any]:
+        return {
+            "workflow_id": self.workflow_id,
+            "task_id": task_id,
+            "request_fingerprint": current["fingerprint"],
+            "request": current["request"],
+            "approval": current.get("decision"),
+            "revalidation": current.get("revalidation"),
+            "attempt": current.get("attempt"),
+            "outcome": outcome,
+            "executed": False,
+            "recovery": recovery,
+            "recorded_at": self._now().astimezone().isoformat(),
+        }
+
+
+def _manifest_digest(manifest: CapabilityManifest) -> str:
+    import hashlib
+    import json
+
+    payload = json.dumps(manifest.model_dump(mode="json"), sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()

--- a/src/cafe/core/capability_approvals.py
+++ b/src/cafe/core/capability_approvals.py
@@ -201,6 +201,13 @@ class CapabilityApprovalService:
                 "source": "capability_approval",
                 "recorded_at": now,
             }
+            if current["state"] == "denied":
+                current["receipt"] = self._terminal_receipt(
+                    task_id=task_id,
+                    current=current,
+                    outcome="denied",
+                    recovery="Create a new capability request if execution is still required.",
+                )
             self.store.transition_capability_approval(
                 workflow_id=self.workflow_id,
                 task_id=task_id,
@@ -248,6 +255,26 @@ class CapabilityApprovalService:
         timeout_sec: float = 600.0,
     ) -> dict[str, Any]:
         """Resume only the approved unchanged request behind its one-attempt fence."""
+        with self.store.transaction():
+            return self._resume_locked(
+                task_id,
+                request=request,
+                registry=registry,
+                repo_root=repo_root,
+                output_file=output_file,
+                timeout_sec=timeout_sec,
+            )
+
+    def _resume_locked(
+        self,
+        task_id: str,
+        *,
+        request: ExecutionRequest,
+        registry: Mapping[str, CapabilityManifest],
+        repo_root: Path,
+        output_file: Path,
+        timeout_sec: float,
+    ) -> dict[str, Any]:
         current = self.inspect(task_id)
         if current["state"] in TERMINAL_STATES:
             receipt = current.get("receipt")
@@ -318,21 +345,24 @@ class CapabilityApprovalService:
                 event_type="capability_policy_rejected",
             )
 
-        self.store.update_capability_approval(
-            workflow_id=self.workflow_id,
-            task_id=task_id,
-            metadata=current,
-            event_type="capability_policy_revalidated",
-        )
         started_at = self._now().astimezone().isoformat()
         current["state"] = "attempt_started"
         current["attempt"] = {"state": "started", "started_at": started_at}
-        self.store.update_capability_approval(
+        persisted, transitioned = self.store.transition_capability_approval_if_state(
             workflow_id=self.workflow_id,
             task_id=task_id,
+            expected_state="approved",
             metadata=current,
             event_type="capability_attempt_started",
         )
+        if not transitioned:
+            persisted_state = persisted.capability_approval
+            if persisted_state is None:
+                raise CapabilityApprovalError("task is not a capability approval")
+            receipt = persisted_state.get("receipt")
+            if isinstance(receipt, Mapping):
+                return dict(receipt)
+            raise CapabilityApprovalError("capability execution attempt is already in progress")
 
         run = dispatch_revalidated_capability_request(
             repo_root=repo_root,

--- a/src/cafe/core/hooks/native.py
+++ b/src/cafe/core/hooks/native.py
@@ -1301,7 +1301,6 @@ class GitHubPRCreator(NoOpHook):
                 task = service.request_approval(
                     request=evaluation.request,
                     manifest=evaluation.manifest,
-                    expires_at=evaluation.request.expires_at,
                     correlation_id=str(run.receipt["correlation_id"]),
                 )
                 approval = service.inspect(task.id)

--- a/src/cafe/core/hooks/native.py
+++ b/src/cafe/core/hooks/native.py
@@ -205,9 +205,7 @@ class UserInputCollector(NoOpHook):
     def _get_previous_output_file(phase: Any, step_name: str) -> Optional[Path]:
         if getattr(phase, "iteration", 0) <= 1:
             return None
-        return Path(
-            phase._get_versioned_file_path(step_name, phase.iteration - 1, phase.phase_dir)
-        )
+        return Path(phase._get_versioned_file_path(step_name, phase.iteration - 1, phase.phase_dir))
 
     @staticmethod
     def _display_previous_output(
@@ -1141,6 +1139,7 @@ class GitHubPRCreator(NoOpHook):
             SCRIPT_EXIT_ERROR,
             TIMEOUT_ERROR,
             CapabilityRegistryError,
+            ExecutionRequest,
             PolicyDecision,
             PrPublishRun,
             _normalize_legacy_pr_request,
@@ -1230,6 +1229,33 @@ class GitHubPRCreator(NoOpHook):
         except CapabilityRegistryError as exc:
             rejection_events: list[dict[str, Any]] = []
             for request in requests:
+                policy_receipt: dict[str, Any] | None = None
+                if isinstance(issue_dir, Path) and isinstance(blackboard_state, BlackboardState):
+                    try:
+                        exact_request = ExecutionRequest.model_validate(
+                            _normalize_legacy_pr_request(request)
+                        )
+                    except (TypeError, ValueError):
+                        exact_request = None
+                    if exact_request is not None:
+                        service = CapabilityApprovalService(
+                            issue_dir=issue_dir,
+                            workflow_id=blackboard_state.workflow_id,
+                            step=step_name,
+                            iteration=int(getattr(phase, "iteration", 1)),
+                        )
+                        policy_receipt = service.terminalize_policy_failure(
+                            request=exact_request,
+                            reason_code="registry_load_error",
+                            evidence={
+                                "error_detail": str(exc),
+                                "registry_paths": [str(path) for path in definition_dirs],
+                            },
+                        )
+                if policy_receipt is not None:
+                    persist_receipt(policy_receipt)
+                    rejection_events.append(capability_receipt_hook_event(policy_receipt))
+                    continue
                 receipt = validation_rejection_receipt(
                     capability=str(request.get("capability") or fallback_capability),
                     code="registry_load_error",
@@ -1275,6 +1301,8 @@ class GitHubPRCreator(NoOpHook):
                 task = service.request_approval(
                     request=evaluation.request,
                     manifest=evaluation.manifest,
+                    expires_at=evaluation.request.expires_at,
+                    correlation_id=str(run.receipt["correlation_id"]),
                 )
                 approval = service.inspect(task.id)
                 if approval["state"] == "pending":
@@ -1284,11 +1312,13 @@ class GitHubPRCreator(NoOpHook):
                             "capability": evaluation.request.capability,
                             "task_id": task.id,
                             "request_fingerprint": evaluation.fingerprint,
+                            "correlation_id": approval["correlation_id"],
                         }
                     )
                     continue
                 receipt = service.resume(
                     task.id,
+                    correlation_id=str(approval["correlation_id"]),
                     request=evaluation.request,
                     registry=registry,
                     repo_root=repo_root,

--- a/src/cafe/core/hooks/native.py
+++ b/src/cafe/core/hooks/native.py
@@ -205,7 +205,9 @@ class UserInputCollector(NoOpHook):
     def _get_previous_output_file(phase: Any, step_name: str) -> Optional[Path]:
         if getattr(phase, "iteration", 0) <= 1:
             return None
-        return phase._get_versioned_file_path(step_name, phase.iteration - 1, phase.phase_dir)
+        return Path(
+            phase._get_versioned_file_path(step_name, phase.iteration - 1, phase.phase_dir)
+        )
 
     @staticmethod
     def _display_previous_output(
@@ -432,6 +434,7 @@ class UserInputCollector(NoOpHook):
         except HumanTaskPolicyError:
             return None
 
+        payload: Any
         if getattr(phase, "interactive", False):
             payload = collect_human_task_payload(policy)
         else:
@@ -769,7 +772,7 @@ class InitialInputProviderResolver(NoOpHook):
         if not config_file.exists():
             return {}
         try:
-            import yaml
+            import yaml  # type: ignore[import-untyped]
 
             data = yaml.safe_load(config_file.read_text(encoding="utf-8")) or {}
         except Exception:
@@ -954,7 +957,9 @@ class GitHubIssueFetcher(NoOpHook):
         source = (
             "workflow_user_input"
             if prefilled is not None
-            else "github" if provider == GITHUB_ISSUE_PROVIDER else "manual"
+            else "github"
+            if provider == GITHUB_ISSUE_PROVIDER
+            else "manual"
         )
         return HookResult(
             continue_pipeline=result.continue_pipeline,
@@ -1136,12 +1141,17 @@ class GitHubPRCreator(NoOpHook):
             SCRIPT_EXIT_ERROR,
             TIMEOUT_ERROR,
             CapabilityRegistryError,
+            PolicyDecision,
+            PrPublishRun,
+            _normalize_legacy_pr_request,
             capability_receipt_hook_event,
             default_capability_definition_dirs,
+            evaluate_capability_request,
             load_capability_registry,
             run_capability_request,
             validation_rejection_receipt,
         )
+        from cafe.core.capability_approvals import CapabilityApprovalService
 
         phase = kwargs.get("phase")
         step_name = str(kwargs.get("step_name") or "")
@@ -1181,7 +1191,9 @@ class GitHubPRCreator(NoOpHook):
         request_file = (
             capability_request_file
             if isinstance(capability_request_file, Path)
-            else publish_request_file if isinstance(publish_request_file, Path) else None
+            else publish_request_file
+            if isinstance(publish_request_file, Path)
+            else None
         )
         try:
             request_payload = self._load_publish_request(
@@ -1198,9 +1210,7 @@ class GitHubPRCreator(NoOpHook):
             if isinstance(request_file, Path):
                 try:
                     rejected_bytes = request_file.resolve().read_bytes()
-                    rejection_source["content_sha256"] = hashlib.sha256(
-                        rejected_bytes
-                    ).hexdigest()
+                    rejection_source["content_sha256"] = hashlib.sha256(rejected_bytes).hexdigest()
                     rejected_value = rejected_bytes.decode("utf-8", errors="replace")
                 except OSError:
                     pass
@@ -1218,7 +1228,7 @@ class GitHubPRCreator(NoOpHook):
         try:
             registry = load_capability_registry(definition_dirs)
         except CapabilityRegistryError as exc:
-            events: list[dict[str, Any]] = []
+            rejection_events: list[dict[str, Any]] = []
             for request in requests:
                 receipt = validation_rejection_receipt(
                     capability=str(request.get("capability") or fallback_capability),
@@ -1232,8 +1242,8 @@ class GitHubPRCreator(NoOpHook):
                     error_detail=str(exc),
                 )
                 persist_receipt(receipt)
-                events.append(capability_receipt_hook_event(receipt))
-            return HookResult(events=events)
+                rejection_events.append(capability_receipt_hook_event(receipt))
+            return HookResult(events=rejection_events)
 
         events: list[dict[str, Any]] = []
         context_updates: dict[str, str] = {}
@@ -1244,6 +1254,53 @@ class GitHubPRCreator(NoOpHook):
                 capability_request=request,
                 output_file=output_file,
             )
+            decision = run.receipt.get("decision")
+            requires_approval = (
+                isinstance(decision, dict)
+                and decision.get("outcome") == PolicyDecision.REQUIRE_APPROVAL.value
+            )
+            if (
+                requires_approval
+                and isinstance(issue_dir, Path)
+                and isinstance(blackboard_state, BlackboardState)
+            ):
+                normalized_request = _normalize_legacy_pr_request(request)
+                evaluation = evaluate_capability_request(registry, normalized_request)
+                service = CapabilityApprovalService(
+                    issue_dir=issue_dir,
+                    workflow_id=blackboard_state.workflow_id,
+                    step=step_name,
+                    iteration=int(getattr(phase, "iteration", 1)),
+                )
+                task = service.request_approval(
+                    request=evaluation.request,
+                    manifest=evaluation.manifest,
+                )
+                approval = service.inspect(task.id)
+                if approval["state"] == "pending":
+                    events.append(
+                        {
+                            "type": "capability_approval_pending",
+                            "capability": evaluation.request.capability,
+                            "task_id": task.id,
+                            "request_fingerprint": evaluation.fingerprint,
+                        }
+                    )
+                    continue
+                receipt = service.resume(
+                    task.id,
+                    request=evaluation.request,
+                    registry=registry,
+                    repo_root=repo_root,
+                    output_file=output_file,
+                )
+                execution = receipt.get("execution")
+                run_receipt = dict(execution) if isinstance(execution, dict) else receipt
+                run = PrPublishRun(
+                    receipt=run_receipt,
+                    pr_synced_event=None,
+                    error_message=None if run_receipt.get("success") else str(receipt["outcome"]),
+                )
             persist_receipt(run.receipt)
 
             if run.pr_synced_event is not None:
@@ -1341,9 +1398,7 @@ class GitHubPRCreator(NoOpHook):
         try:
             payload = json.loads(request_file.read_text(encoding="utf-8"))
         except UnicodeError as exc:
-            raise RuntimeError(
-                f"PR publish request is not valid UTF-8: {request_file}"
-            ) from exc
+            raise RuntimeError(f"PR publish request is not valid UTF-8: {request_file}") from exc
         except OSError as exc:
             raise RuntimeError(f"PR publish request cannot be read: {request_file}") from exc
         except json.JSONDecodeError as exc:

--- a/src/cafe/core/human_task_records.py
+++ b/src/cafe/core/human_task_records.py
@@ -2,23 +2,22 @@
 
 from __future__ import annotations
 
+import json
+import threading
 from contextlib import contextmanager
 from dataclasses import dataclass, replace
 from datetime import datetime
 from enum import Enum
-import json
 from pathlib import Path
-import threading
-from typing import Any, Mapping, Optional
+from typing import Any, Iterator, Mapping, Optional
 from uuid import uuid4
 
 try:
     import fcntl
 except ImportError:  # pragma: no cover - Windows falls back to the local lock.
-    fcntl = None
+    fcntl = None  # type: ignore[assignment]
 
 from cafe.core.packet_io import atomic_write_bytes, canonical_json
-
 
 HUMAN_TASK_RECORD_FILENAME = "human_tasks.json"
 HUMAN_TASK_RECORD_SCHEMA_VERSION = 1
@@ -65,6 +64,7 @@ class HumanTask:
     continuations: dict[str, str]
     status: HumanTaskStatus
     created_at: str
+    capability_approval: Optional[dict[str, Any]] = None
     completed_at: Optional[str] = None
     cancelled_at: Optional[str] = None
 
@@ -82,6 +82,9 @@ class HumanTask:
             "continuations": dict(self.continuations),
             "status": self.status.value,
             "created_at": self.created_at,
+            "capability_approval": (
+                dict(self.capability_approval) if self.capability_approval is not None else None
+            ),
             "completed_at": self.completed_at,
             "cancelled_at": self.cancelled_at,
         }
@@ -102,6 +105,11 @@ class HumanTask:
                 continuations=_string_mapping(data, "continuations"),
                 status=HumanTaskStatus(_required_text(data, "status")),
                 created_at=_required_text(data, "created_at"),
+                capability_approval=(
+                    _mapping(data, "capability_approval")
+                    if data.get("capability_approval") is not None
+                    else None
+                ),
                 completed_at=_optional_text(data.get("completed_at")),
                 cancelled_at=_optional_text(data.get("cancelled_at")),
             )
@@ -270,7 +278,8 @@ class _Envelope:
         version = data.get("schema_version")
         if version != HUMAN_TASK_RECORD_SCHEMA_VERSION:
             raise HumanTaskRecordSchemaError(
-                f"unsupported human-task schema version {version!r}; expected {HUMAN_TASK_RECORD_SCHEMA_VERSION}"
+                f"unsupported human-task schema version {version!r}; "
+                f"expected {HUMAN_TASK_RECORD_SCHEMA_VERSION}"
             )
         workflow_id = _required_text(data, "workflow_id")
         tasks = _records_by_task_id(data, "tasks", HumanTask.from_dict)
@@ -280,7 +289,10 @@ class _Envelope:
         raw_events = data.get("lifecycle_events", [])
         if not isinstance(raw_events, list):
             raise HumanTaskRecordSchemaError("lifecycle_events must be a list")
-        events = [LifecycleEvent.from_dict(_as_mapping(item, "lifecycle event")) for item in raw_events]
+        events = [
+            LifecycleEvent.from_dict(_as_mapping(item, "lifecycle event"))
+            for item in raw_events
+        ]
         envelope = cls(workflow_id, tasks, assignments, waits, results, events)
         envelope.validate()
         return envelope
@@ -288,17 +300,25 @@ class _Envelope:
     def validate(self) -> None:
         for task_id, task in self.tasks.items():
             if task_id != task.id or task.workflow_id != self.workflow_id:
-                raise HumanTaskRecordSchemaError("task identity does not match its workflow envelope")
+                raise HumanTaskRecordSchemaError(
+                    "task identity does not match its workflow envelope"
+                )
             assignment = self.assignments.get(task_id)
             wait_state = self.wait_states.get(task_id)
             if assignment is None or assignment.task_id != task_id:
                 raise HumanTaskRecordSchemaError("every task requires a matching assignment")
-            if wait_state is None or wait_state.task_id != task_id or wait_state.workflow_id != self.workflow_id:
+            if (
+                wait_state is None
+                or wait_state.task_id != task_id
+                or wait_state.workflow_id != self.workflow_id
+            ):
                 raise HumanTaskRecordSchemaError("every task requires a matching wait state")
             result = self.results.get(task_id)
             if task.status is HumanTaskStatus.COMPLETED and result is None:
                 raise HumanTaskRecordSchemaError("completed task has no result")
-            if result is not None and (result.task_id != task_id or result.workflow_id != self.workflow_id):
+            if result is not None and (
+                result.task_id != task_id or result.workflow_id != self.workflow_id
+            ):
                 raise HumanTaskRecordSchemaError("result does not match its task/workflow")
 
 
@@ -381,19 +401,35 @@ class HumanTaskRecordStore:
         continuations: Mapping[str, str],
         assignee_type: str,
         assignee_id: Optional[str] = None,
+        capability_approval: Optional[Mapping[str, Any]] = None,
+        handoff_key: Optional[str] = None,
     ) -> HumanTask:
         with self.transaction():
             envelope = self._load_for_workflow(workflow_id, create=True)
-            handoff_key = _handoff_key(workflow_id, step, iteration, trigger, policy_id)
+            resolved_handoff_key = handoff_key or _handoff_key(
+                workflow_id, step, iteration, trigger, policy_id
+            )
             existing = next(
-                (task for task in envelope.tasks.values() if task.handoff_key == handoff_key), None
+                (
+                    task
+                    for task in envelope.tasks.values()
+                    if task.handoff_key == resolved_handoff_key
+                    and task.status is HumanTaskStatus.PENDING
+                ),
+                None,
             )
             if existing is not None:
                 return existing
             now = _now_iso()
+            task_id = str(uuid4())
+            capability_metadata = (
+                {**dict(capability_approval), "task_id": task_id}
+                if capability_approval is not None
+                else None
+            )
             task = HumanTask(
-                id=str(uuid4()),
-                handoff_key=handoff_key,
+                id=task_id,
+                handoff_key=resolved_handoff_key,
                 workflow_id=workflow_id,
                 step=_text(step, "step"),
                 iteration=_positive(iteration, "iteration"),
@@ -404,6 +440,7 @@ class HumanTaskRecordStore:
                 continuations=_string_mapping_value(continuations, "continuations"),
                 status=HumanTaskStatus.PENDING,
                 created_at=now,
+                capability_approval=capability_metadata,
             )
             envelope.tasks[task.id] = task
             envelope.assignments[task.id] = Assignment(
@@ -418,9 +455,94 @@ class HumanTaskRecordStore:
                 pause_reason=task.trigger,
                 created_at=now,
             )
-            self._append_event(envelope, "created", task_id=task.id, context={"handoff_key": handoff_key})
+            self._append_event(
+                envelope,
+                "created",
+                task_id=task.id,
+                context={"handoff_key": resolved_handoff_key},
+            )
             self._save(envelope)
             return task
+
+    def update_capability_approval(
+        self,
+        *,
+        workflow_id: str,
+        task_id: str,
+        metadata: Mapping[str, Any],
+        event_type: str,
+    ) -> HumanTask:
+        """Atomically replace capability-specific state and append audit evidence."""
+        with self.transaction():
+            envelope = self._load_for_workflow(workflow_id, create=False)
+            task = self._task(envelope, task_id)
+            if task.capability_approval is None:
+                raise HumanTaskCorrelationError(f"task {task.id} is not a capability approval")
+            updated = replace(task, capability_approval=dict(metadata))
+            envelope.tasks[task.id] = updated
+            self._append_event(
+                envelope,
+                _text(event_type, "event_type"),
+                task_id=task.id,
+                context={
+                    "request_fingerprint": metadata.get("fingerprint"),
+                    "state": metadata.get("state"),
+                },
+            )
+            self._save(envelope)
+            return updated
+
+    def transition_capability_approval(
+        self,
+        *,
+        workflow_id: str,
+        task_id: str,
+        metadata: Mapping[str, Any],
+        event_type: str,
+        terminal_status: Optional[HumanTaskStatus] = None,
+        result_payload: Optional[Mapping[str, Any]] = None,
+        result_source: str = "capability_approval",
+    ) -> HumanTask:
+        """Persist capability state and its wait/result boundary in one transaction."""
+        with self.transaction():
+            envelope = self._load_for_workflow(workflow_id, create=False)
+            task = self._task(envelope, task_id)
+            if task.capability_approval is None:
+                raise HumanTaskCorrelationError(f"task {task.id} is not a capability approval")
+            now = _now_iso()
+            updates: dict[str, Any] = {"capability_approval": dict(metadata)}
+            if terminal_status is HumanTaskStatus.COMPLETED:
+                updates["status"] = HumanTaskStatus.COMPLETED
+                updates["completed_at"] = task.completed_at or now
+            elif terminal_status is HumanTaskStatus.CANCELLED:
+                updates["status"] = HumanTaskStatus.CANCELLED
+                updates["cancelled_at"] = task.cancelled_at or now
+            updated = replace(task, **updates)
+            envelope.tasks[task.id] = updated
+            if terminal_status is not None:
+                wait = envelope.wait_states[task.id]
+                if wait.released_at is None:
+                    envelope.wait_states[task.id] = replace(wait, released_at=now)
+            if result_payload is not None and task.id not in envelope.results:
+                envelope.results[task.id] = TaskResult(
+                    id=str(uuid4()),
+                    task_id=task.id,
+                    workflow_id=workflow_id,
+                    payload=dict(result_payload),
+                    source=_text(result_source, "result_source"),
+                    completed_at=now,
+                )
+            self._append_event(
+                envelope,
+                _text(event_type, "event_type"),
+                task_id=task.id,
+                context={
+                    "request_fingerprint": metadata.get("fingerprint"),
+                    "state": metadata.get("state"),
+                },
+            )
+            self._save(envelope)
+            return updated
 
     def complete(
         self,
@@ -451,9 +573,13 @@ class HumanTaskRecordStore:
                 completed_at=now,
             )
             envelope.results[task.id] = result
-            envelope.tasks[task.id] = replace(task, status=HumanTaskStatus.COMPLETED, completed_at=now)
+            envelope.tasks[task.id] = replace(
+                task, status=HumanTaskStatus.COMPLETED, completed_at=now
+            )
             envelope.wait_states[task.id] = replace(wait_state, released_at=now)
-            self._append_event(envelope, "completed", task_id=task.id, context={"result_id": result.id})
+            self._append_event(
+                envelope, "completed", task_id=task.id, context={"result_id": result.id}
+            )
             self._save(envelope)
             return result
 
@@ -507,7 +633,7 @@ class HumanTaskRecordStore:
             self._save(envelope)
 
     @contextmanager
-    def transaction(self):
+    def transaction(self) -> Iterator[None]:
         """Serialize a durable record transition across threads and POSIX processes."""
         if self._transaction_depth:
             self._transaction_depth += 1
@@ -616,7 +742,10 @@ def _string_mapping(data: Mapping[str, Any], field_name: str) -> dict[str, str]:
 
 
 def _string_mapping_value(value: Mapping[str, Any], field_name: str) -> dict[str, str]:
-    return {_text(str(key), field_name): _text(str(item), field_name) for key, item in value.items()}
+    return {
+        _text(str(key), field_name): _text(str(item), field_name)
+        for key, item in value.items()
+    }
 
 
 def _required_text(data: Mapping[str, Any], field_name: str) -> str:

--- a/src/cafe/core/human_task_records.py
+++ b/src/cafe/core/human_task_records.py
@@ -492,6 +492,38 @@ class HumanTaskRecordStore:
             self._save(envelope)
             return updated
 
+    def transition_capability_approval_if_state(
+        self,
+        *,
+        workflow_id: str,
+        task_id: str,
+        expected_state: str,
+        metadata: Mapping[str, Any],
+        event_type: str,
+    ) -> tuple[HumanTask, bool]:
+        """Replace capability state only when the persisted prior state matches."""
+        with self.transaction():
+            envelope = self._load_for_workflow(workflow_id, create=False)
+            task = self._task(envelope, task_id)
+            current = task.capability_approval
+            if current is None:
+                raise HumanTaskCorrelationError(f"task {task.id} is not a capability approval")
+            if current.get("state") != expected_state:
+                return task, False
+            updated = replace(task, capability_approval=dict(metadata))
+            envelope.tasks[task.id] = updated
+            self._append_event(
+                envelope,
+                _text(event_type, "event_type"),
+                task_id=task.id,
+                context={
+                    "request_fingerprint": metadata.get("fingerprint"),
+                    "state": metadata.get("state"),
+                },
+            )
+            self._save(envelope)
+            return updated, True
+
     def transition_capability_approval(
         self,
         *,

--- a/src/cafe/core/human_task_records.py
+++ b/src/cafe/core/human_task_records.py
@@ -290,8 +290,7 @@ class _Envelope:
         if not isinstance(raw_events, list):
             raise HumanTaskRecordSchemaError("lifecycle_events must be a list")
         events = [
-            LifecycleEvent.from_dict(_as_mapping(item, "lifecycle event"))
-            for item in raw_events
+            LifecycleEvent.from_dict(_as_mapping(item, "lifecycle event")) for item in raw_events
         ]
         envelope = cls(workflow_id, tasks, assignments, waits, results, events)
         envelope.validate()
@@ -332,7 +331,7 @@ class HumanTaskRecordStore:
         self.issue_dir = issue_dir
         self.file_path = issue_dir / HUMAN_TASK_RECORD_FILENAME
         self.lock_path = issue_dir / f".{HUMAN_TASK_RECORD_FILENAME}.lock"
-        self._transaction_depth = 0
+        self._transaction_local = threading.local()
 
     @property
     def exists(self) -> bool:
@@ -667,12 +666,13 @@ class HumanTaskRecordStore:
     @contextmanager
     def transaction(self) -> Iterator[None]:
         """Serialize a durable record transition across threads and POSIX processes."""
-        if self._transaction_depth:
-            self._transaction_depth += 1
+        depth = getattr(self._transaction_local, "depth", 0)
+        if depth:
+            self._transaction_local.depth = depth + 1
             try:
                 yield
             finally:
-                self._transaction_depth -= 1
+                self._transaction_local.depth -= 1
             return
 
         with self._thread_lock_for(self.file_path):
@@ -680,11 +680,11 @@ class HumanTaskRecordStore:
             with self.lock_path.open("a+", encoding="utf-8") as lock_file:
                 if fcntl is not None:
                     fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
-                self._transaction_depth = 1
+                self._transaction_local.depth = 1
                 try:
                     yield
                 finally:
-                    self._transaction_depth = 0
+                    self._transaction_local.depth = 0
                     if fcntl is not None:
                         fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
 
@@ -775,8 +775,7 @@ def _string_mapping(data: Mapping[str, Any], field_name: str) -> dict[str, str]:
 
 def _string_mapping_value(value: Mapping[str, Any], field_name: str) -> dict[str, str]:
     return {
-        _text(str(key), field_name): _text(str(item), field_name)
-        for key, item in value.items()
+        _text(str(key), field_name): _text(str(item), field_name) for key, item in value.items()
     }
 
 

--- a/src/cafe/core/task_inbox.py
+++ b/src/cafe/core/task_inbox.py
@@ -108,6 +108,7 @@ class TaskDetail:
     due_state: str
     wait: dict[str, Any]
     result: Optional[dict[str, Any]]
+    capability_approval: Optional[dict[str, Any]]
     timestamps: dict[str, Optional[str]]
 
     def to_dict(self) -> dict[str, Any]:
@@ -129,6 +130,7 @@ class TaskDetail:
             "due_state": self.due_state,
             "wait": self.wait,
             "result": self.result,
+            "capability_approval": self.capability_approval,
             "timestamps": self.timestamps,
         }
 
@@ -403,6 +405,9 @@ class TaskInboxService:
                 "released_at": record.wait.released_at,
             },
             result=record.result.to_dict() if record.result else None,
+            capability_approval=(
+                dict(task.capability_approval) if task.capability_approval is not None else None
+            ),
             timestamps={
                 "created_at": task.created_at,
                 "completed_at": task.completed_at,

--- a/src/cafe/core/workflow_runtime.py
+++ b/src/cafe/core/workflow_runtime.py
@@ -229,6 +229,22 @@ class BlackboardWorkflowRuntime:
         return False
 
     @staticmethod
+    def _pending_capability_approval(execution_result: Any) -> Optional[dict[str, Any]]:
+        events = getattr(execution_result, "events", None)
+        if not isinstance(events, list):
+            return None
+        return next(
+            (
+                event
+                for event in events
+                if isinstance(event, dict)
+                and event.get("type") == "capability_approval_pending"
+                and isinstance(event.get("task_id"), str)
+            ),
+            None,
+        )
+
+    @staticmethod
     def _step_declared_capability_ids(step_def: Dict) -> list[str]:
         raw = step_def.get("capability_requests") or []
         if not isinstance(raw, list):
@@ -273,7 +289,8 @@ class BlackboardWorkflowRuntime:
             f"[BATON ERROR] Your baton was rejected because field '{br.field}' has {value_msg}. "
             f"Valid values are: {br.valid_values}. "
             "Please rewrite next_step.txt with a correct structured baton. "
-            "Retry in baton-only mode: do not rewrite output.md, checklist.md, or questions.xml unless strictly required. "
+            "Retry in baton-only mode: do not rewrite output.md, checklist.md, or "
+            "questions.xml unless strictly required. "
             "If you are asking the user a question, use to_owner='user', "
             "to_step='user', and intent='need_clarification'. "
             "If your step omits safe defaults, you may keep status_code and source empty; "
@@ -300,11 +317,13 @@ class BlackboardWorkflowRuntime:
         )
         if contract.to_owner != HandoffOwner.AGENT:
             raise RuntimeError(
-                f"Baton owner mismatch before step '{current_step}': expected agent, got {contract.to_owner.value}"
+                f"Baton owner mismatch before step '{current_step}': expected agent, "
+                f"got {contract.to_owner.value}"
             )
         if contract.to_step != current_step:
             raise RuntimeError(
-                f"Baton target mismatch before step '{current_step}': baton points to '{contract.to_step}'"
+                f"Baton target mismatch before step '{current_step}': baton points to "
+                f"'{contract.to_step}'"
             )
 
     def _resolve_runtime_position_from_handoff(self) -> RuntimePositionResolution:
@@ -495,7 +514,7 @@ class BlackboardWorkflowRuntime:
         receipt = LongRunningOperationArtifact(
             operation_id=operation_id,
             state=state,
-            reason=reason,
+            reason=reason or "operation_result",
             exit_code=exit_code,
             created_at=current_operation.created_at,
             risk=current_operation.risk,
@@ -762,7 +781,8 @@ class BlackboardWorkflowRuntime:
         assignee_type = str(step_def.get("assignee_type", "agent"))
         if assignee_type != "agent":
             raise RuntimeError(
-                f"Step '{step_name}' has assignee_type={assignee_type}, which is not supported in v0.2. "
+                f"Step '{step_name}' has assignee_type={assignee_type}, which is not "
+                "supported in v0.2. "
                 "Use v0.3+ or change to assignee_type=agent."
             )
 
@@ -1980,6 +2000,7 @@ class BlackboardWorkflowRuntime:
                 missing.append("operation_schema_invalid")
 
         if operation is not None:
+            assert iteration_dir is not None
             if not self._operation_artifact_trusted(
                 current_step=current_step, iteration_dir=iteration_dir, artifact=operation
             ):
@@ -2625,6 +2646,34 @@ class BlackboardWorkflowRuntime:
                     execution_result=frame.execution_result,
                 )
                 if missing_capabilities:
+                    pending_approval = self._pending_capability_approval(frame.execution_result)
+                    if pending_approval is not None:
+                        self.blackboard_store.update_handoff_contract(
+                            self.blackboard,
+                            from_step=current_step,
+                            to_owner=HandoffOwner.USER,
+                            to_step="user",
+                            intent=HandoffIntent.MANUAL_HANDOFF,
+                            status_code="CAPABILITY_APPROVAL_PENDING",
+                            source="workflow.capability_approval",
+                        )
+                        self.blackboard_store.record_event(
+                            self.blackboard,
+                            "capability_approval_requested",
+                            {
+                                "step": current_step,
+                                "capability": pending_approval.get("capability"),
+                                "task_id": pending_approval["task_id"],
+                                "request_fingerprint": pending_approval.get("request_fingerprint"),
+                            },
+                        )
+                        self.blackboard_store.set_current_step(self.blackboard, "user")
+                        return PlaybookRunResult(
+                            final_step=current_step,
+                            final_status_code="CAPABILITY_APPROVAL_PENDING",
+                            completed=False,
+                            detail=str(pending_approval["task_id"]),
+                        )
                     self.blackboard_store.update_handoff_contract(
                         self.blackboard,
                         from_step=current_step,

--- a/src/cafe/ui/commands/tasks.py
+++ b/src/cafe/ui/commands/tasks.py
@@ -6,18 +6,23 @@ import json
 from contextlib import redirect_stdout
 from io import StringIO
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 import typer
 from rich.console import Console
 from rich.table import Table
 
 from cafe.core.blackboard import BlackboardStore
+from cafe.core.capability_approvals import CapabilityApprovalError
 from cafe.core.human_tasks import HumanTaskPolicy
 from cafe.core.task_inbox import TaskInboxError, TaskInboxService
 from cafe.playbooks.loader import PlaybookLoader, apply_issue_playbook_overrides
 from cafe.ui.commands import workflow as workflow_commands
-from cafe.ui.human_tasks import apply_human_task_payload, collect_human_task_payload
+from cafe.ui.human_tasks import (
+    apply_capability_approval_payload,
+    apply_human_task_payload,
+    collect_human_task_payload,
+)
 
 task_app = typer.Typer(help="List, inspect, and complete durable repository tasks")
 console = Console()
@@ -190,9 +195,7 @@ def inspect_task(
 @task_app.command("complete")
 def complete_task(
     task_id: str = typer.Argument(..., help="Stable task identifier"),
-    result: Optional[str] = typer.Option(
-        None, "--result", help="Non-interactive JSON response"
-    ),
+    result: Optional[str] = typer.Option(None, "--result", help="Non-interactive JSON response"),
     result_file: Optional[Path] = typer.Option(
         None, "--result-file", help="Read a non-interactive JSON response from a file"
     ),
@@ -203,7 +206,40 @@ def complete_task(
     try:
         preflight = service.preflight_completion(task_id)
         raw_payload = _load_result(result, result_file)
-        if raw_payload is None:
+        applied: Any
+        if preflight.task.capability_approval is not None:
+            approval = dict(preflight.task.capability_approval)
+            if raw_payload is None:
+                decision = typer.prompt("Capability decision (approve/deny)").strip().lower()
+                raw_payload = {
+                    "decision": decision,
+                    "workflow_id": preflight.workflow_id,
+                    "task_id": task_id,
+                    "request_fingerprint": approval["fingerprint"],
+                }
+            try:
+                blackboard = BlackboardStore(preflight.issue_dir).load_or_create(
+                    preflight.task.step, playbook_id=preflight.playbook_id
+                )
+                applied = apply_capability_approval_payload(
+                    issue_dir=preflight.issue_dir,
+                    blackboard=blackboard,
+                    task=preflight.task,
+                    raw_payload=raw_payload,
+                )
+            except CapabilityApprovalError as exc:
+                raise TaskInboxError(
+                    "invalid_response",
+                    str(exc),
+                    recovery=(
+                        "Inspect capability_approval and submit an exact structured "
+                        "approve or deny decision."
+                    ),
+                    task_id=task_id,
+                    issue=preflight.issue,
+                    workflow_id=preflight.workflow_id,
+                ) from exc
+        elif raw_payload is None:
             try:
                 policy = HumanTaskPolicy.model_validate(preflight.task.expected_result)
             except (TypeError, ValueError) as exc:
@@ -216,45 +252,48 @@ def complete_task(
                     workflow_id=preflight.workflow_id,
                 ) from exc
             raw_payload = collect_human_task_payload(policy)
-        if isinstance(raw_payload, dict):
+        if preflight.task.capability_approval is None and isinstance(raw_payload, dict):
             raw_payload = dict(raw_payload)
             raw_payload.setdefault("task", preflight.task.policy_id)
             raw_payload["human_task_id"] = task_id
         assert raw_payload is not None
 
-        # Reload immediately before the existing locked validator/mutator so a
-        # stale concurrent completion cannot proceed on old ownership evidence.
-        preflight = service.preflight_completion(task_id)
-        playbook_data = PlaybookLoader(project_root=Path.cwd()).load(preflight.playbook_id)
-        playbook_data = apply_issue_playbook_overrides(
-            playbook_data, preflight.issue_dir / "issue.yaml"
-        )
-        blackboard = BlackboardStore(preflight.issue_dir).load_or_create(
-            preflight.task.step, playbook_id=preflight.playbook_id
-        )
-        applied = apply_human_task_payload(
-            issue_dir=preflight.issue_dir,
-            playbook_data=playbook_data,
-            blackboard=blackboard,
-            from_step=preflight.task.step,
-            trigger=preflight.task.trigger,
-            raw_payload=raw_payload,
-            source="command" if result is not None or result_file is not None else "interactive",
-        )
-        if applied.rejection is not None or applied.target is None:
-            message = (
-                applied.rejection.message
-                if applied.rejection is not None
-                else "The response did not select a continuation."
+        if preflight.task.capability_approval is None:
+            # Reload immediately before the existing locked validator/mutator so a
+            # stale concurrent completion cannot proceed on old ownership evidence.
+            preflight = service.preflight_completion(task_id)
+            playbook_data = PlaybookLoader(project_root=Path.cwd()).load(preflight.playbook_id)
+            playbook_data = apply_issue_playbook_overrides(
+                playbook_data, preflight.issue_dir / "issue.yaml"
             )
-            raise TaskInboxError(
-                "invalid_response",
-                message,
-                recovery="Inspect the expected result and submit one declared response.",
-                task_id=task_id,
-                issue=preflight.issue,
-                workflow_id=preflight.workflow_id,
+            blackboard = BlackboardStore(preflight.issue_dir).load_or_create(
+                preflight.task.step, playbook_id=preflight.playbook_id
             )
+            applied = apply_human_task_payload(
+                issue_dir=preflight.issue_dir,
+                playbook_data=playbook_data,
+                blackboard=blackboard,
+                from_step=preflight.task.step,
+                trigger=preflight.task.trigger,
+                raw_payload=raw_payload,
+                source="command"
+                if result is not None or result_file is not None
+                else "interactive",
+            )
+            if applied.rejection is not None or applied.target is None:
+                message = (
+                    applied.rejection.message
+                    if applied.rejection is not None
+                    else "The response did not select a continuation."
+                )
+                raise TaskInboxError(
+                    "invalid_response",
+                    message,
+                    recovery="Inspect the expected result and submit one declared response.",
+                    task_id=task_id,
+                    issue=preflight.issue,
+                    workflow_id=preflight.workflow_id,
+                )
         try:
             if json_output:
                 # The workflow runner is historically stdout-oriented. Capture its

--- a/src/cafe/ui/commands/tasks.py
+++ b/src/cafe/ui/commands/tasks.py
@@ -20,12 +20,35 @@ from cafe.playbooks.loader import PlaybookLoader, apply_issue_playbook_overrides
 from cafe.ui.commands import workflow as workflow_commands
 from cafe.ui.human_tasks import (
     apply_capability_approval_payload,
+    apply_capability_cancellation,
     apply_human_task_payload,
     collect_human_task_payload,
 )
 
 task_app = typer.Typer(help="List, inspect, and complete durable repository tasks")
 console = Console()
+
+
+def _render_capability_approval(approval: dict[str, Any]) -> None:
+    """Render the exact reviewed effects without exposing credential values."""
+    effects = approval.get("effects")
+    effects = effects if isinstance(effects, dict) else {}
+    rows = (
+        ("Capability", approval.get("capability")),
+        ("Risk", approval.get("risk")),
+        ("Arguments", approval.get("argument_summary")),
+        ("Writes", effects.get("writes")),
+        ("Network destinations", effects.get("network_destinations")),
+        ("Credential names", approval.get("credentials")),
+        ("Permissions", approval.get("permissions")),
+        ("Expected outputs", approval.get("expected_outputs")),
+    )
+    table = Table(title="Capability approval: exact reviewed request")
+    table.add_column("Field")
+    table.add_column("Reviewed value")
+    for label, value in rows:
+        table.add_row(label, json.dumps(value, ensure_ascii=False, sort_keys=True))
+    console.print(table)
 
 
 def _envelope(
@@ -186,6 +209,8 @@ def inspect_task(
     console.print(f"Status: {detail.status}  Due: {detail.due_state}")
     console.print(f"Assignment: {detail.assignment['type']} / {detail.assignment['id'] or '-'}")
     console.print(f"Prompt: {detail.prompt}")
+    if detail.capability_approval is not None:
+        _render_capability_approval(detail.capability_approval)
     console.print("Expected result:")
     console.print_json(data=detail.expected_result)
     console.print("Continuations:")
@@ -210,12 +235,14 @@ def complete_task(
         if preflight.task.capability_approval is not None:
             approval = dict(preflight.task.capability_approval)
             if raw_payload is None:
+                _render_capability_approval(approval)
                 decision = typer.prompt("Capability decision (approve/deny)").strip().lower()
                 raw_payload = {
                     "decision": decision,
                     "workflow_id": preflight.workflow_id,
                     "task_id": task_id,
                     "request_fingerprint": approval["fingerprint"],
+                    "correlation_id": approval["correlation_id"],
                 }
             try:
                 blackboard = BlackboardStore(preflight.issue_dir).load_or_create(
@@ -349,4 +376,73 @@ def complete_task(
     console.print(
         f"[green]Completed[/green] task {task_id}; resumed issue {preflight.issue} "
         f"at {applied.target}."
+    )
+
+
+@task_app.command("cancel")
+def cancel_task(
+    task_id: str = typer.Argument(..., help="Stable capability task identifier"),
+    reason: str = typer.Option(..., "--reason", help="Why the capability request was cancelled"),
+    json_output: bool = typer.Option(False, "--json", help="Emit one JSON result object"),
+) -> None:
+    """Cancel one pending capability approval and resume its owning workflow."""
+    service = TaskInboxService(Path(".cafe"))
+    try:
+        preflight = service.preflight_completion(task_id)
+        if preflight.task.capability_approval is None:
+            raise TaskInboxError(
+                "invalid_task_type",
+                "Only capability approval tasks can be cancelled through this command.",
+                recovery="Complete the ordinary task with its declared response contract.",
+                task_id=task_id,
+                issue=preflight.issue,
+                workflow_id=preflight.workflow_id,
+            )
+        blackboard = BlackboardStore(preflight.issue_dir).load_or_create(
+            preflight.task.step, playbook_id=preflight.playbook_id
+        )
+        applied = apply_capability_cancellation(
+            issue_dir=preflight.issue_dir,
+            blackboard=blackboard,
+            task=preflight.task,
+            reason=reason,
+        )
+        if json_output:
+            with redirect_stdout(StringIO()):
+                _resume_issue_workflow(preflight.issue, preflight.playbook_id)
+        else:
+            _resume_issue_workflow(preflight.issue, preflight.playbook_id)
+        detail = service.inspect(task_id)
+    except TaskInboxError as exc:
+        _fail("cancel", exc, json_output)
+    except (CapabilityApprovalError, OSError, ValueError, RuntimeError, typer.Exit) as exc:
+        _fail(
+            "cancel",
+            TaskInboxError(
+                "workflow_unavailable",
+                f"The capability task could not be cancelled and resumed: {exc}",
+                recovery="Inspect the exact task state and retry cancellation if it is pending.",
+                task_id=task_id,
+            ),
+            json_output,
+        )
+    if json_output:
+        _emit_json(
+            _envelope(
+                "cancel",
+                data={
+                    "task": detail.to_dict(),
+                    "workflow": {
+                        "issue": preflight.issue,
+                        "id": preflight.workflow_id,
+                        "playbook": preflight.playbook_id,
+                        "continuation": applied.target,
+                    },
+                },
+            )
+        )
+        return
+    console.print(
+        f"[yellow]Cancelled[/yellow] capability task {task_id}; resumed issue "
+        f"{preflight.issue} at {applied.target}."
     )

--- a/src/cafe/ui/human_tasks.py
+++ b/src/cafe/ui/human_tasks.py
@@ -15,6 +15,7 @@ from cafe.core.blackboard import (
     HandoffIntent,
     HandoffOwner,
 )
+from cafe.core.capability_approvals import CapabilityApprovalService
 from cafe.core.human_task_records import (
     HumanTask,
     HumanTaskCorrelationError,
@@ -76,9 +77,7 @@ def validate_step_human_task_completion(
         skill_loader=skill_loader,
         iteration=iteration,
     )
-    return policy, binding, validate_human_task_completion(
-        policy, raw_payload, questions=questions
-    )
+    return policy, binding, validate_human_task_completion(policy, raw_payload, questions=questions)
 
 
 def resolve_step_human_task_continuation(
@@ -121,7 +120,9 @@ def collect_human_task_payload(
         return payload
 
     if policy.input_schema == "feedback":
-        return with_record_id({"task": policy.id, "feedback": prompt_multiline(policy.prompt).strip()})
+        return with_record_id(
+            {"task": policy.id, "feedback": prompt_multiline(policy.prompt).strip()}
+        )
     if policy.input_schema == "decision":
         choices = [{"name": item.label, "value": item.id} for item in policy.decisions]
         if role and issue_name:
@@ -138,12 +139,14 @@ def collect_human_task_payload(
         feedback = ""
         if selected is not None and selected.requires_feedback:
             feedback = prompt_multiline(policy.prompt).strip()
-        return with_record_id({
-            "task": policy.id,
-            "decision": decision,
-            "target": target,
-            "feedback": feedback,
-        })
+        return with_record_id(
+            {
+                "task": policy.id,
+                "decision": decision,
+                "target": target,
+                "feedback": feedback,
+            }
+        )
     if policy.input_schema == "target":
         target = prompt_list(
             policy.prompt,
@@ -157,15 +160,18 @@ def collect_human_task_payload(
             return None
         from cafe.ui.interactive_qa import interactive_qa_answers
 
-        return with_record_id({
-            "task": policy.id,
-            "answers": interactive_qa_answers(
-                list(questions), role=role, issue_name=issue_name, agent_name=agent_name
-            ),
-        })
+        return with_record_id(
+            {
+                "task": policy.id,
+                "answers": interactive_qa_answers(
+                    list(questions), role=role, issue_name=issue_name, agent_name=agent_name
+                ),
+            }
+        )
 
     answers: dict[str, str | list[str]] = {}
     for question in policy.questions:
+        answer: str | list[str]
         if question.multiple and question.options:
             answer = prompt_checkbox(question.prompt, list(question.options))
         elif question.options:
@@ -183,6 +189,39 @@ class HumanTaskApplication:
     target: Optional[str]
     policy: Optional[HumanTaskPolicy]
     rejection: Optional[HumanTaskRejection] = None
+
+
+def apply_capability_approval_payload(
+    *,
+    issue_dir: Path,
+    blackboard: Any,
+    task: HumanTask,
+    raw_payload: object,
+) -> HumanTaskApplication:
+    """Apply an exact capability decision without using alignment task policy."""
+    service = CapabilityApprovalService(
+        issue_dir=issue_dir,
+        workflow_id=task.workflow_id,
+        step=task.step,
+        iteration=task.iteration,
+    )
+    service.record_decision(task.id, raw_payload)
+    store = BlackboardStore(issue_dir)
+    store.update_handoff_contract(
+        blackboard,
+        from_step=task.step,
+        to_owner=HandoffOwner.AGENT,
+        to_step=task.step,
+        intent=HandoffIntent.AWAIT_AGENT,
+        source="command.capability_approval",
+    )
+    store.set_current_step(blackboard, task.step)
+    store.record_event(
+        blackboard,
+        "capability_approval_completed",
+        {"step": task.step, "task_id": task.id},
+    )
+    return HumanTaskApplication(target=task.step, policy=None)
 
 
 def apply_human_task_payload(
@@ -285,6 +324,7 @@ def _apply_human_task_payload(
 
     recovered_agent_input = ""
     if durable_result is not None:
+        assert durable_task is not None
         blackboard = store.load_or_create(
             from_step, playbook_id=getattr(blackboard, "playbook_id", "default")
         )
@@ -374,16 +414,19 @@ def _apply_human_task_payload(
             )
             return HumanTaskApplication(target=None, policy=policy, rejection=continuation)
 
-    feedback = (
-        durable_result.payload.get("feedback", "")
-        if durable_result is not None
-        else completion.feedback
+    validated_completion = (
+        completion if isinstance(completion, HumanTaskCompletion) else None
     )
-    decision = (
-        durable_result.payload.get("decision")
-        if durable_result is not None
-        else completion.decision
-    )
+    if durable_result is None:
+        assert validated_completion is not None
+
+    if durable_result is not None:
+        feedback = durable_result.payload.get("feedback", "")
+        decision = durable_result.payload.get("decision")
+    else:
+        assert validated_completion is not None
+        feedback = validated_completion.feedback
+        decision = validated_completion.decision
     delivery_decision = next(
         (item for item in policy.decisions if item.id == decision),
         None,
@@ -407,9 +450,7 @@ def _apply_human_task_payload(
                 target_step=continuation,
                 content=feedback,
             )
-            previous = getattr(blackboard, "artifacts", {}).get(
-                binding.feedback_delivery.artifact
-            )
+            previous = getattr(blackboard, "artifacts", {}).get(binding.feedback_delivery.artifact)
             store.put_artifact(
                 blackboard,
                 ArtifactEntry(
@@ -471,11 +512,14 @@ def _apply_human_task_payload(
             )
             return HumanTaskApplication(target=None, policy=policy, rejection=rejection)
         if durable_result is None:
+            assert validated_completion is not None
             try:
                 record_store.complete(
                     workflow_id=blackboard.workflow_id,
                     task_id=durable_task.id,
-                    payload=_validated_completion_payload(completion, continuation),
+                    payload=_validated_completion_payload(
+                        validated_completion, continuation
+                    ),
                     source=source,
                 )
             except HumanTaskCorrelationError as exc:
@@ -489,19 +533,19 @@ def _apply_human_task_payload(
                 )
                 return HumanTaskApplication(target=None, policy=policy, rejection=rejection)
 
-    agent_input = (
-        ""
-        if binding.feedback_delivery is not None
-        else recovered_agent_input
-        if durable_result is not None
-        else completion.agent_input()
-    )
+    if binding.feedback_delivery is not None:
+        agent_input = ""
+    elif durable_result is not None:
+        agent_input = recovered_agent_input
+    else:
+        assert validated_completion is not None
+        agent_input = validated_completion.agent_input()
     if agent_input:
-        has_feedback = (
-            isinstance(durable_result.payload.get("feedback"), str)
-            if durable_result is not None
-            else bool(completion.feedback)
-        )
+        if durable_result is not None:
+            has_feedback = isinstance(durable_result.payload.get("feedback"), str)
+        else:
+            assert validated_completion is not None
+            has_feedback = bool(validated_completion.feedback)
         input_step = continuation if has_feedback and continuation != "_done" else from_step
         _write_next_iteration_user_input(
             issue_dir=issue_dir,
@@ -572,9 +616,13 @@ def _resolve_durable_task(
                 task_id=active.id,
                 reason="response omits the required durable task id",
             )
-            return None, None, HumanTaskRejection(
-                message="This response must identify the pending durable human task.",
-                correction_guidance=policy.correction_guidance,
+            return (
+                None,
+                None,
+                HumanTaskRejection(
+                    message="This response must identify the pending durable human task.",
+                    correction_guidance=policy.correction_guidance,
+                ),
             )
         if submitted_id != active.id:
             record_store.record_rejection(
@@ -582,16 +630,24 @@ def _resolve_durable_task(
                 task_id=active.id,
                 reason="response references a different durable task",
             )
-            return None, None, HumanTaskRejection(
-                message="This response belongs to a different durable human task.",
-                correction_guidance=policy.correction_guidance,
+            return (
+                None,
+                None,
+                HumanTaskRejection(
+                    message="This response belongs to a different durable human task.",
+                    correction_guidance=policy.correction_guidance,
+                ),
             )
         return active, None, None
 
     if not matching:
-        return None, None, HumanTaskRejection(
-            message="This response cannot be correlated to a durable human task.",
-            correction_guidance=policy.correction_guidance,
+        return (
+            None,
+            None,
+            HumanTaskRejection(
+                message="This response cannot be correlated to a durable human task.",
+                correction_guidance=policy.correction_guidance,
+            ),
         )
 
     if submitted_id is None:
@@ -600,13 +656,21 @@ def _resolve_durable_task(
             task_id=matching[0].id,
             reason="response omits the required durable task id",
         )
-        return None, None, HumanTaskRejection(
-            message="This response must identify the pending durable human task.",
-            correction_guidance=policy.correction_guidance,
+        return (
+            None,
+            None,
+            HumanTaskRejection(
+                message="This response must identify the pending durable human task.",
+                correction_guidance=policy.correction_guidance,
+            ),
         )
 
     completed = next(
-        (task for task in matching if task.id == submitted_id and task.status is HumanTaskStatus.COMPLETED),
+        (
+            task
+            for task in matching
+            if task.id == submitted_id and task.status is HumanTaskStatus.COMPLETED
+        ),
         None,
     )
     if completed is not None:
@@ -620,9 +684,13 @@ def _resolve_durable_task(
         task_id=rejected_task.id,
         reason="the task is no longer pending",
     )
-    return None, None, HumanTaskRejection(
-        message="This workflow is not waiting for a matching human task.",
-        correction_guidance=policy.correction_guidance,
+    return (
+        None,
+        None,
+        HumanTaskRejection(
+            message="This workflow is not waiting for a matching human task.",
+            correction_guidance=policy.correction_guidance,
+        ),
     )
 
 
@@ -650,8 +718,10 @@ def _recorded_result_continuation(
         ), ""
     lines = []
     for question, answer in answers.items():
-        if not isinstance(question, str) or not isinstance(answer, list) or not all(
-            isinstance(item, str) for item in answer
+        if (
+            not isinstance(question, str)
+            or not isinstance(answer, list)
+            or not all(isinstance(item, str) for item in answer)
         ):
             return HumanTaskRejection(
                 message="The completed durable human task has invalid recorded answers.",
@@ -676,7 +746,9 @@ def _submitted_human_task_id(raw_payload: str | Mapping[str, Any]) -> Optional[s
     return value.strip()
 
 
-def _validated_completion_payload(completion: HumanTaskCompletion, continuation: str) -> dict[str, Any]:
+def _validated_completion_payload(
+    completion: HumanTaskCompletion, continuation: str
+) -> dict[str, Any]:
     """Store the validated, transport-neutral completion rather than raw input."""
     payload: dict[str, Any] = {"task": completion.task_id, "continuation": continuation}
     if completion.decision is not None:

--- a/src/cafe/ui/human_tasks.py
+++ b/src/cafe/ui/human_tasks.py
@@ -224,6 +224,39 @@ def apply_capability_approval_payload(
     return HumanTaskApplication(target=task.step, policy=None)
 
 
+def apply_capability_cancellation(
+    *,
+    issue_dir: Path,
+    blackboard: Any,
+    task: HumanTask,
+    reason: str,
+) -> HumanTaskApplication:
+    """Cancel one exact capability task and release its owning workflow."""
+    service = CapabilityApprovalService(
+        issue_dir=issue_dir,
+        workflow_id=task.workflow_id,
+        step=task.step,
+        iteration=task.iteration,
+    )
+    service.cancel(task.id, reason=reason)
+    store = BlackboardStore(issue_dir)
+    store.update_handoff_contract(
+        blackboard,
+        from_step=task.step,
+        to_owner=HandoffOwner.AGENT,
+        to_step=task.step,
+        intent=HandoffIntent.AWAIT_AGENT,
+        source="command.capability_approval_cancel",
+    )
+    store.set_current_step(blackboard, task.step)
+    store.record_event(
+        blackboard,
+        "capability_approval_cancelled",
+        {"step": task.step, "task_id": task.id},
+    )
+    return HumanTaskApplication(target=task.step, policy=None)
+
+
 def apply_human_task_payload(
     *,
     issue_dir: Path,
@@ -414,9 +447,7 @@ def _apply_human_task_payload(
             )
             return HumanTaskApplication(target=None, policy=policy, rejection=continuation)
 
-    validated_completion = (
-        completion if isinstance(completion, HumanTaskCompletion) else None
-    )
+    validated_completion = completion if isinstance(completion, HumanTaskCompletion) else None
     if durable_result is None:
         assert validated_completion is not None
 
@@ -517,9 +548,7 @@ def _apply_human_task_payload(
                 record_store.complete(
                     workflow_id=blackboard.workflow_id,
                     task_id=durable_task.id,
-                    payload=_validated_completion_payload(
-                        validated_completion, continuation
-                    ),
+                    payload=_validated_completion_payload(validated_completion, continuation),
                     source=source,
                 )
             except HumanTaskCorrelationError as exc:

--- a/tests/integration/test_capability_approval_workflow.py
+++ b/tests/integration/test_capability_approval_workflow.py
@@ -191,7 +191,7 @@ def test_malformed_and_mismatched_cli_decisions_leave_request_blocked(
 
 @pytest.mark.parametrize("outcome", ["deny", "cancel", "expire"])
 def test_denial_cancellation_and_expiry_are_durable_without_mutation(
-    tmp_path: Path, outcome: str
+    tmp_path: Path, outcome: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Test List integration 2: terminal decisions release wait without mutation."""
     manifest = _manifest()
@@ -223,7 +223,22 @@ def test_denial_cancellation_and_expiry_are_durable_without_mutation(
     else:
         state = service.inspect(task.id)
 
+    monkeypatch.setattr(
+        capability_module,
+        "HOST_CAPABILITY_ADAPTERS",
+        {"open_current_pr": lambda **_kwargs: (_ for _ in ()).throw(AssertionError())},
+    )
+    receipt = service.resume(
+        task.id,
+        request=ExecutionRequest.model_validate(_request()),
+        registry={manifest.id: manifest},
+        repo_root=tmp_path,
+        output_file=tmp_path / "output.md",
+    )
+
     assert state["state"] in {"denied", "cancelled", "expired"}
+    assert receipt["outcome"] == state["state"]
+    assert not receipt["executed"]
     assert service.store.get_wait_state(task.id).released_at is not None
 
 

--- a/tests/integration/test_capability_approval_workflow.py
+++ b/tests/integration/test_capability_approval_workflow.py
@@ -1,0 +1,191 @@
+"""User journeys across capability hook, durable task, CLI, and resume boundaries."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from typer.testing import CliRunner
+
+import cafe.core.capabilities as capability_module
+from cafe.core.blackboard import BlackboardStore
+from cafe.core.capabilities import CapabilityManifest
+from cafe.core.hooks.native import GitHubPRCreator
+from cafe.core.human_task_records import HumanTaskRecordStore
+from cafe.core.status_codes import PhaseStatusCode
+from cafe.ui.cli import app
+
+runner = CliRunner()
+
+
+def _manifest() -> CapabilityManifest:
+    return CapabilityManifest.model_validate(
+        {
+            "id": "demo.mutate",
+            "version": 1,
+            "implementation": "open_current_pr",
+            "arguments": {
+                "required": ["target_ref"],
+                "properties": {"target_ref": {"type": "string", "enum": ["current_pr"]}},
+            },
+            "outputs": {"required": [], "properties": {}},
+            "effects": {
+                "writes": ["artifact.json"],
+                "network_destinations": ["api.example.test"],
+                "browser_open": [],
+            },
+            "credentials": ["example-token"],
+            "permissions": {"network": ["api.example.test"]},
+            "idempotency": "unsafe",
+            "risk": "high",
+            "approval": "required",
+            "policy": "allow",
+        }
+    )
+
+
+def _request() -> dict[str, object]:
+    return {
+        "capability": "demo.mutate",
+        "args": {"target_ref": "current_pr"},
+        "effects": {
+            "writes": ["artifact.json"],
+            "network_destinations": ["api.example.test"],
+            "browser_open": [],
+        },
+        "credentials": ["example-token"],
+        "permissions": {"network": ["api.example.test"]},
+    }
+
+
+def test_approve_restart_and_duplicate_resume_execute_exact_request_once(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test List integration 1/5/6/7: exact CLI approval survives restart and runs once."""
+    monkeypatch.chdir(tmp_path)
+    issue_dir = tmp_path / ".cafe" / "issues" / "approval"
+    iteration_dir = issue_dir / "develop" / "iteration_001"
+    iteration_dir.mkdir(parents=True)
+    (issue_dir / "issue.yaml").write_text("playbook: default\n", encoding="utf-8")
+    output_file = iteration_dir / "output.md"
+    output_file.write_text("# Output\n", encoding="utf-8")
+    request_file = iteration_dir / "capability_request.json"
+    request_file.write_text(json.dumps(_request()), encoding="utf-8")
+    blackboards = BlackboardStore(issue_dir)
+    state = blackboards.load_or_create("develop", playbook_id="default")
+    phase = SimpleNamespace(
+        issue_dir=issue_dir,
+        iteration=1,
+        git_ops=SimpleNamespace(get_repo_root=lambda: tmp_path),
+    )
+    phase._get_issue_config_value = lambda *_args: True
+    manifest = _manifest()
+    calls: list[str] = []
+    monkeypatch.setattr(
+        "cafe.core.capabilities.load_capability_registry",
+        lambda _paths: {manifest.id: manifest},
+    )
+
+    def adapter(**_kwargs: object) -> tuple[dict[str, object], None]:
+        calls.append("mutated")
+        return {}, None
+
+    monkeypatch.setattr(capability_module, "HOST_CAPABILITY_ADAPTERS", {"open_current_pr": adapter})
+    hook = GitHubPRCreator()
+    kwargs = {
+        "stage": "publish_output",
+        "phase": phase,
+        "step_name": "develop",
+        "step_def": {"capability_requests": [manifest.id]},
+        "output_file": output_file,
+        "capability_request_file": request_file,
+        "blackboard_state": state,
+        "status_code": PhaseStatusCode.CONFIRMED,
+    }
+
+    pending = hook.run(**kwargs)
+    task_id = str(pending.events[0]["task_id"])
+    task = HumanTaskRecordStore(issue_dir).get_task(task_id)
+    fingerprint = task.capability_approval["fingerprint"]  # type: ignore[index]
+    monkeypatch.setattr("cafe.ui.commands.tasks._resume_issue_workflow", lambda *_args: None)
+
+    completed = runner.invoke(
+        app,
+        [
+            "task",
+            "complete",
+            task_id,
+            "--result",
+            json.dumps(
+                {
+                    "decision": "approve",
+                    "workflow_id": state.workflow_id,
+                    "task_id": task_id,
+                    "request_fingerprint": fingerprint,
+                }
+            ),
+            "--json",
+        ],
+    )
+    resumed = hook.run(**kwargs)
+    duplicate = hook.run(**kwargs)
+
+    assert completed.exit_code == 0
+    assert calls == ["mutated"]
+    assert resumed.events[-1]["success"] is True
+    assert duplicate.events[-1]["success"] is True
+    detail = runner.invoke(app, ["task", "inspect", task_id, "--json"])
+    inspected = json.loads(detail.stdout)["data"]["task"]["capability_approval"]
+    assert inspected["state"] == "succeeded"
+    assert inspected["attempt"]["state"] == "finished"
+
+
+def test_malformed_and_mismatched_cli_decisions_leave_request_blocked(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test List integration 3/6: generic and mismatched consent cannot release wait."""
+    monkeypatch.chdir(tmp_path)
+    issue_dir = tmp_path / ".cafe" / "issues" / "blocked"
+    iteration_dir = issue_dir / "develop" / "iteration_001"
+    iteration_dir.mkdir(parents=True)
+    (issue_dir / "issue.yaml").write_text("playbook: default\n", encoding="utf-8")
+    state = BlackboardStore(issue_dir).load_or_create("develop", playbook_id="default")
+    from cafe.core.capabilities import ExecutionRequest
+    from cafe.core.capability_approvals import CapabilityApprovalService
+
+    service = CapabilityApprovalService(
+        issue_dir=issue_dir,
+        workflow_id=state.workflow_id,
+        step="develop",
+        iteration=1,
+    )
+    task = service.request_approval(
+        request=ExecutionRequest.model_validate(_request()), manifest=_manifest()
+    )
+
+    affirmative = runner.invoke(app, ["task", "complete", task.id, "--result", '"yes"', "--json"])
+    mismatched = runner.invoke(
+        app,
+        [
+            "task",
+            "complete",
+            task.id,
+            "--result",
+            json.dumps(
+                {
+                    "decision": "approve",
+                    "workflow_id": state.workflow_id,
+                    "task_id": "another-task",
+                    "request_fingerprint": "wrong",
+                }
+            ),
+            "--json",
+        ],
+    )
+
+    assert affirmative.exit_code != 0
+    assert mismatched.exit_code != 0
+    assert service.inspect(task.id)["state"] == "pending"
+    assert service.store.get_wait_state(task.id).released_at is None

--- a/tests/integration/test_capability_approval_workflow.py
+++ b/tests/integration/test_capability_approval_workflow.py
@@ -11,7 +11,7 @@ from typer.testing import CliRunner
 
 import cafe.core.capabilities as capability_module
 from cafe.core.blackboard import BlackboardStore
-from cafe.core.capabilities import CapabilityManifest, ExecutionRequest
+from cafe.core.capabilities import CapabilityManifest, CapabilityRegistryError, ExecutionRequest
 from cafe.core.capability_approvals import CapabilityApprovalService
 from cafe.core.hooks.native import GitHubPRCreator
 from cafe.core.human_task_records import HumanTaskRecordStore
@@ -110,6 +110,7 @@ def test_approve_restart_and_duplicate_resume_execute_exact_request_once(
     task_id = str(pending.events[0]["task_id"])
     task = HumanTaskRecordStore(issue_dir).get_task(task_id)
     fingerprint = task.capability_approval["fingerprint"]  # type: ignore[index]
+    correlation_id = task.capability_approval["correlation_id"]  # type: ignore[index]
     monkeypatch.setattr("cafe.ui.commands.tasks._resume_issue_workflow", lambda *_args: None)
 
     completed = runner.invoke(
@@ -125,6 +126,7 @@ def test_approve_restart_and_duplicate_resume_execute_exact_request_once(
                     "workflow_id": state.workflow_id,
                     "task_id": task_id,
                     "request_fingerprint": fingerprint,
+                    "correlation_id": correlation_id,
                 }
             ),
             "--json",
@@ -137,6 +139,8 @@ def test_approve_restart_and_duplicate_resume_execute_exact_request_once(
     assert calls == ["mutated"]
     assert resumed.events[-1]["success"] is True
     assert duplicate.events[-1]["success"] is True
+    assert resumed.events[-1]["correlation_id"] == correlation_id
+    assert duplicate.events[-1]["correlation_id"] == correlation_id
     detail = runner.invoke(app, ["task", "inspect", task_id, "--json"])
     inspected = json.loads(detail.stdout)["data"]["task"]["capability_approval"]
     assert inspected["state"] == "succeeded"
@@ -216,6 +220,7 @@ def test_denial_cancellation_and_expiry_are_durable_without_mutation(
                 "workflow_id": "workflow-one",
                 "task_id": task.id,
                 "request_fingerprint": approval["fingerprint"],
+                "correlation_id": approval["correlation_id"],
             },
         )
     elif outcome == "cancel":
@@ -230,6 +235,7 @@ def test_denial_cancellation_and_expiry_are_durable_without_mutation(
     )
     receipt = service.resume(
         task.id,
+        correlation_id=service.inspect(task.id)["correlation_id"],
         request=ExecutionRequest.model_validate(_request()),
         registry={manifest.id: manifest},
         repo_root=tmp_path,
@@ -240,6 +246,57 @@ def test_denial_cancellation_and_expiry_are_durable_without_mutation(
     assert receipt["outcome"] == state["state"]
     assert not receipt["executed"]
     assert service.store.get_wait_state(task.id).released_at is not None
+
+
+def test_hook_honors_request_declared_approval_expiry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test List integration 2: the production request path terminalizes expiry."""
+    monkeypatch.chdir(tmp_path)
+    issue_dir = tmp_path / ".cafe" / "issues" / "expired-hook"
+    iteration_dir = issue_dir / "develop" / "iteration_001"
+    iteration_dir.mkdir(parents=True)
+    (issue_dir / "issue.yaml").write_text("playbook: default\n", encoding="utf-8")
+    request_file = iteration_dir / "capability_request.json"
+    request_file.write_text(
+        json.dumps({**_request(), "expires_at": "2000-01-01T00:00:00+00:00"}),
+        encoding="utf-8",
+    )
+    output_file = iteration_dir / "output.md"
+    output_file.write_text("# Output\n", encoding="utf-8")
+    state = BlackboardStore(issue_dir).load_or_create("develop", playbook_id="default")
+    phase = SimpleNamespace(
+        issue_dir=issue_dir,
+        iteration=1,
+        git_ops=SimpleNamespace(get_repo_root=lambda: tmp_path),
+    )
+    phase._get_issue_config_value = lambda *_args: True
+    manifest = _manifest()
+    monkeypatch.setattr(
+        "cafe.core.capabilities.load_capability_registry",
+        lambda _paths: {manifest.id: manifest},
+    )
+    monkeypatch.setattr(
+        capability_module,
+        "HOST_CAPABILITY_ADAPTERS",
+        {"open_current_pr": lambda **_kwargs: (_ for _ in ()).throw(AssertionError())},
+    )
+
+    result = GitHubPRCreator().run(
+        stage="publish_output",
+        phase=phase,
+        step_name="develop",
+        step_def={"capability_requests": [manifest.id]},
+        output_file=output_file,
+        capability_request_file=request_file,
+        blackboard_state=state,
+        status_code=PhaseStatusCode.CONFIRMED,
+    )
+
+    assert result.events[-1]["code"] == "expired"
+    task = HumanTaskRecordStore(issue_dir).tasks()[-1]
+    assert task.capability_approval["expires_at"] == "2000-01-01T00:00:00+00:00"  # type: ignore[index]
+    assert task.capability_approval["receipt"]["executed"] is False  # type: ignore[index]
 
 
 def test_restrictive_policy_and_tampered_resume_remain_non_executed(
@@ -271,6 +328,7 @@ def test_restrictive_policy_and_tampered_resume_remain_non_executed(
                 "workflow_id": "workflow-one",
                 "task_id": task.id,
                 "request_fingerprint": current["fingerprint"],
+                "correlation_id": current["correlation_id"],
             },
         )
         return service, task.id
@@ -279,6 +337,7 @@ def test_restrictive_policy_and_tampered_resume_remain_non_executed(
     restrictive = manifest.model_copy(update={"policy": "deny"})
     policy_receipt = policy_service.resume(
         policy_task_id,
+        correlation_id=policy_service.inspect(policy_task_id)["correlation_id"],
         request=ExecutionRequest.model_validate(_request()),
         registry={manifest.id: restrictive},
         repo_root=tmp_path,
@@ -288,6 +347,7 @@ def test_restrictive_policy_and_tampered_resume_remain_non_executed(
     changed = {**_request(), "args": {"target_ref": "replacement"}}
     tamper_receipt = tamper_service.resume(
         tamper_task_id,
+        correlation_id=tamper_service.inspect(tamper_task_id)["correlation_id"],
         request=ExecutionRequest.model_validate(changed),
         registry={manifest.id: manifest},
         repo_root=tmp_path,
@@ -298,3 +358,88 @@ def test_restrictive_policy_and_tampered_resume_remain_non_executed(
     assert tamper_receipt["outcome"] == "tampered"
     assert not policy_receipt["executed"]
     assert not tamper_receipt["executed"]
+
+
+def test_hook_policy_load_failure_terminalizes_approved_exact_request(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test List integration 4: unavailable current policy consumes the approval."""
+    monkeypatch.chdir(tmp_path)
+    issue_dir = tmp_path / ".cafe" / "issues" / "policy-unavailable"
+    iteration_dir = issue_dir / "develop" / "iteration_001"
+    iteration_dir.mkdir(parents=True)
+    (issue_dir / "issue.yaml").write_text("playbook: default\n", encoding="utf-8")
+    request_file = iteration_dir / "capability_request.json"
+    request_file.write_text(json.dumps(_request()), encoding="utf-8")
+    output_file = iteration_dir / "output.md"
+    output_file.write_text("# Output\n", encoding="utf-8")
+    state = BlackboardStore(issue_dir).load_or_create("develop", playbook_id="default")
+    phase = SimpleNamespace(
+        issue_dir=issue_dir,
+        iteration=1,
+        git_ops=SimpleNamespace(get_repo_root=lambda: tmp_path),
+    )
+    phase._get_issue_config_value = lambda *_args: True
+    manifest = _manifest()
+    registry: object = {manifest.id: manifest}
+    monkeypatch.setattr("cafe.core.capabilities.load_capability_registry", lambda _paths: registry)
+    monkeypatch.setattr(
+        capability_module,
+        "HOST_CAPABILITY_ADAPTERS",
+        {"open_current_pr": lambda **_kwargs: (_ for _ in ()).throw(AssertionError())},
+    )
+    hook = GitHubPRCreator()
+    kwargs = {
+        "stage": "publish_output",
+        "phase": phase,
+        "step_name": "develop",
+        "step_def": {"capability_requests": [manifest.id]},
+        "output_file": output_file,
+        "capability_request_file": request_file,
+        "blackboard_state": state,
+        "status_code": PhaseStatusCode.CONFIRMED,
+    }
+
+    pending = hook.run(**kwargs)
+    task_id = str(pending.events[0]["task_id"])
+    service = CapabilityApprovalService(
+        issue_dir=issue_dir,
+        workflow_id=state.workflow_id,
+        step="develop",
+        iteration=1,
+    )
+    approval = service.inspect(task_id)
+    service.record_decision(
+        task_id,
+        {
+            "decision": "approve",
+            "workflow_id": state.workflow_id,
+            "task_id": task_id,
+            "request_fingerprint": approval["fingerprint"],
+            "correlation_id": approval["correlation_id"],
+        },
+    )
+    registry = CapabilityRegistryError("registry temporarily unreadable")
+
+    def unavailable(_paths: object) -> object:
+        assert isinstance(registry, CapabilityRegistryError)
+        raise registry
+
+    monkeypatch.setattr("cafe.core.capabilities.load_capability_registry", unavailable)
+    rejected = hook.run(**kwargs)
+    rejected_state = service.inspect(task_id)
+
+    assert rejected.events[-1]["code"] == "policy_rejected"
+    assert rejected.events[-1]["correlation_id"] == approval["correlation_id"]
+    assert rejected_state["state"] == "policy_rejected"
+    assert rejected_state["revalidation"]["reason_code"] == "registry_load_error"
+    assert "registry temporarily unreadable" in rejected_state["revalidation"]["error_detail"]
+
+    monkeypatch.setattr(
+        "cafe.core.capabilities.load_capability_registry",
+        lambda _paths: {manifest.id: manifest},
+    )
+    replacement = hook.run(**kwargs)
+
+    assert replacement.events[0]["type"] == "capability_approval_pending"
+    assert replacement.events[0]["task_id"] != task_id

--- a/tests/integration/test_capability_approval_workflow.py
+++ b/tests/integration/test_capability_approval_workflow.py
@@ -11,7 +11,8 @@ from typer.testing import CliRunner
 
 import cafe.core.capabilities as capability_module
 from cafe.core.blackboard import BlackboardStore
-from cafe.core.capabilities import CapabilityManifest
+from cafe.core.capabilities import CapabilityManifest, ExecutionRequest
+from cafe.core.capability_approvals import CapabilityApprovalService
 from cafe.core.hooks.native import GitHubPRCreator
 from cafe.core.human_task_records import HumanTaskRecordStore
 from cafe.core.status_codes import PhaseStatusCode
@@ -152,9 +153,6 @@ def test_malformed_and_mismatched_cli_decisions_leave_request_blocked(
     iteration_dir.mkdir(parents=True)
     (issue_dir / "issue.yaml").write_text("playbook: default\n", encoding="utf-8")
     state = BlackboardStore(issue_dir).load_or_create("develop", playbook_id="default")
-    from cafe.core.capabilities import ExecutionRequest
-    from cafe.core.capability_approvals import CapabilityApprovalService
-
     service = CapabilityApprovalService(
         issue_dir=issue_dir,
         workflow_id=state.workflow_id,
@@ -189,3 +187,99 @@ def test_malformed_and_mismatched_cli_decisions_leave_request_blocked(
     assert mismatched.exit_code != 0
     assert service.inspect(task.id)["state"] == "pending"
     assert service.store.get_wait_state(task.id).released_at is None
+
+
+@pytest.mark.parametrize("outcome", ["deny", "cancel", "expire"])
+def test_denial_cancellation_and_expiry_are_durable_without_mutation(
+    tmp_path: Path, outcome: str
+) -> None:
+    """Test List integration 2: terminal decisions release wait without mutation."""
+    manifest = _manifest()
+    service = CapabilityApprovalService(
+        issue_dir=tmp_path / outcome,
+        workflow_id="workflow-one",
+        step="develop",
+        iteration=1,
+    )
+    task = service.request_approval(
+        request=ExecutionRequest.model_validate(_request()),
+        manifest=manifest,
+        expires_at="2000-01-01T00:00:00+00:00" if outcome == "expire" else None,
+    )
+
+    if outcome == "deny":
+        approval = service.inspect(task.id)
+        state = service.record_decision(
+            task.id,
+            {
+                "decision": "deny",
+                "workflow_id": "workflow-one",
+                "task_id": task.id,
+                "request_fingerprint": approval["fingerprint"],
+            },
+        )
+    elif outcome == "cancel":
+        state = service.cancel(task.id, reason="operator cancelled")
+    else:
+        state = service.inspect(task.id)
+
+    assert state["state"] in {"denied", "cancelled", "expired"}
+    assert service.store.get_wait_state(task.id).released_at is not None
+
+
+def test_restrictive_policy_and_tampered_resume_remain_non_executed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test List integration 3/4: changed request or policy wins over approval."""
+    manifest = _manifest()
+    monkeypatch.setattr(
+        capability_module,
+        "HOST_CAPABILITY_ADAPTERS",
+        {"open_current_pr": lambda **_kwargs: (_ for _ in ()).throw(AssertionError())},
+    )
+
+    def approved_service(name: str) -> tuple[CapabilityApprovalService, str]:
+        service = CapabilityApprovalService(
+            issue_dir=tmp_path / name,
+            workflow_id="workflow-one",
+            step="develop",
+            iteration=1,
+        )
+        task = service.request_approval(
+            request=ExecutionRequest.model_validate(_request()), manifest=manifest
+        )
+        current = service.inspect(task.id)
+        service.record_decision(
+            task.id,
+            {
+                "decision": "approve",
+                "workflow_id": "workflow-one",
+                "task_id": task.id,
+                "request_fingerprint": current["fingerprint"],
+            },
+        )
+        return service, task.id
+
+    policy_service, policy_task_id = approved_service("policy")
+    restrictive = manifest.model_copy(update={"policy": "deny"})
+    policy_receipt = policy_service.resume(
+        policy_task_id,
+        request=ExecutionRequest.model_validate(_request()),
+        registry={manifest.id: restrictive},
+        repo_root=tmp_path,
+        output_file=tmp_path / "output.md",
+    )
+    tamper_service, tamper_task_id = approved_service("tamper")
+    changed = {**_request(), "args": {"target_ref": "replacement"}}
+    tamper_receipt = tamper_service.resume(
+        tamper_task_id,
+        request=ExecutionRequest.model_validate(changed),
+        registry={manifest.id: manifest},
+        repo_root=tmp_path,
+        output_file=tmp_path / "output.md",
+    )
+
+    assert policy_receipt["outcome"] == "policy_rejected"
+    assert tamper_receipt["outcome"] == "tampered"
+    assert not policy_receipt["executed"]
+    assert not tamper_receipt["executed"]

--- a/tests/integration/test_capability_approval_workflow.py
+++ b/tests/integration/test_capability_approval_workflow.py
@@ -205,11 +205,13 @@ def test_denial_cancellation_and_expiry_are_durable_without_mutation(
         step="develop",
         iteration=1,
     )
-    task = service.request_approval(
-        request=ExecutionRequest.model_validate(_request()),
-        manifest=manifest,
-        expires_at="2000-01-01T00:00:00+00:00" if outcome == "expire" else None,
+    request = ExecutionRequest.model_validate(
+        {
+            **_request(),
+            "expires_at": "2000-01-01T00:00:00+00:00" if outcome == "expire" else None,
+        }
     )
+    task = service.request_approval(request=request, manifest=manifest)
 
     if outcome == "deny":
         approval = service.inspect(task.id)
@@ -236,7 +238,7 @@ def test_denial_cancellation_and_expiry_are_durable_without_mutation(
     receipt = service.resume(
         task.id,
         correlation_id=service.inspect(task.id)["correlation_id"],
-        request=ExecutionRequest.model_validate(_request()),
+        request=request,
         registry={manifest.id: manifest},
         repo_root=tmp_path,
         output_file=tmp_path / "output.md",

--- a/tests/integration/test_task_inbox_workflow.py
+++ b/tests/integration/test_task_inbox_workflow.py
@@ -218,6 +218,95 @@ def test_capability_task_inspection_exposes_exact_approval_state(
             "id": "demo.inspect",
             "version": 1,
             "implementation": "open_current_pr",
+            "arguments": {
+                "required": ["target"],
+                "properties": {"target": {"type": "string"}},
+            },
+            "outputs": {
+                "required": ["receipt_path"],
+                "properties": {"receipt_path": {"type": "string"}},
+            },
+            "effects": {
+                "writes": ["approval.txt"],
+                "network_destinations": ["api.example.test"],
+                "browser_open": [],
+            },
+            "credentials": ["example-token"],
+            "permissions": {"network": ["api.example.test"]},
+            "idempotency": "unsafe",
+            "risk": "high",
+            "approval": "required",
+            "policy": "allow",
+        }
+    )
+    request = ExecutionRequest.model_validate(
+        {
+            "capability": manifest.id,
+            "args": {"target": "reviewed"},
+            "effects": {
+                "writes": ["approval.txt"],
+                "network_destinations": ["api.example.test"],
+                "browser_open": [],
+            },
+            "credentials": ["example-token"],
+            "permissions": {"network": ["api.example.test"]},
+        }
+    )
+    task = CapabilityApprovalService(
+        issue_dir=issue_dir,
+        workflow_id=state.workflow_id,
+        step="spec",
+        iteration=1,
+    ).request_approval(request=request, manifest=manifest)
+
+    result = runner.invoke(app, ["task", "inspect", task.id, "--json"])
+    approval = json.loads(result.stdout)["data"]["task"]["capability_approval"]
+
+    assert approval["state"] == "pending"
+    assert approval["capability"] == manifest.id
+    assert approval["request"]["capability"] == manifest.id
+
+    readable = runner.invoke(app, ["task", "inspect", task.id])
+
+    assert readable.exit_code == 0
+    for reviewed_value in (
+        "demo.inspect",
+        "high",
+        "reviewed",
+        "approval.txt",
+        "api.example.test",
+        "example-token",
+        "network",
+        "receipt_path",
+    ):
+        assert reviewed_value in readable.stdout
+
+    monkeypatch.setattr("cafe.ui.commands.tasks._resume_issue_workflow", lambda *_args: None)
+    interactive = runner.invoke(app, ["task", "complete", task.id], input="deny\n")
+
+    assert interactive.exit_code == 0
+    assert "demo.inspect" in interactive.stdout
+    assert "approval.txt" in interactive.stdout
+    assert interactive.stdout.index("demo.inspect") < interactive.stdout.index(
+        "Capability decision"
+    )
+
+
+def test_capability_task_cancel_command_persists_terminal_receipt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test List I2: the production inbox cancel path releases the exact task."""
+    from cafe.core.capabilities import CapabilityManifest, ExecutionRequest
+    from cafe.core.capability_approvals import CapabilityApprovalService
+
+    monkeypatch.chdir(tmp_path)
+    issue_dir, _ordinary = _pending_issue(tmp_path / ".cafe", "capability-cancel")
+    state = BlackboardStore(issue_dir).load_or_create("spec")
+    manifest = CapabilityManifest.model_validate(
+        {
+            "id": "demo.cancel",
+            "version": 1,
+            "implementation": "open_current_pr",
             "arguments": {"required": [], "properties": {}},
             "outputs": {"required": [], "properties": {}},
             "effects": {"writes": [], "network_destinations": [], "browser_open": []},
@@ -238,16 +327,29 @@ def test_capability_task_inspection_exposes_exact_approval_state(
             "permissions": {},
         }
     )
-    task = CapabilityApprovalService(
+    service = CapabilityApprovalService(
         issue_dir=issue_dir,
         workflow_id=state.workflow_id,
         step="spec",
         iteration=1,
-    ).request_approval(request=request, manifest=manifest)
+    )
+    task = service.request_approval(request=request, manifest=manifest)
+    monkeypatch.setattr("cafe.ui.commands.tasks._resume_issue_workflow", lambda *_args: None)
 
-    result = runner.invoke(app, ["task", "inspect", task.id, "--json"])
-    approval = json.loads(result.stdout)["data"]["task"]["capability_approval"]
+    result = runner.invoke(
+        app,
+        ["task", "cancel", task.id, "--reason", "operator stopped request", "--json"],
+    )
+    resumed = service.resume(
+        task.id,
+        correlation_id=service.inspect(task.id)["correlation_id"],
+        request=request,
+        registry={manifest.id: manifest},
+        repo_root=tmp_path,
+        output_file=tmp_path / "output.md",
+    )
 
-    assert approval["state"] == "pending"
-    assert approval["capability"] == manifest.id
-    assert approval["request"]["capability"] == manifest.id
+    assert result.exit_code == 0
+    assert resumed["outcome"] == "cancelled"
+    assert resumed["executed"] is False
+    assert resumed["correlation_id"] == service.inspect(task.id)["correlation_id"]

--- a/tests/integration/test_task_inbox_workflow.py
+++ b/tests/integration/test_task_inbox_workflow.py
@@ -122,9 +122,7 @@ def test_unsafe_completion_stops_without_workflow_progress(
     )
     payload = '{"decision":"unknown"}' if case == "invalid" else '{"decision":"confirm"}'
 
-    result = runner.invoke(
-        app, ["task", "complete", task.id, "--result", payload, "--json"]
-    )
+    result = runner.invoke(app, ["task", "complete", task.id, "--result", payload, "--json"])
 
     assert result.exit_code != 0
     assert json.loads(result.stdout)["error"]["code"] in {
@@ -178,9 +176,7 @@ def test_resume_failure_reports_committed_completion_and_direct_recovery(
     def unavailable_resume(_issue: str, _playbook: str) -> None:
         raise RuntimeError("runner unavailable")
 
-    monkeypatch.setattr(
-        "cafe.ui.commands.tasks._resume_issue_workflow", unavailable_resume
-    )
+    monkeypatch.setattr("cafe.ui.commands.tasks._resume_issue_workflow", unavailable_resume)
 
     result = runner.invoke(
         app,
@@ -205,3 +201,53 @@ def test_resume_failure_reports_committed_completion_and_direct_recovery(
     assert records.get_task(task.id).status is HumanTaskStatus.COMPLETED
     assert len(records.results()) == 1
     assert BlackboardStore(issue_dir).load_or_create("spec").current_step == "plan"
+
+
+def test_capability_task_inspection_exposes_exact_approval_state(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test List I6: inbox inspection exposes the stable capability boundary."""
+    from cafe.core.capabilities import CapabilityManifest, ExecutionRequest
+    from cafe.core.capability_approvals import CapabilityApprovalService
+
+    monkeypatch.chdir(tmp_path)
+    issue_dir, _ordinary = _pending_issue(tmp_path / ".cafe", "capability-inspect")
+    state = BlackboardStore(issue_dir).load_or_create("spec")
+    manifest = CapabilityManifest.model_validate(
+        {
+            "id": "demo.inspect",
+            "version": 1,
+            "implementation": "open_current_pr",
+            "arguments": {"required": [], "properties": {}},
+            "outputs": {"required": [], "properties": {}},
+            "effects": {"writes": [], "network_destinations": [], "browser_open": []},
+            "credentials": [],
+            "permissions": {},
+            "idempotency": "unsafe",
+            "risk": "high",
+            "approval": "required",
+            "policy": "allow",
+        }
+    )
+    request = ExecutionRequest.model_validate(
+        {
+            "capability": manifest.id,
+            "args": {},
+            "effects": {"writes": [], "network_destinations": [], "browser_open": []},
+            "credentials": [],
+            "permissions": {},
+        }
+    )
+    task = CapabilityApprovalService(
+        issue_dir=issue_dir,
+        workflow_id=state.workflow_id,
+        step="spec",
+        iteration=1,
+    ).request_approval(request=request, manifest=manifest)
+
+    result = runner.invoke(app, ["task", "inspect", task.id, "--json"])
+    approval = json.loads(result.stdout)["data"]["task"]["capability_approval"]
+
+    assert approval["state"] == "pending"
+    assert approval["capability"] == manifest.id
+    assert approval["request"]["capability"] == manifest.id

--- a/tests/unit/test_capability_approvals.py
+++ b/tests/unit/test_capability_approvals.py
@@ -266,22 +266,30 @@ def test_concurrent_resumes_cross_one_atomic_attempt_fence(
     manifest = _manifest()
     task = first_service.request_approval(request=_request(), manifest=manifest)
     _approve(first_service, task.id)
-    second_service = _service(tmp_path)
-    original_transition = first_service.store.__class__.transition_capability_approval_if_state
+    original_resume_locked = first_service._resume_locked
+    active = 0
+    active_lock = threading.Lock()
+    overlapped = threading.Event()
+    first_entered = threading.Event()
 
-    def widen_pre_fence_race(self: object, **kwargs: object) -> object:
-        time.sleep(0.05)
-        return original_transition(self, **kwargs)  # type: ignore[arg-type]
+    def track_resume_overlap(task_id: str, **kwargs: object) -> dict[str, object]:
+        nonlocal active
+        with active_lock:
+            active += 1
+            if active > 1:
+                overlapped.set()
+            else:
+                first_entered.set()
+        time.sleep(0.1)
+        try:
+            return original_resume_locked(task_id, **kwargs)  # type: ignore[arg-type]
+        finally:
+            with active_lock:
+                active -= 1
 
-    monkeypatch.setattr(
-        first_service.store.__class__,
-        "transition_capability_approval_if_state",
-        widen_pre_fence_race,
-    )
-    start = threading.Barrier(2)
+    monkeypatch.setattr(first_service, "_resume_locked", track_resume_overlap)
 
     def resume(service: CapabilityApprovalService) -> dict[str, object]:
-        start.wait()
         return service.resume(
             task.id,
             request=_request(),
@@ -291,9 +299,13 @@ def test_concurrent_resumes_cross_one_atomic_attempt_fence(
         )
 
     with ThreadPoolExecutor(max_workers=2) as pool:
-        results = list(pool.map(resume, (first_service, second_service)))
+        first = pool.submit(resume, first_service)
+        assert first_entered.wait(timeout=1)
+        second = pool.submit(resume, first_service)
+        results = [first.result(), second.result()]
 
     assert calls == ["called"]
+    assert not overlapped.is_set()
     assert results[0] == results[1]
     assert results[0]["outcome"] == "succeeded"
 

--- a/tests/unit/test_capability_approvals.py
+++ b/tests/unit/test_capability_approvals.py
@@ -8,6 +8,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
+from pydantic import ValidationError
 
 import cafe.core.capabilities as capability_module
 from cafe.core.capabilities import (
@@ -135,6 +136,36 @@ def test_same_pending_request_deduplicates_but_changed_request_does_not(tmp_path
     )
 
 
+def test_changed_request_expiry_gets_a_distinct_approval_task(tmp_path: Path) -> None:
+    """Test List unit 2/4: approval lifetime belongs to the exact request."""
+    service = _service(tmp_path)
+    first_expiry = (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat()
+    second_expiry = (datetime.now(timezone.utc) + timedelta(hours=2)).isoformat()
+
+    first = service.request_approval(
+        request=_request().model_copy(update={"expires_at": first_expiry}),
+        manifest=_manifest(),
+    )
+    replacement = service.request_approval(
+        request=_request().model_copy(update={"expires_at": second_expiry}),
+        manifest=_manifest(),
+    )
+
+    assert replacement.id != first.id
+    assert replacement.capability_approval is not None
+    assert replacement.capability_approval["expires_at"] == second_expiry
+
+
+@pytest.mark.parametrize("expires_at", ["not-a-timestamp", "2026-08-20T12:00:00"])
+def test_request_rejects_invalid_or_naive_expiry(expires_at: str) -> None:
+    """Test List unit 4: malformed request-owned expiry fails at validation."""
+    payload = _request().model_dump(mode="json")
+    payload["expires_at"] = expires_at
+
+    with pytest.raises(ValidationError):
+        ExecutionRequest.model_validate(payload)
+
+
 @pytest.mark.parametrize(
     "payload",
     [
@@ -224,9 +255,13 @@ def test_cancel_and_request_declared_expiry_are_terminal(tmp_path: Path) -> None
     assert service.store.get_wait_state(cancelled_task.id).released_at is not None
 
     expired_task = service.request_approval(
-        request=_request().model_copy(update={"args": {"target_ref": "current_pr"}}),
+        request=_request().model_copy(
+            update={
+                "args": {"target_ref": "current_pr"},
+                "expires_at": (datetime.now(timezone.utc) - timedelta(seconds=1)).isoformat(),
+            }
+        ),
         manifest=_manifest(version=2),
-        expires_at=(datetime.now(timezone.utc) - timedelta(seconds=1)).isoformat(),
     )
     expired = service.inspect(expired_task.id)
 

--- a/tests/unit/test_capability_approvals.py
+++ b/tests/unit/test_capability_approvals.py
@@ -1,0 +1,193 @@
+"""Security invariants for exact-request capability approvals."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from cafe.core.capabilities import CapabilityManifest, ExecutionRequest, PolicyDecision
+from cafe.core.capability_approvals import (
+    CapabilityApprovalError,
+    CapabilityApprovalService,
+)
+
+
+def _manifest(**overrides: object) -> CapabilityManifest:
+    data: dict[str, object] = {
+        "id": "demo.mutate",
+        "version": 1,
+        "implementation": "open_current_pr",
+        "arguments": {
+            "required": ["target_ref"],
+            "properties": {"target_ref": {"type": "string", "enum": ["current_pr"]}},
+        },
+        "outputs": {"required": [], "properties": {}},
+        "effects": {
+            "writes": ["artifact.json"],
+            "network_destinations": ["api.example.test"],
+            "browser_open": [],
+        },
+        "credentials": ["example-token"],
+        "permissions": {"network": ["api.example.test"]},
+        "idempotency": "unsafe",
+        "risk": "high",
+        "approval": "required",
+        "policy": "allow",
+    }
+    data.update(overrides)
+    return CapabilityManifest.model_validate(data)
+
+
+def _request() -> ExecutionRequest:
+    return ExecutionRequest.model_validate(
+        {
+            "capability": "demo.mutate",
+            "args": {"target_ref": "current_pr"},
+            "effects": {
+                "writes": ["artifact.json"],
+                "network_destinations": ["api.example.test"],
+                "browser_open": [],
+            },
+            "credentials": ["example-token"],
+            "permissions": {"network": ["api.example.test"]},
+        }
+    )
+
+
+def _service(tmp_path: Path) -> CapabilityApprovalService:
+    return CapabilityApprovalService(
+        issue_dir=tmp_path / "issue",
+        workflow_id="workflow-one",
+        step="publish",
+        iteration=1,
+    )
+
+
+def test_task_snapshots_exact_request_and_material_effects(tmp_path: Path) -> None:
+    """Test List unit 1/8: task is capability-specific and exposes reviewed effects."""
+    service = _service(tmp_path)
+    task = service.request_approval(request=_request(), manifest=_manifest())
+
+    approval = task.capability_approval
+    assert approval is not None
+    assert approval["request"]["capability"] == "demo.mutate"
+    assert approval["risk"] == "high"
+    assert approval["effects"]["writes"] == ["artifact.json"]
+    assert approval["effects"]["network_destinations"] == ["api.example.test"]
+    assert approval["credentials"] == ["example-token"]
+    assert approval["permissions"] == {"network": ["api.example.test"]}
+    assert approval["expected_outputs"] == []
+    assert task.trigger == "capability_approval"
+    assert task.policy_id == "capability-approval"
+
+
+def test_same_pending_request_deduplicates_but_changed_request_does_not(tmp_path: Path) -> None:
+    """Test List unit 2: only one task represents an exact pending request."""
+    service = _service(tmp_path)
+    first = service.request_approval(request=_request(), manifest=_manifest())
+    duplicate = service.request_approval(request=_request(), manifest=_manifest())
+    flexible = _manifest(
+        arguments={
+            "required": ["target_ref"],
+            "properties": {
+                "target_ref": {"type": "string", "enum": ["current_pr", "other"]}
+            },
+        }
+    )
+    first = service.request_approval(request=_request(), manifest=flexible)
+    duplicate = service.request_approval(request=_request(), manifest=flexible)
+    changed = _request().model_copy(update={"args": {"target_ref": "other"}})
+    replacement = service.request_approval(request=changed, manifest=flexible)
+
+    assert duplicate.id == first.id
+    assert replacement.id != first.id
+    assert replacement.capability_approval is not None
+    assert replacement.capability_approval["fingerprint"] != first.capability_approval[  # type: ignore[index]
+        "fingerprint"
+    ]
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "yes",
+        {},
+        {"decision": "approve"},
+        {"decision": "approve", "task_id": "other", "request_fingerprint": "wrong"},
+    ],
+)
+def test_decision_requires_structured_exact_correlation(
+    tmp_path: Path, payload: object
+) -> None:
+    """Test List unit 3/8: generic consent and other approval domains fail closed."""
+    service = _service(tmp_path)
+    task = service.request_approval(request=_request(), manifest=_manifest())
+
+    with pytest.raises(CapabilityApprovalError):
+        service.record_decision(task.id, payload)
+
+    assert service.inspect(task.id)["state"] == "pending"
+
+
+def test_denial_is_terminal_and_cannot_be_reopened(tmp_path: Path) -> None:
+    """Test List unit 4: the first exact denial remains authoritative."""
+    service = _service(tmp_path)
+    task = service.request_approval(request=_request(), manifest=_manifest())
+    fingerprint = task.capability_approval["fingerprint"]  # type: ignore[index]
+    payload = {
+        "decision": "deny",
+        "workflow_id": "workflow-one",
+        "task_id": task.id,
+        "request_fingerprint": fingerprint,
+    }
+
+    denied = service.record_decision(task.id, payload)
+    repeated = service.record_decision(task.id, {**payload, "decision": "approve"})
+
+    assert denied["state"] == "denied"
+    assert repeated == denied
+    assert service.inspect(task.id)["state"] == "denied"
+
+
+def test_cancel_and_request_declared_expiry_are_terminal(tmp_path: Path) -> None:
+    """Test List unit 4: cancellation/expiry release the wait without dispatch."""
+    service = _service(tmp_path)
+    cancelled_task = service.request_approval(request=_request(), manifest=_manifest())
+
+    cancelled = service.cancel(cancelled_task.id, reason="operator cancelled")
+
+    assert cancelled["state"] == "cancelled"
+    assert service.store.get_wait_state(cancelled_task.id).released_at is not None
+
+    expired_task = service.request_approval(
+        request=_request().model_copy(update={"args": {"target_ref": "current_pr"}}),
+        manifest=_manifest(version=2),
+        expires_at=(datetime.now(timezone.utc) - timedelta(seconds=1)).isoformat(),
+    )
+    expired = service.inspect(expired_task.id)
+
+    assert expired["state"] == "expired"
+    assert service.store.get_wait_state(expired_task.id).released_at is not None
+
+
+def test_backward_generic_task_records_remain_readable(tmp_path: Path) -> None:
+    """Test List unit 1: optional capability metadata preserves generic records."""
+    from cafe.core.human_task_records import HumanTaskRecordStore
+
+    store = HumanTaskRecordStore(tmp_path / "issue")
+    task = store.materialize(
+        workflow_id="workflow-one",
+        step="develop",
+        iteration=1,
+        trigger="need_clarification",
+        policy_id="clarification-feedback",
+        prompt="Clarify.",
+        expected_result={"input_schema": "feedback"},
+        continuations={"submit": "develop"},
+        assignee_type="user",
+    )
+
+    assert HumanTaskRecordStore(tmp_path / "issue").get_task(task.id).capability_approval is None
+    assert PolicyDecision.REQUIRE_APPROVAL.value == "require_approval"

--- a/tests/unit/test_capability_approvals.py
+++ b/tests/unit/test_capability_approvals.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import threading
-import time
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -271,6 +270,24 @@ def test_concurrent_resumes_cross_one_atomic_attempt_fence(
     active_lock = threading.Lock()
     overlapped = threading.Event()
     first_entered = threading.Event()
+    second_reached_transaction_boundary = threading.Event()
+    transaction_lock = threading.RLock()
+
+    class ObservedTransactionLock:
+        def __enter__(self) -> ObservedTransactionLock:
+            if first_entered.is_set():
+                second_reached_transaction_boundary.set()
+            transaction_lock.acquire()
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            transaction_lock.release()
+
+    monkeypatch.setattr(
+        first_service.store,
+        "_thread_lock_for",
+        lambda _file_path: ObservedTransactionLock(),
+    )
 
     def track_resume_overlap(task_id: str, **kwargs: object) -> dict[str, object]:
         nonlocal active
@@ -278,9 +295,10 @@ def test_concurrent_resumes_cross_one_atomic_attempt_fence(
             active += 1
             if active > 1:
                 overlapped.set()
+                second_reached_transaction_boundary.set()
             else:
                 first_entered.set()
-        time.sleep(0.1)
+        assert second_reached_transaction_boundary.wait(timeout=1)
         try:
             return original_resume_locked(task_id, **kwargs)  # type: ignore[arg-type]
         finally:

--- a/tests/unit/test_capability_approvals.py
+++ b/tests/unit/test_capability_approvals.py
@@ -7,7 +7,13 @@ from pathlib import Path
 
 import pytest
 
-from cafe.core.capabilities import CapabilityManifest, ExecutionRequest, PolicyDecision
+import cafe.core.capabilities as capability_module
+from cafe.core.capabilities import (
+    CapabilityExecutionError,
+    CapabilityManifest,
+    ExecutionRequest,
+    PolicyDecision,
+)
 from cafe.core.capability_approvals import (
     CapabilityApprovalError,
     CapabilityApprovalService,
@@ -65,6 +71,19 @@ def _service(tmp_path: Path) -> CapabilityApprovalService:
     )
 
 
+def _approve(service: CapabilityApprovalService, task_id: str) -> None:
+    approval = service.inspect(task_id)
+    service.record_decision(
+        task_id,
+        {
+            "decision": "approve",
+            "workflow_id": "workflow-one",
+            "task_id": task_id,
+            "request_fingerprint": approval["fingerprint"],
+        },
+    )
+
+
 def test_task_snapshots_exact_request_and_material_effects(tmp_path: Path) -> None:
     """Test List unit 1/8: task is capability-specific and exposes reviewed effects."""
     service = _service(tmp_path)
@@ -91,9 +110,7 @@ def test_same_pending_request_deduplicates_but_changed_request_does_not(tmp_path
     flexible = _manifest(
         arguments={
             "required": ["target_ref"],
-            "properties": {
-                "target_ref": {"type": "string", "enum": ["current_pr", "other"]}
-            },
+            "properties": {"target_ref": {"type": "string", "enum": ["current_pr", "other"]}},
         }
     )
     first = service.request_approval(request=_request(), manifest=flexible)
@@ -104,9 +121,12 @@ def test_same_pending_request_deduplicates_but_changed_request_does_not(tmp_path
     assert duplicate.id == first.id
     assert replacement.id != first.id
     assert replacement.capability_approval is not None
-    assert replacement.capability_approval["fingerprint"] != first.capability_approval[  # type: ignore[index]
-        "fingerprint"
-    ]
+    assert (
+        replacement.capability_approval["fingerprint"]
+        != first.capability_approval[  # type: ignore[index]
+            "fingerprint"
+        ]
+    )
 
 
 @pytest.mark.parametrize(
@@ -118,9 +138,7 @@ def test_same_pending_request_deduplicates_but_changed_request_does_not(tmp_path
         {"decision": "approve", "task_id": "other", "request_fingerprint": "wrong"},
     ],
 )
-def test_decision_requires_structured_exact_correlation(
-    tmp_path: Path, payload: object
-) -> None:
+def test_decision_requires_structured_exact_correlation(tmp_path: Path, payload: object) -> None:
     """Test List unit 3/8: generic consent and other approval domains fail closed."""
     service = _service(tmp_path)
     task = service.request_approval(request=_request(), manifest=_manifest())
@@ -191,3 +209,172 @@ def test_backward_generic_task_records_remain_readable(tmp_path: Path) -> None:
 
     assert HumanTaskRecordStore(tmp_path / "issue").get_task(task.id).capability_approval is None
     assert PolicyDecision.REQUIRE_APPROVAL.value == "require_approval"
+
+
+def test_approved_request_revalidates_and_dispatches_at_most_once(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test List unit 5–7: durable fence precedes one adapter invocation."""
+    calls: list[str] = []
+
+    def adapter(**_kwargs: object) -> tuple[dict[str, object], None]:
+        calls.append("called")
+        return {}, None
+
+    monkeypatch.setattr(capability_module, "HOST_CAPABILITY_ADAPTERS", {"open_current_pr": adapter})
+    service = _service(tmp_path)
+    manifest = _manifest()
+    task = service.request_approval(request=_request(), manifest=manifest)
+    _approve(service, task.id)
+
+    first = service.resume(
+        task.id,
+        request=_request(),
+        registry={manifest.id: manifest},
+        repo_root=tmp_path,
+        output_file=tmp_path / "output.md",
+    )
+    repeated = service.resume(
+        task.id,
+        request=_request(),
+        registry={manifest.id: manifest},
+        repo_root=tmp_path,
+        output_file=tmp_path / "output.md",
+    )
+
+    assert calls == ["called"]
+    assert first["outcome"] == "succeeded"
+    assert repeated == first
+    assert first["attempt"]["state"] == "finished"
+
+
+def test_policy_rejection_and_tampering_never_dispatch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test List unit 5: current policy and exact request remain authoritative."""
+    monkeypatch.setattr(
+        capability_module,
+        "HOST_CAPABILITY_ADAPTERS",
+        {"open_current_pr": lambda **_kwargs: (_ for _ in ()).throw(AssertionError())},
+    )
+    service = _service(tmp_path)
+    manifest = _manifest()
+    policy_task = service.request_approval(request=_request(), manifest=manifest)
+    _approve(service, policy_task.id)
+
+    restrictive = manifest.model_copy(update={"policy": "deny"})
+    policy_receipt = service.resume(
+        policy_task.id,
+        request=_request(),
+        registry={manifest.id: restrictive},
+        repo_root=tmp_path,
+        output_file=tmp_path / "output.md",
+    )
+
+    tamper_task = service.request_approval(request=_request(), manifest=manifest)
+    _approve(service, tamper_task.id)
+    tampered = _request().model_copy(update={"args": {"target_ref": "other"}})
+    tamper_receipt = service.resume(
+        tamper_task.id,
+        request=tampered,
+        registry={manifest.id: manifest},
+        repo_root=tmp_path,
+        output_file=tmp_path / "output.md",
+    )
+
+    assert policy_receipt["outcome"] == "policy_rejected"
+    assert tamper_receipt["outcome"] == "tampered"
+    assert not policy_receipt["executed"]
+    assert not tamper_receipt["executed"]
+
+
+def test_restart_after_attempt_fence_becomes_uncertain_without_retry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test List unit 6/7: a missing post-dispatch receipt never permits retry."""
+    monkeypatch.setattr(
+        capability_module,
+        "HOST_CAPABILITY_ADAPTERS",
+        {"open_current_pr": lambda **_kwargs: (_ for _ in ()).throw(AssertionError())},
+    )
+    service = _service(tmp_path)
+    manifest = _manifest()
+    task = service.request_approval(request=_request(), manifest=manifest)
+    _approve(service, task.id)
+    current = service.inspect(task.id)
+    current["state"] = "attempt_started"
+    current["attempt"] = {"state": "started", "started_at": datetime.now(timezone.utc).isoformat()}
+    service.store.update_capability_approval(
+        workflow_id="workflow-one",
+        task_id=task.id,
+        metadata=current,
+        event_type="capability_attempt_started",
+    )
+
+    receipt = service.resume(
+        task.id,
+        request=_request(),
+        registry={manifest.id: manifest},
+        repo_root=tmp_path,
+        output_file=tmp_path / "output.md",
+    )
+
+    assert receipt["outcome"] == "uncertain"
+    assert receipt["attempt"]["state"] == "uncertain"
+    assert receipt["executed"]
+
+
+def test_failure_receipt_is_terminal_and_pre_fence_persistence_failure_is_safe(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test List unit 6/7: failure is receipted and no dispatch precedes the fence."""
+    manifest = _manifest()
+    failed_service = _service(tmp_path / "failed")
+    failed_task = failed_service.request_approval(request=_request(), manifest=manifest)
+    _approve(failed_service, failed_task.id)
+    monkeypatch.setattr(
+        capability_module,
+        "HOST_CAPABILITY_ADAPTERS",
+        {
+            "open_current_pr": lambda **_kwargs: (_ for _ in ()).throw(
+                CapabilityExecutionError("adapter_error", "host_failed")
+            )
+        },
+    )
+
+    failed = failed_service.resume(
+        failed_task.id,
+        request=_request(),
+        registry={manifest.id: manifest},
+        repo_root=tmp_path,
+        output_file=tmp_path / "output.md",
+    )
+
+    assert failed["outcome"] == "failed"
+    assert failed["execution"]["code"] == "host_failed"
+
+    safe_service = _service(tmp_path / "persistence")
+    safe_task = safe_service.request_approval(request=_request(), manifest=manifest)
+    _approve(safe_service, safe_task.id)
+    original_update = safe_service.store.update_capability_approval
+
+    def fail_before_fence(**kwargs: object) -> object:
+        if kwargs.get("event_type") == "capability_policy_revalidated":
+            raise OSError("disk unavailable")
+        return original_update(**kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(safe_service.store, "update_capability_approval", fail_before_fence)
+    monkeypatch.setattr(
+        capability_module,
+        "HOST_CAPABILITY_ADAPTERS",
+        {"open_current_pr": lambda **_kwargs: (_ for _ in ()).throw(AssertionError())},
+    )
+
+    with pytest.raises(OSError, match="disk unavailable"):
+        safe_service.resume(
+            safe_task.id,
+            request=_request(),
+            registry={manifest.id: manifest},
+            repo_root=tmp_path,
+            output_file=tmp_path / "output.md",
+        )

--- a/tests/unit/test_capability_approvals.py
+++ b/tests/unit/test_capability_approvals.py
@@ -82,6 +82,7 @@ def _approve(service: CapabilityApprovalService, task_id: str) -> None:
             "workflow_id": "workflow-one",
             "task_id": task_id,
             "request_fingerprint": approval["fingerprint"],
+            "correlation_id": approval["correlation_id"],
         },
     )
 
@@ -89,10 +90,13 @@ def _approve(service: CapabilityApprovalService, task_id: str) -> None:
 def test_task_snapshots_exact_request_and_material_effects(tmp_path: Path) -> None:
     """Test List unit 1/8: task is capability-specific and exposes reviewed effects."""
     service = _service(tmp_path)
-    task = service.request_approval(request=_request(), manifest=_manifest())
+    task = service.request_approval(
+        request=_request(), manifest=_manifest(), correlation_id="host-request-one"
+    )
 
     approval = task.capability_approval
     assert approval is not None
+    assert approval["correlation_id"] == "host-request-one"
     assert approval["request"]["capability"] == "demo.mutate"
     assert approval["risk"] == "high"
     assert approval["effects"]["writes"] == ["artifact.json"]
@@ -143,12 +147,49 @@ def test_same_pending_request_deduplicates_but_changed_request_does_not(tmp_path
 def test_decision_requires_structured_exact_correlation(tmp_path: Path, payload: object) -> None:
     """Test List unit 3/8: generic consent and other approval domains fail closed."""
     service = _service(tmp_path)
-    task = service.request_approval(request=_request(), manifest=_manifest())
+    task = service.request_approval(
+        request=_request(), manifest=_manifest(), correlation_id="host-request-one"
+    )
 
     with pytest.raises(CapabilityApprovalError):
         service.record_decision(task.id, payload)
 
     assert service.inspect(task.id)["state"] == "pending"
+
+
+def test_decision_and_receipt_reject_mismatched_host_correlation(tmp_path: Path) -> None:
+    """Test List unit 3/7: approval remains bound to the originating host request."""
+    service = _service(tmp_path)
+    task = service.request_approval(
+        request=_request(), manifest=_manifest(), correlation_id="host-request-one"
+    )
+    approval = service.inspect(task.id)
+
+    with pytest.raises(CapabilityApprovalError):
+        service.record_decision(
+            task.id,
+            {
+                "decision": "approve",
+                "workflow_id": "workflow-one",
+                "task_id": task.id,
+                "request_fingerprint": approval["fingerprint"],
+                "correlation_id": "host-request-two",
+            },
+        )
+
+    assert service.inspect(task.id)["state"] == "pending"
+
+    _approve(service, task.id)
+    with pytest.raises(CapabilityApprovalError):
+        service.resume(
+            task.id,
+            correlation_id="host-request-two",
+            request=_request(),
+            registry={"demo.mutate": _manifest()},
+            repo_root=tmp_path,
+            output_file=tmp_path / "output.md",
+        )
+    assert service.inspect(task.id)["state"] == "approved"
 
 
 def test_denial_is_terminal_and_cannot_be_reopened(tmp_path: Path) -> None:
@@ -161,6 +202,7 @@ def test_denial_is_terminal_and_cannot_be_reopened(tmp_path: Path) -> None:
         "workflow_id": "workflow-one",
         "task_id": task.id,
         "request_fingerprint": fingerprint,
+        "correlation_id": task.capability_approval["correlation_id"],  # type: ignore[index]
     }
 
     denied = service.record_decision(task.id, payload)
@@ -231,6 +273,7 @@ def test_approved_request_revalidates_and_dispatches_at_most_once(
 
     first = service.resume(
         task.id,
+        correlation_id=service.inspect(task.id)["correlation_id"],
         request=_request(),
         registry={manifest.id: manifest},
         repo_root=tmp_path,
@@ -238,6 +281,7 @@ def test_approved_request_revalidates_and_dispatches_at_most_once(
     )
     repeated = service.resume(
         task.id,
+        correlation_id=service.inspect(task.id)["correlation_id"],
         request=_request(),
         registry={manifest.id: manifest},
         repo_root=tmp_path,
@@ -247,6 +291,7 @@ def test_approved_request_revalidates_and_dispatches_at_most_once(
     assert calls == ["called"]
     assert first["outcome"] == "succeeded"
     assert repeated == first
+    assert first["correlation_id"] == service.inspect(task.id)["correlation_id"]
     assert first["attempt"]["state"] == "finished"
 
 
@@ -310,6 +355,7 @@ def test_concurrent_resumes_cross_one_atomic_attempt_fence(
     def resume(service: CapabilityApprovalService) -> dict[str, object]:
         return service.resume(
             task.id,
+            correlation_id=service.inspect(task.id)["correlation_id"],
             request=_request(),
             registry={manifest.id: manifest},
             repo_root=tmp_path,
@@ -345,6 +391,7 @@ def test_policy_rejection_and_tampering_never_dispatch(
     restrictive = manifest.model_copy(update={"policy": "deny"})
     policy_receipt = service.resume(
         policy_task.id,
+        correlation_id=service.inspect(policy_task.id)["correlation_id"],
         request=_request(),
         registry={manifest.id: restrictive},
         repo_root=tmp_path,
@@ -357,6 +404,7 @@ def test_policy_rejection_and_tampering_never_dispatch(
     tampered = _request().model_copy(update={"args": {"target_ref": "other"}})
     tamper_receipt = tamper_service.resume(
         tamper_task.id,
+        correlation_id=tamper_service.inspect(tamper_task.id)["correlation_id"],
         request=tampered,
         registry={manifest.id: manifest},
         repo_root=tmp_path,
@@ -394,6 +442,7 @@ def test_restart_after_attempt_fence_becomes_uncertain_without_retry(
 
     receipt = service.resume(
         task.id,
+        correlation_id=service.inspect(task.id)["correlation_id"],
         request=_request(),
         registry={manifest.id: manifest},
         repo_root=tmp_path,
@@ -425,6 +474,7 @@ def test_failure_receipt_is_terminal_and_pre_fence_persistence_failure_is_safe(
 
     failed = failed_service.resume(
         failed_task.id,
+        correlation_id=failed_service.inspect(failed_task.id)["correlation_id"],
         request=_request(),
         registry={manifest.id: manifest},
         repo_root=tmp_path,
@@ -456,6 +506,7 @@ def test_failure_receipt_is_terminal_and_pre_fence_persistence_failure_is_safe(
     with pytest.raises(OSError, match="disk unavailable"):
         safe_service.resume(
             safe_task.id,
+            correlation_id=safe_service.inspect(safe_task.id)["correlation_id"],
             request=_request(),
             registry={manifest.id: manifest},
             repo_root=tmp_path,

--- a/tests/unit/test_capability_approvals.py
+++ b/tests/unit/test_capability_approvals.py
@@ -271,10 +271,11 @@ def test_policy_rejection_and_tampering_never_dispatch(
         output_file=tmp_path / "output.md",
     )
 
-    tamper_task = service.request_approval(request=_request(), manifest=manifest)
-    _approve(service, tamper_task.id)
+    tamper_service = _service(tmp_path / "tamper")
+    tamper_task = tamper_service.request_approval(request=_request(), manifest=manifest)
+    _approve(tamper_service, tamper_task.id)
     tampered = _request().model_copy(update={"args": {"target_ref": "other"}})
-    tamper_receipt = service.resume(
+    tamper_receipt = tamper_service.resume(
         tamper_task.id,
         request=tampered,
         registry={manifest.id: manifest},

--- a/tests/unit/test_capability_approvals.py
+++ b/tests/unit/test_capability_approvals.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -248,6 +251,53 @@ def test_approved_request_revalidates_and_dispatches_at_most_once(
     assert first["attempt"]["state"] == "finished"
 
 
+def test_concurrent_resumes_cross_one_atomic_attempt_fence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test List unit 6: concurrent resumes serialize before host dispatch."""
+    calls: list[str] = []
+
+    def adapter(**_kwargs: object) -> tuple[dict[str, object], None]:
+        calls.append("called")
+        return {}, None
+
+    monkeypatch.setattr(capability_module, "HOST_CAPABILITY_ADAPTERS", {"open_current_pr": adapter})
+    first_service = _service(tmp_path)
+    manifest = _manifest()
+    task = first_service.request_approval(request=_request(), manifest=manifest)
+    _approve(first_service, task.id)
+    second_service = _service(tmp_path)
+    original_transition = first_service.store.__class__.transition_capability_approval_if_state
+
+    def widen_pre_fence_race(self: object, **kwargs: object) -> object:
+        time.sleep(0.05)
+        return original_transition(self, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(
+        first_service.store.__class__,
+        "transition_capability_approval_if_state",
+        widen_pre_fence_race,
+    )
+    start = threading.Barrier(2)
+
+    def resume(service: CapabilityApprovalService) -> dict[str, object]:
+        start.wait()
+        return service.resume(
+            task.id,
+            request=_request(),
+            registry={manifest.id: manifest},
+            repo_root=tmp_path,
+            output_file=tmp_path / "output.md",
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(resume, (first_service, second_service)))
+
+    assert calls == ["called"]
+    assert results[0] == results[1]
+    assert results[0]["outcome"] == "succeeded"
+
+
 def test_policy_rejection_and_tampering_never_dispatch(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -357,14 +407,16 @@ def test_failure_receipt_is_terminal_and_pre_fence_persistence_failure_is_safe(
     safe_service = _service(tmp_path / "persistence")
     safe_task = safe_service.request_approval(request=_request(), manifest=manifest)
     _approve(safe_service, safe_task.id)
-    original_update = safe_service.store.update_capability_approval
+    original_transition = safe_service.store.transition_capability_approval_if_state
 
     def fail_before_fence(**kwargs: object) -> object:
-        if kwargs.get("event_type") == "capability_policy_revalidated":
+        if kwargs.get("event_type") == "capability_attempt_started":
             raise OSError("disk unavailable")
-        return original_update(**kwargs)  # type: ignore[arg-type]
+        return original_transition(**kwargs)  # type: ignore[arg-type]
 
-    monkeypatch.setattr(safe_service.store, "update_capability_approval", fail_before_fence)
+    monkeypatch.setattr(
+        safe_service.store, "transition_capability_approval_if_state", fail_before_fence
+    )
     monkeypatch.setattr(
         capability_module,
         "HOST_CAPABILITY_ADAPTERS",

--- a/tests/unit/test_capability_registry.py
+++ b/tests/unit/test_capability_registry.py
@@ -291,6 +291,30 @@ def test_dispatch_gate_records_approval_without_calling_adapter(
     assert run.receipt["requested_effects"]["browser_open"] == ["current_pr"]
 
 
+@pytest.mark.parametrize("expires_at", ["not-a-timestamp", "2026-08-20T12:00:00"])
+def test_dispatch_gate_rejects_malformed_request_expiry(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, expires_at: str
+) -> None:
+    """Test List unit 4: the public dispatch gate validates request-owned expiry."""
+    import cafe.core.capabilities as cap_mod
+
+    monkeypatch.setattr(
+        cap_mod,
+        "HOST_CAPABILITY_ADAPTERS",
+        {"open_current_pr": lambda **_kwargs: (_ for _ in ()).throw(AssertionError())},
+    )
+    run = run_capability_request(
+        repo_root=tmp_path,
+        registry={"demo.echo": _typed_manifest(approval="required")},
+        capability_request={**_browser_request(), "expires_at": expires_at},
+        output_file=tmp_path / "output.md",
+    )
+
+    assert run.receipt["success"] is False
+    assert run.receipt["outcome"] == "validation_rejection"
+    assert run.receipt["code"] == "malformed_request"
+
+
 def test_dispatch_gate_records_policy_denial_without_calling_adapter(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/unit/test_workflow_runtime.py
+++ b/tests/unit/test_workflow_runtime.py
@@ -9,11 +9,13 @@ from cafe.core.blackboard import (
     BlackboardStore,
     HandoffIntent,
     HandoffOwner,
-    LongRunningOperationArtifact as _LongRunningOperationArtifact,
     LongRunningOperationState,
     OperationLogPolicy,
     OperationMonitoring,
     OperationRisk,
+)
+from cafe.core.blackboard import (
+    LongRunningOperationArtifact as _LongRunningOperationArtifact,
 )
 from cafe.core.human_task_records import HumanTaskRecordStore
 from cafe.core.workflow_models import BatonRejected, StepExecutionResult
@@ -29,7 +31,7 @@ _OPERATION_DECISION = {
 }
 
 
-def LongRunningOperationArtifact(**kwargs):
+def LongRunningOperationArtifact(**kwargs):  # noqa: N802
     """Create explicit test operation decisions without production defaults."""
     return _LongRunningOperationArtifact(
         risk=OperationRisk.LOW,
@@ -135,9 +137,7 @@ def test_runtime_rejects_undeclared_alignment_baton_before_routing(
     assert result.completed is True
     assert calls == 2
     blackboard = BlackboardStore(issue_dir).load_or_create("develop")
-    rejected = [
-        event for event in blackboard.events if event.event_type == "baton_rejected"
-    ]
+    rejected = [event for event in blackboard.events if event.event_type == "baton_rejected"]
     assert rejected[-1].data["field"] == "intent"
     assert rejected[-1].data["invalid_value"] == "alignment_checkpoint"
 
@@ -179,7 +179,13 @@ def test_runtime_blocks_pr_done_without_publish_receipt(tmp_path: Path) -> None:
     playbook = {
         "playbook": {"id": "default"},
         "steps": {
-            "pr": {"skill": "spec_first", "role": "developer", "behavior": {"completion": "baton", "publish_confirmation": True}, "capability_requests": ["cafe.pr.publish"], "on": {"await_agent": "_done"}},
+            "pr": {
+                "skill": "spec_first",
+                "role": "developer",
+                "behavior": {"completion": "baton", "publish_confirmation": True},
+                "capability_requests": ["cafe.pr.publish"],
+                "on": {"await_agent": "_done"},
+            },
         },
     }
 
@@ -242,7 +248,13 @@ def test_runtime_completes_pr_when_publish_receipt_exists(tmp_path: Path) -> Non
     playbook = {
         "playbook": {"id": "default"},
         "steps": {
-            "pr": {"skill": "spec_first", "role": "developer", "behavior": {"completion": "baton", "publish_confirmation": True}, "capability_requests": ["cafe.pr.publish"], "on": {"await_agent": "_done"}},
+            "pr": {
+                "skill": "spec_first",
+                "role": "developer",
+                "behavior": {"completion": "baton", "publish_confirmation": True},
+                "capability_requests": ["cafe.pr.publish"],
+                "on": {"await_agent": "_done"},
+            },
         },
     }
 
@@ -273,7 +285,13 @@ def test_runtime_completes_pr_when_capability_receipt_success_exists(tmp_path: P
     playbook = {
         "playbook": {"id": "default"},
         "steps": {
-            "pr": {"skill": "spec_first", "role": "developer", "behavior": {"completion": "baton", "publish_confirmation": True}, "capability_requests": ["cafe.pr.publish"], "on": {"await_agent": "_done"}},
+            "pr": {
+                "skill": "spec_first",
+                "role": "developer",
+                "behavior": {"completion": "baton", "publish_confirmation": True},
+                "capability_requests": ["cafe.pr.publish"],
+                "on": {"await_agent": "_done"},
+            },
         },
     }
 
@@ -347,6 +365,56 @@ def test_runtime_blocks_declared_capability_step_without_receipt(tmp_path: Path)
         event for event in blackboard.events if event.event_type == "workflow_blocked"
     ]
     assert blocked_events[-1].data["missing_capabilities"] == ["demo.publish"]
+
+
+def test_runtime_pauses_on_distinct_capability_approval_task(tmp_path: Path) -> None:
+    """Test List integration 1/7: approval pending routes to user, not alignment."""
+    issue_dir = tmp_path / ".cafe" / "issues" / "demo-capability-approval"
+    playbook = {
+        "playbook": {"id": "default"},
+        "steps": {
+            "publish": {
+                "skill": "spec_first",
+                "role": "developer",
+                "capability_requests": ["demo.publish"],
+                "on": {"await_agent": "_done"},
+            },
+        },
+    }
+
+    def executor(step_name: str, step_def: dict, state: object) -> StepExecutionResult:
+        _write_baton(
+            issue_dir,
+            from_step="publish",
+            to_owner="done",
+            to_step="done",
+            intent="workflow_complete",
+        )
+        return StepExecutionResult(
+            response="done",
+            artifacts={"publish_result": "p1"},
+            events=[
+                {
+                    "type": "capability_approval_pending",
+                    "capability": "demo.publish",
+                    "task_id": "approval-task",
+                    "request_fingerprint": "fingerprint",
+                }
+            ],
+        )
+
+    result = BlackboardWorkflowRuntime(
+        issue_dir=issue_dir,
+        playbook=playbook,
+        executor=executor,
+    ).run(start_step="publish")
+
+    assert result.final_status_code == "CAPABILITY_APPROVAL_PENDING"
+    assert result.detail == "approval-task"
+    blackboard = BlackboardStore(issue_dir).load_or_create("publish")
+    assert blackboard.current_step == "user"
+    assert blackboard.handoff_contract is not None
+    assert blackboard.handoff_contract.intent.value == "manual_handoff"
 
 
 def test_runtime_completes_declared_capability_step_with_receipt(tmp_path: Path) -> None:
@@ -1700,7 +1768,7 @@ def test_runtime_prefers_step_baton_over_invalid_status_text(tmp_path: Path) -> 
 
 
 def test_runtime_status_code_missing_no_handoff_contract(tmp_path: Path) -> None:
-    """When the agent omits a status code and no handoff contract exists, the runtime still pauses."""
+    """When status and handoff are absent, the runtime still pauses."""
     issue_dir = tmp_path / ".cafe" / "issues" / "missing-no-handoff"
     playbook = {
         "playbook": {"id": "default"},
@@ -1773,7 +1841,9 @@ def test_runtime_pauses_ready_for_review_with_confirm_output_intent(tmp_path: Pa
     assert blackboard.handoff_contract.intent == HandoffIntent.CONFIRM_OUTPUT
 
 
-def test_runtime_materializes_one_declared_task_and_recovers_it_after_restart(tmp_path: Path) -> None:
+def test_runtime_materializes_one_declared_task_and_recovers_it_after_restart(
+    tmp_path: Path,
+) -> None:
     """IT-001: pause/restart preserves the exact durable task and wait state."""
     issue_dir = tmp_path / ".cafe" / "issues" / "durable-restart"
     playbook = PlaybookLoader().load("default")
@@ -1972,7 +2042,13 @@ def test_runtime_emits_expected_runtime_labels_per_path(tmp_path: Path) -> None:
                 "valid_intents": ["confirmed"],
                 "on": {"await_agent": "pr"},
             },
-            "pr": {"skill": "spec_first", "role": "developer", "behavior": {"completion": "baton", "publish_confirmation": True}, "capability_requests": ["cafe.pr.publish"], "on": {"await_agent": "_done"}},
+            "pr": {
+                "skill": "spec_first",
+                "role": "developer",
+                "behavior": {"completion": "baton", "publish_confirmation": True},
+                "capability_requests": ["cafe.pr.publish"],
+                "on": {"await_agent": "_done"},
+            },
         },
     }
 
@@ -2012,7 +2088,13 @@ def test_runtime_emits_expected_runtime_labels_per_path(tmp_path: Path) -> None:
     playbook_pr = {
         "playbook": {"id": "default"},
         "steps": {
-            "pr": {"skill": "spec_first", "role": "developer", "behavior": {"completion": "baton", "publish_confirmation": True}, "capability_requests": ["cafe.pr.publish"], "on": {"await_agent": "_done"}},
+            "pr": {
+                "skill": "spec_first",
+                "role": "developer",
+                "behavior": {"completion": "baton", "publish_confirmation": True},
+                "capability_requests": ["cafe.pr.publish"],
+                "on": {"await_agent": "_done"},
+            },
         },
     }
 
@@ -2103,7 +2185,13 @@ def test_runtime_chains_pr_need_changes_through_develop_to_review(tmp_path: Path
     playbook = {
         "playbook": {"id": "default"},
         "steps": {
-            "pr": {"skill": "spec_first", "role": "developer", "assignee_type": "agent", "behavior": {"completion": "baton", "feedback_target": "develop"}, "on": {}},
+            "pr": {
+                "skill": "spec_first",
+                "role": "developer",
+                "assignee_type": "agent",
+                "behavior": {"completion": "baton", "feedback_target": "develop"},
+                "on": {},
+            },
             "develop": {
                 "skill": "develop",
                 "role": "developer",
@@ -2178,7 +2266,7 @@ def test_runtime_chains_pr_need_changes_through_develop_to_review(tmp_path: Path
 
 
 def test_runtime_rejects_plain_text_baton_written_by_pr_agent(tmp_path: Path) -> None:
-    """Issue #386: a plain step-name baton is never normalized, even at the pr/baton-driven boundary."""
+    """Issue #386: a plain step-name baton is never normalized at the PR boundary."""
     issue_dir = tmp_path / ".cafe" / "issues" / "legacy-pr-handoff"
     issue_dir.mkdir(parents=True)
     _write_baton(issue_dir, from_step="pr", to_owner="agent", to_step="pr", intent="await_agent")
@@ -2218,7 +2306,7 @@ def test_runtime_rejects_plain_text_baton_written_by_pr_agent(tmp_path: Path) ->
 
 
 def test_runtime_handles_keyboard_interrupt(tmp_path: Path) -> None:
-    """KeyboardInterrupt during step execution records step_interrupted event and returns INTERRUPTED result."""
+    """KeyboardInterrupt records step_interrupted and returns INTERRUPTED."""
     issue_dir = tmp_path / ".cafe" / "issues" / "demo-interrupt"
     playbook = {
         "playbook": {"id": "default"},
@@ -2268,7 +2356,7 @@ def test_runtime_handles_keyboard_interrupt(tmp_path: Path) -> None:
 
 
 def test_runtime_handles_agent_execution_error(tmp_path: Path) -> None:
-    """AgentExecutionError (e.g. rate_limit) records step_interrupted event and returns INTERRUPTED result."""
+    """AgentExecutionError records step_interrupted and returns INTERRUPTED."""
     from cafe.agents.executor import AgentExecutionError
 
     issue_dir = tmp_path / ".cafe" / "issues" / "demo-agent-error"
@@ -2739,7 +2827,7 @@ def _make_invalid_target_baton_text(
 def _make_missing_intent_baton_text(
     issue_dir: Path, *, from_step: str = "spec", to_step: str = "done"
 ) -> None:
-    """Write JSON baton payload missing `intent`. """
+    """Write JSON baton payload missing `intent`."""
     (issue_dir / "next_step.txt").write_text(
         json.dumps(
             {
@@ -2757,7 +2845,7 @@ def _make_missing_intent_baton_text(
 
 
 def test_runtime_retries_once_on_baton_rejected_then_succeeds(tmp_path: Path) -> None:
-    """第 1 次寫出無效 baton，第 2 次（retry 1）寫出合法 baton → workflow 正常繼續，blackboard 有 1 筆 baton_rejected 事件。"""
+    """第一次 baton 無效、第二次合法時 workflow 繼續並記錄 rejection。"""
     issue_dir = tmp_path / ".cafe" / "issues" / "retry-1"
     issue_dir.mkdir(parents=True)
     call_count = [0]
@@ -2855,7 +2943,7 @@ def test_runtime_retries_owner_intent_mismatch_then_succeeds(tmp_path: Path) -> 
 
 
 def test_runtime_retries_twice_on_baton_rejected_then_succeeds(tmp_path: Path) -> None:
-    """第 1、2 次無效，第 3 次（retry 2）合法 → workflow 繼續，blackboard 有 2 筆 baton_rejected 事件。"""
+    """前兩次 baton 無效、第三次合法時 workflow 繼續並記錄兩次 rejection。"""
     issue_dir = tmp_path / ".cafe" / "issues" / "retry-2"
     issue_dir.mkdir(parents=True)
     call_count = [0]
@@ -3277,7 +3365,9 @@ def test_running_operation_without_helper_evidence_becomes_lost_without_duplicat
 
     playbook = {
         "playbook": {"id": "default"},
-        "steps": {"develop": {"skill": "develop", "role": "developer", "on": {"confirmed": "_done"}}},
+        "steps": {
+            "develop": {"skill": "develop", "role": "developer", "on": {"confirmed": "_done"}}
+        },
     }
     calls: list[str] = []
 
@@ -3427,7 +3517,9 @@ def test_failed_receipt_promoted_during_reconciliation_records_failed_not_runnin
 
     playbook = {
         "playbook": {"id": "default"},
-        "steps": {"develop": {"skill": "develop", "role": "developer", "on": {"confirmed": "_done"}}},
+        "steps": {
+            "develop": {"skill": "develop", "role": "developer", "on": {"confirmed": "_done"}}
+        },
     }
     runtime = BlackboardWorkflowRuntime(
         issue_dir=issue_dir,
@@ -3534,7 +3626,9 @@ def test_failed_or_lost_operation_blocks_without_retry(tmp_path: Path, op_state:
 
     playbook = {
         "playbook": {"id": "default"},
-        "steps": {"develop": {"skill": "develop", "role": "developer", "on": {"confirmed": "_done"}}},
+        "steps": {
+            "develop": {"skill": "develop", "role": "developer", "on": {"confirmed": "_done"}}
+        },
     }
     calls: list[str] = []
 
@@ -3550,8 +3644,7 @@ def test_failed_or_lost_operation_blocks_without_retry(tmp_path: Path, op_state:
     assert result.final_status_code == f"OPERATION_{op_state.upper()}"
     bb = BlackboardStore(issue_dir).load_or_create("develop")
     assert any(
-        e.event_type == "operation_blocked" and e.data.get("outcome") == op_state
-        for e in bb.events
+        e.event_type == "operation_blocked" and e.data.get("outcome") == op_state for e in bb.events
     )
 
 
@@ -3560,11 +3653,15 @@ def test_schema_invalid_operation_blocks_clearly(tmp_path: Path) -> None:
     issue_dir = tmp_path / ".cafe" / "issues" / "demo-op-invalid"
     _setup_interrupted_step(issue_dir, step="develop")
     iteration_dir = _write_iteration_evidence(issue_dir, "develop")
-    (iteration_dir / "operation.json").write_text(json.dumps({"state": "pending"}), encoding="utf-8")
+    (iteration_dir / "operation.json").write_text(
+        json.dumps({"state": "pending"}), encoding="utf-8"
+    )
 
     playbook = {
         "playbook": {"id": "default"},
-        "steps": {"develop": {"skill": "develop", "role": "developer", "on": {"confirmed": "_done"}}},
+        "steps": {
+            "develop": {"skill": "develop", "role": "developer", "on": {"confirmed": "_done"}}
+        },
     }
     calls: list[str] = []
 
@@ -3603,7 +3700,9 @@ def test_succeeded_operation_without_evidence_blocks_as_unverified(tmp_path: Pat
 
     playbook = {
         "playbook": {"id": "default"},
-        "steps": {"develop": {"skill": "develop", "role": "developer", "on": {"confirmed": "_done"}}},
+        "steps": {
+            "develop": {"skill": "develop", "role": "developer", "on": {"confirmed": "_done"}}
+        },
     }
     calls: list[str] = []
 
@@ -3667,7 +3766,9 @@ def test_generic_agent_error_does_not_create_operation_artifact(tmp_path: Path) 
         call_count[0] += 1
         iteration_dir = issue_dir / step_name / "iteration_001"
         iteration_dir.mkdir(parents=True, exist_ok=True)
-        (iteration_dir / "iteration.json").write_text(json.dumps({"iteration": 1}), encoding="utf-8")
+        (iteration_dir / "iteration.json").write_text(
+            json.dumps({"iteration": 1}), encoding="utf-8"
+        )
         raise TimeoutError("simulated unrelated tool error")
 
     runtime = BlackboardWorkflowRuntime(issue_dir=issue_dir, playbook=playbook, executor=executor)
@@ -3701,7 +3802,9 @@ def test_agent_timeout_cannot_fabricate_an_operation_policy(tmp_path: Path) -> N
         call_count[0] += 1
         iteration_dir = issue_dir / step_name / "iteration_001"
         iteration_dir.mkdir(parents=True, exist_ok=True)
-        (iteration_dir / "iteration.json").write_text(json.dumps({"iteration": 1}), encoding="utf-8")
+        (iteration_dir / "iteration.json").write_text(
+            json.dumps({"iteration": 1}), encoding="utf-8"
+        )
         raise AgentExecutionError(
             "agent did not produce output before the execution timeout", error_type="timeout"
         )
@@ -3991,7 +4094,9 @@ def test_recorded_operation_artifact_state_mismatch_is_not_trusted(tmp_path: Pat
 
     playbook = {
         "playbook": {"id": "default"},
-        "steps": {"develop": {"skill": "develop", "role": "developer", "on": {"confirmed": "_done"}}},
+        "steps": {
+            "develop": {"skill": "develop", "role": "developer", "on": {"confirmed": "_done"}}
+        },
     }
     calls: list[str] = []
 
@@ -4032,7 +4137,9 @@ def test_status_code_missing_does_not_create_operation_artifact(tmp_path: Path) 
     def executor(step_name: str, step_def: dict, state: object):
         iteration_dir = issue_dir / step_name / "iteration_001"
         iteration_dir.mkdir(parents=True, exist_ok=True)
-        (iteration_dir / "iteration.json").write_text(json.dumps({"iteration": 1}), encoding="utf-8")
+        (iteration_dir / "iteration.json").write_text(
+            json.dumps({"iteration": 1}), encoding="utf-8"
+        )
         return ("plain response without status token", {})
 
     runtime = BlackboardWorkflowRuntime(


### PR DESCRIPTION
# Implement exact-request capability approval with expiry-boundary validation

## Summary

Implements Issue #401 by hardening exact-request capability approval around request expiry metadata, while retaining durable wait/resume, policy revalidation, and one-attempt host execution semantics. Approval now depends on the immutable, validated request fingerprint and safe structured decisions; expired or malformed requests stay blocked and observable.

This PR includes the latest develop/review correction in iteration 006 and confirms full-scope verification remains valid on current HEAD.

## Changes

- Added expiry-boundary correction to the issue401 capability approval lifecycle:
  - `b1d7d78b validate capability approval expiry`
- Bound approval decisions to exact host request fingerprints:
  - `281f0a61 bind capability approvals to host requests`
  - `98e0d66e make concurrent resume regression deterministic`
  - `32a1d1c6 serialize same-store capability resumes`
  - `81c6496e fix capability approval resume races`
  - `62926ef2 cover capability approval recovery paths`
  - `9925ee31 route capability decisions through task inbox`
  - `d11cabe1 pause workflows for capability approval`
  - `4f907f11 enforce one capability execution attempt`
  - `46934318 persist exact capability approvals`
- Tightened expiry handling in `src/cafe/core/capabilities.py` and `src/cafe/core/capability_approvals.py` so:
  - approval expiry is validated as timezone-aware request data
  - request changes (including expiry changes) produce a distinct task
  - malformed expiry never authorizes host execution
- Kept capability approval path separate from confirm-output / alignment confirmation and sandbox permission.
- Preserved resume/disconnect safety:
  - durable wait/result/receipt states
  - at-most-once attempt fence
  - terminal recovery outcomes for cancellation, denial, expiry, tampering, policy change, and restart/replay
- Updated task-inspection and task completion behavior for strict structured approval/denial payloads in strict review/replay paths.

## Test Plan

- `pytest -q tests/unit/test_capability_approvals.py tests/unit/test_human_task_records.py` (passed)
- `pytest -q tests/unit/test_capability_approvals.py tests/unit/test_human_task_records.py tests/integration/test_capability_approval_workflow.py tests/integration/test_workflow_e2e.py` (passed)
- `pytest -q tests/integration/test_task_inbox_workflow.py` (passed)
- `pytest -q tests/unit/test_capability_registry.py tests/integration/test_capability_approval_workflow.py` (passed)
- `ruff check src/cafe/core/capability_approvals.py src/cafe/core/capabilities.py src/cafe/core/human_task_records.py` (passed)
- `ruff format --check src/cafe/core/capability_approvals.py src/cafe/core/capabilities.py src/cafe/core/human_task_records.py` (passed)
- `mypy src/cafe/core/capability_approvals.py src/cafe/core/capabilities.py src/cafe/core/human_task_records.py` (passed)
- `cafe verification check --output-file ./.cafe/issues/issue401/develop/iteration_006/output.md --require-scope full` (valid, full scope on clean HEAD `b1d7d78b64f375e2208bef3a4e70561766b84b18`)
