### PR TITLE
Add issue 419 acceptance journey fixture

### DIFF
--- a/docs/acceptance/fixture-issue-419.md
+++ b/docs/acceptance/fixture-issue-419.md
@@ -1,0 +1,5 @@
+# Issue 419 Acceptance Fixture
+
+GitHub issue #421 is the documentation-only acceptance subject for issue #419. This fixture covers one single clean-repository CAFE journey from an issue to a pull request ready for human review.
+
+The journey does not change runtime code, dependencies, playbooks, hooks, product behavior, or any other product artifact. Any setup, notification, or workflow incompatibility encountered during the journey remains in the workflow evidence and is not fixed as part of issue #421.


### PR DESCRIPTION
## Summary

Add the documentation-only acceptance fixture requested by GitHub issue #421 for issue #419. The fixture records the single clean-repository CAFE journey while preserving the requirement that workflow incompatibilities remain evidence rather than prompting product changes.

## Changes

- Add `docs/acceptance/fixture-issue-419.md` as the sole product artifact.
- Identify issue #421 as the acceptance subject for issue #419 and document the issue-to-PR journey.
- State the boundary against runtime, dependency, playbook, hook, or product-behavior changes.
- Include commit `7276e38f` (`add issue 419 acceptance fixture`).

## Test Plan

- Confirm the fixture exists and contains the required issue references, documentation-only purpose, and clean-repository journey description.
- Verify the branch changes only `docs/acceptance/fixture-issue-419.md` relative to `main`.
- Reuse the valid clean-HEAD verification receipt for `uv run pytest`: 2,855 passed, 1 skipped, and 1 expected failure.