### PR TITLE
Add secure Slack notifications for HumanTasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,14 @@ known and includes a recovery action. Repair or explicitly restore the named
 workflow, then retry the same stable identifier; the inbox never switches the
 active issue or chooses an ambiguous record automatically.
 
+To make new HumanTasks in the built-in `standard` workflow discoverable in a
+fixed Slack channel, follow the supported
+[Slack HumanTask notification guide](docs/human-task-slack-notifications.md).
+The channel-bound credential stays in `~/.slack-webhook`; project playbooks,
+hooks, tasks, and agents cannot choose another destination or receive the
+credential. Slack delivery never replaces `cafe task inspect` or
+`cafe task complete`.
+
 ### Inspect and recover
 
 Ask the driver for the information or recovery outcome you need:

--- a/docs/human-task-runtime.md
+++ b/docs/human-task-runtime.md
@@ -1,8 +1,10 @@
 # Durable human-task runtime
 
-CAFE persists user-owned handoffs as workflow-local records. This is a runtime
-foundation only: it does not provide an inbox, scheduling, reminders,
-notifications, or a task-management UI.
+CAFE persists user-owned handoffs as workflow-local records and exposes them
+through the repository task inbox. The built-in `standard` workflow also has
+one optional, fixed-destination [Slack notification path](human-task-slack-notifications.md)
+for newly materialized tasks. It does not provide scheduling, reminders,
+bidirectional Slack interaction, or a general task-management service.
 
 ## Files and ownership
 
@@ -36,6 +38,9 @@ Each task has:
 Invalid responses retain the pending wait and append rejection evidence. A
 cancelled or completed task cannot create another result. Replaying a completed
 request leaves the original result intact and never emits another continuation.
+Only the transaction that creates a new task is eligible for the optional
+standard-workflow Slack attempt; task recovery after a restart does not send a
+duplicate notification.
 
 ## Completion and correlation
 

--- a/docs/human-task-slack-notifications.md
+++ b/docs/human-task-slack-notifications.md
@@ -25,7 +25,9 @@ project hook, task, agent response, or environment variable.
 3. Put only the channel-bound Incoming Webhook URL in that file, on one line.
    The supported form is `https://hooks.slack.com/services/...`. Never commit
    this file or copy its value into `.cafe/config.yaml`, a playbook, a task, or
-   a script.
+   a script. CAFE resolves the login account's home directory independently of
+   `HOME` and rejects credential files that are symlinks, non-regular files,
+   owned by another user, hard-linked, or accessible by group/other users.
 4. Run the built-in `standard` workflow normally. Do not invoke a notification
    script or synthetic hook. When CAFE durably creates a real pending
    HumanTask, such as an output-review task, it makes one immediate attempt.
@@ -55,7 +57,8 @@ network effect is fixed to `hooks.slack.com`, and its symbolic credential is
 
 The trusted package adapter reads `~/.slack-webhook` only after the capability
 request passes validation and policy. It accepts HTTPS Slack Incoming Webhook
-URLs only. The URL is used as the outbound request destination but is not put in
+URLs only, rejects redirects, and bounds the connection attempt to five
+seconds. The URL is used as the outbound request destination but is not put in
 the message, repository, HumanTask record, project-hook input, log, or receipt.
 Project-authored hooks remain sandboxed and never inherit this capability or
 credential.
@@ -81,9 +84,10 @@ Interpret the stable fields as follows:
 | --- | --- | --- |
 | Successful | `success: true`, `outcome: success` | Slack returned HTTP 200 with `ok`. |
 | Denied | `success: false`, decision outcome `deny` | The exact request failed registered argument, effect, credential, permission, or package policy checks; the adapter did not run. |
-| Missing or unreadable credential | code `slack_credentials_missing`, `slack_credentials_empty`, or `slack_credentials_unreadable` | Repair the fixed user credential file and its permissions. |
+| Missing or unreadable credential | code `slack_credentials_missing`, `slack_credentials_empty`, `slack_credentials_unreadable`, or `slack_credentials_unsafe` | Repair the fixed user credential file, ownership, and permissions. |
 | Invalid credential | code `slack_credentials_invalid` | Replace the file contents with a valid channel-bound Slack HTTPS Incoming Webhook URL. |
 | Slack/transport failure | code `slack_http_error`, `slack_response_not_ok`, `slack_timeout`, or `slack_transport_error` | Slack rejected the post or could not be reached. |
+| Interrupted | code `slack_notification_interrupted` | CAFE durably began an attempt but stopped before its final outcome could be recorded; it does not resend because Slack may already have accepted the post. |
 | Internal fail-closed error | code `slack_notification_internal_error` | The trusted path could not complete evaluation; inspect local installation/runtime health. |
 
 ## Recover safely
@@ -97,9 +101,13 @@ cafe task inspect <task-id>
 cafe task complete <task-id>
 ```
 
-Fix credentials or connectivity before the next HumanTask is created. CAFE
-does not automatically retry an existing task or report a failed attempt as a
-success, so the receipt remains the accurate record of that attempt.
+If a process stops after the task is durable but before an attempt begins, the
+next workflow resume performs the missing attempt. Once the attempt has begun,
+CAFE records that state before outbound I/O; an interrupted attempt is not sent
+again because Slack Incoming Webhooks offer no idempotent resend contract. Fix
+credentials or connectivity before the next HumanTask is created. CAFE does
+not report a failed or interrupted attempt as a success, so the receipt remains
+the accurate record of that attempt.
 
 ## Scope
 

--- a/docs/human-task-slack-notifications.md
+++ b/docs/human-task-slack-notifications.md
@@ -1,0 +1,110 @@
+# Slack notifications for HumanTasks
+
+CAFE can make one Slack Incoming Webhook attempt when the built-in `standard`
+workflow creates a new, durable HumanTask. This path is optional. The task inbox
+remains authoritative whether delivery succeeds, is denied, or fails.
+
+The webhook selects one channel when it is created in Slack. CAFE does not
+accept a channel, destination, webhook URL, or credential path from a playbook,
+project hook, task, agent response, or environment variable.
+
+## Set up the supported path
+
+1. In Slack, create an Incoming Webhook for the channel that should receive
+   CAFE HumanTask notifications. This is an operator action governed by the
+   workspace's Slack administration policy. Installing or running CAFE does not
+   authorize CAFE to create a Slack app or webhook.
+2. Create the fixed user-owned credential file and restrict it to your account:
+
+   ```bash
+   install -m 600 /dev/null ~/.slack-webhook
+   ${EDITOR:-vi} ~/.slack-webhook
+   chmod 600 ~/.slack-webhook
+   ```
+
+3. Put only the channel-bound Incoming Webhook URL in that file, on one line.
+   The supported form is `https://hooks.slack.com/services/...`. Never commit
+   this file or copy its value into `.cafe/config.yaml`, a playbook, a task, or
+   a script.
+4. Run the built-in `standard` workflow normally. Do not invoke a notification
+   script or synthetic hook. When CAFE durably creates a real pending
+   HumanTask, such as an output-review task, it makes one immediate attempt.
+
+No project-specific playbook, skill, credential, or script is required in a
+clean repository.
+
+## What the notification contains
+
+The notification identifies the repository, workflow ID, HumanTask ID, and
+reason human action is required. It also includes the supported commands:
+
+```text
+cafe task inspect <task-id>
+cafe task complete <task-id>
+```
+
+Use `cafe task ls` to find other pending work. Slack is a discovery aid only;
+it cannot inspect, answer, approve, cancel, or complete a task.
+
+## Trust and credential boundary
+
+The package-owned `cafe.slack.human_task` capability declares exactly four
+non-secret inputs: repository, workflow ID, task ID, and reason. Its registered
+network effect is fixed to `hooks.slack.com`, and its symbolic credential is
+`slack_human_task_webhook`.
+
+The trusted package adapter reads `~/.slack-webhook` only after the capability
+request passes validation and policy. It accepts HTTPS Slack Incoming Webhook
+URLs only. The URL is used as the outbound request destination but is not put in
+the message, repository, HumanTask record, project-hook input, log, or receipt.
+Project-authored hooks remain sandboxed and never inherit this capability or
+credential.
+
+## Inspect delivery receipts
+
+Every allowed, denied, failed, or successful attempt appends a receipt to the
+issue blackboard. The receipt is correlated by `workflow_id` and `task_id` and
+contains the request decision and outcome without the webhook value.
+
+For a focused local inspection:
+
+```bash
+jq '.capability_receipts[]
+  | select(.capability == "cafe.slack.human_task")
+  | {workflow_id, task_id, success, category, code, decision, outcome}' \
+  .cafe/issues/<issue>/blackboard.json
+```
+
+Interpret the stable fields as follows:
+
+| Result | Receipt evidence | Meaning |
+| --- | --- | --- |
+| Successful | `success: true`, `outcome: success` | Slack returned HTTP 200 with `ok`. |
+| Denied | `success: false`, decision outcome `deny` | The exact request failed registered argument, effect, credential, permission, or package policy checks; the adapter did not run. |
+| Missing or unreadable credential | code `slack_credentials_missing`, `slack_credentials_empty`, or `slack_credentials_unreadable` | Repair the fixed user credential file and its permissions. |
+| Invalid credential | code `slack_credentials_invalid` | Replace the file contents with a valid channel-bound Slack HTTPS Incoming Webhook URL. |
+| Slack/transport failure | code `slack_http_error`, `slack_response_not_ok`, `slack_timeout`, or `slack_transport_error` | Slack rejected the post or could not be reached. |
+| Internal fail-closed error | code `slack_notification_internal_error` | The trusted path could not complete evaluation; inspect local installation/runtime health. |
+
+## Recover safely
+
+A notification result never completes, erases, redirects, or changes the
+HumanTask. Inspect and complete the same pending task through the normal inbox:
+
+```bash
+cafe task ls
+cafe task inspect <task-id>
+cafe task complete <task-id>
+```
+
+Fix credentials or connectivity before the next HumanTask is created. CAFE
+does not automatically retry an existing task or report a failed attempt as a
+success, so the receipt remains the accurate record of that attempt.
+
+## Scope
+
+This feature does not provide bidirectional Slack interaction, task completion
+from Slack, callbacks, a daemon, scheduling, reminders, due dates, an SLA,
+automatic retries, multiple or dynamic destinations, a generic provider
+interface, or direct notification-script execution. Project and legacy
+notification scripts are not the supported authority path.

--- a/src/cafe/core/blackboard.py
+++ b/src/cafe/core/blackboard.py
@@ -10,12 +10,17 @@ from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, Iterator, List, Optional
+from typing import IO, Any, Dict, Iterator, List, Optional
 
 try:
     import fcntl
-except ImportError:  # pragma: no cover - Windows falls back to the local lock.
+except ImportError:  # pragma: no cover - unavailable on Windows.
     fcntl = None  # type: ignore[assignment]
+
+try:
+    import msvcrt
+except ImportError:  # pragma: no cover - available only on Windows.
+    msvcrt = None  # type: ignore[assignment]
 
 from cafe.core.packet_io import atomic_write_bytes
 from cafe.core.workflow_models import BatonRejected
@@ -38,6 +43,27 @@ def _legacy_workflow_id(data: Dict[str, Any], initial_step: str) -> str:
         "updated_at": str(data.get("updated_at", "")),
     }
     return str(uuid.uuid5(uuid.NAMESPACE_URL, json.dumps(identity, sort_keys=True)))
+
+
+@contextmanager
+def _process_file_lock(lock_file: IO[str]) -> Iterator[None]:
+    """Hold an exclusive kernel file lock for the current process."""
+    if fcntl is not None:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+        return
+    if msvcrt is None:
+        raise RuntimeError("cross-process file locking is unavailable")
+    lock_file.seek(0)
+    msvcrt.locking(lock_file.fileno(), msvcrt.LK_LOCK, 1)
+    try:
+        yield
+    finally:
+        lock_file.seek(0)
+        msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
 
 
 class ArtifactKind(str, Enum):
@@ -721,18 +747,13 @@ class BlackboardStore:
         with self._thread_lock_for(self.file_path):
             self.issue_dir.mkdir(parents=True, exist_ok=True)
             with self.receipt_lock_path.open("a+", encoding="utf-8") as lock_file:
-                if fcntl is not None:
-                    fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
-                try:
+                with _process_file_lock(lock_file):
                     if self.file_path.exists():
                         raw = json.loads(self.file_path.read_text(encoding="utf-8"))
                         persisted = BlackboardState.from_dict(raw, initial_step=state.current_step)
                         state.__dict__.clear()
                         state.__dict__.update(persisted.__dict__)
                     yield state
-                finally:
-                    if fcntl is not None:
-                        fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
 
     @classmethod
     def _thread_lock_for(cls, file_path: Path) -> threading.RLock:

--- a/src/cafe/core/blackboard.py
+++ b/src/cafe/core/blackboard.py
@@ -3,12 +3,19 @@
 from __future__ import annotations
 
 import json
+import threading
 import uuid
+from contextlib import contextmanager
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Iterator, List, Optional
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - Windows falls back to the local lock.
+    fcntl = None  # type: ignore[assignment]
 
 from cafe.core.packet_io import atomic_write_bytes
 from cafe.core.workflow_models import BatonRejected
@@ -453,9 +460,13 @@ class BlackboardState:
 class BlackboardStore:
     """Persist blackboard data in issue directory."""
 
+    _thread_locks: Dict[Path, threading.RLock] = {}
+    _thread_locks_guard = threading.Lock()
+
     def __init__(self, issue_dir: Path) -> None:
         self.issue_dir = issue_dir
         self.file_path = issue_dir / BLACKBOARD_FILENAME
+        self.receipt_lock_path = issue_dir / f".{BLACKBOARD_FILENAME}.receipt.lock"
         self.next_step_path = issue_dir / NEXT_STEP_FILENAME
 
     def load_or_create(
@@ -701,6 +712,33 @@ class BlackboardStore:
                 return
         state.capability_receipts.append(dict(receipt))
         self.save(state)
+
+    @contextmanager
+    def capability_receipt_transaction(
+        self, state: BlackboardState
+    ) -> Iterator[BlackboardState]:
+        """Serialize one receipt-backed dispatch across runtimes and processes."""
+        with self._thread_lock_for(self.file_path):
+            self.issue_dir.mkdir(parents=True, exist_ok=True)
+            with self.receipt_lock_path.open("a+", encoding="utf-8") as lock_file:
+                if fcntl is not None:
+                    fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+                try:
+                    if self.file_path.exists():
+                        raw = json.loads(self.file_path.read_text(encoding="utf-8"))
+                        persisted = BlackboardState.from_dict(raw, initial_step=state.current_step)
+                        state.__dict__.clear()
+                        state.__dict__.update(persisted.__dict__)
+                    yield state
+                finally:
+                    if fcntl is not None:
+                        fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+    @classmethod
+    def _thread_lock_for(cls, file_path: Path) -> threading.RLock:
+        resolved = file_path.resolve()
+        with cls._thread_locks_guard:
+            return cls._thread_locks.setdefault(resolved, threading.RLock())
 
     def set_current_step(self, state: BlackboardState, step: str) -> None:
         state.current_step = step

--- a/src/cafe/core/blackboard.py
+++ b/src/cafe/core/blackboard.py
@@ -689,6 +689,19 @@ class BlackboardStore:
         state.capability_receipts.append(dict(receipt))
         self.save(state)
 
+    def upsert_capability_receipt(self, state: BlackboardState, receipt: Dict[str, Any]) -> None:
+        """Persist one evolving attempt receipt without duplicating its audit identity."""
+        attempt_id = str(receipt.get("notification_attempt_id") or "")
+        if not attempt_id:
+            raise ValueError("notification_attempt_id is required for receipt upsert")
+        for index, existing in enumerate(state.capability_receipts):
+            if str(existing.get("notification_attempt_id") or "") == attempt_id:
+                state.capability_receipts[index] = dict(receipt)
+                self.save(state)
+                return
+        state.capability_receipts.append(dict(receipt))
+        self.save(state)
+
     def set_current_step(self, state: BlackboardState, step: str) -> None:
         state.current_step = step
         self.save(state)

--- a/src/cafe/core/capabilities.py
+++ b/src/cafe/core/capabilities.py
@@ -1117,9 +1117,31 @@ def _notify_slack_human_task_adapter(
     output_file: Path,
     timeout_sec: float,
 ) -> tuple[Dict[str, Any], Optional[Dict[str, Any]]]:
-    """Reserved package adapter completed by the Slack delivery slice."""
-    del repo_root, request, manifest, output_file, timeout_sec
-    raise CapabilityExecutionError(VALIDATION_ERROR, "slack_adapter_unavailable")
+    """Deliver one package-owned HumanTask notification without exposing credentials."""
+    from cafe.core.human_task_notifications import (
+        SlackNotificationError,
+        build_human_task_message,
+        load_slack_webhook_url,
+        post_slack_notification,
+    )
+
+    del repo_root, manifest, output_file
+    message = build_human_task_message(
+        repository=str(request.args["repository"]),
+        workflow_id=str(request.args["workflow_id"]),
+        task_id=str(request.args["task_id"]),
+        reason=str(request.args["reason"]),
+    )
+    try:
+        webhook_url = load_slack_webhook_url()
+        post_slack_notification(webhook_url, message, timeout_sec=timeout_sec)
+    except SlackNotificationError as exc:
+        raise CapabilityExecutionError(exc.category, exc.code) from exc
+    return {
+        "delivered": True,
+        "workflow_id": message.workflow_id,
+        "task_id": message.task_id,
+    }, None
 
 
 HOST_CAPABILITY_ADAPTERS: Mapping[str, Any] = {

--- a/src/cafe/core/capabilities.py
+++ b/src/cafe/core/capabilities.py
@@ -34,6 +34,7 @@ from cafe.utils.github import GitHubOps
 CAPABILITY_PR_PUBLISH_ID = "cafe.pr.publish"
 CAPABILITY_BROWSER_OPEN_ID = "cafe.browser.open"
 CAPABILITY_ISSUE_COMMENT_ID = "cafe.github.issue_comment"
+CAPABILITY_SLACK_HUMAN_TASK_ID = "cafe.slack.human_task"
 
 # Failure categories surfaced on capability receipts (distinct from validation_error).
 SCRIPT_EXIT_ERROR = "script_exit_error"
@@ -105,7 +106,12 @@ class CapabilityEffects(StrictCapabilityModel):
 class CapabilityManifest(StrictCapabilityModel):
     id: str = Field(min_length=1)
     version: int = Field(ge=1)
-    implementation: Literal["sync_pr", "open_current_pr", "sync_issue_comment"]
+    implementation: Literal[
+        "sync_pr",
+        "open_current_pr",
+        "sync_issue_comment",
+        "notify_slack_human_task",
+    ]
     arguments: ObjectSchema
     outputs: ObjectSchema
     effects: CapabilityEffects
@@ -1103,10 +1109,24 @@ def _sync_issue_comment_adapter(
     }
 
 
+def _notify_slack_human_task_adapter(
+    *,
+    repo_root: Path,
+    request: ExecutionRequest,
+    manifest: CapabilityManifest,
+    output_file: Path,
+    timeout_sec: float,
+) -> tuple[Dict[str, Any], Optional[Dict[str, Any]]]:
+    """Reserved package adapter completed by the Slack delivery slice."""
+    del repo_root, request, manifest, output_file, timeout_sec
+    raise CapabilityExecutionError(VALIDATION_ERROR, "slack_adapter_unavailable")
+
+
 HOST_CAPABILITY_ADAPTERS: Mapping[str, Any] = {
     "sync_pr": _sync_pr_adapter,
     "open_current_pr": _open_current_pr_adapter,
     "sync_issue_comment": _sync_issue_comment_adapter,
+    "notify_slack_human_task": _notify_slack_human_task_adapter,
 }
 
 

--- a/src/cafe/core/human_task_notifications.py
+++ b/src/cafe/core/human_task_notifications.py
@@ -1,0 +1,136 @@
+"""Trusted Slack delivery for newly materialized HumanTasks."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlparse
+from urllib.request import Request, urlopen
+
+SLACK_WEBHOOK_FILENAME = ".slack-webhook"
+SLACK_WEBHOOK_HOST = "hooks.slack.com"
+
+
+class SlackNotificationError(RuntimeError):
+    """A stable, secret-free Slack delivery failure."""
+
+    def __init__(self, category: str, code: str) -> None:
+        super().__init__(code)
+        self.category = category
+        self.code = code
+
+
+@dataclass(frozen=True)
+class HumanTaskSlackMessage:
+    """Actionable, non-secret fields for one pending HumanTask."""
+
+    repository: str
+    workflow_id: str
+    task_id: str
+    reason: str
+    inspect_command: str
+    complete_command: str
+
+    def to_slack_payload(self) -> dict[str, str]:
+        text = "\n".join(
+            (
+                "CAFE HumanTask requires action",
+                f"Repository: {self.repository}",
+                f"Workflow: {self.workflow_id}",
+                f"HumanTask: {self.task_id}",
+                f"Reason: {self.reason}",
+                f"Inspect: {self.inspect_command}",
+                f"Complete: {self.complete_command}",
+            )
+        )
+        return {"text": text}
+
+
+def build_human_task_message(
+    *, repository: str, workflow_id: str, task_id: str, reason: str
+) -> HumanTaskSlackMessage:
+    """Build the supported task inspection and completion journey."""
+    return HumanTaskSlackMessage(
+        repository=repository,
+        workflow_id=workflow_id,
+        task_id=task_id,
+        reason=reason,
+        inspect_command=f"cafe task inspect {task_id}",
+        complete_command=f"cafe task complete {task_id}",
+    )
+
+
+def _validate_slack_webhook_url(raw_url: str) -> str:
+    try:
+        parsed = urlparse(raw_url)
+        port = parsed.port
+    except ValueError as exc:
+        raise SlackNotificationError("validation_error", "slack_credentials_invalid") from exc
+    path_parts = parsed.path.removeprefix("/").split("/")
+    valid_tokens = (
+        len(path_parts) == 4
+        and path_parts[0] == "services"
+        and all(re.fullmatch(r"[A-Za-z0-9_-]+", token) for token in path_parts[1:])
+    )
+    if not (
+        parsed.scheme == "https"
+        and parsed.hostname == SLACK_WEBHOOK_HOST
+        and port in {None, 443}
+        and parsed.username is None
+        and parsed.password is None
+        and not parsed.params
+        and not parsed.query
+        and not parsed.fragment
+        and valid_tokens
+    ):
+        raise SlackNotificationError("validation_error", "slack_credentials_invalid")
+    return raw_url
+
+
+def load_slack_webhook_url() -> str:
+    """Read and validate only the fixed user-owned Slack credential file."""
+    credential_file = Path.home() / SLACK_WEBHOOK_FILENAME
+    try:
+        webhook_url = credential_file.read_text(encoding="utf-8").strip()
+    except FileNotFoundError as exc:
+        raise SlackNotificationError("validation_error", "slack_credentials_missing") from exc
+    except OSError as exc:
+        raise SlackNotificationError("validation_error", "slack_credentials_unreadable") from exc
+    if not webhook_url:
+        raise SlackNotificationError("validation_error", "slack_credentials_empty")
+    return _validate_slack_webhook_url(webhook_url)
+
+
+def post_slack_notification(
+    webhook_url: str,
+    message: HumanTaskSlackMessage,
+    *,
+    timeout_sec: float,
+) -> None:
+    """Submit one Slack Incoming Webhook request through the HTTPS boundary."""
+    validated_url = _validate_slack_webhook_url(webhook_url)
+    request = Request(
+        validated_url,
+        data=json.dumps(message.to_slack_payload()).encode("utf-8"),
+        headers={"Content-Type": "application/json; charset=utf-8"},
+        method="POST",
+    )
+    try:
+        with urlopen(
+            request, timeout=timeout_sec
+        ) as response:  # noqa: S310 - URL is fixed/validated.
+            status = response.status
+            body = response.read(64).decode("utf-8", errors="replace").strip()
+    except HTTPError as exc:
+        raise SlackNotificationError("script_exit_error", "slack_http_error") from exc
+    except TimeoutError as exc:
+        raise SlackNotificationError("timeout_error", "slack_timeout") from exc
+    except (URLError, OSError) as exc:
+        raise SlackNotificationError("script_exit_error", "slack_transport_error") from exc
+    if status != 200:
+        raise SlackNotificationError("script_exit_error", "slack_http_error")
+    if body != "ok":
+        raise SlackNotificationError("script_exit_error", "slack_response_not_ok")

--- a/src/cafe/core/human_task_notifications.py
+++ b/src/cafe/core/human_task_notifications.py
@@ -3,15 +3,18 @@
 from __future__ import annotations
 
 import json
+import os
 import re
+import stat
 from dataclasses import dataclass
 from pathlib import Path
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlparse
-from urllib.request import Request, urlopen
+from urllib.request import HTTPRedirectHandler, Request, build_opener
 
 SLACK_WEBHOOK_FILENAME = ".slack-webhook"
 SLACK_WEBHOOK_HOST = "hooks.slack.com"
+MAX_CREDENTIAL_BYTES = 8192
 
 
 class SlackNotificationError(RuntimeError):
@@ -90,18 +93,65 @@ def _validate_slack_webhook_url(raw_url: str) -> str:
     return raw_url
 
 
+def _trusted_user_home() -> Path:
+    """Resolve the login account home without consulting the mutable HOME variable."""
+    if os.name != "posix":  # pragma: no cover - Windows has no pwd database.
+        return Path.home()
+    import pwd
+
+    return Path(pwd.getpwuid(os.getuid()).pw_dir)
+
+
 def load_slack_webhook_url() -> str:
     """Read and validate only the fixed user-owned Slack credential file."""
-    credential_file = Path.home() / SLACK_WEBHOOK_FILENAME
+    credential_file = _trusted_user_home() / SLACK_WEBHOOK_FILENAME
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
     try:
-        webhook_url = credential_file.read_text(encoding="utf-8").strip()
+        descriptor = os.open(credential_file, flags)
     except FileNotFoundError as exc:
         raise SlackNotificationError("validation_error", "slack_credentials_missing") from exc
     except OSError as exc:
+        if credential_file.is_symlink():
+            raise SlackNotificationError("validation_error", "slack_credentials_unsafe") from exc
         raise SlackNotificationError("validation_error", "slack_credentials_unreadable") from exc
+    try:
+        metadata = os.fstat(descriptor)
+        private_mode = stat.S_IMODE(metadata.st_mode) & 0o077 == 0
+        owned_by_user = not hasattr(os, "getuid") or metadata.st_uid == os.getuid()
+        if not (
+            stat.S_ISREG(metadata.st_mode)
+            and private_mode
+            and owned_by_user
+            and metadata.st_nlink == 1
+        ):
+            raise SlackNotificationError("validation_error", "slack_credentials_unsafe")
+        with os.fdopen(descriptor, encoding="utf-8") as credential_stream:
+            descriptor = -1
+            webhook_url = credential_stream.read(MAX_CREDENTIAL_BYTES + 1).strip()
+    except UnicodeError as exc:
+        raise SlackNotificationError("validation_error", "slack_credentials_invalid") from exc
+    except OSError as exc:
+        raise SlackNotificationError("validation_error", "slack_credentials_unreadable") from exc
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+    if len(webhook_url.encode("utf-8")) > MAX_CREDENTIAL_BYTES:
+        raise SlackNotificationError("validation_error", "slack_credentials_invalid")
     if not webhook_url:
         raise SlackNotificationError("validation_error", "slack_credentials_empty")
     return _validate_slack_webhook_url(webhook_url)
+
+
+class _RejectRedirectHandler(HTTPRedirectHandler):
+    """Keep every request on the manifest-declared Slack destination."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        del req, fp, code, msg, headers, newurl
+        return None
+
+
+def _open_slack_request(request: Request, *, timeout: float):
+    return build_opener(_RejectRedirectHandler()).open(request, timeout=timeout)
 
 
 def post_slack_notification(
@@ -119,7 +169,7 @@ def post_slack_notification(
         method="POST",
     )
     try:
-        with urlopen(
+        with _open_slack_request(
             request, timeout=timeout_sec
         ) as response:  # noqa: S310 - URL is fixed/validated.
             status = response.status

--- a/src/cafe/core/human_task_notifications.py
+++ b/src/cafe/core/human_task_notifications.py
@@ -105,7 +105,11 @@ def _trusted_user_home() -> Path:
 def load_slack_webhook_url() -> str:
     """Read and validate only the fixed user-owned Slack credential file."""
     credential_file = _trusted_user_home() / SLACK_WEBHOOK_FILENAME
-    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    flags = (
+        os.O_RDONLY
+        | getattr(os, "O_NOFOLLOW", 0)
+        | getattr(os, "O_NONBLOCK", 0)
+    )
     try:
         descriptor = os.open(credential_file, flags)
     except FileNotFoundError as exc:

--- a/src/cafe/core/human_task_records.py
+++ b/src/cafe/core/human_task_records.py
@@ -118,6 +118,14 @@ class HumanTask:
 
 
 @dataclass(frozen=True)
+class HumanTaskMaterialization:
+    """The durable task and whether this transaction created it."""
+
+    task: HumanTask
+    created: bool
+
+
+@dataclass(frozen=True)
 class Assignment:
     """The declared human assignee for one task."""
 
@@ -403,6 +411,37 @@ class HumanTaskRecordStore:
         capability_approval: Optional[Mapping[str, Any]] = None,
         handoff_key: Optional[str] = None,
     ) -> HumanTask:
+        return self.materialize_with_status(
+            workflow_id=workflow_id,
+            step=step,
+            iteration=iteration,
+            trigger=trigger,
+            policy_id=policy_id,
+            prompt=prompt,
+            expected_result=expected_result,
+            continuations=continuations,
+            assignee_type=assignee_type,
+            assignee_id=assignee_id,
+            capability_approval=capability_approval,
+            handoff_key=handoff_key,
+        ).task
+
+    def materialize_with_status(
+        self,
+        *,
+        workflow_id: str,
+        step: str,
+        iteration: int,
+        trigger: str,
+        policy_id: str,
+        prompt: str,
+        expected_result: Mapping[str, Any],
+        continuations: Mapping[str, str],
+        assignee_type: str,
+        assignee_id: Optional[str] = None,
+        capability_approval: Optional[Mapping[str, Any]] = None,
+        handoff_key: Optional[str] = None,
+    ) -> HumanTaskMaterialization:
         with self.transaction():
             envelope = self._load_for_workflow(workflow_id, create=True)
             resolved_handoff_key = handoff_key or _handoff_key(
@@ -418,7 +457,7 @@ class HumanTaskRecordStore:
                 None,
             )
             if existing is not None:
-                return existing
+                return HumanTaskMaterialization(task=existing, created=False)
             now = _now_iso()
             task_id = str(uuid4())
             capability_metadata = (
@@ -461,7 +500,7 @@ class HumanTaskRecordStore:
                 context={"handoff_key": resolved_handoff_key},
             )
             self._save(envelope)
-            return task
+            return HumanTaskMaterialization(task=task, created=True)
 
     def update_capability_approval(
         self,

--- a/src/cafe/core/playbook.py
+++ b/src/cafe/core/playbook.py
@@ -720,9 +720,8 @@ class PlaybookDefinition(BaseModel):
             self.entry_point = next(iter(self.steps.keys()))
 
         def declares_workflow_feedback(step: StepConfig) -> bool:
-            return (
-                "input_artifacts" in step.model_fields_set
-                and "workflow_feedback" in (step.input_artifacts or [])
+            return "input_artifacts" in step.model_fields_set and "workflow_feedback" in (
+                step.input_artifacts or []
             )
 
         def github_pr_feedback_source_stages(step: StepConfig) -> list[str]:
@@ -736,10 +735,7 @@ class PlaybookDefinition(BaseModel):
                 )
                 if any(
                     hook == "GitHubPRFeedbackSource"
-                    or (
-                        isinstance(hook, dict)
-                        and hook.get("name") == "GitHubPRFeedbackSource"
-                    )
+                    or (isinstance(hook, dict) and hook.get("name") == "GitHubPRFeedbackSource")
                     for hook in hooks
                 )
             ]
@@ -785,10 +781,7 @@ class PlaybookDefinition(BaseModel):
                             f"steps.{step_name}.human_tasks feedback_delivery target "
                             f"{delivery_target!r} must declare workflow_feedback in input_artifacts"
                         )
-            if (
-                behavior.publish_confirmation
-                and "cafe.pr.publish" not in step.capability_requests
-            ):
+            if behavior.publish_confirmation and "cafe.pr.publish" not in step.capability_requests:
                 raise ValueError(
                     f"steps.{step_name}.behavior.publish_confirmation requires "
                     "the cafe.pr.publish capability request"
@@ -905,7 +898,26 @@ class LoadedPlaybook:
     warnings: List[str]
 
     def as_dict(self) -> Dict:
-        return self.model.model_dump(exclude_none=True)
+        return PlaybookData(
+            self.model.model_dump(exclude_none=True),
+            source=self.source,
+            path=self.path,
+        )
+
+
+class PlaybookData(dict):
+    """Validated playbook data retaining trusted loader provenance out of band."""
+
+    def __init__(
+        self,
+        *args: Any,
+        source: str = "unknown",
+        path: Optional[Path] = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.source = source
+        self.path = path
 
 
 def normalize_playbook_yaml(data: Dict) -> Dict:
@@ -1060,8 +1072,7 @@ def _validate_initial_input_declarations(model: PlaybookDefinition, *, source: s
             raise ValueError(f"{field_path} is only allowed on entry_point {model.entry_point!r}")
         if declaration.legacy_presentation and (
             source != "builtin"
-            or model.playbook.id
-            not in {"standard", "standard-qa", "simple", "tdd", "tdd-qa"}
+            or model.playbook.id not in {"standard", "standard-qa", "simple", "tdd", "tdd-qa"}
         ):
             raise ValueError(
                 f"{field_path}.legacy_presentation is reserved for bundled development playbooks"
@@ -1288,6 +1299,7 @@ def _validate_feedback_target_prompt_inputs(
     skill_loader: SkillLoader,
 ) -> None:
     """Ensure routed feedback is exposed to every possible target skill."""
+
     def receives_workflow_feedback(skill_name: str) -> bool:
         return any(
             mapping.artifacts[0] == "workflow_feedback"
@@ -1311,9 +1323,7 @@ def _validate_feedback_target_prompt_inputs(
         for source, target_name in targets:
             target = model.steps[target_name]
             selectors = (
-                [target.skill]
-                if isinstance(target.skill, str)
-                else list(target.skill.values())
+                [target.skill] if isinstance(target.skill, str) else list(target.skill.values())
             )
             missing = [
                 canonical_skill_name(skill_name)

--- a/src/cafe/core/workflow_runtime.py
+++ b/src/cafe/core/workflow_runtime.py
@@ -158,94 +158,101 @@ class BlackboardWorkflowRuntime:
         if self.playbook_id != "standard" or self.playbook_source != "builtin":
             return
         attempt_id = f"slack-human-task:{task.id}"
-        with self.blackboard_store.capability_receipt_transaction(self.blackboard):
-            existing_receipt = next(
-                (
-                    receipt
-                    for receipt in self.blackboard.capability_receipts
-                    if receipt.get("capability") == CAPABILITY_SLACK_HUMAN_TASK_ID
-                    and receipt.get("workflow_id") == task.workflow_id
-                    and receipt.get("task_id") == task.id
-                ),
-                None,
+        try:
+            with self.blackboard_store.capability_receipt_transaction(self.blackboard):
+                self._dispatch_human_task_notification(task, attempt_id=attempt_id)
+        except Exception:
+            # Lock and persistence failures must not make Slack authoritative over human work.
+            return
+
+    def _dispatch_human_task_notification(self, task: HumanTask, *, attempt_id: str) -> None:
+        existing_receipt = next(
+            (
+                receipt
+                for receipt in self.blackboard.capability_receipts
+                if receipt.get("capability") == CAPABILITY_SLACK_HUMAN_TASK_ID
+                and receipt.get("workflow_id") == task.workflow_id
+                and receipt.get("task_id") == task.id
+            ),
+            None,
+        )
+        if existing_receipt is not None:
+            if existing_receipt.get("code") == "slack_notification_attempting":
+                interrupted_receipt = dict(existing_receipt)
+                interrupted_receipt.update(
+                    {
+                        "success": False,
+                        "category": "adapter_error",
+                        "code": "slack_notification_interrupted",
+                        "decision": "allow",
+                        "outcome": "execution_interrupted",
+                    }
+                )
+                self.blackboard_store.upsert_capability_receipt(
+                    self.blackboard, interrupted_receipt
+                )
+            return
+        repo_root = self._repository_root()
+        capability_request = {
+            "capability": CAPABILITY_SLACK_HUMAN_TASK_ID,
+            "args": {
+                "repository": repo_root.name,
+                "workflow_id": task.workflow_id,
+                "task_id": task.id,
+                "reason": task.prompt,
+            },
+            "effects": {
+                "writes": [],
+                "network_destinations": ["hooks.slack.com"],
+                "browser_open": [],
+            },
+            "credentials": ["slack_human_task_webhook"],
+            "permissions": {"network": ["hooks.slack.com"]},
+        }
+        attempting_receipt = {
+            "notification_attempt_id": attempt_id,
+            "correlation_id": attempt_id,
+            "capability": CAPABILITY_SLACK_HUMAN_TASK_ID,
+            "success": False,
+            "category": "pending",
+            "code": "slack_notification_attempting",
+            "decision": "pending",
+            "outcome": "attempting",
+            "inputs": {
+                "repository": repo_root.name,
+                "workflow_id": task.workflow_id,
+                "task_id": task.id,
+            },
+            "outputs": {},
+            "workflow_id": task.workflow_id,
+            "task_id": task.id,
+        }
+        self.blackboard_store.upsert_capability_receipt(self.blackboard, attempting_receipt)
+        try:
+            registry = load_capability_registry(default_capability_definition_dirs(repo_root))
+            run = run_capability_request(
+                repo_root=repo_root,
+                registry=registry,
+                capability_request=capability_request,
+                output_file=self.issue_dir / "blackboard.json",
+                timeout_sec=SLACK_HUMAN_TASK_TIMEOUT_SEC,
             )
-            if existing_receipt is not None:
-                if existing_receipt.get("code") == "slack_notification_attempting":
-                    interrupted_receipt = dict(existing_receipt)
-                    interrupted_receipt.update(
-                        {
-                            "success": False,
-                            "category": "adapter_error",
-                            "code": "slack_notification_interrupted",
-                            "decision": "allow",
-                            "outcome": "execution_interrupted",
-                        }
-                    )
-                    self.blackboard_store.upsert_capability_receipt(
-                        self.blackboard, interrupted_receipt
-                    )
-                return
-            repo_root = self._repository_root()
-            capability_request = {
-                "capability": CAPABILITY_SLACK_HUMAN_TASK_ID,
-                "args": {
-                    "repository": repo_root.name,
-                    "workflow_id": task.workflow_id,
-                    "task_id": task.id,
-                    "reason": task.prompt,
-                },
-                "effects": {
-                    "writes": [],
-                    "network_destinations": ["hooks.slack.com"],
-                    "browser_open": [],
-                },
-                "credentials": ["slack_human_task_webhook"],
-                "permissions": {"network": ["hooks.slack.com"]},
-            }
-            attempting_receipt = {
+            receipt = dict(run.receipt)
+        except Exception:  # The durable HumanTask remains authoritative on host failure.
+            receipt = validation_rejection_receipt(
+                capability=CAPABILITY_SLACK_HUMAN_TASK_ID,
+                code="slack_notification_internal_error",
+                raw_request=capability_request,
+                error_detail="slack_notification_internal_error",
+            )
+        receipt.update(
+            {
                 "notification_attempt_id": attempt_id,
-                "correlation_id": attempt_id,
-                "capability": CAPABILITY_SLACK_HUMAN_TASK_ID,
-                "success": False,
-                "category": "pending",
-                "code": "slack_notification_attempting",
-                "decision": "pending",
-                "outcome": "attempting",
-                "inputs": {
-                    "repository": repo_root.name,
-                    "workflow_id": task.workflow_id,
-                    "task_id": task.id,
-                },
-                "outputs": {},
                 "workflow_id": task.workflow_id,
                 "task_id": task.id,
             }
-            self.blackboard_store.upsert_capability_receipt(self.blackboard, attempting_receipt)
-            try:
-                registry = load_capability_registry(default_capability_definition_dirs(repo_root))
-                run = run_capability_request(
-                    repo_root=repo_root,
-                    registry=registry,
-                    capability_request=capability_request,
-                    output_file=self.issue_dir / "blackboard.json",
-                    timeout_sec=SLACK_HUMAN_TASK_TIMEOUT_SEC,
-                )
-                receipt = dict(run.receipt)
-            except Exception:  # The durable HumanTask remains authoritative on host failure.
-                receipt = validation_rejection_receipt(
-                    capability=CAPABILITY_SLACK_HUMAN_TASK_ID,
-                    code="slack_notification_internal_error",
-                    raw_request=capability_request,
-                    error_detail="slack_notification_internal_error",
-                )
-            receipt.update(
-                {
-                    "notification_attempt_id": attempt_id,
-                    "workflow_id": task.workflow_id,
-                    "task_id": task.id,
-                }
-            )
-            self.blackboard_store.upsert_capability_receipt(self.blackboard, receipt)
+        )
+        self.blackboard_store.upsert_capability_receipt(self.blackboard, receipt)
 
     @staticmethod
     def _extract_goto_target(response: str) -> Optional[str]:

--- a/src/cafe/core/workflow_runtime.py
+++ b/src/cafe/core/workflow_runtime.py
@@ -158,93 +158,94 @@ class BlackboardWorkflowRuntime:
         if self.playbook_id != "standard" or self.playbook_source != "builtin":
             return
         attempt_id = f"slack-human-task:{task.id}"
-        existing_receipt = next(
-            (
-                receipt
-                for receipt in self.blackboard.capability_receipts
-                if receipt.get("capability") == CAPABILITY_SLACK_HUMAN_TASK_ID
-                and receipt.get("workflow_id") == task.workflow_id
-                and receipt.get("task_id") == task.id
-            ),
-            None,
-        )
-        if existing_receipt is not None:
-            if existing_receipt.get("code") == "slack_notification_attempting":
-                interrupted_receipt = dict(existing_receipt)
-                interrupted_receipt.update(
-                    {
-                        "success": False,
-                        "category": "adapter_error",
-                        "code": "slack_notification_interrupted",
-                        "decision": "allow",
-                        "outcome": "execution_interrupted",
-                    }
-                )
-                self.blackboard_store.upsert_capability_receipt(
-                    self.blackboard, interrupted_receipt
-                )
-            return
-        repo_root = self._repository_root()
-        capability_request = {
-            "capability": CAPABILITY_SLACK_HUMAN_TASK_ID,
-            "args": {
-                "repository": repo_root.name,
-                "workflow_id": task.workflow_id,
-                "task_id": task.id,
-                "reason": task.prompt,
-            },
-            "effects": {
-                "writes": [],
-                "network_destinations": ["hooks.slack.com"],
-                "browser_open": [],
-            },
-            "credentials": ["slack_human_task_webhook"],
-            "permissions": {"network": ["hooks.slack.com"]},
-        }
-        attempting_receipt = {
-            "notification_attempt_id": attempt_id,
-            "correlation_id": attempt_id,
-            "capability": CAPABILITY_SLACK_HUMAN_TASK_ID,
-            "success": False,
-            "category": "pending",
-            "code": "slack_notification_attempting",
-            "decision": "pending",
-            "outcome": "attempting",
-            "inputs": {
-                "repository": repo_root.name,
-                "workflow_id": task.workflow_id,
-                "task_id": task.id,
-            },
-            "outputs": {},
-            "workflow_id": task.workflow_id,
-            "task_id": task.id,
-        }
-        self.blackboard_store.upsert_capability_receipt(self.blackboard, attempting_receipt)
-        try:
-            registry = load_capability_registry(default_capability_definition_dirs(repo_root))
-            run = run_capability_request(
-                repo_root=repo_root,
-                registry=registry,
-                capability_request=capability_request,
-                output_file=self.issue_dir / "blackboard.json",
-                timeout_sec=SLACK_HUMAN_TASK_TIMEOUT_SEC,
+        with self.blackboard_store.capability_receipt_transaction(self.blackboard):
+            existing_receipt = next(
+                (
+                    receipt
+                    for receipt in self.blackboard.capability_receipts
+                    if receipt.get("capability") == CAPABILITY_SLACK_HUMAN_TASK_ID
+                    and receipt.get("workflow_id") == task.workflow_id
+                    and receipt.get("task_id") == task.id
+                ),
+                None,
             )
-            receipt = dict(run.receipt)
-        except Exception:  # The durable HumanTask remains authoritative on host failure.
-            receipt = validation_rejection_receipt(
-                capability=CAPABILITY_SLACK_HUMAN_TASK_ID,
-                code="slack_notification_internal_error",
-                raw_request=capability_request,
-                error_detail="slack_notification_internal_error",
-            )
-        receipt.update(
-            {
+            if existing_receipt is not None:
+                if existing_receipt.get("code") == "slack_notification_attempting":
+                    interrupted_receipt = dict(existing_receipt)
+                    interrupted_receipt.update(
+                        {
+                            "success": False,
+                            "category": "adapter_error",
+                            "code": "slack_notification_interrupted",
+                            "decision": "allow",
+                            "outcome": "execution_interrupted",
+                        }
+                    )
+                    self.blackboard_store.upsert_capability_receipt(
+                        self.blackboard, interrupted_receipt
+                    )
+                return
+            repo_root = self._repository_root()
+            capability_request = {
+                "capability": CAPABILITY_SLACK_HUMAN_TASK_ID,
+                "args": {
+                    "repository": repo_root.name,
+                    "workflow_id": task.workflow_id,
+                    "task_id": task.id,
+                    "reason": task.prompt,
+                },
+                "effects": {
+                    "writes": [],
+                    "network_destinations": ["hooks.slack.com"],
+                    "browser_open": [],
+                },
+                "credentials": ["slack_human_task_webhook"],
+                "permissions": {"network": ["hooks.slack.com"]},
+            }
+            attempting_receipt = {
                 "notification_attempt_id": attempt_id,
+                "correlation_id": attempt_id,
+                "capability": CAPABILITY_SLACK_HUMAN_TASK_ID,
+                "success": False,
+                "category": "pending",
+                "code": "slack_notification_attempting",
+                "decision": "pending",
+                "outcome": "attempting",
+                "inputs": {
+                    "repository": repo_root.name,
+                    "workflow_id": task.workflow_id,
+                    "task_id": task.id,
+                },
+                "outputs": {},
                 "workflow_id": task.workflow_id,
                 "task_id": task.id,
             }
-        )
-        self.blackboard_store.upsert_capability_receipt(self.blackboard, receipt)
+            self.blackboard_store.upsert_capability_receipt(self.blackboard, attempting_receipt)
+            try:
+                registry = load_capability_registry(default_capability_definition_dirs(repo_root))
+                run = run_capability_request(
+                    repo_root=repo_root,
+                    registry=registry,
+                    capability_request=capability_request,
+                    output_file=self.issue_dir / "blackboard.json",
+                    timeout_sec=SLACK_HUMAN_TASK_TIMEOUT_SEC,
+                )
+                receipt = dict(run.receipt)
+            except Exception:  # The durable HumanTask remains authoritative on host failure.
+                receipt = validation_rejection_receipt(
+                    capability=CAPABILITY_SLACK_HUMAN_TASK_ID,
+                    code="slack_notification_internal_error",
+                    raw_request=capability_request,
+                    error_detail="slack_notification_internal_error",
+                )
+            receipt.update(
+                {
+                    "notification_attempt_id": attempt_id,
+                    "workflow_id": task.workflow_id,
+                    "task_id": task.id,
+                }
+            )
+            self.blackboard_store.upsert_capability_receipt(self.blackboard, receipt)
 
     @staticmethod
     def _extract_goto_target(response: str) -> Optional[str]:

--- a/src/cafe/core/workflow_runtime.py
+++ b/src/cafe/core/workflow_runtime.py
@@ -25,8 +25,15 @@ from cafe.core.blackboard import (
     HandoffIntent,
     HandoffOwner,
 )
-from cafe.core.capabilities import CAPABILITY_PR_PUBLISH_ID
-from cafe.core.human_task_records import HumanTaskRecordStore
+from cafe.core.capabilities import (
+    CAPABILITY_PR_PUBLISH_ID,
+    CAPABILITY_SLACK_HUMAN_TASK_ID,
+    default_capability_definition_dirs,
+    load_capability_registry,
+    run_capability_request,
+    validation_rejection_receipt,
+)
+from cafe.core.human_task_records import HumanTask, HumanTaskRecordStore
 from cafe.core.human_tasks import resolve_step_human_task
 from cafe.core.playbook import resolve_step_behavior
 from cafe.core.questions_schema import validate_questions_xml
@@ -138,6 +145,51 @@ class BlackboardWorkflowRuntime:
                     f"Step '{step_name}' has an invalid automatic executor declaration"
                 )
             self.automatic_registry.validate_inputs(executor_id, inputs)
+
+    def _repository_root(self) -> Path:
+        if self.issue_dir.parent.name == "issues" and self.issue_dir.parent.parent.name == ".cafe":
+            return self.issue_dir.parent.parent.parent
+        return self.issue_dir.parent
+
+    def _notify_new_human_task(self, task: HumanTask) -> None:
+        """Audit one fixed-boundary Slack attempt for a new standard task."""
+        if self.playbook_id != "standard":
+            return
+        repo_root = self._repository_root()
+        capability_request = {
+            "capability": CAPABILITY_SLACK_HUMAN_TASK_ID,
+            "args": {
+                "repository": repo_root.name,
+                "workflow_id": task.workflow_id,
+                "task_id": task.id,
+                "reason": task.prompt,
+            },
+            "effects": {
+                "writes": [],
+                "network_destinations": ["hooks.slack.com"],
+                "browser_open": [],
+            },
+            "credentials": ["slack_human_task_webhook"],
+            "permissions": {"network": ["hooks.slack.com"]},
+        }
+        try:
+            registry = load_capability_registry(default_capability_definition_dirs(repo_root))
+            run = run_capability_request(
+                repo_root=repo_root,
+                registry=registry,
+                capability_request=capability_request,
+                output_file=self.issue_dir / "blackboard.json",
+            )
+            receipt = dict(run.receipt)
+        except Exception:  # The durable HumanTask remains authoritative on host failure.
+            receipt = validation_rejection_receipt(
+                capability=CAPABILITY_SLACK_HUMAN_TASK_ID,
+                code="slack_notification_internal_error",
+                raw_request=capability_request,
+                error_detail="slack_notification_internal_error",
+            )
+        receipt.update({"workflow_id": task.workflow_id, "task_id": task.id})
+        self.blackboard_store.append_capability_receipt(self.blackboard, receipt)
 
     @staticmethod
     def _extract_goto_target(response: str) -> Optional[str]:
@@ -696,13 +748,7 @@ class BlackboardWorkflowRuntime:
                 completed=False,
             )
 
-        existing_wait = records.active_wait_state(
-            self.blackboard.workflow_id,
-            step=current_step,
-            trigger=trigger,
-            policy_id=policy.id,
-        )
-        task = records.materialize(
+        materialization = records.materialize_with_status(
             workflow_id=self.blackboard.workflow_id,
             step=current_step,
             iteration=iteration,
@@ -713,6 +759,9 @@ class BlackboardWorkflowRuntime:
             continuations=binding.outcomes,
             assignee_type="human",
         )
+        task = materialization.task
+        if materialization.created:
+            self._notify_new_human_task(task)
         if cursor is not None:
             cursor["task_id"] = task.id
             self.blackboard.ownership_cursor = cursor
@@ -727,7 +776,7 @@ class BlackboardWorkflowRuntime:
             source="workflow.owner_human",
         )
         self.blackboard_store.set_current_step(self.blackboard, "user")
-        if existing_wait is None:
+        if materialization.created:
             self.blackboard_store.record_event(
                 self.blackboard,
                 "human_task_materialized",
@@ -1453,13 +1502,7 @@ class BlackboardWorkflowRuntime:
             )
             return
 
-        existing_wait = records.active_wait_state(
-            self.blackboard.workflow_id,
-            step=current_step,
-            trigger=trigger,
-            policy_id=policy.id,
-        )
-        task = records.materialize(
+        materialization = records.materialize_with_status(
             workflow_id=self.blackboard.workflow_id,
             step=current_step,
             iteration=iteration,
@@ -1470,7 +1513,9 @@ class BlackboardWorkflowRuntime:
             continuations=binding.outcomes,
             assignee_type="user",
         )
-        if existing_wait is None:
+        task = materialization.task
+        if materialization.created:
+            self._notify_new_human_task(task)
             self.blackboard_store.record_event(
                 self.blackboard,
                 "human_task_materialized",

--- a/src/cafe/core/workflow_runtime.py
+++ b/src/cafe/core/workflow_runtime.py
@@ -63,6 +63,7 @@ PAUSE_STATUS_CODES = {
     PhaseStatusCode.NEED_CLARIFICATION.value,
     PhaseStatusCode.NEED_PERMISSION.value,
 }
+SLACK_HUMAN_TASK_TIMEOUT_SEC = 5.0
 
 
 @dataclass
@@ -115,6 +116,7 @@ class BlackboardWorkflowRuntime:
 
         playbook_meta = playbook["playbook"]
         self.playbook_id = str(playbook_meta["id"])
+        self.playbook_source = str(getattr(playbook, "source", "unknown"))
         self.steps: Dict = playbook["steps"]
         self.start_step = str(playbook.get("entry_point") or next(iter(self.steps.keys())))
         self._validate_automatic_executor_declarations()
@@ -153,7 +155,34 @@ class BlackboardWorkflowRuntime:
 
     def _notify_new_human_task(self, task: HumanTask) -> None:
         """Audit one fixed-boundary Slack attempt for a new standard task."""
-        if self.playbook_id != "standard":
+        if self.playbook_id != "standard" or self.playbook_source != "builtin":
+            return
+        attempt_id = f"slack-human-task:{task.id}"
+        existing_receipt = next(
+            (
+                receipt
+                for receipt in self.blackboard.capability_receipts
+                if receipt.get("capability") == CAPABILITY_SLACK_HUMAN_TASK_ID
+                and receipt.get("workflow_id") == task.workflow_id
+                and receipt.get("task_id") == task.id
+            ),
+            None,
+        )
+        if existing_receipt is not None:
+            if existing_receipt.get("code") == "slack_notification_attempting":
+                interrupted_receipt = dict(existing_receipt)
+                interrupted_receipt.update(
+                    {
+                        "success": False,
+                        "category": "adapter_error",
+                        "code": "slack_notification_interrupted",
+                        "decision": "allow",
+                        "outcome": "execution_interrupted",
+                    }
+                )
+                self.blackboard_store.upsert_capability_receipt(
+                    self.blackboard, interrupted_receipt
+                )
             return
         repo_root = self._repository_root()
         capability_request = {
@@ -172,6 +201,25 @@ class BlackboardWorkflowRuntime:
             "credentials": ["slack_human_task_webhook"],
             "permissions": {"network": ["hooks.slack.com"]},
         }
+        attempting_receipt = {
+            "notification_attempt_id": attempt_id,
+            "correlation_id": attempt_id,
+            "capability": CAPABILITY_SLACK_HUMAN_TASK_ID,
+            "success": False,
+            "category": "pending",
+            "code": "slack_notification_attempting",
+            "decision": "pending",
+            "outcome": "attempting",
+            "inputs": {
+                "repository": repo_root.name,
+                "workflow_id": task.workflow_id,
+                "task_id": task.id,
+            },
+            "outputs": {},
+            "workflow_id": task.workflow_id,
+            "task_id": task.id,
+        }
+        self.blackboard_store.upsert_capability_receipt(self.blackboard, attempting_receipt)
         try:
             registry = load_capability_registry(default_capability_definition_dirs(repo_root))
             run = run_capability_request(
@@ -179,6 +227,7 @@ class BlackboardWorkflowRuntime:
                 registry=registry,
                 capability_request=capability_request,
                 output_file=self.issue_dir / "blackboard.json",
+                timeout_sec=SLACK_HUMAN_TASK_TIMEOUT_SEC,
             )
             receipt = dict(run.receipt)
         except Exception:  # The durable HumanTask remains authoritative on host failure.
@@ -188,8 +237,14 @@ class BlackboardWorkflowRuntime:
                 raw_request=capability_request,
                 error_detail="slack_notification_internal_error",
             )
-        receipt.update({"workflow_id": task.workflow_id, "task_id": task.id})
-        self.blackboard_store.append_capability_receipt(self.blackboard, receipt)
+        receipt.update(
+            {
+                "notification_attempt_id": attempt_id,
+                "workflow_id": task.workflow_id,
+                "task_id": task.id,
+            }
+        )
+        self.blackboard_store.upsert_capability_receipt(self.blackboard, receipt)
 
     @staticmethod
     def _extract_goto_target(response: str) -> Optional[str]:
@@ -760,8 +815,7 @@ class BlackboardWorkflowRuntime:
             assignee_type="human",
         )
         task = materialization.task
-        if materialization.created:
-            self._notify_new_human_task(task)
+        self._notify_new_human_task(task)
         if cursor is not None:
             cursor["task_id"] = task.id
             self.blackboard.ownership_cursor = cursor
@@ -1514,8 +1568,8 @@ class BlackboardWorkflowRuntime:
             assignee_type="user",
         )
         task = materialization.task
+        self._notify_new_human_task(task)
         if materialization.created:
-            self._notify_new_human_task(task)
             self.blackboard_store.record_event(
                 self.blackboard,
                 "human_task_materialized",

--- a/src/cafe/data/capabilities/cafe.slack.human_task.yaml
+++ b/src/cafe/data/capabilities/cafe.slack.human_task.yaml
@@ -1,0 +1,27 @@
+id: cafe.slack.human_task
+version: 1
+implementation: notify_slack_human_task
+arguments:
+  required: [repository, workflow_id, task_id, reason]
+  properties:
+    repository: {type: string}
+    workflow_id: {type: string}
+    task_id: {type: string}
+    reason: {type: string}
+outputs:
+  required: [delivered, workflow_id, task_id]
+  properties:
+    delivered: {type: boolean}
+    workflow_id: {type: string}
+    task_id: {type: string}
+effects:
+  writes: []
+  network_destinations: [hooks.slack.com]
+  browser_open: []
+credentials: [slack_human_task_webhook]
+permissions:
+  network: [hooks.slack.com]
+idempotency: unsafe
+risk: medium
+approval: not_required
+policy: allow

--- a/tests/integration/test_human_task_slack_notification.py
+++ b/tests/integration/test_human_task_slack_notification.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from urllib.error import URLError
 
 import pytest
+import yaml
 from typer.testing import CliRunner
 
 from cafe.core.blackboard import BlackboardStore, HandoffOwner
@@ -40,7 +41,16 @@ class _SlackResponse:
 
 
 def _set_home(monkeypatch: pytest.MonkeyPatch, home: Path) -> None:
-    monkeypatch.setattr(Path, "home", classmethod(lambda _cls: home))
+    import cafe.core.human_task_notifications as notification_mod
+
+    monkeypatch.setattr(notification_mod, "_trusted_user_home", lambda: home)
+
+
+def _write_credential(home: Path, value: str = VALID_WEBHOOK) -> Path:
+    credential = home / ".slack-webhook"
+    credential.write_text(value, encoding="utf-8")
+    credential.chmod(0o600)
+    return credential
 
 
 def _pause_for_output_review(issue_dir: Path, *, response: str = "ready_for_review"):
@@ -68,15 +78,15 @@ def test_clean_repository_notification_succeeds(
     issue_dir = repo_root / ".cafe" / "issues" / "success"
     home = tmp_path / "home-success"
     home.mkdir()
-    (home / ".slack-webhook").write_text(VALID_WEBHOOK, encoding="utf-8")
+    _write_credential(home)
     _set_home(monkeypatch, home)
     posts = []
 
-    def _urlopen(request, *, timeout: float):
+    def _open_slack_request(request, *, timeout: float):
         posts.append((request, timeout))
         return _SlackResponse()
 
-    monkeypatch.setattr(notification_mod, "urlopen", _urlopen)
+    monkeypatch.setattr(notification_mod, "_open_slack_request", _open_slack_request)
 
     result = _pause_for_output_review(issue_dir)
 
@@ -90,6 +100,7 @@ def test_clean_repository_notification_succeeds(
     assert state.current_step == "user"
     assert len(posts) == 1
     assert posts[0][0].full_url == VALID_WEBHOOK
+    assert posts[0][1] == 5.0
     assert repo_root.name in payload["text"]
     assert task.workflow_id in payload["text"]
     assert task.id in payload["text"]
@@ -116,12 +127,12 @@ def test_project_content_cannot_redirect_or_gain_notification_authority(
     project_hook.chmod(0o755)
     home = tmp_path / "home-redirect"
     home.mkdir()
-    (home / ".slack-webhook").write_text(VALID_WEBHOOK, encoding="utf-8")
+    _write_credential(home)
     _set_home(monkeypatch, home)
     posts = []
     monkeypatch.setattr(
         notification_mod,
-        "urlopen",
+        "_open_slack_request",
         lambda request, *, timeout: posts.append((request, timeout)) or _SlackResponse(),
     )
 
@@ -144,6 +155,49 @@ def test_project_content_cannot_redirect_or_gain_notification_authority(
     assert "integration-secret" not in payload_text
     assert "integration-secret" not in receipt_text
     assert "integration-secret" not in task_text
+
+
+def test_project_playbook_named_standard_cannot_gain_notification_authority(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Integration 2: loader provenance, not mutable playbook ID, gates authority."""
+    import cafe.core.human_task_notifications as notification_mod
+
+    repo_root = tmp_path / "project-standard"
+    issue_dir = repo_root / ".cafe" / "issues" / "project-standard"
+    project_playbooks = repo_root / ".cafe" / "playbooks"
+    project_playbooks.mkdir(parents=True)
+    loader = PlaybookLoader(project_root=repo_root, global_root=tmp_path / "global")
+    builtin = loader.load("standard")
+    builtin["steps"]["spec"]["initial_input"].pop("legacy_presentation", None)
+    (project_playbooks / "standard.yaml").write_text(
+        yaml.safe_dump(dict(builtin), sort_keys=False),
+        encoding="utf-8",
+    )
+    project_standard = loader.load("standard")
+    posts = []
+    monkeypatch.setattr(
+        notification_mod,
+        "_open_slack_request",
+        lambda request, *, timeout: posts.append((request, timeout)) or _SlackResponse(),
+    )
+
+    BlackboardWorkflowRuntime(
+        issue_dir=issue_dir,
+        playbook=project_standard,
+        executor=lambda *_args: StepExecutionResult(
+            response="ready_for_review",
+            artifacts={},
+            status_code="ready_for_review",
+            auto_continue=False,
+        ),
+    ).run(start_step="spec")
+
+    task = HumanTaskRecordStore(issue_dir).tasks()[0]
+    state = BlackboardStore(issue_dir).load_or_create("spec")
+    assert task.status is HumanTaskStatus.PENDING
+    assert posts == []
+    assert state.capability_receipts == []
 
 
 @pytest.mark.parametrize(
@@ -171,19 +225,19 @@ def test_notification_failure_is_recoverable_through_normal_task_commands(
     home = tmp_path / f"home-{case}"
     home.mkdir()
     if credential is not None:
-        (home / ".slack-webhook").write_text(credential, encoding="utf-8")
+        _write_credential(home, credential)
     _set_home(monkeypatch, home)
 
     if case == "transport":
         monkeypatch.setattr(
             notification_mod,
-            "urlopen",
+            "_open_slack_request",
             lambda *_args, **_kwargs: (_ for _ in ()).throw(URLError("offline")),
         )
     else:
         monkeypatch.setattr(
             notification_mod,
-            "urlopen",
+            "_open_slack_request",
             lambda *_args, **_kwargs: (_ for _ in ()).throw(
                 AssertionError("denied credentials must not reach HTTPS")
             ),

--- a/tests/integration/test_human_task_slack_notification.py
+++ b/tests/integration/test_human_task_slack_notification.py
@@ -1,0 +1,232 @@
+"""Supported default-workflow Slack notification journeys."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from urllib.error import URLError
+
+import pytest
+from typer.testing import CliRunner
+
+from cafe.core.blackboard import BlackboardStore, HandoffOwner
+from cafe.core.capabilities import (
+    CAPABILITY_SLACK_HUMAN_TASK_ID,
+    default_capability_definition_dirs,
+    load_capability_registry,
+)
+from cafe.core.human_task_records import HumanTaskRecordStore, HumanTaskStatus
+from cafe.core.workflow_models import StepExecutionResult
+from cafe.core.workflow_runtime import BlackboardWorkflowRuntime
+from cafe.playbooks.loader import PlaybookLoader
+from cafe.ui.cli import app
+
+
+VALID_WEBHOOK = "https://hooks.slack.com/services/T00000000/B00000000/integration-secret"
+runner = CliRunner()
+
+
+class _SlackResponse:
+    status = 200
+
+    def __enter__(self) -> "_SlackResponse":
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def read(self, _limit: int = -1) -> bytes:
+        return b"ok"
+
+
+def _set_home(monkeypatch: pytest.MonkeyPatch, home: Path) -> None:
+    monkeypatch.setattr(Path, "home", classmethod(lambda _cls: home))
+
+
+def _pause_for_output_review(issue_dir: Path, *, response: str = "ready_for_review"):
+    playbook = PlaybookLoader().load("standard")
+    runtime = BlackboardWorkflowRuntime(
+        issue_dir=issue_dir,
+        playbook=playbook,
+        executor=lambda *_args: StepExecutionResult(
+            response=response,
+            artifacts={},
+            status_code="ready_for_review",
+            auto_continue=False,
+        ),
+    )
+    return runtime.run(start_step="spec")
+
+
+def test_clean_repository_notification_succeeds(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A genuine output-review task produces one actionable mocked Slack POST."""
+    import cafe.core.human_task_notifications as notification_mod
+
+    repo_root = tmp_path / "clean-repository"
+    issue_dir = repo_root / ".cafe" / "issues" / "success"
+    home = tmp_path / "home-success"
+    home.mkdir()
+    (home / ".slack-webhook").write_text(VALID_WEBHOOK, encoding="utf-8")
+    _set_home(monkeypatch, home)
+    posts = []
+
+    def _urlopen(request, *, timeout: float):
+        posts.append((request, timeout))
+        return _SlackResponse()
+
+    monkeypatch.setattr(notification_mod, "urlopen", _urlopen)
+
+    result = _pause_for_output_review(issue_dir)
+
+    task = HumanTaskRecordStore(issue_dir).tasks()[0]
+    state = BlackboardStore(issue_dir).load_or_create("spec")
+    receipt = state.capability_receipts[0]
+    payload = json.loads(posts[0][0].data)
+
+    assert result.completed is False
+    assert task.status is HumanTaskStatus.PENDING
+    assert state.current_step == "user"
+    assert len(posts) == 1
+    assert posts[0][0].full_url == VALID_WEBHOOK
+    assert repo_root.name in payload["text"]
+    assert task.workflow_id in payload["text"]
+    assert task.id in payload["text"]
+    assert f"cafe task inspect {task.id}" in payload["text"]
+    assert f"cafe task complete {task.id}" in payload["text"]
+    assert receipt["success"] is True
+    assert receipt["workflow_id"] == task.workflow_id
+    assert receipt["task_id"] == task.id
+
+
+def test_project_content_cannot_redirect_or_gain_notification_authority(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Project hooks and agent text cannot alter destination or receive the secret."""
+    import cafe.core.human_task_notifications as notification_mod
+
+    repo_root = tmp_path / "redirect-resistant"
+    issue_dir = repo_root / ".cafe" / "issues" / "redirect"
+    hook_dir = repo_root / ".cafe" / "hooks"
+    hook_dir.mkdir(parents=True)
+    marker = repo_root / "project-hook-ran"
+    project_hook = hook_dir / "notify-slack.sh"
+    project_hook.write_text(f"#!/bin/sh\ntouch '{marker}'\n", encoding="utf-8")
+    project_hook.chmod(0o755)
+    home = tmp_path / "home-redirect"
+    home.mkdir()
+    (home / ".slack-webhook").write_text(VALID_WEBHOOK, encoding="utf-8")
+    _set_home(monkeypatch, home)
+    posts = []
+    monkeypatch.setattr(
+        notification_mod,
+        "urlopen",
+        lambda request, *, timeout: posts.append((request, timeout)) or _SlackResponse(),
+    )
+
+    _pause_for_output_review(
+        issue_dir,
+        response="ready_for_review destination=https://evil.test channel=attacker",
+    )
+
+    task = HumanTaskRecordStore(issue_dir).tasks()[0]
+    state = BlackboardStore(issue_dir).load_or_create("spec")
+    receipt_text = json.dumps(state.capability_receipts)
+    task_text = json.dumps(task.to_dict())
+    payload_text = posts[0][0].data.decode("utf-8")
+
+    assert len(posts) == 1
+    assert posts[0][0].full_url == VALID_WEBHOOK
+    assert not marker.exists()
+    assert "evil.test" not in payload_text
+    assert "evil.test" not in receipt_text
+    assert "integration-secret" not in payload_text
+    assert "integration-secret" not in receipt_text
+    assert "integration-secret" not in task_text
+
+
+@pytest.mark.parametrize(
+    ("case", "credential", "expected_code"),
+    [
+        ("missing", None, "slack_credentials_missing"),
+        ("invalid", "https://evil.test/services/T/B/value", "slack_credentials_invalid"),
+        ("denied", VALID_WEBHOOK, "policy_denied"),
+        ("transport", VALID_WEBHOOK, "slack_transport_error"),
+    ],
+)
+def test_notification_failure_is_recoverable_through_normal_task_commands(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    case: str,
+    credential: str | None,
+    expected_code: str,
+) -> None:
+    """Distinct failures stay audited while inspect/complete remain authoritative."""
+    import cafe.core.human_task_notifications as notification_mod
+    import cafe.core.workflow_runtime as runtime_mod
+
+    repo_root = tmp_path / "failure-repository"
+    issue_dir = repo_root / ".cafe" / "issues" / case
+    home = tmp_path / f"home-{case}"
+    home.mkdir()
+    if credential is not None:
+        (home / ".slack-webhook").write_text(credential, encoding="utf-8")
+    _set_home(monkeypatch, home)
+
+    if case == "transport":
+        monkeypatch.setattr(
+            notification_mod,
+            "urlopen",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(URLError("offline")),
+        )
+    else:
+        monkeypatch.setattr(
+            notification_mod,
+            "urlopen",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                AssertionError("denied credentials must not reach HTTPS")
+            ),
+        )
+    if case == "denied":
+        registry = dict(load_capability_registry(default_capability_definition_dirs(repo_root)))
+        registry[CAPABILITY_SLACK_HUMAN_TASK_ID] = registry[
+            CAPABILITY_SLACK_HUMAN_TASK_ID
+        ].model_copy(update={"policy": "deny"})
+        monkeypatch.setattr(runtime_mod, "load_capability_registry", lambda _dirs: registry)
+
+    _pause_for_output_review(issue_dir)
+
+    task = HumanTaskRecordStore(issue_dir).tasks()[0]
+    state = BlackboardStore(issue_dir).load_or_create("spec")
+    receipt = state.capability_receipts[0]
+
+    assert task.status is HumanTaskStatus.PENDING
+    assert state.current_step == "user"
+    assert state.handoff_contract.to_owner is HandoffOwner.USER
+    assert receipt["success"] is False
+    assert receipt["code"] == expected_code
+    assert receipt["workflow_id"] == task.workflow_id
+    assert receipt["task_id"] == task.id
+    assert "integration-secret" not in json.dumps(receipt)
+
+    monkeypatch.chdir(repo_root)
+    inspected = runner.invoke(app, ["task", "inspect", task.id, "--json"])
+    assert inspected.exit_code == 0
+    assert json.loads(inspected.stdout)["data"]["task"]["status"] == "pending"
+
+    if case == "transport":
+        monkeypatch.setattr("cafe.ui.commands.tasks._resume_issue_workflow", lambda *_args: None)
+        completed = runner.invoke(
+            app,
+            [
+                "task",
+                "complete",
+                task.id,
+                "--result",
+                '{"task":"output-review","decision":"confirm"}',
+                "--json",
+            ],
+        )
+        assert completed.exit_code == 0
+        assert HumanTaskRecordStore(issue_dir).get_task(task.id).status is HumanTaskStatus.COMPLETED

--- a/tests/unit/test_capability_registry.py
+++ b/tests/unit/test_capability_registry.py
@@ -36,7 +36,9 @@ def test_default_registry_and_sync_pr_entrypoint_ignore_project_overrides(tmp_pa
     skill_script.parent.mkdir(parents=True)
     skill_script.write_text("#!/bin/sh\nexit 99\n", encoding="utf-8")
 
-    assert cap_mod.default_capability_definition_dirs(tmp_path) == [cap_mod._package_capabilities_dir()]
+    assert cap_mod.default_capability_definition_dirs(tmp_path) == [
+        cap_mod._package_capabilities_dir()
+    ]
     resolved = cap_mod.resolve_sync_pr_script(tmp_path)
     assert resolved != skill_script
     assert "src/cafe/data/skills/cafe-pr/scripts/sync_pr.sh" in resolved.as_posix()
@@ -46,9 +48,13 @@ def test_capability_receipt_redacts_secret_named_values() -> None:
     import cafe.core.capabilities as cap_mod
 
     receipt = cap_mod._base_receipt(
-        correlation_id="c", capability="demo", success=False,
-        category="validation", code="denied",
-        inputs={"api_token": "sentinel"}, outputs={"password": "sentinel"},
+        correlation_id="c",
+        capability="demo",
+        success=False,
+        category="validation",
+        code="denied",
+        inputs={"api_token": "sentinel"},
+        outputs={"password": "sentinel"},
     )
     assert "sentinel" not in str(receipt)
 

--- a/tests/unit/test_capability_registry.py
+++ b/tests/unit/test_capability_registry.py
@@ -8,16 +8,22 @@ import yaml
 from cafe.core.capabilities import (
     CAPABILITY_BROWSER_OPEN_ID,
     CAPABILITY_PR_PUBLISH_ID,
+    CAPABILITY_SLACK_HUMAN_TASK_ID,
     CapabilityManifest,
     CapabilityRegistryError,
     ExecutionRequest,
     PolicyDecision,
     canonical_request_fingerprint,
     evaluate_capability_request,
+    default_capability_definition_dirs,
     load_capability_registry,
     run_capability_request,
     run_pr_publish_capability,
 )
+
+
+SLACK_CREDENTIAL = "slack_human_task_webhook"
+SLACK_DESTINATION = "hooks.slack.com"
 
 
 def test_default_registry_and_sync_pr_entrypoint_ignore_project_overrides(tmp_path: Path) -> None:
@@ -188,6 +194,96 @@ def _browser_request(**overrides: object) -> dict[str, object]:
     }
     request.update(overrides)
     return request
+
+
+def _slack_request(**overrides: object) -> dict[str, object]:
+    request: dict[str, object] = {
+        "capability": CAPABILITY_SLACK_HUMAN_TASK_ID,
+        "args": {
+            "repository": "openfunltd/cafe",
+            "workflow_id": "workflow-one",
+            "task_id": "task-one",
+            "reason": "Review the implementation plan.",
+        },
+        "effects": {
+            "writes": [],
+            "network_destinations": [SLACK_DESTINATION],
+            "browser_open": [],
+        },
+        "credentials": [SLACK_CREDENTIAL],
+        "permissions": {"network": [SLACK_DESTINATION]},
+    }
+    request.update(overrides)
+    return request
+
+
+def test_registered_slack_human_task_capability_has_fixed_boundary(tmp_path: Path) -> None:
+    """The package registry owns one narrow non-secret HumanTask request contract."""
+    registry = load_capability_registry(default_capability_definition_dirs(tmp_path))
+
+    manifest = registry[CAPABILITY_SLACK_HUMAN_TASK_ID]
+
+    assert manifest.implementation == "notify_slack_human_task"
+    assert set(manifest.arguments.required) == {
+        "repository",
+        "workflow_id",
+        "task_id",
+        "reason",
+    }
+    assert set(manifest.arguments.properties) == set(manifest.arguments.required)
+    assert manifest.effects.network_destinations == (SLACK_DESTINATION,)
+    assert manifest.effects.writes == ()
+    assert manifest.credentials == (SLACK_CREDENTIAL,)
+    assert manifest.permissions == {"network": (SLACK_DESTINATION,)}
+
+    evaluation = evaluate_capability_request(registry, _slack_request())
+    assert evaluation.decision is PolicyDecision.ALLOW
+
+
+@pytest.mark.parametrize(
+    "redirect_input",
+    ["destination", "channel", "webhook", "credential_path", "adapter"],
+)
+def test_slack_human_task_capability_denies_redirectable_arguments(
+    tmp_path: Path, redirect_input: str
+) -> None:
+    """Project, agent, and task content cannot add destination authority."""
+    registry = load_capability_registry(default_capability_definition_dirs(tmp_path))
+    args = dict(_slack_request()["args"])
+    args[redirect_input] = "https://evil.test/redirect"
+
+    evaluation = evaluate_capability_request(registry, _slack_request(args=args))
+
+    assert evaluation.decision is PolicyDecision.DENY
+    assert evaluation.reason_code == "argument_not_allowed"
+
+
+@pytest.mark.parametrize(
+    ("request_update", "reason_code"),
+    [
+        (
+            {
+                "effects": {
+                    "writes": [],
+                    "network_destinations": ["evil.test"],
+                    "browser_open": [],
+                }
+            },
+            "effect_not_allowed",
+        ),
+        ({"credentials": ["project_webhook"]}, "credential_not_allowed"),
+        ({"permissions": {"network": ["evil.test"]}}, "permission_not_allowed"),
+    ],
+)
+def test_slack_human_task_capability_denies_redirectable_authority(
+    tmp_path: Path, request_update: dict[str, object], reason_code: str
+) -> None:
+    registry = load_capability_registry(default_capability_definition_dirs(tmp_path))
+
+    evaluation = evaluate_capability_request(registry, _slack_request(**request_update))
+
+    assert evaluation.decision is PolicyDecision.DENY
+    assert evaluation.reason_code == reason_code
 
 
 def test_execution_request_is_strict_and_fingerprint_covers_security_boundary() -> None:

--- a/tests/unit/test_human_task_notifications.py
+++ b/tests/unit/test_human_task_notifications.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from types import SimpleNamespace
 from urllib.error import URLError
 
 import pytest
@@ -62,7 +63,16 @@ def _slack_request(**overrides: object) -> dict[str, object]:
 
 
 def _set_home(monkeypatch: pytest.MonkeyPatch, home: Path) -> None:
-    monkeypatch.setattr(Path, "home", classmethod(lambda _cls: home))
+    import cafe.core.human_task_notifications as notification_mod
+
+    monkeypatch.setattr(notification_mod, "_trusted_user_home", lambda: home)
+
+
+def _write_credential(home: Path, value: str = VALID_WEBHOOK) -> Path:
+    credential = home / ".slack-webhook"
+    credential.write_text(value, encoding="utf-8")
+    credential.chmod(0o600)
+    return credential
 
 
 def test_actionable_message_exposes_task_journey_without_credentials() -> None:
@@ -91,7 +101,7 @@ def test_credential_resolver_reads_only_the_fixed_user_file(
     project = tmp_path / "project"
     home.mkdir()
     project.mkdir()
-    (home / ".slack-webhook").write_text(VALID_WEBHOOK, encoding="utf-8")
+    _write_credential(home)
     (project / ".slack-webhook").write_text(
         "https://hooks.slack.com/services/PROJECT/REDIRECT/value", encoding="utf-8"
     )
@@ -100,6 +110,63 @@ def test_credential_resolver_reads_only_the_fixed_user_file(
     _set_home(monkeypatch, home)
 
     assert load_slack_webhook_url() == VALID_WEBHOOK
+
+
+def test_credential_resolver_ignores_home_environment(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Unit Test 5: HOME cannot select a project-adjacent credential."""
+    trusted_home = tmp_path / "trusted-home"
+    injected_home = tmp_path / "project" / "home"
+    trusted_home.mkdir()
+    injected_home.mkdir(parents=True)
+    _write_credential(trusted_home)
+    _write_credential(
+        injected_home,
+        "https://hooks.slack.com/services/PROJECT/REDIRECT/value",
+    )
+    monkeypatch.setenv("HOME", str(injected_home))
+    _set_home(monkeypatch, trusted_home)
+
+    assert load_slack_webhook_url() == VALID_WEBHOOK
+
+
+@pytest.mark.parametrize("unsafe_kind", ["mode", "owner", "symlink"])
+def test_credential_resolver_rejects_unsafe_user_files(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, unsafe_kind: str
+) -> None:
+    """Unit Test 5: the fixed credential must be private, regular, and unsymlinked."""
+    home = tmp_path / "home"
+    home.mkdir()
+    credential = home / ".slack-webhook"
+    if unsafe_kind in {"mode", "owner"}:
+        _write_credential(home)
+        if unsafe_kind == "mode":
+            credential.chmod(0o644)
+        else:
+            import cafe.core.human_task_notifications as notification_mod
+
+            metadata = credential.stat()
+            monkeypatch.setattr(
+                notification_mod.os,
+                "fstat",
+                lambda _descriptor: SimpleNamespace(
+                    st_mode=metadata.st_mode,
+                    st_uid=metadata.st_uid + 1,
+                    st_nlink=metadata.st_nlink,
+                ),
+            )
+    else:
+        target = tmp_path / "project-credential"
+        target.write_text(VALID_WEBHOOK, encoding="utf-8")
+        target.chmod(0o600)
+        credential.symlink_to(target)
+    _set_home(monkeypatch, home)
+
+    with pytest.raises(SlackNotificationError) as exc:
+        load_slack_webhook_url()
+
+    assert exc.value.code == "slack_credentials_unsafe"
 
 
 @pytest.mark.parametrize(
@@ -122,7 +189,7 @@ def test_credential_resolver_fails_closed(
     home = tmp_path / "home"
     home.mkdir()
     if credential is not None:
-        (home / ".slack-webhook").write_text(credential, encoding="utf-8")
+        _write_credential(home, credential)
     _set_home(monkeypatch, home)
 
     with pytest.raises(SlackNotificationError) as exc:
@@ -152,13 +219,13 @@ def test_outbound_adapter_classifies_delivery_outcomes(
 
     requests = []
 
-    def _urlopen(request, *, timeout: float):
+    def _open_slack_request(request, *, timeout: float):
         requests.append((request, timeout))
         if raised is not None:
             raise raised
         return response
 
-    monkeypatch.setattr(notification_mod, "urlopen", _urlopen)
+    monkeypatch.setattr(notification_mod, "_open_slack_request", _open_slack_request)
     message = build_human_task_message(
         repository="openfunltd/cafe",
         workflow_id="workflow-one",
@@ -179,6 +246,37 @@ def test_outbound_adapter_classifies_delivery_outcomes(
 
     assert exc.value.code == expected_code
     assert "secret-value" not in str(exc.value)
+
+
+def test_outbound_adapter_installs_a_redirect_rejecting_opener(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unit Test 5: the fixed Slack destination remains fixed after HTTP responses."""
+    import cafe.core.human_task_notifications as notification_mod
+
+    handlers = []
+
+    class _Opener:
+        def open(self, _request, *, timeout: float):
+            assert timeout == 4.0
+            return _SlackResponse()
+
+    def _build_opener(*items):
+        handlers.extend(items)
+        return _Opener()
+
+    monkeypatch.setattr(notification_mod, "build_opener", _build_opener)
+    message = build_human_task_message(
+        repository="openfunltd/cafe",
+        workflow_id="workflow-one",
+        task_id="task-one",
+        reason="Review the implementation plan.",
+    )
+
+    post_slack_notification(VALID_WEBHOOK, message, timeout_sec=4.0)
+
+    assert len(handlers) == 1
+    assert handlers[0].redirect_request(None, None, 302, "Found", {}, "https://evil.test") is None
 
 
 @pytest.mark.parametrize(
@@ -205,16 +303,16 @@ def test_capability_receipts_classify_failures_without_secret_material(
     home = tmp_path / "home"
     home.mkdir()
     if credential is not None:
-        (home / ".slack-webhook").write_text(credential, encoding="utf-8")
+        _write_credential(home, credential)
     _set_home(monkeypatch, home)
 
-    def _urlopen(_request, *, timeout: float):
+    def _open_slack_request(_request, *, timeout: float):
         del timeout
         if raised is not None:
             raise raised
         return response
 
-    monkeypatch.setattr(notification_mod, "urlopen", _urlopen)
+    monkeypatch.setattr(notification_mod, "_open_slack_request", _open_slack_request)
     registry = load_capability_registry(default_capability_definition_dirs(tmp_path))
 
     run = run_capability_request(
@@ -238,9 +336,13 @@ def test_capability_receipt_records_success_and_policy_denial(
 
     home = tmp_path / "home"
     home.mkdir()
-    (home / ".slack-webhook").write_text(VALID_WEBHOOK, encoding="utf-8")
+    _write_credential(home)
     _set_home(monkeypatch, home)
-    monkeypatch.setattr(notification_mod, "urlopen", lambda _request, *, timeout: _SlackResponse())
+    monkeypatch.setattr(
+        notification_mod,
+        "_open_slack_request",
+        lambda _request, *, timeout: _SlackResponse(),
+    )
     registry = load_capability_registry(default_capability_definition_dirs(tmp_path))
 
     successful = run_capability_request(

--- a/tests/unit/test_human_task_notifications.py
+++ b/tests/unit/test_human_task_notifications.py
@@ -1,0 +1,274 @@
+"""Invariant coverage for the package-owned Slack HumanTask notification path."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from urllib.error import URLError
+
+import pytest
+
+from cafe.core.capabilities import (
+    CAPABILITY_SLACK_HUMAN_TASK_ID,
+    default_capability_definition_dirs,
+    load_capability_registry,
+    run_capability_request,
+)
+from cafe.core.human_task_notifications import (
+    SlackNotificationError,
+    build_human_task_message,
+    load_slack_webhook_url,
+    post_slack_notification,
+)
+
+
+VALID_WEBHOOK = "https://hooks.slack.com/services/T00000000/B00000000/secret-value"
+
+
+class _SlackResponse:
+    def __init__(self, *, status: int = 200, body: bytes = b"ok") -> None:
+        self.status = status
+        self._body = body
+
+    def __enter__(self) -> "_SlackResponse":
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def read(self, _limit: int = -1) -> bytes:
+        return self._body
+
+
+def _slack_request(**overrides: object) -> dict[str, object]:
+    request: dict[str, object] = {
+        "capability": CAPABILITY_SLACK_HUMAN_TASK_ID,
+        "args": {
+            "repository": "openfunltd/cafe",
+            "workflow_id": "workflow-one",
+            "task_id": "task-one",
+            "reason": "Review the implementation plan.",
+        },
+        "effects": {
+            "writes": [],
+            "network_destinations": ["hooks.slack.com"],
+            "browser_open": [],
+        },
+        "credentials": ["slack_human_task_webhook"],
+        "permissions": {"network": ["hooks.slack.com"]},
+    }
+    request.update(overrides)
+    return request
+
+
+def _set_home(monkeypatch: pytest.MonkeyPatch, home: Path) -> None:
+    monkeypatch.setattr(Path, "home", classmethod(lambda _cls: home))
+
+
+def test_actionable_message_exposes_task_journey_without_credentials() -> None:
+    """Unit Test 4: task identity and supported actions are stable message fields."""
+    message = build_human_task_message(
+        repository="openfunltd/cafe",
+        workflow_id="workflow-one",
+        task_id="task-one",
+        reason="Review the implementation plan.",
+    )
+
+    assert message.repository == "openfunltd/cafe"
+    assert message.workflow_id == "workflow-one"
+    assert message.task_id == "task-one"
+    assert message.reason == "Review the implementation plan."
+    assert message.inspect_command == "cafe task inspect task-one"
+    assert message.complete_command == "cafe task complete task-one"
+    assert "secret-value" not in json.dumps(message.to_slack_payload())
+
+
+def test_credential_resolver_reads_only_the_fixed_user_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Unit Test 5: project files and environment hints cannot replace the credential."""
+    home = tmp_path / "home"
+    project = tmp_path / "project"
+    home.mkdir()
+    project.mkdir()
+    (home / ".slack-webhook").write_text(VALID_WEBHOOK, encoding="utf-8")
+    (project / ".slack-webhook").write_text(
+        "https://hooks.slack.com/services/PROJECT/REDIRECT/value", encoding="utf-8"
+    )
+    monkeypatch.chdir(project)
+    monkeypatch.setenv("CAFE_SLACK_WEBHOOK", "https://hooks.slack.com/services/ENV/REDIRECT/value")
+    _set_home(monkeypatch, home)
+
+    assert load_slack_webhook_url() == VALID_WEBHOOK
+
+
+@pytest.mark.parametrize(
+    ("credential", "expected_code"),
+    [
+        (None, "slack_credentials_missing"),
+        ("", "slack_credentials_empty"),
+        ("http://hooks.slack.com/services/T/B/value", "slack_credentials_invalid"),
+        ("https://evil.test/services/T/B/value", "slack_credentials_invalid"),
+        ("https://hooks.slack.com/not-services/T/B/value", "slack_credentials_invalid"),
+        ("https://hooks.slack.com/services/T/B/value?redirect=1", "slack_credentials_invalid"),
+    ],
+)
+def test_credential_resolver_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    credential: str | None,
+    expected_code: str,
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    if credential is not None:
+        (home / ".slack-webhook").write_text(credential, encoding="utf-8")
+    _set_home(monkeypatch, home)
+
+    with pytest.raises(SlackNotificationError) as exc:
+        load_slack_webhook_url()
+
+    assert exc.value.code == expected_code
+    assert VALID_WEBHOOK not in str(exc.value)
+
+
+@pytest.mark.parametrize(
+    ("response", "raised", "expected_code"),
+    [
+        (_SlackResponse(), None, None),
+        (_SlackResponse(status=503), None, "slack_http_error"),
+        (_SlackResponse(body=b"invalid_payload"), None, "slack_response_not_ok"),
+        (None, URLError("network unavailable"), "slack_transport_error"),
+    ],
+)
+def test_outbound_adapter_classifies_delivery_outcomes(
+    monkeypatch: pytest.MonkeyPatch,
+    response: _SlackResponse | None,
+    raised: Exception | None,
+    expected_code: str | None,
+) -> None:
+    """Unit Test 6: the HTTPS boundary yields stable secret-free outcome codes."""
+    import cafe.core.human_task_notifications as notification_mod
+
+    requests = []
+
+    def _urlopen(request, *, timeout: float):
+        requests.append((request, timeout))
+        if raised is not None:
+            raise raised
+        return response
+
+    monkeypatch.setattr(notification_mod, "urlopen", _urlopen)
+    message = build_human_task_message(
+        repository="openfunltd/cafe",
+        workflow_id="workflow-one",
+        task_id="task-one",
+        reason="Review the implementation plan.",
+    )
+
+    if expected_code is None:
+        post_slack_notification(VALID_WEBHOOK, message, timeout_sec=4.0)
+        payload = json.loads(requests[0][0].data)
+        assert requests[0][0].full_url == VALID_WEBHOOK
+        assert requests[0][1] == 4.0
+        assert "task-one" in payload["text"]
+        return
+
+    with pytest.raises(SlackNotificationError) as exc:
+        post_slack_notification(VALID_WEBHOOK, message, timeout_sec=4.0)
+
+    assert exc.value.code == expected_code
+    assert "secret-value" not in str(exc.value)
+
+
+@pytest.mark.parametrize(
+    ("credential", "response", "raised", "expected_code"),
+    [
+        (None, None, None, "slack_credentials_missing"),
+        ("", None, None, "slack_credentials_empty"),
+        ("https://evil.test/services/T/B/value", None, None, "slack_credentials_invalid"),
+        (VALID_WEBHOOK, _SlackResponse(status=500), None, "slack_http_error"),
+        (VALID_WEBHOOK, _SlackResponse(body=b"no"), None, "slack_response_not_ok"),
+        (VALID_WEBHOOK, None, URLError("offline"), "slack_transport_error"),
+    ],
+)
+def test_capability_receipts_classify_failures_without_secret_material(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    credential: str | None,
+    response: _SlackResponse | None,
+    raised: Exception | None,
+    expected_code: str,
+) -> None:
+    import cafe.core.human_task_notifications as notification_mod
+
+    home = tmp_path / "home"
+    home.mkdir()
+    if credential is not None:
+        (home / ".slack-webhook").write_text(credential, encoding="utf-8")
+    _set_home(monkeypatch, home)
+
+    def _urlopen(_request, *, timeout: float):
+        del timeout
+        if raised is not None:
+            raise raised
+        return response
+
+    monkeypatch.setattr(notification_mod, "urlopen", _urlopen)
+    registry = load_capability_registry(default_capability_definition_dirs(tmp_path))
+
+    run = run_capability_request(
+        repo_root=tmp_path,
+        registry=registry,
+        capability_request=_slack_request(),
+        output_file=tmp_path / "output.md",
+        timeout_sec=4.0,
+    )
+
+    assert run.receipt["success"] is False
+    assert run.receipt["code"] == expected_code
+    assert run.receipt["outcome"] == "execution_failure"
+    assert "secret-value" not in json.dumps(run.receipt)
+
+
+def test_capability_receipt_records_success_and_policy_denial(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import cafe.core.human_task_notifications as notification_mod
+
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".slack-webhook").write_text(VALID_WEBHOOK, encoding="utf-8")
+    _set_home(monkeypatch, home)
+    monkeypatch.setattr(notification_mod, "urlopen", lambda _request, *, timeout: _SlackResponse())
+    registry = load_capability_registry(default_capability_definition_dirs(tmp_path))
+
+    successful = run_capability_request(
+        repo_root=tmp_path,
+        registry=registry,
+        capability_request=_slack_request(),
+        output_file=tmp_path / "output.md",
+    )
+    denied = run_capability_request(
+        repo_root=tmp_path,
+        registry=registry,
+        capability_request=_slack_request(
+            effects={
+                "writes": [],
+                "network_destinations": ["evil.test"],
+                "browser_open": [],
+            }
+        ),
+        output_file=tmp_path / "output.md",
+    )
+
+    assert successful.receipt["success"] is True
+    assert successful.receipt["outputs"] == {
+        "delivered": True,
+        "workflow_id": "workflow-one",
+        "task_id": "task-one",
+    }
+    assert denied.receipt["success"] is False
+    assert denied.receipt["code"] == "effect_not_allowed"
+    assert denied.receipt["outcome"] == "policy_denied"
+    assert "secret-value" not in json.dumps([successful.receipt, denied.receipt])

--- a/tests/unit/test_human_task_notifications.py
+++ b/tests/unit/test_human_task_notifications.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from types import SimpleNamespace
 from urllib.error import URLError
@@ -161,6 +162,22 @@ def test_credential_resolver_rejects_unsafe_user_files(
         target.write_text(VALID_WEBHOOK, encoding="utf-8")
         target.chmod(0o600)
         credential.symlink_to(target)
+    _set_home(monkeypatch, home)
+
+    with pytest.raises(SlackNotificationError) as exc:
+        load_slack_webhook_url()
+
+    assert exc.value.code == "slack_credentials_unsafe"
+
+
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="requires POSIX FIFO support")
+def test_credential_resolver_rejects_fifo_without_blocking(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Unit Test 5: a non-regular credential cannot block the HumanTask handoff."""
+    home = tmp_path / "home"
+    home.mkdir()
+    os.mkfifo(home / ".slack-webhook", mode=0o600)
     _set_home(monkeypatch, home)
 
     with pytest.raises(SlackNotificationError) as exc:

--- a/tests/unit/test_human_task_records.py
+++ b/tests/unit/test_human_task_records.py
@@ -11,6 +11,7 @@ import pytest
 
 from cafe.core.human_task_records import (
     HumanTaskCorrelationError,
+    HumanTaskMaterialization,
     HumanTaskRecordSchemaError,
     HumanTaskRecordStore,
     HumanTaskStatus,
@@ -38,6 +39,26 @@ def _materialize_in_process(issue_dir: str, barrier, results) -> None:
         results.put(("ok", _materialize(HumanTaskRecordStore(Path(issue_dir))).id))
     except BaseException as exc:
         results.put(("error", repr(exc)))
+
+
+def _materialize_with_status_in_process(issue_dir: str, barrier, results) -> None:
+    """Exercise the atomic creation signal across separate processes."""
+    try:
+        barrier.wait(timeout=5)
+        result = HumanTaskRecordStore(Path(issue_dir)).materialize_with_status(
+            workflow_id="workflow-one",
+            step="develop",
+            iteration=1,
+            trigger="need_clarification",
+            policy_id="clarification-feedback",
+            prompt="Describe the compatibility requirement.",
+            expected_result={"input_schema": "feedback", "required": True},
+            continuations={"submit": "develop"},
+            assignee_type="user",
+        )
+        results.put(("ok", result.task.id, result.created))
+    except BaseException as exc:
+        results.put(("error", repr(exc), False))
 
 
 def _complete_in_process(issue_dir: str, task_id: str, barrier, results) -> None:
@@ -97,6 +118,67 @@ def test_materialization_is_idempotent_per_handoff_key(tmp_path: Path) -> None:
     assert store.active_wait_state("workflow-one").task_id == first.id
     assert next_iteration.id != first.id
     assert len(store.tasks()) == 2
+
+
+def test_materialization_reports_creation_atomically_across_restart(tmp_path: Path) -> None:
+    """The durable store distinguishes a new task from recovery without a second read."""
+    issue_dir = tmp_path / "issue"
+
+    first = HumanTaskRecordStore(issue_dir).materialize_with_status(
+        workflow_id="workflow-one",
+        step="develop",
+        iteration=1,
+        trigger="need_clarification",
+        policy_id="clarification-feedback",
+        prompt="Describe the compatibility requirement.",
+        expected_result={"input_schema": "feedback", "required": True},
+        continuations={"submit": "develop"},
+        assignee_type="user",
+    )
+    recovered = HumanTaskRecordStore(issue_dir).materialize_with_status(
+        workflow_id="workflow-one",
+        step="develop",
+        iteration=1,
+        trigger="need_clarification",
+        policy_id="clarification-feedback",
+        prompt="Describe the compatibility requirement.",
+        expected_result={"input_schema": "feedback", "required": True},
+        continuations={"submit": "develop"},
+        assignee_type="user",
+    )
+
+    assert isinstance(first, HumanTaskMaterialization)
+    assert first.created is True
+    assert recovered.created is False
+    assert recovered.task == first.task
+
+
+@pytest.mark.skipif(os.name == "nt", reason="the durable record lock is POSIX file based")
+def test_only_one_concurrent_materialization_reports_creation(tmp_path: Path) -> None:
+    """Only the process that durably creates the shared task reports creation."""
+    context = multiprocessing.get_context("fork")
+    issue_dir = tmp_path / "issue"
+    worker_count = 8
+    barrier = context.Barrier(worker_count)
+    results = context.Queue()
+    workers = [
+        context.Process(
+            target=_materialize_with_status_in_process,
+            args=(str(issue_dir), barrier, results),
+        )
+        for _ in range(worker_count)
+    ]
+
+    for process in workers:
+        process.start()
+    materializations = [results.get(timeout=10) for _ in workers]
+    for process in workers:
+        process.join(timeout=10)
+
+    assert all(process.exitcode == 0 for process in workers)
+    assert all(status == "ok" for status, _task_id, _created in materializations)
+    assert len({task_id for _status, task_id, _created in materializations}) == 1
+    assert sum(created for _status, _task_id, created in materializations) == 1
 
 
 @pytest.mark.skipif(os.name == "nt", reason="the durable record lock is POSIX file based")

--- a/tests/unit/test_playbook_loader.py
+++ b/tests/unit/test_playbook_loader.py
@@ -50,6 +50,24 @@ def test_issue_can_override_only_one_step_iteration_limit(tmp_path: Path) -> Non
     assert playbook["steps"]["review"]["max_iterations"] == 5
 
 
+def test_issue_override_preserves_trusted_playbook_source(tmp_path: Path) -> None:
+    """Runtime authority survives the supported narrow issue override path."""
+    issue_yaml = tmp_path / "issue.yaml"
+    issue_yaml.write_text(
+        "playbook_overrides:\n  steps:\n    spec:\n      max_iterations: 7\n",
+        encoding="utf-8",
+    )
+    loaded = PlaybookLoader(
+        project_root=tmp_path / "project",
+        global_root=tmp_path / "global",
+    ).load("standard")
+
+    resolved = apply_issue_playbook_overrides(loaded, issue_yaml)
+
+    assert getattr(resolved, "source", None) == "builtin"
+    assert resolved["steps"]["spec"]["max_iterations"] == 7
+
+
 @pytest.mark.parametrize(
     ("override", "message"),
     [
@@ -1129,9 +1147,7 @@ steps:
         loader.load_model("intake-flow")
 
 
-@pytest.mark.parametrize(
-    "playbook_name", ["standard", "standard-qa", "simple", "tdd", "tdd-qa"]
-)
+@pytest.mark.parametrize("playbook_name", ["standard", "standard-qa", "simple", "tdd", "tdd-qa"])
 def test_builtin_entry_steps_use_declared_initial_input_resolver(
     playbook_name: str, tmp_path: Path
 ) -> None:

--- a/tests/unit/test_workflow_runtime.py
+++ b/tests/unit/test_workflow_runtime.py
@@ -2,8 +2,10 @@
 
 from concurrent.futures import ThreadPoolExecutor
 import json
+import multiprocessing
 from pathlib import Path
 import threading
+import time
 from types import SimpleNamespace
 
 import pytest
@@ -14,6 +16,43 @@ from cafe.core.human_tasks import HumanTaskBinding, HumanTaskDecision, HumanTask
 from cafe.core.workflow_models import BatonRejected, StepExecutionResult
 from cafe.core.workflow_runtime import BlackboardWorkflowRuntime
 from cafe.playbooks.loader import PlaybookLoader
+
+
+def _notify_human_task_in_process(
+    issue_dir_value: str,
+    rendezvous: object,
+    result_queue: object,
+) -> None:
+    """Run one stale notification claimant in an independent process."""
+    import cafe.core.workflow_runtime as runtime_mod
+
+    dispatched = False
+
+    def _dispatch(**_kwargs: object) -> SimpleNamespace:
+        nonlocal dispatched
+        dispatched = True
+        time.sleep(0.25)
+        return SimpleNamespace(
+            receipt={"capability": "cafe.slack.human_task", "success": True}
+        )
+
+    try:
+        issue_dir = Path(issue_dir_value)
+        runtime_mod.load_capability_registry = lambda _dirs: {}
+        runtime_mod.default_capability_definition_dirs = lambda _root: []
+        runtime_mod.run_capability_request = _dispatch
+        runtime = BlackboardWorkflowRuntime(
+            issue_dir=issue_dir,
+            playbook=PlaybookLoader().load("standard"),
+            executor=lambda *_args: None,
+        )
+        task = HumanTaskRecordStore(issue_dir).tasks()[0]
+        rendezvous.wait(timeout=10)
+        runtime._notify_new_human_task(task)
+    except BaseException as exc:
+        result_queue.put(("error", repr(exc)))
+        return
+    result_queue.put(("ok", dispatched))
 
 
 def _write_baton(
@@ -2152,6 +2191,90 @@ def test_concurrent_stale_runtimes_claim_one_notification_attempt(
     ]
     assert len(dispatches) == 1
     assert len(matching_receipts) == 1
+
+
+def test_independent_runtimes_claim_one_notification_attempt_across_processes(
+    tmp_path: Path,
+) -> None:
+    """Unit Tests 7-8: process-level claim serialization permits one dispatch."""
+    issue_dir = tmp_path / ".cafe" / "issues" / "process-notification-recovery"
+    runtime = BlackboardWorkflowRuntime(
+        issue_dir=issue_dir,
+        playbook=PlaybookLoader().load("standard"),
+        executor=lambda *_args: None,
+    )
+    task = HumanTaskRecordStore(issue_dir).materialize(
+        workflow_id=runtime.blackboard.workflow_id,
+        step="spec",
+        iteration=1,
+        trigger="output_ready",
+        policy_id="output-review",
+        prompt="Review the requirements specification and choose how to continue.",
+        expected_result={"input_schema": "decision"},
+        continuations={"agree": "plan"},
+        assignee_type="human",
+    )
+    context = multiprocessing.get_context("spawn")
+    rendezvous = context.Barrier(2)
+    result_queue = context.Queue()
+    workers = [
+        context.Process(
+            target=_notify_human_task_in_process,
+            args=(str(issue_dir), rendezvous, result_queue),
+        )
+        for _ in range(2)
+    ]
+
+    for worker in workers:
+        worker.start()
+    for worker in workers:
+        worker.join(timeout=15)
+
+    assert [worker.exitcode for worker in workers] == [0, 0]
+    results = [result_queue.get(timeout=5) for _ in workers]
+    assert [result[0] for result in results] == ["ok", "ok"]
+    assert sum(bool(result[1]) for result in results) == 1
+    state = BlackboardStore(issue_dir).load_or_create("spec")
+    matching_receipts = [
+        receipt
+        for receipt in state.capability_receipts
+        if receipt.get("capability") == "cafe.slack.human_task"
+        and receipt.get("task_id") == task.id
+    ]
+    assert len(matching_receipts) == 1
+
+
+def test_receipt_transaction_uses_windows_process_lock_without_fcntl(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Unit Test 7: the Windows fallback remains a cross-process file lock."""
+    import cafe.core.blackboard as blackboard_mod
+
+    lock_calls: list[tuple[int, int, int]] = []
+    windows_lock = SimpleNamespace(
+        LK_LOCK=1,
+        LK_UNLCK=2,
+        locking=lambda descriptor, mode, count: lock_calls.append(
+            (descriptor, mode, count)
+        ),
+    )
+    monkeypatch.setattr(blackboard_mod, "fcntl", None)
+    monkeypatch.setattr(blackboard_mod, "msvcrt", windows_lock)
+    store = BlackboardStore(tmp_path / "issue")
+    state = store.load_or_create("spec")
+
+    with store.capability_receipt_transaction(state):
+        assert [(mode, count) for _, mode, count in lock_calls] == [(1, 1)]
+
+    assert [(mode, count) for _, mode, count in lock_calls] == [(1, 1), (2, 1)]
+    assert lock_calls[0][0] == lock_calls[1][0]
+
+    monkeypatch.setattr(blackboard_mod, "msvcrt", None)
+    unavailable_store = BlackboardStore(tmp_path / "unavailable")
+    unavailable_state = unavailable_store.load_or_create("spec")
+    with pytest.raises(RuntimeError, match="cross-process file locking is unavailable"):
+        with unavailable_store.capability_receipt_transaction(unavailable_state):
+            pytest.fail("a process-local fallback must not enter the transaction")
 
 
 def test_runtime_records_non_actionable_configuration_error_for_bad_task_binding(

--- a/tests/unit/test_workflow_runtime.py
+++ b/tests/unit/test_workflow_runtime.py
@@ -2,14 +2,17 @@
 
 import json
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
 from cafe.core.blackboard import BlackboardStore, HandoffIntent, HandoffOwner
 from cafe.core.human_task_records import HumanTaskRecordStore
+from cafe.core.human_tasks import HumanTaskBinding, HumanTaskDecision, HumanTaskPolicy
 from cafe.core.workflow_models import BatonRejected, StepExecutionResult
 from cafe.core.workflow_runtime import BlackboardWorkflowRuntime
 from cafe.playbooks.loader import PlaybookLoader
+
 
 def _write_baton(
     issue_dir: Path,
@@ -1810,11 +1813,29 @@ def test_runtime_pauses_ready_for_review_with_confirm_output_intent(tmp_path: Pa
 
 
 def test_runtime_materializes_one_declared_task_and_recovers_it_after_restart(
-    tmp_path: Path,
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """IT-001: pause/restart preserves the exact durable task and wait state."""
+    import cafe.core.workflow_runtime as runtime_mod
+
     issue_dir = tmp_path / ".cafe" / "issues" / "durable-restart"
     playbook = PlaybookLoader().load("standard")
+    capability_calls: list[dict[str, object]] = []
+    monkeypatch.setattr(runtime_mod, "load_capability_registry", lambda _dirs: {"registered": True})
+    monkeypatch.setattr(runtime_mod, "default_capability_definition_dirs", lambda _root: [])
+
+    def _run_capability_request(**kwargs: object) -> SimpleNamespace:
+        capability_calls.append(kwargs)
+        request = kwargs["capability_request"]
+        return SimpleNamespace(
+            receipt={
+                "capability": "cafe.slack.human_task",
+                "success": True,
+                "inputs": dict(request["args"]),
+            }
+        )
+
+    monkeypatch.setattr(runtime_mod, "run_capability_request", _run_capability_request)
 
     def executor(step_name: str, step_def: dict, state: object) -> StepExecutionResult:
         return StepExecutionResult(
@@ -1841,6 +1862,122 @@ def test_runtime_materializes_one_declared_task_and_recovers_it_after_restart(
     assert restored.tasks()[0].id == task.id
     assert restored.get_wait_state(task.id) == wait
     assert state.workflow_id == task.workflow_id
+    assert len(capability_calls) == 1
+    request = capability_calls[0]["capability_request"]
+    assert request["args"]["task_id"] == task.id
+    assert request["args"]["workflow_id"] == task.workflow_id
+    assert request["args"]["repository"] == tmp_path.name
+
+
+def test_runtime_notifies_human_owned_creation_but_not_nonstandard_tasks(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Both creation paths use the registered capability, gated to standard."""
+    import cafe.core.workflow_runtime as runtime_mod
+
+    policy = HumanTaskPolicy(
+        id="approval",
+        pattern="no_changes_needed",
+        prompt="Approve this work",
+        input_schema="decision",
+        decisions=(HumanTaskDecision(id="accept", label="Accept"),),
+    )
+    binding = HumanTaskBinding(trigger="initial", task_id="approval", outcomes={"accept": "done"})
+    monkeypatch.setattr(runtime_mod, "resolve_step_human_task", lambda **_kwargs: (policy, binding))
+    monkeypatch.setattr(runtime_mod, "load_capability_registry", lambda _dirs: {"registered": True})
+    monkeypatch.setattr(runtime_mod, "default_capability_definition_dirs", lambda _root: [])
+    calls: list[dict[str, object]] = []
+
+    def _run_capability_request(**kwargs: object) -> SimpleNamespace:
+        calls.append(kwargs)
+        return SimpleNamespace(receipt={"capability": "cafe.slack.human_task", "success": True})
+
+    monkeypatch.setattr(runtime_mod, "run_capability_request", _run_capability_request)
+
+    def _human_playbook(playbook_id: str) -> dict[str, object]:
+        return {
+            "playbook": {"id": playbook_id},
+            "entry_point": "approval",
+            "steps": {
+                "approval": {
+                    "skill": "phase",
+                    "role": "operator",
+                    "assignee_type": "human",
+                    "human_tasks": [binding.model_dump()],
+                    "on": {},
+                }
+            },
+        }
+
+    standard_dir = tmp_path / ".cafe" / "issues" / "human-standard"
+    standard = BlackboardWorkflowRuntime(
+        issue_dir=standard_dir,
+        playbook=_human_playbook("standard"),
+        executor=lambda *_args: (_ for _ in ()).throw(AssertionError("human step ran agent")),
+    )
+    standard.run(start_step="approval")
+    standard.run(max_transitions=2)
+
+    project_dir = tmp_path / ".cafe" / "issues" / "human-project"
+    BlackboardWorkflowRuntime(
+        issue_dir=project_dir,
+        playbook=_human_playbook("project"),
+        executor=lambda *_args: (_ for _ in ()).throw(AssertionError("human step ran agent")),
+    ).run(start_step="approval")
+
+    assert len(calls) == 1
+    standard_task = HumanTaskRecordStore(standard_dir).tasks()[0]
+    project_task = HumanTaskRecordStore(project_dir).tasks()[0]
+    assert calls[0]["capability_request"]["args"]["task_id"] == standard_task.id
+    assert project_task.id != standard_task.id
+    assert BlackboardStore(project_dir).load_or_create("approval").capability_receipts == []
+
+
+def test_notification_failure_preserves_pending_task_and_user_handoff(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failed delivery is audited but cannot consume or reroute human work."""
+    import cafe.core.workflow_runtime as runtime_mod
+
+    issue_dir = tmp_path / ".cafe" / "issues" / "notification-failure"
+    playbook = PlaybookLoader().load("standard")
+    monkeypatch.setattr(runtime_mod, "load_capability_registry", lambda _dirs: {"registered": True})
+    monkeypatch.setattr(runtime_mod, "default_capability_definition_dirs", lambda _root: [])
+    monkeypatch.setattr(
+        runtime_mod,
+        "run_capability_request",
+        lambda **_kwargs: SimpleNamespace(
+            receipt={
+                "capability": "cafe.slack.human_task",
+                "success": False,
+                "code": "slack_transport_error",
+            }
+        ),
+    )
+
+    result = BlackboardWorkflowRuntime(
+        issue_dir=issue_dir,
+        playbook=playbook,
+        executor=lambda *_args: StepExecutionResult(
+            response="ready_for_review",
+            artifacts={},
+            status_code="ready_for_review",
+            auto_continue=False,
+        ),
+    ).run(start_step="spec")
+
+    task = HumanTaskRecordStore(issue_dir).tasks()[0]
+    state = BlackboardStore(issue_dir).load_or_create("spec")
+    receipt = state.capability_receipts[0]
+
+    assert result.completed is False
+    assert task.status.value == "pending"
+    assert state.current_step == "user"
+    assert state.handoff_contract.to_owner is HandoffOwner.USER
+    assert state.handoff_contract.from_step == "spec"
+    assert receipt["success"] is False
+    assert receipt["workflow_id"] == task.workflow_id
+    assert receipt["task_id"] == task.id
 
 
 def test_runtime_records_non_actionable_configuration_error_for_bad_task_binding(

--- a/tests/unit/test_workflow_runtime.py
+++ b/tests/unit/test_workflow_runtime.py
@@ -1,7 +1,9 @@
 """Tests for the blackboard-first workflow runtime."""
 
+from concurrent.futures import ThreadPoolExecutor
 import json
 from pathlib import Path
+import threading
 from types import SimpleNamespace
 
 import pytest
@@ -2089,6 +2091,67 @@ def test_runtime_audits_interrupted_attempt_without_duplicate_dispatch(
     assert len(state.capability_receipts) == 1
     assert state.capability_receipts[0]["code"] == "slack_notification_interrupted"
     assert state.capability_receipts[0]["task_id"] == task.id
+
+
+def test_concurrent_stale_runtimes_claim_one_notification_attempt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Unit Tests 7-8: concurrent recovery has one dispatch and one audited attempt."""
+    import cafe.core.workflow_runtime as runtime_mod
+
+    issue_dir = tmp_path / ".cafe" / "issues" / "concurrent-notification-recovery"
+
+    monkeypatch.setattr(runtime_mod, "load_capability_registry", lambda _dirs: {})
+    monkeypatch.setattr(runtime_mod, "default_capability_definition_dirs", lambda _root: [])
+    dispatches: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        runtime_mod,
+        "run_capability_request",
+        lambda **kwargs: dispatches.append(kwargs)
+        or SimpleNamespace(receipt={"capability": "cafe.slack.human_task", "success": True}),
+    )
+
+    runtimes = [
+        BlackboardWorkflowRuntime(
+            issue_dir=issue_dir,
+            playbook=PlaybookLoader().load("standard"),
+            executor=lambda *_args: None,
+        )
+        for _ in range(2)
+    ]
+    task = HumanTaskRecordStore(issue_dir).materialize(
+        workflow_id=runtimes[0].blackboard.workflow_id,
+        step="spec",
+        iteration=1,
+        trigger="output_ready",
+        policy_id="output-review",
+        prompt="Review the requirements specification and choose how to continue.",
+        expected_result={"input_schema": "decision"},
+        continuations={"agree": "plan"},
+        assignee_type="human",
+    )
+    rendezvous = threading.Barrier(2)
+
+    def _notify(runtime: BlackboardWorkflowRuntime) -> None:
+        rendezvous.wait(timeout=5)
+        runtime._notify_new_human_task(task)
+
+    with ThreadPoolExecutor(max_workers=2) as workers:
+        futures = [workers.submit(_notify, runtime) for runtime in runtimes]
+        for future in futures:
+            future.result(timeout=10)
+
+    for runtime in runtimes:
+        runtime.blackboard_store.save(runtime.blackboard)
+    state = BlackboardStore(issue_dir).load_or_create("spec")
+    matching_receipts = [
+        receipt
+        for receipt in state.capability_receipts
+        if receipt.get("capability") == "cafe.slack.human_task"
+        and receipt.get("task_id") == task.id
+    ]
+    assert len(dispatches) == 1
+    assert len(matching_receipts) == 1
 
 
 def test_runtime_records_non_actionable_configuration_error_for_bad_task_binding(

--- a/tests/unit/test_workflow_runtime.py
+++ b/tests/unit/test_workflow_runtime.py
@@ -2277,6 +2277,114 @@ def test_receipt_transaction_uses_windows_process_lock_without_fcntl(
             pytest.fail("a process-local fallback must not enter the transaction")
 
 
+def test_unavailable_process_lock_preserves_user_handoff(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Unit Tests 7-8: no lock backend cannot block a durable user handoff."""
+    import cafe.core.blackboard as blackboard_mod
+    import cafe.core.workflow_runtime as runtime_mod
+
+    monkeypatch.setattr(blackboard_mod, "fcntl", None)
+    monkeypatch.setattr(blackboard_mod, "msvcrt", None)
+    dispatches: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        runtime_mod,
+        "run_capability_request",
+        lambda **kwargs: dispatches.append(kwargs)
+        or SimpleNamespace(receipt={"capability": "cafe.slack.human_task", "success": True}),
+    )
+    issue_dir = tmp_path / ".cafe" / "issues" / "lock-unavailable-user-handoff"
+
+    result = BlackboardWorkflowRuntime(
+        issue_dir=issue_dir,
+        playbook=PlaybookLoader().load("standard"),
+        executor=lambda *_args: StepExecutionResult(
+            response="ready_for_review",
+            artifacts={},
+            status_code="ready_for_review",
+            auto_continue=False,
+        ),
+    ).run(start_step="spec")
+
+    task = HumanTaskRecordStore(issue_dir).tasks()[0]
+    state = BlackboardStore(issue_dir).load_or_create("spec")
+    assert result.completed is False
+    assert task.status.value == "pending"
+    assert state.current_step == "user"
+    assert state.handoff_contract.to_owner is HandoffOwner.USER
+    assert dispatches == []
+
+
+def test_windows_process_lock_failure_preserves_human_owned_handoff(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Unit Tests 7-8: Windows lock failure cannot block human-owned work."""
+    import cafe.core.blackboard as blackboard_mod
+    import cafe.core.workflow_runtime as runtime_mod
+
+    lock_calls: list[tuple[int, int, int]] = []
+
+    def _fail_lock(descriptor: int, mode: int, count: int) -> None:
+        lock_calls.append((descriptor, mode, count))
+        raise OSError("simulated Windows process lock failure")
+
+    monkeypatch.setattr(blackboard_mod, "fcntl", None)
+    monkeypatch.setattr(
+        blackboard_mod,
+        "msvcrt",
+        SimpleNamespace(LK_LOCK=1, LK_UNLCK=2, locking=_fail_lock),
+    )
+    dispatches: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        runtime_mod,
+        "run_capability_request",
+        lambda **kwargs: dispatches.append(kwargs)
+        or SimpleNamespace(receipt={"capability": "cafe.slack.human_task", "success": True}),
+    )
+    policy = HumanTaskPolicy(
+        id="approval",
+        pattern="no_changes_needed",
+        prompt="Approve this work",
+        input_schema="decision",
+        decisions=(HumanTaskDecision(id="accept", label="Accept"),),
+    )
+    binding = HumanTaskBinding(trigger="initial", task_id="approval", outcomes={"accept": "done"})
+    monkeypatch.setattr(runtime_mod, "resolve_step_human_task", lambda **_kwargs: (policy, binding))
+    playbook = PlaybookLoader().load("standard")
+    playbook.clear()
+    playbook.update(
+        {
+            "playbook": {"id": "standard"},
+            "entry_point": "approval",
+            "steps": {
+                "approval": {
+                    "skill": "phase",
+                    "role": "operator",
+                    "assignee_type": "human",
+                    "human_tasks": [binding.model_dump()],
+                    "on": {},
+                }
+            },
+        }
+    )
+    issue_dir = tmp_path / ".cafe" / "issues" / "lock-failure-human-owned"
+
+    result = BlackboardWorkflowRuntime(
+        issue_dir=issue_dir,
+        playbook=playbook,
+        executor=lambda *_args: (_ for _ in ()).throw(AssertionError("human step ran agent")),
+    ).run(start_step="approval")
+
+    task = HumanTaskRecordStore(issue_dir).tasks()[0]
+    state = BlackboardStore(issue_dir).load_or_create("approval")
+    assert result.completed is False
+    assert task.status.value == "pending"
+    assert state.current_step == "user"
+    assert state.handoff_contract.to_owner is HandoffOwner.USER
+    assert [(mode, count) for _, mode, count in lock_calls] == [(1, 1)]
+    assert dispatches == []
+
+
 def test_runtime_records_non_actionable_configuration_error_for_bad_task_binding(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_workflow_runtime.py
+++ b/tests/unit/test_workflow_runtime.py
@@ -1869,7 +1869,7 @@ def test_runtime_materializes_one_declared_task_and_recovers_it_after_restart(
     assert request["args"]["repository"] == tmp_path.name
 
 
-def test_runtime_notifies_human_owned_creation_but_not_nonstandard_tasks(
+def test_runtime_notifies_trusted_human_owned_creation_but_not_spoofed_standard_tasks(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Both creation paths use the registered capability, gated to standard."""
@@ -1909,19 +1909,22 @@ def test_runtime_notifies_human_owned_creation_but_not_nonstandard_tasks(
             },
         }
 
+    trusted_playbook = PlaybookLoader().load("standard")
+    trusted_playbook.clear()
+    trusted_playbook.update(_human_playbook("standard"))
     standard_dir = tmp_path / ".cafe" / "issues" / "human-standard"
     standard = BlackboardWorkflowRuntime(
         issue_dir=standard_dir,
-        playbook=_human_playbook("standard"),
+        playbook=trusted_playbook,
         executor=lambda *_args: (_ for _ in ()).throw(AssertionError("human step ran agent")),
     )
     standard.run(start_step="approval")
     standard.run(max_transitions=2)
 
-    project_dir = tmp_path / ".cafe" / "issues" / "human-project"
+    project_dir = tmp_path / ".cafe" / "issues" / "spoofed-standard"
     BlackboardWorkflowRuntime(
         issue_dir=project_dir,
-        playbook=_human_playbook("project"),
+        playbook=_human_playbook("standard"),
         executor=lambda *_args: (_ for _ in ()).throw(AssertionError("human step ran agent")),
     ).run(start_step="approval")
 
@@ -1929,6 +1932,7 @@ def test_runtime_notifies_human_owned_creation_but_not_nonstandard_tasks(
     standard_task = HumanTaskRecordStore(standard_dir).tasks()[0]
     project_task = HumanTaskRecordStore(project_dir).tasks()[0]
     assert calls[0]["capability_request"]["args"]["task_id"] == standard_task.id
+    assert calls[0]["timeout_sec"] == 5.0
     assert project_task.id != standard_task.id
     assert BlackboardStore(project_dir).load_or_create("approval").capability_receipts == []
 
@@ -1978,6 +1982,113 @@ def test_notification_failure_preserves_pending_task_and_user_handoff(
     assert receipt["success"] is False
     assert receipt["workflow_id"] == task.workflow_id
     assert receipt["task_id"] == task.id
+
+
+def test_runtime_recovers_notification_when_task_commit_precedes_attempt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Unit Tests 7-8: recovery repairs a durable task with no begun attempt."""
+    import cafe.core.workflow_runtime as runtime_mod
+
+    issue_dir = tmp_path / ".cafe" / "issues" / "notification-before-attempt-stop"
+    playbook = PlaybookLoader().load("standard")
+
+    def _executor(*_args: object) -> StepExecutionResult:
+        return StepExecutionResult(
+            response="ready_for_review",
+            artifacts={},
+            status_code="ready_for_review",
+            auto_continue=False,
+        )
+
+    interrupted = BlackboardWorkflowRuntime(
+        issue_dir=issue_dir,
+        playbook=playbook,
+        executor=_executor,
+    )
+    monkeypatch.setattr(
+        interrupted,
+        "_notify_new_human_task",
+        lambda _task: (_ for _ in ()).throw(SystemExit("simulated process stop")),
+    )
+    with pytest.raises(SystemExit, match="simulated process stop"):
+        interrupted.run(start_step="spec")
+
+    task = HumanTaskRecordStore(issue_dir).tasks()[0]
+    assert BlackboardStore(issue_dir).load_or_create("spec").capability_receipts == []
+    calls = []
+    monkeypatch.setattr(runtime_mod, "load_capability_registry", lambda _dirs: {})
+    monkeypatch.setattr(runtime_mod, "default_capability_definition_dirs", lambda _root: [])
+    monkeypatch.setattr(
+        runtime_mod,
+        "run_capability_request",
+        lambda **kwargs: calls.append(kwargs)
+        or SimpleNamespace(receipt={"capability": "cafe.slack.human_task", "success": True}),
+    )
+
+    BlackboardWorkflowRuntime(
+        issue_dir=issue_dir,
+        playbook=PlaybookLoader().load("standard"),
+        executor=_executor,
+    ).run(start_step="spec")
+
+    state = BlackboardStore(issue_dir).load_or_create("spec")
+    assert len(calls) == 1
+    assert len(state.capability_receipts) == 1
+    assert state.capability_receipts[0]["task_id"] == task.id
+
+
+def test_runtime_audits_interrupted_attempt_without_duplicate_dispatch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Unit Tests 7-8: a begun attempt is durable before I/O and never duplicated."""
+    import cafe.core.workflow_runtime as runtime_mod
+
+    issue_dir = tmp_path / ".cafe" / "issues" / "notification-after-dispatch-stop"
+
+    def _executor(*_args: object) -> StepExecutionResult:
+        return StepExecutionResult(
+            response="ready_for_review",
+            artifacts={},
+            status_code="ready_for_review",
+            auto_continue=False,
+        )
+
+    monkeypatch.setattr(runtime_mod, "load_capability_registry", lambda _dirs: {})
+    monkeypatch.setattr(runtime_mod, "default_capability_definition_dirs", lambda _root: [])
+
+    def _stop_after_attempt_begins(**_kwargs: object):
+        receipt = BlackboardStore(issue_dir).load_or_create("spec").capability_receipts[0]
+        assert receipt["outcome"] == "attempting"
+        raise SystemExit("simulated process stop")
+
+    monkeypatch.setattr(runtime_mod, "run_capability_request", _stop_after_attempt_begins)
+    with pytest.raises(SystemExit, match="simulated process stop"):
+        BlackboardWorkflowRuntime(
+            issue_dir=issue_dir,
+            playbook=PlaybookLoader().load("standard"),
+            executor=_executor,
+        ).run(start_step="spec")
+
+    dispatches = []
+    monkeypatch.setattr(
+        runtime_mod,
+        "run_capability_request",
+        lambda **kwargs: dispatches.append(kwargs)
+        or SimpleNamespace(receipt={"capability": "cafe.slack.human_task", "success": True}),
+    )
+    BlackboardWorkflowRuntime(
+        issue_dir=issue_dir,
+        playbook=PlaybookLoader().load("standard"),
+        executor=_executor,
+    ).run(start_step="spec")
+
+    task = HumanTaskRecordStore(issue_dir).tasks()[0]
+    state = BlackboardStore(issue_dir).load_or_create("spec")
+    assert dispatches == []
+    assert len(state.capability_receipts) == 1
+    assert state.capability_receipts[0]["code"] == "slack_notification_interrupted"
+    assert state.capability_receipts[0]["task_id"] == task.id
 
 
 def test_runtime_records_non_actionable_configuration_error_for_bad_task_binding(


### PR DESCRIPTION
## Summary

- Adds the supported, opt-in Slack notification path for genuine pending
  HumanTasks in the built-in `standard` workflow, fulfilling issue #423.
- Preserves the trusted capability boundary with a package-owned,
  fixed-destination capability and user-owned credential file; delivery
  failures—including notification-lock failures—cannot interrupt HumanTask
  persistence or its user handoff.
- Documents clean-repository setup, task completion, receipt inspection, and
  recovery without adding a generic messaging system or background service.

## Changes

- Register the narrow `cafe.slack.human_task` capability; add Slack-specific
  message construction, credential and endpoint validation, HTTPS delivery,
  and secret-free audited outcome classification. (`7da7dcf1`, `fdab9013`)
- Notify only for atomically new HumanTasks in the built-in standard workflow,
  keeping delivery non-authoritative for task and handoff progression with
  end-to-end coverage. (`347d23d8`)
- Add the supported setup and recovery guide, linked from the README and
  HumanTask runtime documentation. (`530a08ac`)
- Harden recovery and credential handling; serialize concurrent notification
  attempts and capability receipts across POSIX and Windows so stale runtimes
  cannot duplicate delivery. Lock or persistence failures fail closed without
  dispatching Slack or losing the pending task. (`26c71c48`, `8bb76eb7`,
  `71ea0acf`, `9300a809`)

## Test Plan

- `pytest -q` — 3051 passed, 1 skipped, 1 xfailed.
- `./scripts/test-coverage.sh` — 80.74% total coverage (75% required).
- Focused workflow runtime and HumanTask/ownership integration tests —
  110 passed.
- Verified the clean-HEAD full-suite receipt for `13760213` with
  `cafe verification check --require-scope full`.

## Rebase verification

- Rebased onto the current `origin/develop` before publishing.
- Rebase HEAD `9300a809e034d5743801041f7dd9ec53f664f916` passed `pytest -q`
  with 3051 passed, 1 skipped, and 1 expected xfail.